### PR TITLE
Strict date parsing regeneration

### DIFF
--- a/clients/client-accessanalyzer/protocols/Aws_restJson1.ts
+++ b/clients/client-accessanalyzer/protocols/Aws_restJson1.ts
@@ -117,6 +117,7 @@ import {
   expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
+  parseRfc3339DateTime as __parseRfc3339DateTime,
   strictParseInt32 as __strictParseInt32,
 } from "@aws-sdk/smithy-client";
 import {
@@ -4023,7 +4024,10 @@ const deserializeAws_restJson1AccessPreview = (output: any, context: __SerdeCont
       output.configurations !== undefined && output.configurations !== null
         ? deserializeAws_restJson1ConfigurationsMap(output.configurations, context)
         : undefined,
-    createdAt: output.createdAt !== undefined && output.createdAt !== null ? new Date(output.createdAt) : undefined,
+    createdAt:
+      output.createdAt !== undefined && output.createdAt !== null
+        ? __expectNonNull(__parseRfc3339DateTime(output.createdAt))
+        : undefined,
     id: __expectString(output.id),
     status: __expectString(output.status),
     statusReason:
@@ -4044,7 +4048,10 @@ const deserializeAws_restJson1AccessPreviewFinding = (output: any, context: __Se
       output.condition !== undefined && output.condition !== null
         ? deserializeAws_restJson1ConditionKeyMap(output.condition, context)
         : undefined,
-    createdAt: output.createdAt !== undefined && output.createdAt !== null ? new Date(output.createdAt) : undefined,
+    createdAt:
+      output.createdAt !== undefined && output.createdAt !== null
+        ? __expectNonNull(__parseRfc3339DateTime(output.createdAt))
+        : undefined,
     error: __expectString(output.error),
     existingFindingId: __expectString(output.existingFindingId),
     existingFindingStatus: __expectString(output.existingFindingStatus),
@@ -4102,7 +4109,10 @@ const deserializeAws_restJson1AccessPreviewStatusReason = (
 const deserializeAws_restJson1AccessPreviewSummary = (output: any, context: __SerdeContext): AccessPreviewSummary => {
   return {
     analyzerArn: __expectString(output.analyzerArn),
-    createdAt: output.createdAt !== undefined && output.createdAt !== null ? new Date(output.createdAt) : undefined,
+    createdAt:
+      output.createdAt !== undefined && output.createdAt !== null
+        ? __expectNonNull(__parseRfc3339DateTime(output.createdAt))
+        : undefined,
     id: __expectString(output.id),
     status: __expectString(output.status),
     statusReason:
@@ -4139,8 +4149,14 @@ const deserializeAws_restJson1AnalyzedResource = (output: any, context: __SerdeC
       output.actions !== undefined && output.actions !== null
         ? deserializeAws_restJson1ActionList(output.actions, context)
         : undefined,
-    analyzedAt: output.analyzedAt !== undefined && output.analyzedAt !== null ? new Date(output.analyzedAt) : undefined,
-    createdAt: output.createdAt !== undefined && output.createdAt !== null ? new Date(output.createdAt) : undefined,
+    analyzedAt:
+      output.analyzedAt !== undefined && output.analyzedAt !== null
+        ? __expectNonNull(__parseRfc3339DateTime(output.analyzedAt))
+        : undefined,
+    createdAt:
+      output.createdAt !== undefined && output.createdAt !== null
+        ? __expectNonNull(__parseRfc3339DateTime(output.createdAt))
+        : undefined,
     error: __expectString(output.error),
     isPublic: __expectBoolean(output.isPublic),
     resourceArn: __expectString(output.resourceArn),
@@ -4151,7 +4167,10 @@ const deserializeAws_restJson1AnalyzedResource = (output: any, context: __SerdeC
         ? deserializeAws_restJson1SharedViaList(output.sharedVia, context)
         : undefined,
     status: __expectString(output.status),
-    updatedAt: output.updatedAt !== undefined && output.updatedAt !== null ? new Date(output.updatedAt) : undefined,
+    updatedAt:
+      output.updatedAt !== undefined && output.updatedAt !== null
+        ? __expectNonNull(__parseRfc3339DateTime(output.updatedAt))
+        : undefined,
   } as any;
 };
 
@@ -4194,11 +4213,14 @@ const deserializeAws_restJson1AnalyzersList = (output: any, context: __SerdeCont
 const deserializeAws_restJson1AnalyzerSummary = (output: any, context: __SerdeContext): AnalyzerSummary => {
   return {
     arn: __expectString(output.arn),
-    createdAt: output.createdAt !== undefined && output.createdAt !== null ? new Date(output.createdAt) : undefined,
+    createdAt:
+      output.createdAt !== undefined && output.createdAt !== null
+        ? __expectNonNull(__parseRfc3339DateTime(output.createdAt))
+        : undefined,
     lastResourceAnalyzed: __expectString(output.lastResourceAnalyzed),
     lastResourceAnalyzedAt:
       output.lastResourceAnalyzedAt !== undefined && output.lastResourceAnalyzedAt !== null
-        ? new Date(output.lastResourceAnalyzedAt)
+        ? __expectNonNull(__parseRfc3339DateTime(output.lastResourceAnalyzedAt))
         : undefined,
     name: __expectString(output.name),
     status: __expectString(output.status),
@@ -4227,20 +4249,32 @@ const deserializeAws_restJson1ArchiveRulesList = (output: any, context: __SerdeC
 
 const deserializeAws_restJson1ArchiveRuleSummary = (output: any, context: __SerdeContext): ArchiveRuleSummary => {
   return {
-    createdAt: output.createdAt !== undefined && output.createdAt !== null ? new Date(output.createdAt) : undefined,
+    createdAt:
+      output.createdAt !== undefined && output.createdAt !== null
+        ? __expectNonNull(__parseRfc3339DateTime(output.createdAt))
+        : undefined,
     filter:
       output.filter !== undefined && output.filter !== null
         ? deserializeAws_restJson1FilterCriteriaMap(output.filter, context)
         : undefined,
     ruleName: __expectString(output.ruleName),
-    updatedAt: output.updatedAt !== undefined && output.updatedAt !== null ? new Date(output.updatedAt) : undefined,
+    updatedAt:
+      output.updatedAt !== undefined && output.updatedAt !== null
+        ? __expectNonNull(__parseRfc3339DateTime(output.updatedAt))
+        : undefined,
   } as any;
 };
 
 const deserializeAws_restJson1CloudTrailProperties = (output: any, context: __SerdeContext): CloudTrailProperties => {
   return {
-    endTime: output.endTime !== undefined && output.endTime !== null ? new Date(output.endTime) : undefined,
-    startTime: output.startTime !== undefined && output.startTime !== null ? new Date(output.startTime) : undefined,
+    endTime:
+      output.endTime !== undefined && output.endTime !== null
+        ? __expectNonNull(__parseRfc3339DateTime(output.endTime))
+        : undefined,
+    startTime:
+      output.startTime !== undefined && output.startTime !== null
+        ? __expectNonNull(__parseRfc3339DateTime(output.startTime))
+        : undefined,
     trailProperties:
       output.trailProperties !== undefined && output.trailProperties !== null
         ? deserializeAws_restJson1TrailPropertiesList(output.trailProperties, context)
@@ -4344,12 +4378,18 @@ const deserializeAws_restJson1Finding = (output: any, context: __SerdeContext): 
       output.action !== undefined && output.action !== null
         ? deserializeAws_restJson1ActionList(output.action, context)
         : undefined,
-    analyzedAt: output.analyzedAt !== undefined && output.analyzedAt !== null ? new Date(output.analyzedAt) : undefined,
+    analyzedAt:
+      output.analyzedAt !== undefined && output.analyzedAt !== null
+        ? __expectNonNull(__parseRfc3339DateTime(output.analyzedAt))
+        : undefined,
     condition:
       output.condition !== undefined && output.condition !== null
         ? deserializeAws_restJson1ConditionKeyMap(output.condition, context)
         : undefined,
-    createdAt: output.createdAt !== undefined && output.createdAt !== null ? new Date(output.createdAt) : undefined,
+    createdAt:
+      output.createdAt !== undefined && output.createdAt !== null
+        ? __expectNonNull(__parseRfc3339DateTime(output.createdAt))
+        : undefined,
     error: __expectString(output.error),
     id: __expectString(output.id),
     isPublic: __expectBoolean(output.isPublic),
@@ -4365,7 +4405,10 @@ const deserializeAws_restJson1Finding = (output: any, context: __SerdeContext): 
         ? deserializeAws_restJson1FindingSourceList(output.sources, context)
         : undefined,
     status: __expectString(output.status),
-    updatedAt: output.updatedAt !== undefined && output.updatedAt !== null ? new Date(output.updatedAt) : undefined,
+    updatedAt:
+      output.updatedAt !== undefined && output.updatedAt !== null
+        ? __expectNonNull(__parseRfc3339DateTime(output.updatedAt))
+        : undefined,
   } as any;
 };
 
@@ -4413,12 +4456,18 @@ const deserializeAws_restJson1FindingSummary = (output: any, context: __SerdeCon
       output.action !== undefined && output.action !== null
         ? deserializeAws_restJson1ActionList(output.action, context)
         : undefined,
-    analyzedAt: output.analyzedAt !== undefined && output.analyzedAt !== null ? new Date(output.analyzedAt) : undefined,
+    analyzedAt:
+      output.analyzedAt !== undefined && output.analyzedAt !== null
+        ? __expectNonNull(__parseRfc3339DateTime(output.analyzedAt))
+        : undefined,
     condition:
       output.condition !== undefined && output.condition !== null
         ? deserializeAws_restJson1ConditionKeyMap(output.condition, context)
         : undefined,
-    createdAt: output.createdAt !== undefined && output.createdAt !== null ? new Date(output.createdAt) : undefined,
+    createdAt:
+      output.createdAt !== undefined && output.createdAt !== null
+        ? __expectNonNull(__parseRfc3339DateTime(output.createdAt))
+        : undefined,
     error: __expectString(output.error),
     id: __expectString(output.id),
     isPublic: __expectBoolean(output.isPublic),
@@ -4434,7 +4483,10 @@ const deserializeAws_restJson1FindingSummary = (output: any, context: __SerdeCon
         ? deserializeAws_restJson1FindingSourceList(output.sources, context)
         : undefined,
     status: __expectString(output.status),
-    updatedAt: output.updatedAt !== undefined && output.updatedAt !== null ? new Date(output.updatedAt) : undefined,
+    updatedAt:
+      output.updatedAt !== undefined && output.updatedAt !== null
+        ? __expectNonNull(__parseRfc3339DateTime(output.updatedAt))
+        : undefined,
   } as any;
 };
 
@@ -4495,13 +4547,18 @@ const deserializeAws_restJson1InternetConfiguration = (output: any, context: __S
 const deserializeAws_restJson1JobDetails = (output: any, context: __SerdeContext): JobDetails => {
   return {
     completedOn:
-      output.completedOn !== undefined && output.completedOn !== null ? new Date(output.completedOn) : undefined,
+      output.completedOn !== undefined && output.completedOn !== null
+        ? __expectNonNull(__parseRfc3339DateTime(output.completedOn))
+        : undefined,
     jobError:
       output.jobError !== undefined && output.jobError !== null
         ? deserializeAws_restJson1JobError(output.jobError, context)
         : undefined,
     jobId: __expectString(output.jobId),
-    startedOn: output.startedOn !== undefined && output.startedOn !== null ? new Date(output.startedOn) : undefined,
+    startedOn:
+      output.startedOn !== undefined && output.startedOn !== null
+        ? __expectNonNull(__parseRfc3339DateTime(output.startedOn))
+        : undefined,
     status: __expectString(output.status),
   } as any;
 };
@@ -4680,10 +4737,15 @@ const deserializeAws_restJson1PathElementList = (output: any, context: __SerdeCo
 const deserializeAws_restJson1PolicyGeneration = (output: any, context: __SerdeContext): PolicyGeneration => {
   return {
     completedOn:
-      output.completedOn !== undefined && output.completedOn !== null ? new Date(output.completedOn) : undefined,
+      output.completedOn !== undefined && output.completedOn !== null
+        ? __expectNonNull(__parseRfc3339DateTime(output.completedOn))
+        : undefined,
     jobId: __expectString(output.jobId),
     principalArn: __expectString(output.principalArn),
-    startedOn: output.startedOn !== undefined && output.startedOn !== null ? new Date(output.startedOn) : undefined,
+    startedOn:
+      output.startedOn !== undefined && output.startedOn !== null
+        ? __expectNonNull(__parseRfc3339DateTime(output.startedOn))
+        : undefined,
     status: __expectString(output.status),
   } as any;
 };

--- a/clients/client-acm-pca/protocols/Aws_json1_1.ts
+++ b/clients/client-acm-pca/protocols/Aws_json1_1.ts
@@ -143,7 +143,10 @@ import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@a
 import {
   expectBoolean as __expectBoolean,
   expectInt32 as __expectInt32,
+  expectNonNull as __expectNonNull,
+  expectNumber as __expectNumber,
   expectString as __expectString,
+  parseEpochTimestamp as __parseEpochTimestamp,
 } from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
@@ -3297,26 +3300,26 @@ const deserializeAws_json1_1CertificateAuthority = (output: any, context: __Serd
         : undefined,
     CreatedAt:
       output.CreatedAt !== undefined && output.CreatedAt !== null
-        ? new Date(Math.round(output.CreatedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreatedAt)))
         : undefined,
     FailureReason: __expectString(output.FailureReason),
     KeyStorageSecurityStandard: __expectString(output.KeyStorageSecurityStandard),
     LastStateChangeAt:
       output.LastStateChangeAt !== undefined && output.LastStateChangeAt !== null
-        ? new Date(Math.round(output.LastStateChangeAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastStateChangeAt)))
         : undefined,
     NotAfter:
       output.NotAfter !== undefined && output.NotAfter !== null
-        ? new Date(Math.round(output.NotAfter * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.NotAfter)))
         : undefined,
     NotBefore:
       output.NotBefore !== undefined && output.NotBefore !== null
-        ? new Date(Math.round(output.NotBefore * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.NotBefore)))
         : undefined,
     OwnerAccount: __expectString(output.OwnerAccount),
     RestorableUntil:
       output.RestorableUntil !== undefined && output.RestorableUntil !== null
-        ? new Date(Math.round(output.RestorableUntil * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.RestorableUntil)))
         : undefined,
     RevocationConfiguration:
       output.RevocationConfiguration !== undefined && output.RevocationConfiguration !== null
@@ -3414,7 +3417,7 @@ const deserializeAws_json1_1DescribeCertificateAuthorityAuditReportResponse = (
     AuditReportStatus: __expectString(output.AuditReportStatus),
     CreatedAt:
       output.CreatedAt !== undefined && output.CreatedAt !== null
-        ? new Date(Math.round(output.CreatedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreatedAt)))
         : undefined,
     S3BucketName: __expectString(output.S3BucketName),
     S3Key: __expectString(output.S3Key),
@@ -3654,7 +3657,7 @@ const deserializeAws_json1_1Permission = (output: any, context: __SerdeContext):
     CertificateAuthorityArn: __expectString(output.CertificateAuthorityArn),
     CreatedAt:
       output.CreatedAt !== undefined && output.CreatedAt !== null
-        ? new Date(Math.round(output.CreatedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreatedAt)))
         : undefined,
     Policy: __expectString(output.Policy),
     Principal: __expectString(output.Principal),

--- a/clients/client-acm/protocols/Aws_json1_1.ts
+++ b/clients/client-acm/protocols/Aws_json1_1.ts
@@ -94,7 +94,13 @@ import {
   ValidationException,
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
-import { expectInt32 as __expectInt32, expectString as __expectString } from "@aws-sdk/smithy-client";
+import {
+  expectInt32 as __expectInt32,
+  expectNonNull as __expectNonNull,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
+  parseEpochTimestamp as __parseEpochTimestamp,
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   HeaderBag as __HeaderBag,
@@ -1981,7 +1987,7 @@ const deserializeAws_json1_1CertificateDetail = (output: any, context: __SerdeCo
     CertificateAuthorityArn: __expectString(output.CertificateAuthorityArn),
     CreatedAt:
       output.CreatedAt !== undefined && output.CreatedAt !== null
-        ? new Date(Math.round(output.CreatedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreatedAt)))
         : undefined,
     DomainName: __expectString(output.DomainName),
     DomainValidationOptions:
@@ -1995,7 +2001,7 @@ const deserializeAws_json1_1CertificateDetail = (output: any, context: __SerdeCo
     FailureReason: __expectString(output.FailureReason),
     ImportedAt:
       output.ImportedAt !== undefined && output.ImportedAt !== null
-        ? new Date(Math.round(output.ImportedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.ImportedAt)))
         : undefined,
     InUseBy:
       output.InUseBy !== undefined && output.InUseBy !== null
@@ -2003,7 +2009,7 @@ const deserializeAws_json1_1CertificateDetail = (output: any, context: __SerdeCo
         : undefined,
     IssuedAt:
       output.IssuedAt !== undefined && output.IssuedAt !== null
-        ? new Date(Math.round(output.IssuedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.IssuedAt)))
         : undefined,
     Issuer: __expectString(output.Issuer),
     KeyAlgorithm: __expectString(output.KeyAlgorithm),
@@ -2013,11 +2019,11 @@ const deserializeAws_json1_1CertificateDetail = (output: any, context: __SerdeCo
         : undefined,
     NotAfter:
       output.NotAfter !== undefined && output.NotAfter !== null
-        ? new Date(Math.round(output.NotAfter * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.NotAfter)))
         : undefined,
     NotBefore:
       output.NotBefore !== undefined && output.NotBefore !== null
-        ? new Date(Math.round(output.NotBefore * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.NotBefore)))
         : undefined,
     Options:
       output.Options !== undefined && output.Options !== null
@@ -2031,7 +2037,7 @@ const deserializeAws_json1_1CertificateDetail = (output: any, context: __SerdeCo
     RevocationReason: __expectString(output.RevocationReason),
     RevokedAt:
       output.RevokedAt !== undefined && output.RevokedAt !== null
-        ? new Date(Math.round(output.RevokedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.RevokedAt)))
         : undefined,
     Serial: __expectString(output.Serial),
     SignatureAlgorithm: __expectString(output.SignatureAlgorithm),
@@ -2303,7 +2309,7 @@ const deserializeAws_json1_1RenewalSummary = (output: any, context: __SerdeConte
     RenewalStatusReason: __expectString(output.RenewalStatusReason),
     UpdatedAt:
       output.UpdatedAt !== undefined && output.UpdatedAt !== null
-        ? new Date(Math.round(output.UpdatedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.UpdatedAt)))
         : undefined,
   } as any;
 };

--- a/clients/client-alexa-for-business/protocols/Aws_json1_1.ts
+++ b/clients/client-alexa-for-business/protocols/Aws_json1_1.ts
@@ -478,7 +478,10 @@ import {
   expectBoolean as __expectBoolean,
   expectInt32 as __expectInt32,
   expectLong as __expectLong,
+  expectNonNull as __expectNonNull,
+  expectNumber as __expectNumber,
   expectString as __expectString,
+  parseEpochTimestamp as __parseEpochTimestamp,
 } from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
@@ -8870,7 +8873,7 @@ const deserializeAws_json1_1BusinessReport = (output: any, context: __SerdeConte
   return {
     DeliveryTime:
       output.DeliveryTime !== undefined && output.DeliveryTime !== null
-        ? new Date(Math.round(output.DeliveryTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.DeliveryTime)))
         : undefined,
     DownloadUrl: __expectString(output.DownloadUrl),
     FailureCode: __expectString(output.FailureCode),
@@ -9252,7 +9255,7 @@ const deserializeAws_json1_1DeviceData = (output: any, context: __SerdeContext):
   return {
     CreatedTime:
       output.CreatedTime !== undefined && output.CreatedTime !== null
-        ? new Date(Math.round(output.CreatedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreatedTime)))
         : undefined,
     DeviceArn: __expectString(output.DeviceArn),
     DeviceName: __expectString(output.DeviceName),
@@ -9287,7 +9290,7 @@ const deserializeAws_json1_1DeviceEvent = (output: any, context: __SerdeContext)
   return {
     Timestamp:
       output.Timestamp !== undefined && output.Timestamp !== null
-        ? new Date(Math.round(output.Timestamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.Timestamp)))
         : undefined,
     Type: __expectString(output.Type),
     Value: __expectString(output.Value),
@@ -9313,7 +9316,7 @@ const deserializeAws_json1_1DeviceNetworkProfileInfo = (
     CertificateArn: __expectString(output.CertificateArn),
     CertificateExpirationTime:
       output.CertificateExpirationTime !== undefined && output.CertificateExpirationTime !== null
-        ? new Date(Math.round(output.CertificateExpirationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CertificateExpirationTime)))
         : undefined,
     NetworkProfileArn: __expectString(output.NetworkProfileArn),
   } as any;
@@ -9351,7 +9354,7 @@ const deserializeAws_json1_1DeviceStatusInfo = (output: any, context: __SerdeCon
     ConnectionStatus: __expectString(output.ConnectionStatus),
     ConnectionStatusUpdatedTime:
       output.ConnectionStatusUpdatedTime !== undefined && output.ConnectionStatusUpdatedTime !== null
-        ? new Date(Math.round(output.ConnectionStatusUpdatedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.ConnectionStatusUpdatedTime)))
         : undefined,
     DeviceStatusDetails:
       output.DeviceStatusDetails !== undefined && output.DeviceStatusDetails !== null

--- a/clients/client-amp/protocols/Aws_restJson1.ts
+++ b/clients/client-amp/protocols/Aws_restJson1.ts
@@ -22,9 +22,11 @@ import {
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
   expectNonNull as __expectNonNull,
+  expectNumber as __expectNumber,
   expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
+  parseEpochTimestamp as __parseEpochTimestamp,
   strictParseInt32 as __strictParseInt32,
 } from "@aws-sdk/smithy-client";
 import {
@@ -845,7 +847,7 @@ const deserializeAws_restJson1WorkspaceDescription = (output: any, context: __Se
     arn: __expectString(output.arn),
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
-        ? new Date(Math.round(output.createdAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.createdAt)))
         : undefined,
     prometheusEndpoint: __expectString(output.prometheusEndpoint),
     status:
@@ -868,7 +870,7 @@ const deserializeAws_restJson1WorkspaceSummary = (output: any, context: __SerdeC
     arn: __expectString(output.arn),
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
-        ? new Date(Math.round(output.createdAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.createdAt)))
         : undefined,
     status:
       output.status !== undefined && output.status !== null

--- a/clients/client-amplify/protocols/Aws_restJson1.ts
+++ b/clients/client-amplify/protocols/Aws_restJson1.ts
@@ -92,9 +92,11 @@ import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@a
 import {
   expectBoolean as __expectBoolean,
   expectNonNull as __expectNonNull,
+  expectNumber as __expectNumber,
   expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
+  parseEpochTimestamp as __parseEpochTimestamp,
 } from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
@@ -4961,7 +4963,7 @@ const deserializeAws_restJson1App = (output: any, context: __SerdeContext): App 
     buildSpec: __expectString(output.buildSpec),
     createTime:
       output.createTime !== undefined && output.createTime !== null
-        ? new Date(Math.round(output.createTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.createTime)))
         : undefined,
     customHeaders: __expectString(output.customHeaders),
     customRules:
@@ -4992,7 +4994,7 @@ const deserializeAws_restJson1App = (output: any, context: __SerdeContext): App 
         : undefined,
     updateTime:
       output.updateTime !== undefined && output.updateTime !== null
-        ? new Date(Math.round(output.updateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.updateTime)))
         : undefined,
   } as any;
 };
@@ -5085,14 +5087,14 @@ const deserializeAws_restJson1BackendEnvironment = (output: any, context: __Serd
     backendEnvironmentArn: __expectString(output.backendEnvironmentArn),
     createTime:
       output.createTime !== undefined && output.createTime !== null
-        ? new Date(Math.round(output.createTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.createTime)))
         : undefined,
     deploymentArtifacts: __expectString(output.deploymentArtifacts),
     environmentName: __expectString(output.environmentName),
     stackName: __expectString(output.stackName),
     updateTime:
       output.updateTime !== undefined && output.updateTime !== null
-        ? new Date(Math.round(output.updateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.updateTime)))
         : undefined,
   } as any;
 };
@@ -5122,7 +5124,7 @@ const deserializeAws_restJson1Branch = (output: any, context: __SerdeContext): B
     buildSpec: __expectString(output.buildSpec),
     createTime:
       output.createTime !== undefined && output.createTime !== null
-        ? new Date(Math.round(output.createTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.createTime)))
         : undefined,
     customDomains:
       output.customDomains !== undefined && output.customDomains !== null
@@ -5153,7 +5155,7 @@ const deserializeAws_restJson1Branch = (output: any, context: __SerdeContext): B
     ttl: __expectString(output.ttl),
     updateTime:
       output.updateTime !== undefined && output.updateTime !== null
-        ? new Date(Math.round(output.updateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.updateTime)))
         : undefined,
   } as any;
 };
@@ -5288,16 +5290,18 @@ const deserializeAws_restJson1JobSummary = (output: any, context: __SerdeContext
     commitMessage: __expectString(output.commitMessage),
     commitTime:
       output.commitTime !== undefined && output.commitTime !== null
-        ? new Date(Math.round(output.commitTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.commitTime)))
         : undefined,
     endTime:
-      output.endTime !== undefined && output.endTime !== null ? new Date(Math.round(output.endTime * 1000)) : undefined,
+      output.endTime !== undefined && output.endTime !== null
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.endTime)))
+        : undefined,
     jobArn: __expectString(output.jobArn),
     jobId: __expectString(output.jobId),
     jobType: __expectString(output.jobType),
     startTime:
       output.startTime !== undefined && output.startTime !== null
-        ? new Date(Math.round(output.startTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.startTime)))
         : undefined,
     status: __expectString(output.status),
   } as any;
@@ -5308,7 +5312,7 @@ const deserializeAws_restJson1ProductionBranch = (output: any, context: __SerdeC
     branchName: __expectString(output.branchName),
     lastDeployTime:
       output.lastDeployTime !== undefined && output.lastDeployTime !== null
-        ? new Date(Math.round(output.lastDeployTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastDeployTime)))
         : undefined,
     status: __expectString(output.status),
     thumbnailUrl: __expectString(output.thumbnailUrl),
@@ -5332,7 +5336,9 @@ const deserializeAws_restJson1Step = (output: any, context: __SerdeContext): Ste
     artifactsUrl: __expectString(output.artifactsUrl),
     context: __expectString(output.context),
     endTime:
-      output.endTime !== undefined && output.endTime !== null ? new Date(Math.round(output.endTime * 1000)) : undefined,
+      output.endTime !== undefined && output.endTime !== null
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.endTime)))
+        : undefined,
     logUrl: __expectString(output.logUrl),
     screenshots:
       output.screenshots !== undefined && output.screenshots !== null
@@ -5340,7 +5346,7 @@ const deserializeAws_restJson1Step = (output: any, context: __SerdeContext): Ste
         : undefined,
     startTime:
       output.startTime !== undefined && output.startTime !== null
-        ? new Date(Math.round(output.startTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.startTime)))
         : undefined,
     status: __expectString(output.status),
     statusReason: __expectString(output.statusReason),
@@ -5407,12 +5413,12 @@ const deserializeAws_restJson1Webhook = (output: any, context: __SerdeContext): 
     branchName: __expectString(output.branchName),
     createTime:
       output.createTime !== undefined && output.createTime !== null
-        ? new Date(Math.round(output.createTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.createTime)))
         : undefined,
     description: __expectString(output.description),
     updateTime:
       output.updateTime !== undefined && output.updateTime !== null
-        ? new Date(Math.round(output.updateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.updateTime)))
         : undefined,
     webhookArn: __expectString(output.webhookArn),
     webhookId: __expectString(output.webhookId),

--- a/clients/client-api-gateway/protocols/Aws_restJson1.ts
+++ b/clients/client-api-gateway/protocols/Aws_restJson1.ts
@@ -280,10 +280,12 @@ import {
   expectInt32 as __expectInt32,
   expectLong as __expectLong,
   expectNonNull as __expectNonNull,
+  expectNumber as __expectNumber,
   expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   limitedParseDouble as __limitedParseDouble,
+  parseEpochTimestamp as __parseEpochTimestamp,
   serializeFloat as __serializeFloat,
 } from "@aws-sdk/smithy-client";
 import {
@@ -5165,7 +5167,7 @@ export const deserializeAws_restJson1CreateApiKeyCommand = async (
   };
   const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.createdDate !== undefined && data.createdDate !== null) {
-    contents.createdDate = new Date(Math.round(data.createdDate * 1000));
+    contents.createdDate = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.createdDate)));
   }
   if (data.customerId !== undefined && data.customerId !== null) {
     contents.customerId = __expectString(data.customerId);
@@ -5180,7 +5182,7 @@ export const deserializeAws_restJson1CreateApiKeyCommand = async (
     contents.id = __expectString(data.id);
   }
   if (data.lastUpdatedDate !== undefined && data.lastUpdatedDate !== null) {
-    contents.lastUpdatedDate = new Date(Math.round(data.lastUpdatedDate * 1000));
+    contents.lastUpdatedDate = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.lastUpdatedDate)));
   }
   if (data.name !== undefined && data.name !== null) {
     contents.name = __expectString(data.name);
@@ -5527,7 +5529,7 @@ export const deserializeAws_restJson1CreateDeploymentCommand = async (
     contents.apiSummary = deserializeAws_restJson1PathToMapOfMethodSnapshot(data.apiSummary, context);
   }
   if (data.createdDate !== undefined && data.createdDate !== null) {
-    contents.createdDate = new Date(Math.round(data.createdDate * 1000));
+    contents.createdDate = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.createdDate)));
   }
   if (data.description !== undefined && data.description !== null) {
     contents.description = __expectString(data.description);
@@ -5741,7 +5743,7 @@ export const deserializeAws_restJson1CreateDocumentationVersionCommand = async (
   };
   const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.createdDate !== undefined && data.createdDate !== null) {
-    contents.createdDate = new Date(Math.round(data.createdDate * 1000));
+    contents.createdDate = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.createdDate)));
   }
   if (data.description !== undefined && data.description !== null) {
     contents.description = __expectString(data.description);
@@ -5864,7 +5866,7 @@ export const deserializeAws_restJson1CreateDomainNameCommand = async (
     contents.certificateName = __expectString(data.certificateName);
   }
   if (data.certificateUploadDate !== undefined && data.certificateUploadDate !== null) {
-    contents.certificateUploadDate = new Date(Math.round(data.certificateUploadDate * 1000));
+    contents.certificateUploadDate = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.certificateUploadDate)));
   }
   if (data.distributionDomainName !== undefined && data.distributionDomainName !== null) {
     contents.distributionDomainName = __expectString(data.distributionDomainName);
@@ -6343,7 +6345,7 @@ export const deserializeAws_restJson1CreateRestApiCommand = async (
     contents.binaryMediaTypes = deserializeAws_restJson1ListOfString(data.binaryMediaTypes, context);
   }
   if (data.createdDate !== undefined && data.createdDate !== null) {
-    contents.createdDate = new Date(Math.round(data.createdDate * 1000));
+    contents.createdDate = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.createdDate)));
   }
   if (data.description !== undefined && data.description !== null) {
     contents.description = __expectString(data.description);
@@ -6494,7 +6496,7 @@ export const deserializeAws_restJson1CreateStageCommand = async (
     contents.clientCertificateId = __expectString(data.clientCertificateId);
   }
   if (data.createdDate !== undefined && data.createdDate !== null) {
-    contents.createdDate = new Date(Math.round(data.createdDate * 1000));
+    contents.createdDate = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.createdDate)));
   }
   if (data.deploymentId !== undefined && data.deploymentId !== null) {
     contents.deploymentId = __expectString(data.deploymentId);
@@ -6506,7 +6508,7 @@ export const deserializeAws_restJson1CreateStageCommand = async (
     contents.documentationVersion = __expectString(data.documentationVersion);
   }
   if (data.lastUpdatedDate !== undefined && data.lastUpdatedDate !== null) {
-    contents.lastUpdatedDate = new Date(Math.round(data.lastUpdatedDate * 1000));
+    contents.lastUpdatedDate = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.lastUpdatedDate)));
   }
   if (data.methodSettings !== undefined && data.methodSettings !== null) {
     contents.methodSettings = deserializeAws_restJson1MapOfMethodSettings(data.methodSettings, context);
@@ -8901,13 +8903,13 @@ export const deserializeAws_restJson1GenerateClientCertificateCommand = async (
     contents.clientCertificateId = __expectString(data.clientCertificateId);
   }
   if (data.createdDate !== undefined && data.createdDate !== null) {
-    contents.createdDate = new Date(Math.round(data.createdDate * 1000));
+    contents.createdDate = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.createdDate)));
   }
   if (data.description !== undefined && data.description !== null) {
     contents.description = __expectString(data.description);
   }
   if (data.expirationDate !== undefined && data.expirationDate !== null) {
-    contents.expirationDate = new Date(Math.round(data.expirationDate * 1000));
+    contents.expirationDate = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.expirationDate)));
   }
   if (data.pemEncodedCertificate !== undefined && data.pemEncodedCertificate !== null) {
     contents.pemEncodedCertificate = __expectString(data.pemEncodedCertificate);
@@ -9100,7 +9102,7 @@ export const deserializeAws_restJson1GetApiKeyCommand = async (
   };
   const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.createdDate !== undefined && data.createdDate !== null) {
-    contents.createdDate = new Date(Math.round(data.createdDate * 1000));
+    contents.createdDate = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.createdDate)));
   }
   if (data.customerId !== undefined && data.customerId !== null) {
     contents.customerId = __expectString(data.customerId);
@@ -9115,7 +9117,7 @@ export const deserializeAws_restJson1GetApiKeyCommand = async (
     contents.id = __expectString(data.id);
   }
   if (data.lastUpdatedDate !== undefined && data.lastUpdatedDate !== null) {
-    contents.lastUpdatedDate = new Date(Math.round(data.lastUpdatedDate * 1000));
+    contents.lastUpdatedDate = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.lastUpdatedDate)));
   }
   if (data.name !== undefined && data.name !== null) {
     contents.name = __expectString(data.name);
@@ -9669,13 +9671,13 @@ export const deserializeAws_restJson1GetClientCertificateCommand = async (
     contents.clientCertificateId = __expectString(data.clientCertificateId);
   }
   if (data.createdDate !== undefined && data.createdDate !== null) {
-    contents.createdDate = new Date(Math.round(data.createdDate * 1000));
+    contents.createdDate = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.createdDate)));
   }
   if (data.description !== undefined && data.description !== null) {
     contents.description = __expectString(data.description);
   }
   if (data.expirationDate !== undefined && data.expirationDate !== null) {
-    contents.expirationDate = new Date(Math.round(data.expirationDate * 1000));
+    contents.expirationDate = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.expirationDate)));
   }
   if (data.pemEncodedCertificate !== undefined && data.pemEncodedCertificate !== null) {
     contents.pemEncodedCertificate = __expectString(data.pemEncodedCertificate);
@@ -9849,7 +9851,7 @@ export const deserializeAws_restJson1GetDeploymentCommand = async (
     contents.apiSummary = deserializeAws_restJson1PathToMapOfMethodSnapshot(data.apiSummary, context);
   }
   if (data.createdDate !== undefined && data.createdDate !== null) {
-    contents.createdDate = new Date(Math.round(data.createdDate * 1000));
+    contents.createdDate = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.createdDate)));
   }
   if (data.description !== undefined && data.description !== null) {
     contents.description = __expectString(data.description);
@@ -10205,7 +10207,7 @@ export const deserializeAws_restJson1GetDocumentationVersionCommand = async (
   };
   const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.createdDate !== undefined && data.createdDate !== null) {
-    contents.createdDate = new Date(Math.round(data.createdDate * 1000));
+    contents.createdDate = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.createdDate)));
   }
   if (data.description !== undefined && data.description !== null) {
     contents.description = __expectString(data.description);
@@ -10387,7 +10389,7 @@ export const deserializeAws_restJson1GetDomainNameCommand = async (
     contents.certificateName = __expectString(data.certificateName);
   }
   if (data.certificateUploadDate !== undefined && data.certificateUploadDate !== null) {
-    contents.certificateUploadDate = new Date(Math.round(data.certificateUploadDate * 1000));
+    contents.certificateUploadDate = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.certificateUploadDate)));
   }
   if (data.distributionDomainName !== undefined && data.distributionDomainName !== null) {
     contents.distributionDomainName = __expectString(data.distributionDomainName);
@@ -11915,7 +11917,7 @@ export const deserializeAws_restJson1GetRestApiCommand = async (
     contents.binaryMediaTypes = deserializeAws_restJson1ListOfString(data.binaryMediaTypes, context);
   }
   if (data.createdDate !== undefined && data.createdDate !== null) {
-    contents.createdDate = new Date(Math.round(data.createdDate * 1000));
+    contents.createdDate = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.createdDate)));
   }
   if (data.description !== undefined && data.description !== null) {
     contents.description = __expectString(data.description);
@@ -12415,7 +12417,7 @@ export const deserializeAws_restJson1GetStageCommand = async (
     contents.clientCertificateId = __expectString(data.clientCertificateId);
   }
   if (data.createdDate !== undefined && data.createdDate !== null) {
-    contents.createdDate = new Date(Math.round(data.createdDate * 1000));
+    contents.createdDate = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.createdDate)));
   }
   if (data.deploymentId !== undefined && data.deploymentId !== null) {
     contents.deploymentId = __expectString(data.deploymentId);
@@ -12427,7 +12429,7 @@ export const deserializeAws_restJson1GetStageCommand = async (
     contents.documentationVersion = __expectString(data.documentationVersion);
   }
   if (data.lastUpdatedDate !== undefined && data.lastUpdatedDate !== null) {
-    contents.lastUpdatedDate = new Date(Math.round(data.lastUpdatedDate * 1000));
+    contents.lastUpdatedDate = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.lastUpdatedDate)));
   }
   if (data.methodSettings !== undefined && data.methodSettings !== null) {
     contents.methodSettings = deserializeAws_restJson1MapOfMethodSettings(data.methodSettings, context);
@@ -13575,7 +13577,7 @@ export const deserializeAws_restJson1ImportRestApiCommand = async (
     contents.binaryMediaTypes = deserializeAws_restJson1ListOfString(data.binaryMediaTypes, context);
   }
   if (data.createdDate !== undefined && data.createdDate !== null) {
-    contents.createdDate = new Date(Math.round(data.createdDate * 1000));
+    contents.createdDate = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.createdDate)));
   }
   if (data.description !== undefined && data.description !== null) {
     contents.description = __expectString(data.description);
@@ -14332,7 +14334,7 @@ export const deserializeAws_restJson1PutRestApiCommand = async (
     contents.binaryMediaTypes = deserializeAws_restJson1ListOfString(data.binaryMediaTypes, context);
   }
   if (data.createdDate !== undefined && data.createdDate !== null) {
-    contents.createdDate = new Date(Math.round(data.createdDate * 1000));
+    contents.createdDate = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.createdDate)));
   }
   if (data.description !== undefined && data.description !== null) {
     contents.description = __expectString(data.description);
@@ -14957,7 +14959,7 @@ export const deserializeAws_restJson1UpdateApiKeyCommand = async (
   };
   const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.createdDate !== undefined && data.createdDate !== null) {
-    contents.createdDate = new Date(Math.round(data.createdDate * 1000));
+    contents.createdDate = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.createdDate)));
   }
   if (data.customerId !== undefined && data.customerId !== null) {
     contents.customerId = __expectString(data.customerId);
@@ -14972,7 +14974,7 @@ export const deserializeAws_restJson1UpdateApiKeyCommand = async (
     contents.id = __expectString(data.id);
   }
   if (data.lastUpdatedDate !== undefined && data.lastUpdatedDate !== null) {
-    contents.lastUpdatedDate = new Date(Math.round(data.lastUpdatedDate * 1000));
+    contents.lastUpdatedDate = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.lastUpdatedDate)));
   }
   if (data.name !== undefined && data.name !== null) {
     contents.name = __expectString(data.name);
@@ -15321,13 +15323,13 @@ export const deserializeAws_restJson1UpdateClientCertificateCommand = async (
     contents.clientCertificateId = __expectString(data.clientCertificateId);
   }
   if (data.createdDate !== undefined && data.createdDate !== null) {
-    contents.createdDate = new Date(Math.round(data.createdDate * 1000));
+    contents.createdDate = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.createdDate)));
   }
   if (data.description !== undefined && data.description !== null) {
     contents.description = __expectString(data.description);
   }
   if (data.expirationDate !== undefined && data.expirationDate !== null) {
-    contents.expirationDate = new Date(Math.round(data.expirationDate * 1000));
+    contents.expirationDate = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.expirationDate)));
   }
   if (data.pemEncodedCertificate !== undefined && data.pemEncodedCertificate !== null) {
     contents.pemEncodedCertificate = __expectString(data.pemEncodedCertificate);
@@ -15434,7 +15436,7 @@ export const deserializeAws_restJson1UpdateDeploymentCommand = async (
     contents.apiSummary = deserializeAws_restJson1PathToMapOfMethodSnapshot(data.apiSummary, context);
   }
   if (data.createdDate !== undefined && data.createdDate !== null) {
-    contents.createdDate = new Date(Math.round(data.createdDate * 1000));
+    contents.createdDate = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.createdDate)));
   }
   if (data.description !== undefined && data.description !== null) {
     contents.description = __expectString(data.description);
@@ -15648,7 +15650,7 @@ export const deserializeAws_restJson1UpdateDocumentationVersionCommand = async (
   };
   const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.createdDate !== undefined && data.createdDate !== null) {
-    contents.createdDate = new Date(Math.round(data.createdDate * 1000));
+    contents.createdDate = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.createdDate)));
   }
   if (data.description !== undefined && data.description !== null) {
     contents.description = __expectString(data.description);
@@ -15771,7 +15773,7 @@ export const deserializeAws_restJson1UpdateDomainNameCommand = async (
     contents.certificateName = __expectString(data.certificateName);
   }
   if (data.certificateUploadDate !== undefined && data.certificateUploadDate !== null) {
-    contents.certificateUploadDate = new Date(Math.round(data.certificateUploadDate * 1000));
+    contents.certificateUploadDate = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.certificateUploadDate)));
   }
   if (data.distributionDomainName !== undefined && data.distributionDomainName !== null) {
     contents.distributionDomainName = __expectString(data.distributionDomainName);
@@ -16856,7 +16858,7 @@ export const deserializeAws_restJson1UpdateRestApiCommand = async (
     contents.binaryMediaTypes = deserializeAws_restJson1ListOfString(data.binaryMediaTypes, context);
   }
   if (data.createdDate !== undefined && data.createdDate !== null) {
-    contents.createdDate = new Date(Math.round(data.createdDate * 1000));
+    contents.createdDate = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.createdDate)));
   }
   if (data.description !== undefined && data.description !== null) {
     contents.description = __expectString(data.description);
@@ -17015,7 +17017,7 @@ export const deserializeAws_restJson1UpdateStageCommand = async (
     contents.clientCertificateId = __expectString(data.clientCertificateId);
   }
   if (data.createdDate !== undefined && data.createdDate !== null) {
-    contents.createdDate = new Date(Math.round(data.createdDate * 1000));
+    contents.createdDate = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.createdDate)));
   }
   if (data.deploymentId !== undefined && data.deploymentId !== null) {
     contents.deploymentId = __expectString(data.deploymentId);
@@ -17027,7 +17029,7 @@ export const deserializeAws_restJson1UpdateStageCommand = async (
     contents.documentationVersion = __expectString(data.documentationVersion);
   }
   if (data.lastUpdatedDate !== undefined && data.lastUpdatedDate !== null) {
-    contents.lastUpdatedDate = new Date(Math.round(data.lastUpdatedDate * 1000));
+    contents.lastUpdatedDate = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.lastUpdatedDate)));
   }
   if (data.methodSettings !== undefined && data.methodSettings !== null) {
     contents.methodSettings = deserializeAws_restJson1MapOfMethodSettings(data.methodSettings, context);
@@ -17854,7 +17856,7 @@ const deserializeAws_restJson1ApiKey = (output: any, context: __SerdeContext): A
   return {
     createdDate:
       output.createdDate !== undefined && output.createdDate !== null
-        ? new Date(Math.round(output.createdDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.createdDate)))
         : undefined,
     customerId: __expectString(output.customerId),
     description: __expectString(output.description),
@@ -17862,7 +17864,7 @@ const deserializeAws_restJson1ApiKey = (output: any, context: __SerdeContext): A
     id: __expectString(output.id),
     lastUpdatedDate:
       output.lastUpdatedDate !== undefined && output.lastUpdatedDate !== null
-        ? new Date(Math.round(output.lastUpdatedDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastUpdatedDate)))
         : undefined,
     name: __expectString(output.name),
     stageKeys:
@@ -17931,12 +17933,12 @@ const deserializeAws_restJson1ClientCertificate = (output: any, context: __Serde
     clientCertificateId: __expectString(output.clientCertificateId),
     createdDate:
       output.createdDate !== undefined && output.createdDate !== null
-        ? new Date(Math.round(output.createdDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.createdDate)))
         : undefined,
     description: __expectString(output.description),
     expirationDate:
       output.expirationDate !== undefined && output.expirationDate !== null
-        ? new Date(Math.round(output.expirationDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.expirationDate)))
         : undefined,
     pemEncodedCertificate: __expectString(output.pemEncodedCertificate),
     tags:
@@ -17954,7 +17956,7 @@ const deserializeAws_restJson1Deployment = (output: any, context: __SerdeContext
         : undefined,
     createdDate:
       output.createdDate !== undefined && output.createdDate !== null
-        ? new Date(Math.round(output.createdDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.createdDate)))
         : undefined,
     description: __expectString(output.description),
     id: __expectString(output.id),
@@ -17989,7 +17991,7 @@ const deserializeAws_restJson1DocumentationVersion = (output: any, context: __Se
   return {
     createdDate:
       output.createdDate !== undefined && output.createdDate !== null
-        ? new Date(Math.round(output.createdDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.createdDate)))
         : undefined,
     description: __expectString(output.description),
     version: __expectString(output.version),
@@ -18002,7 +18004,7 @@ const deserializeAws_restJson1DomainName = (output: any, context: __SerdeContext
     certificateName: __expectString(output.certificateName),
     certificateUploadDate:
       output.certificateUploadDate !== undefined && output.certificateUploadDate !== null
-        ? new Date(Math.round(output.certificateUploadDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.certificateUploadDate)))
         : undefined,
     distributionDomainName: __expectString(output.distributionDomainName),
     distributionHostedZoneId: __expectString(output.distributionHostedZoneId),
@@ -18689,7 +18691,7 @@ const deserializeAws_restJson1RestApi = (output: any, context: __SerdeContext): 
         : undefined,
     createdDate:
       output.createdDate !== undefined && output.createdDate !== null
-        ? new Date(Math.round(output.createdDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.createdDate)))
         : undefined,
     description: __expectString(output.description),
     disableExecuteApiEndpoint: __expectBoolean(output.disableExecuteApiEndpoint),
@@ -18754,14 +18756,14 @@ const deserializeAws_restJson1Stage = (output: any, context: __SerdeContext): St
     clientCertificateId: __expectString(output.clientCertificateId),
     createdDate:
       output.createdDate !== undefined && output.createdDate !== null
-        ? new Date(Math.round(output.createdDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.createdDate)))
         : undefined,
     deploymentId: __expectString(output.deploymentId),
     description: __expectString(output.description),
     documentationVersion: __expectString(output.documentationVersion),
     lastUpdatedDate:
       output.lastUpdatedDate !== undefined && output.lastUpdatedDate !== null
-        ? new Date(Math.round(output.lastUpdatedDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastUpdatedDate)))
         : undefined,
     methodSettings:
       output.methodSettings !== undefined && output.methodSettings !== null

--- a/clients/client-apigatewaymanagementapi/protocols/Aws_restJson1.ts
+++ b/clients/client-apigatewaymanagementapi/protocols/Aws_restJson1.ts
@@ -14,6 +14,7 @@ import {
   expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
+  parseRfc3339DateTime as __parseRfc3339DateTime,
 } from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
@@ -197,13 +198,13 @@ export const deserializeAws_restJson1GetConnectionCommand = async (
   };
   const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.connectedAt !== undefined && data.connectedAt !== null) {
-    contents.ConnectedAt = new Date(data.connectedAt);
+    contents.ConnectedAt = __expectNonNull(__parseRfc3339DateTime(data.connectedAt));
   }
   if (data.identity !== undefined && data.identity !== null) {
     contents.Identity = deserializeAws_restJson1Identity(data.identity, context);
   }
   if (data.lastActiveAt !== undefined && data.lastActiveAt !== null) {
-    contents.LastActiveAt = new Date(data.lastActiveAt);
+    contents.LastActiveAt = __expectNonNull(__parseRfc3339DateTime(data.lastActiveAt));
   }
   return Promise.resolve(contents);
 };

--- a/clients/client-apigatewayv2/protocols/Aws_restJson1.ts
+++ b/clients/client-apigatewayv2/protocols/Aws_restJson1.ts
@@ -147,6 +147,7 @@ import {
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   limitedParseDouble as __limitedParseDouble,
+  parseRfc3339DateTime as __parseRfc3339DateTime,
   serializeFloat as __serializeFloat,
 } from "@aws-sdk/smithy-client";
 import {
@@ -3201,7 +3202,7 @@ export const deserializeAws_restJson1CreateApiCommand = async (
     contents.CorsConfiguration = deserializeAws_restJson1Cors(data.corsConfiguration, context);
   }
   if (data.createdDate !== undefined && data.createdDate !== null) {
-    contents.CreatedDate = new Date(data.createdDate);
+    contents.CreatedDate = __expectNonNull(__parseRfc3339DateTime(data.createdDate));
   }
   if (data.description !== undefined && data.description !== null) {
     contents.Description = __expectString(data.description);
@@ -3528,7 +3529,7 @@ export const deserializeAws_restJson1CreateDeploymentCommand = async (
     contents.AutoDeployed = __expectBoolean(data.autoDeployed);
   }
   if (data.createdDate !== undefined && data.createdDate !== null) {
-    contents.CreatedDate = new Date(data.createdDate);
+    contents.CreatedDate = __expectNonNull(__parseRfc3339DateTime(data.createdDate));
   }
   if (data.deploymentId !== undefined && data.deploymentId !== null) {
     contents.DeploymentId = __expectString(data.deploymentId);
@@ -4327,7 +4328,7 @@ export const deserializeAws_restJson1CreateStageCommand = async (
     contents.ClientCertificateId = __expectString(data.clientCertificateId);
   }
   if (data.createdDate !== undefined && data.createdDate !== null) {
-    contents.CreatedDate = new Date(data.createdDate);
+    contents.CreatedDate = __expectNonNull(__parseRfc3339DateTime(data.createdDate));
   }
   if (data.defaultRouteSettings !== undefined && data.defaultRouteSettings !== null) {
     contents.DefaultRouteSettings = deserializeAws_restJson1RouteSettings(data.defaultRouteSettings, context);
@@ -4342,7 +4343,7 @@ export const deserializeAws_restJson1CreateStageCommand = async (
     contents.LastDeploymentStatusMessage = __expectString(data.lastDeploymentStatusMessage);
   }
   if (data.lastUpdatedDate !== undefined && data.lastUpdatedDate !== null) {
-    contents.LastUpdatedDate = new Date(data.lastUpdatedDate);
+    contents.LastUpdatedDate = __expectNonNull(__parseRfc3339DateTime(data.lastUpdatedDate));
   }
   if (data.routeSettings !== undefined && data.routeSettings !== null) {
     contents.RouteSettings = deserializeAws_restJson1RouteSettingsMap(data.routeSettings, context);
@@ -4441,7 +4442,7 @@ export const deserializeAws_restJson1CreateVpcLinkCommand = async (
   };
   const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.createdDate !== undefined && data.createdDate !== null) {
-    contents.CreatedDate = new Date(data.createdDate);
+    contents.CreatedDate = __expectNonNull(__parseRfc3339DateTime(data.createdDate));
   }
   if (data.name !== undefined && data.name !== null) {
     contents.Name = __expectString(data.name);
@@ -5579,7 +5580,7 @@ export const deserializeAws_restJson1GetApiCommand = async (
     contents.CorsConfiguration = deserializeAws_restJson1Cors(data.corsConfiguration, context);
   }
   if (data.createdDate !== undefined && data.createdDate !== null) {
-    contents.CreatedDate = new Date(data.createdDate);
+    contents.CreatedDate = __expectNonNull(__parseRfc3339DateTime(data.createdDate));
   }
   if (data.description !== undefined && data.description !== null) {
     contents.Description = __expectString(data.description);
@@ -6091,7 +6092,7 @@ export const deserializeAws_restJson1GetDeploymentCommand = async (
     contents.AutoDeployed = __expectBoolean(data.autoDeployed);
   }
   if (data.createdDate !== undefined && data.createdDate !== null) {
-    contents.CreatedDate = new Date(data.createdDate);
+    contents.CreatedDate = __expectNonNull(__parseRfc3339DateTime(data.createdDate));
   }
   if (data.deploymentId !== undefined && data.deploymentId !== null) {
     contents.DeploymentId = __expectString(data.deploymentId);
@@ -7358,7 +7359,7 @@ export const deserializeAws_restJson1GetStageCommand = async (
     contents.ClientCertificateId = __expectString(data.clientCertificateId);
   }
   if (data.createdDate !== undefined && data.createdDate !== null) {
-    contents.CreatedDate = new Date(data.createdDate);
+    contents.CreatedDate = __expectNonNull(__parseRfc3339DateTime(data.createdDate));
   }
   if (data.defaultRouteSettings !== undefined && data.defaultRouteSettings !== null) {
     contents.DefaultRouteSettings = deserializeAws_restJson1RouteSettings(data.defaultRouteSettings, context);
@@ -7373,7 +7374,7 @@ export const deserializeAws_restJson1GetStageCommand = async (
     contents.LastDeploymentStatusMessage = __expectString(data.lastDeploymentStatusMessage);
   }
   if (data.lastUpdatedDate !== undefined && data.lastUpdatedDate !== null) {
-    contents.LastUpdatedDate = new Date(data.lastUpdatedDate);
+    contents.LastUpdatedDate = __expectNonNull(__parseRfc3339DateTime(data.lastUpdatedDate));
   }
   if (data.routeSettings !== undefined && data.routeSettings !== null) {
     contents.RouteSettings = deserializeAws_restJson1RouteSettingsMap(data.routeSettings, context);
@@ -7610,7 +7611,7 @@ export const deserializeAws_restJson1GetVpcLinkCommand = async (
   };
   const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.createdDate !== undefined && data.createdDate !== null) {
-    contents.CreatedDate = new Date(data.createdDate);
+    contents.CreatedDate = __expectNonNull(__parseRfc3339DateTime(data.createdDate));
   }
   if (data.name !== undefined && data.name !== null) {
     contents.Name = __expectString(data.name);
@@ -7794,7 +7795,7 @@ export const deserializeAws_restJson1ImportApiCommand = async (
     contents.CorsConfiguration = deserializeAws_restJson1Cors(data.corsConfiguration, context);
   }
   if (data.createdDate !== undefined && data.createdDate !== null) {
-    contents.CreatedDate = new Date(data.createdDate);
+    contents.CreatedDate = __expectNonNull(__parseRfc3339DateTime(data.createdDate));
   }
   if (data.description !== undefined && data.description !== null) {
     contents.Description = __expectString(data.description);
@@ -7933,7 +7934,7 @@ export const deserializeAws_restJson1ReimportApiCommand = async (
     contents.CorsConfiguration = deserializeAws_restJson1Cors(data.corsConfiguration, context);
   }
   if (data.createdDate !== undefined && data.createdDate !== null) {
-    contents.CreatedDate = new Date(data.createdDate);
+    contents.CreatedDate = __expectNonNull(__parseRfc3339DateTime(data.createdDate));
   }
   if (data.description !== undefined && data.description !== null) {
     contents.Description = __expectString(data.description);
@@ -8281,7 +8282,7 @@ export const deserializeAws_restJson1UpdateApiCommand = async (
     contents.CorsConfiguration = deserializeAws_restJson1Cors(data.corsConfiguration, context);
   }
   if (data.createdDate !== undefined && data.createdDate !== null) {
-    contents.CreatedDate = new Date(data.createdDate);
+    contents.CreatedDate = __expectNonNull(__parseRfc3339DateTime(data.createdDate));
   }
   if (data.description !== undefined && data.description !== null) {
     contents.Description = __expectString(data.description);
@@ -8608,7 +8609,7 @@ export const deserializeAws_restJson1UpdateDeploymentCommand = async (
     contents.AutoDeployed = __expectBoolean(data.autoDeployed);
   }
   if (data.createdDate !== undefined && data.createdDate !== null) {
-    contents.CreatedDate = new Date(data.createdDate);
+    contents.CreatedDate = __expectNonNull(__parseRfc3339DateTime(data.createdDate));
   }
   if (data.deploymentId !== undefined && data.deploymentId !== null) {
     contents.DeploymentId = __expectString(data.deploymentId);
@@ -9399,7 +9400,7 @@ export const deserializeAws_restJson1UpdateStageCommand = async (
     contents.ClientCertificateId = __expectString(data.clientCertificateId);
   }
   if (data.createdDate !== undefined && data.createdDate !== null) {
-    contents.CreatedDate = new Date(data.createdDate);
+    contents.CreatedDate = __expectNonNull(__parseRfc3339DateTime(data.createdDate));
   }
   if (data.defaultRouteSettings !== undefined && data.defaultRouteSettings !== null) {
     contents.DefaultRouteSettings = deserializeAws_restJson1RouteSettings(data.defaultRouteSettings, context);
@@ -9414,7 +9415,7 @@ export const deserializeAws_restJson1UpdateStageCommand = async (
     contents.LastDeploymentStatusMessage = __expectString(data.lastDeploymentStatusMessage);
   }
   if (data.lastUpdatedDate !== undefined && data.lastUpdatedDate !== null) {
-    contents.LastUpdatedDate = new Date(data.lastUpdatedDate);
+    contents.LastUpdatedDate = __expectNonNull(__parseRfc3339DateTime(data.lastUpdatedDate));
   }
   if (data.routeSettings !== undefined && data.routeSettings !== null) {
     contents.RouteSettings = deserializeAws_restJson1RouteSettingsMap(data.routeSettings, context);
@@ -9513,7 +9514,7 @@ export const deserializeAws_restJson1UpdateVpcLinkCommand = async (
   };
   const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.createdDate !== undefined && data.createdDate !== null) {
-    contents.CreatedDate = new Date(data.createdDate);
+    contents.CreatedDate = __expectNonNull(__parseRfc3339DateTime(data.createdDate));
   }
   if (data.name !== undefined && data.name !== null) {
     contents.Name = __expectString(data.name);
@@ -10170,7 +10171,9 @@ const deserializeAws_restJson1Api = (output: any, context: __SerdeContext): Api 
         ? deserializeAws_restJson1Cors(output.corsConfiguration, context)
         : undefined,
     CreatedDate:
-      output.createdDate !== undefined && output.createdDate !== null ? new Date(output.createdDate) : undefined,
+      output.createdDate !== undefined && output.createdDate !== null
+        ? __expectNonNull(__parseRfc3339DateTime(output.createdDate))
+        : undefined,
     Description: __expectString(output.description),
     DisableExecuteApiEndpoint: __expectBoolean(output.disableExecuteApiEndpoint),
     DisableSchemaValidation: __expectBoolean(output.disableSchemaValidation),
@@ -10295,7 +10298,9 @@ const deserializeAws_restJson1Deployment = (output: any, context: __SerdeContext
   return {
     AutoDeployed: __expectBoolean(output.autoDeployed),
     CreatedDate:
-      output.createdDate !== undefined && output.createdDate !== null ? new Date(output.createdDate) : undefined,
+      output.createdDate !== undefined && output.createdDate !== null
+        ? __expectNonNull(__parseRfc3339DateTime(output.createdDate))
+        : undefined,
     DeploymentId: __expectString(output.deploymentId),
     DeploymentStatus: __expectString(output.deploymentStatus),
     DeploymentStatusMessage: __expectString(output.deploymentStatusMessage),
@@ -10332,7 +10337,7 @@ const deserializeAws_restJson1DomainNameConfiguration = (
     CertificateName: __expectString(output.certificateName),
     CertificateUploadDate:
       output.certificateUploadDate !== undefined && output.certificateUploadDate !== null
-        ? new Date(output.certificateUploadDate)
+        ? __expectNonNull(__parseRfc3339DateTime(output.certificateUploadDate))
         : undefined,
     DomainNameStatus: __expectString(output.domainNameStatus),
     DomainNameStatusMessage: __expectString(output.domainNameStatusMessage),
@@ -10611,7 +10616,9 @@ const deserializeAws_restJson1Stage = (output: any, context: __SerdeContext): St
     AutoDeploy: __expectBoolean(output.autoDeploy),
     ClientCertificateId: __expectString(output.clientCertificateId),
     CreatedDate:
-      output.createdDate !== undefined && output.createdDate !== null ? new Date(output.createdDate) : undefined,
+      output.createdDate !== undefined && output.createdDate !== null
+        ? __expectNonNull(__parseRfc3339DateTime(output.createdDate))
+        : undefined,
     DefaultRouteSettings:
       output.defaultRouteSettings !== undefined && output.defaultRouteSettings !== null
         ? deserializeAws_restJson1RouteSettings(output.defaultRouteSettings, context)
@@ -10621,7 +10628,7 @@ const deserializeAws_restJson1Stage = (output: any, context: __SerdeContext): St
     LastDeploymentStatusMessage: __expectString(output.lastDeploymentStatusMessage),
     LastUpdatedDate:
       output.lastUpdatedDate !== undefined && output.lastUpdatedDate !== null
-        ? new Date(output.lastUpdatedDate)
+        ? __expectNonNull(__parseRfc3339DateTime(output.lastUpdatedDate))
         : undefined,
     RouteSettings:
       output.routeSettings !== undefined && output.routeSettings !== null
@@ -10695,7 +10702,9 @@ const deserializeAws_restJson1TlsConfig = (output: any, context: __SerdeContext)
 const deserializeAws_restJson1VpcLink = (output: any, context: __SerdeContext): VpcLink => {
   return {
     CreatedDate:
-      output.createdDate !== undefined && output.createdDate !== null ? new Date(output.createdDate) : undefined,
+      output.createdDate !== undefined && output.createdDate !== null
+        ? __expectNonNull(__parseRfc3339DateTime(output.createdDate))
+        : undefined,
     Name: __expectString(output.name),
     SecurityGroupIds:
       output.securityGroupIds !== undefined && output.securityGroupIds !== null

--- a/clients/client-app-mesh/protocols/Aws_restJson1.ts
+++ b/clients/client-app-mesh/protocols/Aws_restJson1.ts
@@ -245,9 +245,11 @@ import {
   expectInt32 as __expectInt32,
   expectLong as __expectLong,
   expectNonNull as __expectNonNull,
+  expectNumber as __expectNumber,
   expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
+  parseEpochTimestamp as __parseEpochTimestamp,
 } from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
@@ -7630,12 +7632,12 @@ const deserializeAws_restJson1GatewayRouteRef = (output: any, context: __SerdeCo
     arn: __expectString(output.arn),
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
-        ? new Date(Math.round(output.createdAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.createdAt)))
         : undefined,
     gatewayRouteName: __expectString(output.gatewayRouteName),
     lastUpdatedAt:
       output.lastUpdatedAt !== undefined && output.lastUpdatedAt !== null
-        ? new Date(Math.round(output.lastUpdatedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastUpdatedAt)))
         : undefined,
     meshName: __expectString(output.meshName),
     meshOwner: __expectString(output.meshOwner),
@@ -8435,11 +8437,11 @@ const deserializeAws_restJson1MeshRef = (output: any, context: __SerdeContext): 
     arn: __expectString(output.arn),
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
-        ? new Date(Math.round(output.createdAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.createdAt)))
         : undefined,
     lastUpdatedAt:
       output.lastUpdatedAt !== undefined && output.lastUpdatedAt !== null
-        ? new Date(Math.round(output.lastUpdatedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastUpdatedAt)))
         : undefined,
     meshName: __expectString(output.meshName),
     meshOwner: __expectString(output.meshOwner),
@@ -8507,11 +8509,11 @@ const deserializeAws_restJson1ResourceMetadata = (output: any, context: __SerdeC
     arn: __expectString(output.arn),
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
-        ? new Date(Math.round(output.createdAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.createdAt)))
         : undefined,
     lastUpdatedAt:
       output.lastUpdatedAt !== undefined && output.lastUpdatedAt !== null
-        ? new Date(Math.round(output.lastUpdatedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastUpdatedAt)))
         : undefined,
     meshOwner: __expectString(output.meshOwner),
     resourceOwner: __expectString(output.resourceOwner),
@@ -8556,11 +8558,11 @@ const deserializeAws_restJson1RouteRef = (output: any, context: __SerdeContext):
     arn: __expectString(output.arn),
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
-        ? new Date(Math.round(output.createdAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.createdAt)))
         : undefined,
     lastUpdatedAt:
       output.lastUpdatedAt !== undefined && output.lastUpdatedAt !== null
-        ? new Date(Math.round(output.lastUpdatedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastUpdatedAt)))
         : undefined,
     meshName: __expectString(output.meshName),
     meshOwner: __expectString(output.meshOwner),
@@ -9130,11 +9132,11 @@ const deserializeAws_restJson1VirtualGatewayRef = (output: any, context: __Serde
     arn: __expectString(output.arn),
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
-        ? new Date(Math.round(output.createdAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.createdAt)))
         : undefined,
     lastUpdatedAt:
       output.lastUpdatedAt !== undefined && output.lastUpdatedAt !== null
-        ? new Date(Math.round(output.lastUpdatedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastUpdatedAt)))
         : undefined,
     meshName: __expectString(output.meshName),
     meshOwner: __expectString(output.meshOwner),
@@ -9325,11 +9327,11 @@ const deserializeAws_restJson1VirtualNodeRef = (output: any, context: __SerdeCon
     arn: __expectString(output.arn),
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
-        ? new Date(Math.round(output.createdAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.createdAt)))
         : undefined,
     lastUpdatedAt:
       output.lastUpdatedAt !== undefined && output.lastUpdatedAt !== null
-        ? new Date(Math.round(output.lastUpdatedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastUpdatedAt)))
         : undefined,
     meshName: __expectString(output.meshName),
     meshOwner: __expectString(output.meshOwner),
@@ -9446,11 +9448,11 @@ const deserializeAws_restJson1VirtualRouterRef = (output: any, context: __SerdeC
     arn: __expectString(output.arn),
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
-        ? new Date(Math.round(output.createdAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.createdAt)))
         : undefined,
     lastUpdatedAt:
       output.lastUpdatedAt !== undefined && output.lastUpdatedAt !== null
-        ? new Date(Math.round(output.lastUpdatedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastUpdatedAt)))
         : undefined,
     meshName: __expectString(output.meshName),
     meshOwner: __expectString(output.meshOwner),
@@ -9546,11 +9548,11 @@ const deserializeAws_restJson1VirtualServiceRef = (output: any, context: __Serde
     arn: __expectString(output.arn),
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
-        ? new Date(Math.round(output.createdAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.createdAt)))
         : undefined,
     lastUpdatedAt:
       output.lastUpdatedAt !== undefined && output.lastUpdatedAt !== null
-        ? new Date(Math.round(output.lastUpdatedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastUpdatedAt)))
         : undefined,
     meshName: __expectString(output.meshName),
     meshOwner: __expectString(output.meshOwner),

--- a/clients/client-appconfig/protocols/Aws_restJson1.ts
+++ b/clients/client-appconfig/protocols/Aws_restJson1.ts
@@ -105,6 +105,7 @@ import {
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   limitedParseFloat32 as __limitedParseFloat32,
+  parseRfc3339DateTime as __parseRfc3339DateTime,
   serializeFloat as __serializeFloat,
   strictParseInt32 as __strictParseInt32,
 } from "@aws-sdk/smithy-client";
@@ -2489,7 +2490,7 @@ export const deserializeAws_restJson1GetDeploymentCommand = async (
     contents.ApplicationId = __expectString(data.ApplicationId);
   }
   if (data.CompletedAt !== undefined && data.CompletedAt !== null) {
-    contents.CompletedAt = new Date(data.CompletedAt);
+    contents.CompletedAt = __expectNonNull(__parseRfc3339DateTime(data.CompletedAt));
   }
   if (data.ConfigurationLocationUri !== undefined && data.ConfigurationLocationUri !== null) {
     contents.ConfigurationLocationUri = __expectString(data.ConfigurationLocationUri);
@@ -2534,7 +2535,7 @@ export const deserializeAws_restJson1GetDeploymentCommand = async (
     contents.PercentageComplete = __limitedParseFloat32(data.PercentageComplete);
   }
   if (data.StartedAt !== undefined && data.StartedAt !== null) {
-    contents.StartedAt = new Date(data.StartedAt);
+    contents.StartedAt = __expectNonNull(__parseRfc3339DateTime(data.StartedAt));
   }
   if (data.State !== undefined && data.State !== null) {
     contents.State = __expectString(data.State);
@@ -3412,7 +3413,7 @@ export const deserializeAws_restJson1StartDeploymentCommand = async (
     contents.ApplicationId = __expectString(data.ApplicationId);
   }
   if (data.CompletedAt !== undefined && data.CompletedAt !== null) {
-    contents.CompletedAt = new Date(data.CompletedAt);
+    contents.CompletedAt = __expectNonNull(__parseRfc3339DateTime(data.CompletedAt));
   }
   if (data.ConfigurationLocationUri !== undefined && data.ConfigurationLocationUri !== null) {
     contents.ConfigurationLocationUri = __expectString(data.ConfigurationLocationUri);
@@ -3457,7 +3458,7 @@ export const deserializeAws_restJson1StartDeploymentCommand = async (
     contents.PercentageComplete = __limitedParseFloat32(data.PercentageComplete);
   }
   if (data.StartedAt !== undefined && data.StartedAt !== null) {
-    contents.StartedAt = new Date(data.StartedAt);
+    contents.StartedAt = __expectNonNull(__parseRfc3339DateTime(data.StartedAt));
   }
   if (data.State !== undefined && data.State !== null) {
     contents.State = __expectString(data.State);
@@ -3559,7 +3560,7 @@ export const deserializeAws_restJson1StopDeploymentCommand = async (
     contents.ApplicationId = __expectString(data.ApplicationId);
   }
   if (data.CompletedAt !== undefined && data.CompletedAt !== null) {
-    contents.CompletedAt = new Date(data.CompletedAt);
+    contents.CompletedAt = __expectNonNull(__parseRfc3339DateTime(data.CompletedAt));
   }
   if (data.ConfigurationLocationUri !== undefined && data.ConfigurationLocationUri !== null) {
     contents.ConfigurationLocationUri = __expectString(data.ConfigurationLocationUri);
@@ -3604,7 +3605,7 @@ export const deserializeAws_restJson1StopDeploymentCommand = async (
     contents.PercentageComplete = __limitedParseFloat32(data.PercentageComplete);
   }
   if (data.StartedAt !== undefined && data.StartedAt !== null) {
-    contents.StartedAt = new Date(data.StartedAt);
+    contents.StartedAt = __expectNonNull(__parseRfc3339DateTime(data.StartedAt));
   }
   if (data.State !== undefined && data.State !== null) {
     contents.State = __expectString(data.State);
@@ -4449,7 +4450,10 @@ const deserializeAws_restJson1DeploymentEvent = (output: any, context: __SerdeCo
   return {
     Description: __expectString(output.Description),
     EventType: __expectString(output.EventType),
-    OccurredAt: output.OccurredAt !== undefined && output.OccurredAt !== null ? new Date(output.OccurredAt) : undefined,
+    OccurredAt:
+      output.OccurredAt !== undefined && output.OccurredAt !== null
+        ? __expectNonNull(__parseRfc3339DateTime(output.OccurredAt))
+        : undefined,
     TriggeredBy: __expectString(output.TriggeredBy),
   } as any;
 };
@@ -4503,7 +4507,9 @@ const deserializeAws_restJson1DeploymentStrategyList = (output: any, context: __
 const deserializeAws_restJson1DeploymentSummary = (output: any, context: __SerdeContext): DeploymentSummary => {
   return {
     CompletedAt:
-      output.CompletedAt !== undefined && output.CompletedAt !== null ? new Date(output.CompletedAt) : undefined,
+      output.CompletedAt !== undefined && output.CompletedAt !== null
+        ? __expectNonNull(__parseRfc3339DateTime(output.CompletedAt))
+        : undefined,
     ConfigurationName: __expectString(output.ConfigurationName),
     ConfigurationVersion: __expectString(output.ConfigurationVersion),
     DeploymentDurationInMinutes: __expectInt32(output.DeploymentDurationInMinutes),
@@ -4512,7 +4518,10 @@ const deserializeAws_restJson1DeploymentSummary = (output: any, context: __Serde
     GrowthFactor: __limitedParseFloat32(output.GrowthFactor),
     GrowthType: __expectString(output.GrowthType),
     PercentageComplete: __limitedParseFloat32(output.PercentageComplete),
-    StartedAt: output.StartedAt !== undefined && output.StartedAt !== null ? new Date(output.StartedAt) : undefined,
+    StartedAt:
+      output.StartedAt !== undefined && output.StartedAt !== null
+        ? __expectNonNull(__parseRfc3339DateTime(output.StartedAt))
+        : undefined,
     State: __expectString(output.State),
   } as any;
 };

--- a/clients/client-appflow/protocols/Aws_restJson1.ts
+++ b/clients/client-appflow/protocols/Aws_restJson1.ts
@@ -179,9 +179,11 @@ import {
   expectInt32 as __expectInt32,
   expectLong as __expectLong,
   expectNonNull as __expectNonNull,
+  expectNumber as __expectNumber,
   expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
+  parseEpochTimestamp as __parseEpochTimestamp,
 } from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
@@ -1313,7 +1315,7 @@ export const deserializeAws_restJson1DescribeFlowCommand = async (
   };
   const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.createdAt !== undefined && data.createdAt !== null) {
-    contents.createdAt = new Date(Math.round(data.createdAt * 1000));
+    contents.createdAt = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.createdAt)));
   }
   if (data.createdBy !== undefined && data.createdBy !== null) {
     contents.createdBy = __expectString(data.createdBy);
@@ -1346,7 +1348,7 @@ export const deserializeAws_restJson1DescribeFlowCommand = async (
     contents.lastRunExecutionDetails = deserializeAws_restJson1ExecutionDetails(data.lastRunExecutionDetails, context);
   }
   if (data.lastUpdatedAt !== undefined && data.lastUpdatedAt !== null) {
-    contents.lastUpdatedAt = new Date(Math.round(data.lastUpdatedAt * 1000));
+    contents.lastUpdatedAt = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.lastUpdatedAt)));
   }
   if (data.lastUpdatedBy !== undefined && data.lastUpdatedBy !== null) {
     contents.lastUpdatedBy = __expectString(data.lastUpdatedBy);
@@ -3838,12 +3840,12 @@ const deserializeAws_restJson1ConnectorProfile = (output: any, context: __SerdeC
     connectorType: __expectString(output.connectorType),
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
-        ? new Date(Math.round(output.createdAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.createdAt)))
         : undefined,
     credentialsArn: __expectString(output.credentialsArn),
     lastUpdatedAt:
       output.lastUpdatedAt !== undefined && output.lastUpdatedAt !== null
-        ? new Date(Math.round(output.lastUpdatedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastUpdatedAt)))
         : undefined,
     privateConnectionProvisioningState:
       output.privateConnectionProvisioningState !== undefined && output.privateConnectionProvisioningState !== null
@@ -4144,7 +4146,7 @@ const deserializeAws_restJson1ExecutionDetails = (output: any, context: __SerdeC
     mostRecentExecutionStatus: __expectString(output.mostRecentExecutionStatus),
     mostRecentExecutionTime:
       output.mostRecentExecutionTime !== undefined && output.mostRecentExecutionTime !== null
-        ? new Date(Math.round(output.mostRecentExecutionTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.mostRecentExecutionTime)))
         : undefined,
   } as any;
 };
@@ -4153,11 +4155,11 @@ const deserializeAws_restJson1ExecutionRecord = (output: any, context: __SerdeCo
   return {
     dataPullEndTime:
       output.dataPullEndTime !== undefined && output.dataPullEndTime !== null
-        ? new Date(Math.round(output.dataPullEndTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.dataPullEndTime)))
         : undefined,
     dataPullStartTime:
       output.dataPullStartTime !== undefined && output.dataPullStartTime !== null
-        ? new Date(Math.round(output.dataPullStartTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.dataPullStartTime)))
         : undefined,
     executionId: __expectString(output.executionId),
     executionResult:
@@ -4167,11 +4169,11 @@ const deserializeAws_restJson1ExecutionRecord = (output: any, context: __SerdeCo
     executionStatus: __expectString(output.executionStatus),
     lastUpdatedAt:
       output.lastUpdatedAt !== undefined && output.lastUpdatedAt !== null
-        ? new Date(Math.round(output.lastUpdatedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastUpdatedAt)))
         : undefined,
     startedAt:
       output.startedAt !== undefined && output.startedAt !== null
-        ? new Date(Math.round(output.startedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.startedAt)))
         : undefined,
   } as any;
 };
@@ -4217,7 +4219,7 @@ const deserializeAws_restJson1FlowDefinition = (output: any, context: __SerdeCon
   return {
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
-        ? new Date(Math.round(output.createdAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.createdAt)))
         : undefined,
     createdBy: __expectString(output.createdBy),
     description: __expectString(output.description),
@@ -4231,7 +4233,7 @@ const deserializeAws_restJson1FlowDefinition = (output: any, context: __SerdeCon
         : undefined,
     lastUpdatedAt:
       output.lastUpdatedAt !== undefined && output.lastUpdatedAt !== null
-        ? new Date(Math.round(output.lastUpdatedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastUpdatedAt)))
         : undefined,
     lastUpdatedBy: __expectString(output.lastUpdatedBy),
     sourceConnectorType: __expectString(output.sourceConnectorType),
@@ -4598,17 +4600,17 @@ const deserializeAws_restJson1ScheduledTriggerProperties = (
     dataPullMode: __expectString(output.dataPullMode),
     firstExecutionFrom:
       output.firstExecutionFrom !== undefined && output.firstExecutionFrom !== null
-        ? new Date(Math.round(output.firstExecutionFrom * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.firstExecutionFrom)))
         : undefined,
     scheduleEndTime:
       output.scheduleEndTime !== undefined && output.scheduleEndTime !== null
-        ? new Date(Math.round(output.scheduleEndTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.scheduleEndTime)))
         : undefined,
     scheduleExpression: __expectString(output.scheduleExpression),
     scheduleOffset: __expectLong(output.scheduleOffset),
     scheduleStartTime:
       output.scheduleStartTime !== undefined && output.scheduleStartTime !== null
-        ? new Date(Math.round(output.scheduleStartTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.scheduleStartTime)))
         : undefined,
     timezone: __expectString(output.timezone),
   } as any;

--- a/clients/client-application-auto-scaling/protocols/Aws_json1_1.ts
+++ b/clients/client-application-auto-scaling/protocols/Aws_json1_1.ts
@@ -78,8 +78,11 @@ import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@a
 import {
   expectBoolean as __expectBoolean,
   expectInt32 as __expectInt32,
+  expectNonNull as __expectNonNull,
+  expectNumber as __expectNumber,
   expectString as __expectString,
   limitedParseDouble as __limitedParseDouble,
+  parseEpochTimestamp as __parseEpochTimestamp,
   serializeFloat as __serializeFloat,
 } from "@aws-sdk/smithy-client";
 import {
@@ -1686,7 +1689,7 @@ const deserializeAws_json1_1ScalableTarget = (output: any, context: __SerdeConte
   return {
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     MaxCapacity: __expectInt32(output.MaxCapacity),
     MinCapacity: __expectInt32(output.MinCapacity),
@@ -1737,13 +1740,15 @@ const deserializeAws_json1_1ScalingActivity = (output: any, context: __SerdeCont
     Description: __expectString(output.Description),
     Details: __expectString(output.Details),
     EndTime:
-      output.EndTime !== undefined && output.EndTime !== null ? new Date(Math.round(output.EndTime * 1000)) : undefined,
+      output.EndTime !== undefined && output.EndTime !== null
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.EndTime)))
+        : undefined,
     ResourceId: __expectString(output.ResourceId),
     ScalableDimension: __expectString(output.ScalableDimension),
     ServiceNamespace: __expectString(output.ServiceNamespace),
     StartTime:
       output.StartTime !== undefined && output.StartTime !== null
-        ? new Date(Math.round(output.StartTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.StartTime)))
         : undefined,
     StatusCode: __expectString(output.StatusCode),
     StatusMessage: __expectString(output.StatusMessage),
@@ -1769,7 +1774,7 @@ const deserializeAws_json1_1ScalingPolicy = (output: any, context: __SerdeContex
         : undefined,
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     PolicyARN: __expectString(output.PolicyARN),
     PolicyName: __expectString(output.PolicyName),
@@ -1796,10 +1801,12 @@ const deserializeAws_json1_1ScheduledAction = (output: any, context: __SerdeCont
   return {
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     EndTime:
-      output.EndTime !== undefined && output.EndTime !== null ? new Date(Math.round(output.EndTime * 1000)) : undefined,
+      output.EndTime !== undefined && output.EndTime !== null
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.EndTime)))
+        : undefined,
     ResourceId: __expectString(output.ResourceId),
     ScalableDimension: __expectString(output.ScalableDimension),
     ScalableTargetAction:
@@ -1812,7 +1819,7 @@ const deserializeAws_json1_1ScheduledAction = (output: any, context: __SerdeCont
     ServiceNamespace: __expectString(output.ServiceNamespace),
     StartTime:
       output.StartTime !== undefined && output.StartTime !== null
-        ? new Date(Math.round(output.StartTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.StartTime)))
         : undefined,
     Timezone: __expectString(output.Timezone),
   } as any;

--- a/clients/client-application-discovery-service/protocols/Aws_json1_1.ts
+++ b/clients/client-application-discovery-service/protocols/Aws_json1_1.ts
@@ -151,7 +151,10 @@ import {
   expectBoolean as __expectBoolean,
   expectInt32 as __expectInt32,
   expectLong as __expectLong,
+  expectNonNull as __expectNonNull,
+  expectNumber as __expectNumber,
   expectString as __expectString,
+  parseEpochTimestamp as __parseEpochTimestamp,
 } from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
@@ -3544,7 +3547,7 @@ const deserializeAws_json1_1ConfigurationTag = (output: any, context: __SerdeCon
     key: __expectString(output.key),
     timeOfCreation:
       output.timeOfCreation !== undefined && output.timeOfCreation !== null
-        ? new Date(Math.round(output.timeOfCreation * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.timeOfCreation)))
         : undefined,
     value: __expectString(output.value),
   } as any;
@@ -3581,13 +3584,13 @@ const deserializeAws_json1_1ContinuousExportDescription = (
         : undefined,
     startTime:
       output.startTime !== undefined && output.startTime !== null
-        ? new Date(Math.round(output.startTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.startTime)))
         : undefined,
     status: __expectString(output.status),
     statusDetail: __expectString(output.statusDetail),
     stopTime:
       output.stopTime !== undefined && output.stopTime !== null
-        ? new Date(Math.round(output.stopTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.stopTime)))
         : undefined,
   } as any;
 };
@@ -3789,17 +3792,17 @@ const deserializeAws_json1_1ExportInfo = (output: any, context: __SerdeContext):
     exportId: __expectString(output.exportId),
     exportRequestTime:
       output.exportRequestTime !== undefined && output.exportRequestTime !== null
-        ? new Date(Math.round(output.exportRequestTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.exportRequestTime)))
         : undefined,
     exportStatus: __expectString(output.exportStatus),
     isTruncated: __expectBoolean(output.isTruncated),
     requestedEndTime:
       output.requestedEndTime !== undefined && output.requestedEndTime !== null
-        ? new Date(Math.round(output.requestedEndTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.requestedEndTime)))
         : undefined,
     requestedStartTime:
       output.requestedStartTime !== undefined && output.requestedStartTime !== null
-        ? new Date(Math.round(output.requestedStartTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.requestedStartTime)))
         : undefined,
     statusMessage: __expectString(output.statusMessage),
   } as any;
@@ -3853,15 +3856,15 @@ const deserializeAws_json1_1ImportTask = (output: any, context: __SerdeContext):
     errorsAndFailedEntriesZip: __expectString(output.errorsAndFailedEntriesZip),
     importCompletionTime:
       output.importCompletionTime !== undefined && output.importCompletionTime !== null
-        ? new Date(Math.round(output.importCompletionTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.importCompletionTime)))
         : undefined,
     importDeletedTime:
       output.importDeletedTime !== undefined && output.importDeletedTime !== null
-        ? new Date(Math.round(output.importDeletedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.importDeletedTime)))
         : undefined,
     importRequestTime:
       output.importRequestTime !== undefined && output.importRequestTime !== null
-        ? new Date(Math.round(output.importRequestTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.importRequestTime)))
         : undefined,
     importTaskId: __expectString(output.importTaskId),
     importUrl: __expectString(output.importUrl),
@@ -4014,7 +4017,7 @@ const deserializeAws_json1_1StartContinuousExportResponse = (
         : undefined,
     startTime:
       output.startTime !== undefined && output.startTime !== null
-        ? new Date(Math.round(output.startTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.startTime)))
         : undefined,
   } as any;
 };
@@ -4059,11 +4062,11 @@ const deserializeAws_json1_1StopContinuousExportResponse = (
   return {
     startTime:
       output.startTime !== undefined && output.startTime !== null
-        ? new Date(Math.round(output.startTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.startTime)))
         : undefined,
     stopTime:
       output.stopTime !== undefined && output.stopTime !== null
-        ? new Date(Math.round(output.stopTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.stopTime)))
         : undefined,
   } as any;
 };

--- a/clients/client-application-insights/protocols/Aws_json1_1.ts
+++ b/clients/client-application-insights/protocols/Aws_json1_1.ts
@@ -129,8 +129,11 @@ import {
   expectBoolean as __expectBoolean,
   expectInt32 as __expectInt32,
   expectLong as __expectLong,
+  expectNonNull as __expectNonNull,
+  expectNumber as __expectNumber,
   expectString as __expectString,
   limitedParseDouble as __limitedParseDouble,
+  parseEpochTimestamp as __parseEpochTimestamp,
 } from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
@@ -2959,7 +2962,7 @@ const deserializeAws_json1_1ConfigurationEvent = (output: any, context: __SerdeC
     EventStatus: __expectString(output.EventStatus),
     EventTime:
       output.EventTime !== undefined && output.EventTime !== null
-        ? new Date(Math.round(output.EventTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.EventTime)))
         : undefined,
     MonitoredResourceARN: __expectString(output.MonitoredResourceARN),
   } as any;
@@ -3304,7 +3307,9 @@ const deserializeAws_json1_1Observation = (output: any, context: __SerdeContext)
     EbsResult: __expectString(output.EbsResult),
     Ec2State: __expectString(output.Ec2State),
     EndTime:
-      output.EndTime !== undefined && output.EndTime !== null ? new Date(Math.round(output.EndTime * 1000)) : undefined,
+      output.EndTime !== undefined && output.EndTime !== null
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.EndTime)))
+        : undefined,
     HealthEventArn: __expectString(output.HealthEventArn),
     HealthEventDescription: __expectString(output.HealthEventDescription),
     HealthEventTypeCategory: __expectString(output.HealthEventTypeCategory),
@@ -3313,7 +3318,7 @@ const deserializeAws_json1_1Observation = (output: any, context: __SerdeContext)
     Id: __expectString(output.Id),
     LineTime:
       output.LineTime !== undefined && output.LineTime !== null
-        ? new Date(Math.round(output.LineTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LineTime)))
         : undefined,
     LogFilter: __expectString(output.LogFilter),
     LogGroup: __expectString(output.LogGroup),
@@ -3327,7 +3332,7 @@ const deserializeAws_json1_1Observation = (output: any, context: __SerdeContext)
     SourceType: __expectString(output.SourceType),
     StartTime:
       output.StartTime !== undefined && output.StartTime !== null
-        ? new Date(Math.round(output.StartTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.StartTime)))
         : undefined,
     StatesArn: __expectString(output.StatesArn),
     StatesExecutionArn: __expectString(output.StatesExecutionArn),
@@ -3360,7 +3365,9 @@ const deserializeAws_json1_1Problem = (output: any, context: __SerdeContext): Pr
   return {
     AffectedResource: __expectString(output.AffectedResource),
     EndTime:
-      output.EndTime !== undefined && output.EndTime !== null ? new Date(Math.round(output.EndTime * 1000)) : undefined,
+      output.EndTime !== undefined && output.EndTime !== null
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.EndTime)))
+        : undefined,
     Feedback:
       output.Feedback !== undefined && output.Feedback !== null
         ? deserializeAws_json1_1Feedback(output.Feedback, context)
@@ -3371,7 +3378,7 @@ const deserializeAws_json1_1Problem = (output: any, context: __SerdeContext): Pr
     SeverityLevel: __expectString(output.SeverityLevel),
     StartTime:
       output.StartTime !== undefined && output.StartTime !== null
-        ? new Date(Math.round(output.StartTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.StartTime)))
         : undefined,
     Status: __expectString(output.Status),
     Title: __expectString(output.Title),

--- a/clients/client-applicationcostprofiler/protocols/Aws_restJson1.ts
+++ b/clients/client-applicationcostprofiler/protocols/Aws_restJson1.ts
@@ -35,9 +35,11 @@ import {
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
   expectNonNull as __expectNonNull,
+  expectNumber as __expectNumber,
   expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
+  parseEpochTimestamp as __parseEpochTimestamp,
 } from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
@@ -329,7 +331,7 @@ export const deserializeAws_restJson1GetReportDefinitionCommand = async (
   };
   const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.createdAt !== undefined && data.createdAt !== null) {
-    contents.createdAt = new Date(Math.round(data.createdAt * 1000));
+    contents.createdAt = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.createdAt)));
   }
   if (data.destinationS3Location !== undefined && data.destinationS3Location !== null) {
     contents.destinationS3Location = deserializeAws_restJson1S3Location(data.destinationS3Location, context);
@@ -338,7 +340,7 @@ export const deserializeAws_restJson1GetReportDefinitionCommand = async (
     contents.format = __expectString(data.format);
   }
   if (data.lastUpdated !== undefined && data.lastUpdated !== null) {
-    contents.lastUpdated = new Date(Math.round(data.lastUpdated * 1000));
+    contents.lastUpdated = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.lastUpdated)));
   }
   if (data.reportDescription !== undefined && data.reportDescription !== null) {
     contents.reportDescription = __expectString(data.reportDescription);
@@ -845,7 +847,7 @@ const deserializeAws_restJson1ReportDefinition = (output: any, context: __SerdeC
   return {
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
-        ? new Date(Math.round(output.createdAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.createdAt)))
         : undefined,
     destinationS3Location:
       output.destinationS3Location !== undefined && output.destinationS3Location !== null
@@ -854,7 +856,7 @@ const deserializeAws_restJson1ReportDefinition = (output: any, context: __SerdeC
     format: __expectString(output.format),
     lastUpdatedAt:
       output.lastUpdatedAt !== undefined && output.lastUpdatedAt !== null
-        ? new Date(Math.round(output.lastUpdatedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastUpdatedAt)))
         : undefined,
     reportDescription: __expectString(output.reportDescription),
     reportFrequency: __expectString(output.reportFrequency),

--- a/clients/client-apprunner/protocols/Aws_json1_0.ts
+++ b/clients/client-apprunner/protocols/Aws_json1_0.ts
@@ -120,7 +120,10 @@ import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@a
 import {
   expectBoolean as __expectBoolean,
   expectInt32 as __expectInt32,
+  expectNonNull as __expectNonNull,
+  expectNumber as __expectNumber,
   expectString as __expectString,
+  parseEpochTimestamp as __parseEpochTimestamp,
 } from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
@@ -2511,11 +2514,11 @@ const deserializeAws_json1_0AutoScalingConfiguration = (
     AutoScalingConfigurationRevision: __expectInt32(output.AutoScalingConfigurationRevision),
     CreatedAt:
       output.CreatedAt !== undefined && output.CreatedAt !== null
-        ? new Date(Math.round(output.CreatedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreatedAt)))
         : undefined,
     DeletedAt:
       output.DeletedAt !== undefined && output.DeletedAt !== null
-        ? new Date(Math.round(output.DeletedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.DeletedAt)))
         : undefined,
     Latest: __expectBoolean(output.Latest),
     MaxConcurrency: __expectInt32(output.MaxConcurrency),
@@ -2622,7 +2625,7 @@ const deserializeAws_json1_0Connection = (output: any, context: __SerdeContext):
     ConnectionName: __expectString(output.ConnectionName),
     CreatedAt:
       output.CreatedAt !== undefined && output.CreatedAt !== null
-        ? new Date(Math.round(output.CreatedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreatedAt)))
         : undefined,
     ProviderType: __expectString(output.ProviderType),
     Status: __expectString(output.Status),
@@ -2635,7 +2638,7 @@ const deserializeAws_json1_0ConnectionSummary = (output: any, context: __SerdeCo
     ConnectionName: __expectString(output.ConnectionName),
     CreatedAt:
       output.CreatedAt !== undefined && output.CreatedAt !== null
-        ? new Date(Math.round(output.CreatedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreatedAt)))
         : undefined,
     ProviderType: __expectString(output.ProviderType),
     Status: __expectString(output.Status),
@@ -2935,18 +2938,20 @@ const deserializeAws_json1_0ListTagsForResourceResponse = (
 const deserializeAws_json1_0OperationSummary = (output: any, context: __SerdeContext): OperationSummary => {
   return {
     EndedAt:
-      output.EndedAt !== undefined && output.EndedAt !== null ? new Date(Math.round(output.EndedAt * 1000)) : undefined,
+      output.EndedAt !== undefined && output.EndedAt !== null
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.EndedAt)))
+        : undefined,
     Id: __expectString(output.Id),
     StartedAt:
       output.StartedAt !== undefined && output.StartedAt !== null
-        ? new Date(Math.round(output.StartedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.StartedAt)))
         : undefined,
     Status: __expectString(output.Status),
     TargetArn: __expectString(output.TargetArn),
     Type: __expectString(output.Type),
     UpdatedAt:
       output.UpdatedAt !== undefined && output.UpdatedAt !== null
-        ? new Date(Math.round(output.UpdatedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.UpdatedAt)))
         : undefined,
   } as any;
 };
@@ -3014,11 +3019,11 @@ const deserializeAws_json1_0Service = (output: any, context: __SerdeContext): Se
         : undefined,
     CreatedAt:
       output.CreatedAt !== undefined && output.CreatedAt !== null
-        ? new Date(Math.round(output.CreatedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreatedAt)))
         : undefined,
     DeletedAt:
       output.DeletedAt !== undefined && output.DeletedAt !== null
-        ? new Date(Math.round(output.DeletedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.DeletedAt)))
         : undefined,
     EncryptionConfiguration:
       output.EncryptionConfiguration !== undefined && output.EncryptionConfiguration !== null
@@ -3043,7 +3048,7 @@ const deserializeAws_json1_0Service = (output: any, context: __SerdeContext): Se
     Status: __expectString(output.Status),
     UpdatedAt:
       output.UpdatedAt !== undefined && output.UpdatedAt !== null
-        ? new Date(Math.round(output.UpdatedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.UpdatedAt)))
         : undefined,
   } as any;
 };
@@ -3061,7 +3066,7 @@ const deserializeAws_json1_0ServiceSummary = (output: any, context: __SerdeConte
   return {
     CreatedAt:
       output.CreatedAt !== undefined && output.CreatedAt !== null
-        ? new Date(Math.round(output.CreatedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreatedAt)))
         : undefined,
     ServiceArn: __expectString(output.ServiceArn),
     ServiceId: __expectString(output.ServiceId),
@@ -3070,7 +3075,7 @@ const deserializeAws_json1_0ServiceSummary = (output: any, context: __SerdeConte
     Status: __expectString(output.Status),
     UpdatedAt:
       output.UpdatedAt !== undefined && output.UpdatedAt !== null
-        ? new Date(Math.round(output.UpdatedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.UpdatedAt)))
         : undefined,
   } as any;
 };

--- a/clients/client-appstream/protocols/Aws_json1_1.ts
+++ b/clients/client-appstream/protocols/Aws_json1_1.ts
@@ -246,7 +246,10 @@ import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@a
 import {
   expectBoolean as __expectBoolean,
   expectInt32 as __expectInt32,
+  expectNonNull as __expectNonNull,
+  expectNumber as __expectNumber,
   expectString as __expectString,
+  parseEpochTimestamp as __parseEpochTimestamp,
 } from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
@@ -5624,7 +5627,9 @@ const deserializeAws_json1_1CreateImageBuilderStreamingURLResult = (
 ): CreateImageBuilderStreamingURLResult => {
   return {
     Expires:
-      output.Expires !== undefined && output.Expires !== null ? new Date(Math.round(output.Expires * 1000)) : undefined,
+      output.Expires !== undefined && output.Expires !== null
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.Expires)))
+        : undefined,
     StreamingURL: __expectString(output.StreamingURL),
   } as any;
 };
@@ -5644,7 +5649,9 @@ const deserializeAws_json1_1CreateStreamingURLResult = (
 ): CreateStreamingURLResult => {
   return {
     Expires:
-      output.Expires !== undefined && output.Expires !== null ? new Date(Math.round(output.Expires * 1000)) : undefined,
+      output.Expires !== undefined && output.Expires !== null
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.Expires)))
+        : undefined,
     StreamingURL: __expectString(output.StreamingURL),
   } as any;
 };
@@ -5850,7 +5857,7 @@ const deserializeAws_json1_1DirectoryConfig = (output: any, context: __SerdeCont
   return {
     CreatedTime:
       output.CreatedTime !== undefined && output.CreatedTime !== null
-        ? new Date(Math.round(output.CreatedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreatedTime)))
         : undefined,
     DirectoryName: __expectString(output.DirectoryName),
     OrganizationalUnitDistinguishedNames:
@@ -5935,7 +5942,7 @@ const deserializeAws_json1_1Fleet = (output: any, context: __SerdeContext): Flee
         : undefined,
     CreatedTime:
       output.CreatedTime !== undefined && output.CreatedTime !== null
-        ? new Date(Math.round(output.CreatedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreatedTime)))
         : undefined,
     Description: __expectString(output.Description),
     DisconnectTimeoutInSeconds: __expectInt32(output.DisconnectTimeoutInSeconds),
@@ -6006,7 +6013,7 @@ const deserializeAws_json1_1Image = (output: any, context: __SerdeContext): Imag
     BaseImageArn: __expectString(output.BaseImageArn),
     CreatedTime:
       output.CreatedTime !== undefined && output.CreatedTime !== null
-        ? new Date(Math.round(output.CreatedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreatedTime)))
         : undefined,
     Description: __expectString(output.Description),
     DisplayName: __expectString(output.DisplayName),
@@ -6024,7 +6031,7 @@ const deserializeAws_json1_1Image = (output: any, context: __SerdeContext): Imag
     Platform: __expectString(output.Platform),
     PublicBaseImageReleasedDate:
       output.PublicBaseImageReleasedDate !== undefined && output.PublicBaseImageReleasedDate !== null
-        ? new Date(Math.round(output.PublicBaseImageReleasedDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.PublicBaseImageReleasedDate)))
         : undefined,
     State: __expectString(output.State),
     StateChangeReason:
@@ -6045,7 +6052,7 @@ const deserializeAws_json1_1ImageBuilder = (output: any, context: __SerdeContext
     Arn: __expectString(output.Arn),
     CreatedTime:
       output.CreatedTime !== undefined && output.CreatedTime !== null
-        ? new Date(Math.round(output.CreatedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreatedTime)))
         : undefined,
     Description: __expectString(output.Description),
     DisplayName: __expectString(output.DisplayName),
@@ -6293,7 +6300,7 @@ const deserializeAws_json1_1ResourceError = (output: any, context: __SerdeContex
     ErrorMessage: __expectString(output.ErrorMessage),
     ErrorTimestamp:
       output.ErrorTimestamp !== undefined && output.ErrorTimestamp !== null
-        ? new Date(Math.round(output.ErrorTimestamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.ErrorTimestamp)))
         : undefined,
   } as any;
 };
@@ -6362,7 +6369,7 @@ const deserializeAws_json1_1Session = (output: any, context: __SerdeContext): Se
     Id: __expectString(output.Id),
     MaxExpirationTime:
       output.MaxExpirationTime !== undefined && output.MaxExpirationTime !== null
-        ? new Date(Math.round(output.MaxExpirationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.MaxExpirationTime)))
         : undefined,
     NetworkAccessConfiguration:
       output.NetworkAccessConfiguration !== undefined && output.NetworkAccessConfiguration !== null
@@ -6371,7 +6378,7 @@ const deserializeAws_json1_1Session = (output: any, context: __SerdeContext): Se
     StackName: __expectString(output.StackName),
     StartTime:
       output.StartTime !== undefined && output.StartTime !== null
-        ? new Date(Math.round(output.StartTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.StartTime)))
         : undefined,
     State: __expectString(output.State),
     UserId: __expectString(output.UserId),
@@ -6426,7 +6433,7 @@ const deserializeAws_json1_1Stack = (output: any, context: __SerdeContext): Stac
     Arn: __expectString(output.Arn),
     CreatedTime:
       output.CreatedTime !== undefined && output.CreatedTime !== null
-        ? new Date(Math.round(output.CreatedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreatedTime)))
         : undefined,
     Description: __expectString(output.Description),
     DisplayName: __expectString(output.DisplayName),
@@ -6618,7 +6625,7 @@ const deserializeAws_json1_1UsageReportSubscription = (
   return {
     LastGeneratedReportDate:
       output.LastGeneratedReportDate !== undefined && output.LastGeneratedReportDate !== null
-        ? new Date(Math.round(output.LastGeneratedReportDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastGeneratedReportDate)))
         : undefined,
     S3BucketName: __expectString(output.S3BucketName),
     Schedule: __expectString(output.Schedule),
@@ -6649,7 +6656,7 @@ const deserializeAws_json1_1User = (output: any, context: __SerdeContext): User 
     AuthenticationType: __expectString(output.AuthenticationType),
     CreatedTime:
       output.CreatedTime !== undefined && output.CreatedTime !== null
-        ? new Date(Math.round(output.CreatedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreatedTime)))
         : undefined,
     Enabled: __expectBoolean(output.Enabled),
     FirstName: __expectString(output.FirstName),

--- a/clients/client-athena/protocols/Aws_json1_1.ts
+++ b/clients/client-athena/protocols/Aws_json1_1.ts
@@ -167,7 +167,10 @@ import {
   expectBoolean as __expectBoolean,
   expectInt32 as __expectInt32,
   expectLong as __expectLong,
+  expectNonNull as __expectNonNull,
+  expectNumber as __expectNumber,
   expectString as __expectString,
+  parseEpochTimestamp as __parseEpochTimestamp,
 } from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
@@ -3862,7 +3865,7 @@ const deserializeAws_json1_1PreparedStatement = (output: any, context: __SerdeCo
     Description: __expectString(output.Description),
     LastModifiedTime:
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
-        ? new Date(Math.round(output.LastModifiedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastModifiedTime)))
         : undefined,
     QueryStatement: __expectString(output.QueryStatement),
     StatementName: __expectString(output.StatementName),
@@ -3891,7 +3894,7 @@ const deserializeAws_json1_1PreparedStatementSummary = (
   return {
     LastModifiedTime:
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
-        ? new Date(Math.round(output.LastModifiedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastModifiedTime)))
         : undefined,
     StatementName: __expectString(output.StatementName),
   } as any;
@@ -3974,13 +3977,13 @@ const deserializeAws_json1_1QueryExecutionStatus = (output: any, context: __Serd
   return {
     CompletionDateTime:
       output.CompletionDateTime !== undefined && output.CompletionDateTime !== null
-        ? new Date(Math.round(output.CompletionDateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CompletionDateTime)))
         : undefined,
     State: __expectString(output.State),
     StateChangeReason: __expectString(output.StateChangeReason),
     SubmissionDateTime:
       output.SubmissionDateTime !== undefined && output.SubmissionDateTime !== null
-        ? new Date(Math.round(output.SubmissionDateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.SubmissionDateTime)))
         : undefined,
   } as any;
 };
@@ -4071,11 +4074,11 @@ const deserializeAws_json1_1TableMetadata = (output: any, context: __SerdeContex
         : undefined,
     CreateTime:
       output.CreateTime !== undefined && output.CreateTime !== null
-        ? new Date(Math.round(output.CreateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreateTime)))
         : undefined,
     LastAccessTime:
       output.LastAccessTime !== undefined && output.LastAccessTime !== null
-        ? new Date(Math.round(output.LastAccessTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastAccessTime)))
         : undefined,
     Name: __expectString(output.Name),
     Parameters:
@@ -4213,7 +4216,7 @@ const deserializeAws_json1_1WorkGroup = (output: any, context: __SerdeContext): 
         : undefined,
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     Description: __expectString(output.Description),
     Name: __expectString(output.Name),
@@ -4253,7 +4256,7 @@ const deserializeAws_json1_1WorkGroupSummary = (output: any, context: __SerdeCon
   return {
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     Description: __expectString(output.Description),
     EngineVersion:

--- a/clients/client-auditmanager/protocols/Aws_restJson1.ts
+++ b/clients/client-auditmanager/protocols/Aws_restJson1.ts
@@ -187,9 +187,11 @@ import {
   expectBoolean as __expectBoolean,
   expectInt32 as __expectInt32,
   expectNonNull as __expectNonNull,
+  expectNumber as __expectNumber,
   expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
+  parseEpochTimestamp as __parseEpochTimestamp,
 } from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
@@ -6373,7 +6375,10 @@ const deserializeAws_restJson1AssessmentEvidenceFolder = (
     controlName: __expectString(output.controlName),
     controlSetId: __expectString(output.controlSetId),
     dataSource: __expectString(output.dataSource),
-    date: output.date !== undefined && output.date !== null ? new Date(Math.round(output.date * 1000)) : undefined,
+    date:
+      output.date !== undefined && output.date !== null
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.date)))
+        : undefined,
     evidenceAwsServiceSourceCount: __expectInt32(output.evidenceAwsServiceSourceCount),
     evidenceByTypeComplianceCheckCount: __expectInt32(output.evidenceByTypeComplianceCheckCount),
     evidenceByTypeComplianceCheckIssuesCount: __expectInt32(output.evidenceByTypeComplianceCheckIssuesCount),
@@ -6427,13 +6432,13 @@ const deserializeAws_restJson1AssessmentFrameworkMetadata = (
     controlsCount: __expectInt32(output.controlsCount),
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
-        ? new Date(Math.round(output.createdAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.createdAt)))
         : undefined,
     description: __expectString(output.description),
     id: __expectString(output.id),
     lastUpdatedAt:
       output.lastUpdatedAt !== undefined && output.lastUpdatedAt !== null
-        ? new Date(Math.round(output.lastUpdatedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastUpdatedAt)))
         : undefined,
     logo: __expectString(output.logo),
     name: __expectString(output.name),
@@ -6450,7 +6455,7 @@ const deserializeAws_restJson1AssessmentMetadata = (output: any, context: __Serd
     complianceType: __expectString(output.complianceType),
     creationTime:
       output.creationTime !== undefined && output.creationTime !== null
-        ? new Date(Math.round(output.creationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.creationTime)))
         : undefined,
     delegations:
       output.delegations !== undefined && output.delegations !== null
@@ -6460,7 +6465,7 @@ const deserializeAws_restJson1AssessmentMetadata = (output: any, context: __Serd
     id: __expectString(output.id),
     lastUpdated:
       output.lastUpdated !== undefined && output.lastUpdated !== null
-        ? new Date(Math.round(output.lastUpdated * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastUpdated)))
         : undefined,
     name: __expectString(output.name),
     roles:
@@ -6483,7 +6488,7 @@ const deserializeAws_restJson1AssessmentMetadataItem = (
     complianceType: __expectString(output.complianceType),
     creationTime:
       output.creationTime !== undefined && output.creationTime !== null
-        ? new Date(Math.round(output.creationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.creationTime)))
         : undefined,
     delegations:
       output.delegations !== undefined && output.delegations !== null
@@ -6492,7 +6497,7 @@ const deserializeAws_restJson1AssessmentMetadataItem = (
     id: __expectString(output.id),
     lastUpdated:
       output.lastUpdated !== undefined && output.lastUpdated !== null
-        ? new Date(Math.round(output.lastUpdated * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastUpdated)))
         : undefined,
     name: __expectString(output.name),
     roles:
@@ -6511,7 +6516,7 @@ const deserializeAws_restJson1AssessmentReport = (output: any, context: __SerdeC
     awsAccountId: __expectString(output.awsAccountId),
     creationTime:
       output.creationTime !== undefined && output.creationTime !== null
-        ? new Date(Math.round(output.creationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.creationTime)))
         : undefined,
     description: __expectString(output.description),
     id: __expectString(output.id),
@@ -6555,7 +6560,7 @@ const deserializeAws_restJson1AssessmentReportMetadata = (
     author: __expectString(output.author),
     creationTime:
       output.creationTime !== undefined && output.creationTime !== null
-        ? new Date(Math.round(output.creationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.creationTime)))
         : undefined,
     description: __expectString(output.description),
     id: __expectString(output.id),
@@ -6710,7 +6715,7 @@ const deserializeAws_restJson1ChangeLog = (output: any, context: __SerdeContext)
     action: __expectString(output.action),
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
-        ? new Date(Math.round(output.createdAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.createdAt)))
         : undefined,
     createdBy: __expectString(output.createdBy),
     objectName: __expectString(output.objectName),
@@ -6741,14 +6746,14 @@ const deserializeAws_restJson1Control = (output: any, context: __SerdeContext): 
     controlSources: __expectString(output.controlSources),
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
-        ? new Date(Math.round(output.createdAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.createdAt)))
         : undefined,
     createdBy: __expectString(output.createdBy),
     description: __expectString(output.description),
     id: __expectString(output.id),
     lastUpdatedAt:
       output.lastUpdatedAt !== undefined && output.lastUpdatedAt !== null
-        ? new Date(Math.round(output.lastUpdatedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastUpdatedAt)))
         : undefined,
     lastUpdatedBy: __expectString(output.lastUpdatedBy),
     name: __expectString(output.name),
@@ -6767,7 +6772,7 @@ const deserializeAws_restJson1ControlComment = (output: any, context: __SerdeCon
     commentBody: __expectString(output.commentBody),
     postedDate:
       output.postedDate !== undefined && output.postedDate !== null
-        ? new Date(Math.round(output.postedDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.postedDate)))
         : undefined,
   } as any;
 };
@@ -6819,12 +6824,12 @@ const deserializeAws_restJson1ControlMetadata = (output: any, context: __SerdeCo
     controlSources: __expectString(output.controlSources),
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
-        ? new Date(Math.round(output.createdAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.createdAt)))
         : undefined,
     id: __expectString(output.id),
     lastUpdatedAt:
       output.lastUpdatedAt !== undefined && output.lastUpdatedAt !== null
-        ? new Date(Math.round(output.lastUpdatedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastUpdatedAt)))
         : undefined,
     name: __expectString(output.name),
   } as any;
@@ -6895,12 +6900,12 @@ const deserializeAws_restJson1Delegation = (output: any, context: __SerdeContext
     createdBy: __expectString(output.createdBy),
     creationTime:
       output.creationTime !== undefined && output.creationTime !== null
-        ? new Date(Math.round(output.creationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.creationTime)))
         : undefined,
     id: __expectString(output.id),
     lastUpdated:
       output.lastUpdated !== undefined && output.lastUpdated !== null
-        ? new Date(Math.round(output.lastUpdated * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastUpdated)))
         : undefined,
     roleArn: __expectString(output.roleArn),
     roleType: __expectString(output.roleType),
@@ -6915,7 +6920,7 @@ const deserializeAws_restJson1DelegationMetadata = (output: any, context: __Serd
     controlSetName: __expectString(output.controlSetName),
     creationTime:
       output.creationTime !== undefined && output.creationTime !== null
-        ? new Date(Math.round(output.creationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.creationTime)))
         : undefined,
     id: __expectString(output.id),
     roleArn: __expectString(output.roleArn),
@@ -6967,7 +6972,10 @@ const deserializeAws_restJson1Evidence = (output: any, context: __SerdeContext):
       output.resourcesIncluded !== undefined && output.resourcesIncluded !== null
         ? deserializeAws_restJson1Resources(output.resourcesIncluded, context)
         : undefined,
-    time: output.time !== undefined && output.time !== null ? new Date(Math.round(output.time * 1000)) : undefined,
+    time:
+      output.time !== undefined && output.time !== null
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.time)))
+        : undefined,
   } as any;
 };
 
@@ -7030,14 +7038,14 @@ const deserializeAws_restJson1Framework = (output: any, context: __SerdeContext)
     controlSources: __expectString(output.controlSources),
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
-        ? new Date(Math.round(output.createdAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.createdAt)))
         : undefined,
     createdBy: __expectString(output.createdBy),
     description: __expectString(output.description),
     id: __expectString(output.id),
     lastUpdatedAt:
       output.lastUpdatedAt !== undefined && output.lastUpdatedAt !== null
-        ? new Date(Math.round(output.lastUpdatedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastUpdatedAt)))
         : undefined,
     lastUpdatedBy: __expectString(output.lastUpdatedBy),
     logo: __expectString(output.logo),
@@ -7113,7 +7121,7 @@ const deserializeAws_restJson1Notification = (output: any, context: __SerdeConte
     description: __expectString(output.description),
     eventTime:
       output.eventTime !== undefined && output.eventTime !== null
-        ? new Date(Math.round(output.eventTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.eventTime)))
         : undefined,
     id: __expectString(output.id),
     source: __expectString(output.source),

--- a/clients/client-auto-scaling-plans/protocols/Aws_json1_1.ts
+++ b/clients/client-auto-scaling-plans/protocols/Aws_json1_1.ts
@@ -51,8 +51,11 @@ import {
   expectBoolean as __expectBoolean,
   expectInt32 as __expectInt32,
   expectLong as __expectLong,
+  expectNonNull as __expectNonNull,
+  expectNumber as __expectNumber,
   expectString as __expectString,
   limitedParseDouble as __limitedParseDouble,
+  parseEpochTimestamp as __parseEpochTimestamp,
   serializeFloat as __serializeFloat,
 } from "@aws-sdk/smithy-client";
 import {
@@ -1090,7 +1093,7 @@ const deserializeAws_json1_1Datapoint = (output: any, context: __SerdeContext): 
   return {
     Timestamp:
       output.Timestamp !== undefined && output.Timestamp !== null
-        ? new Date(Math.round(output.Timestamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.Timestamp)))
         : undefined,
     Value: __limitedParseDouble(output.Value),
   } as any;
@@ -1270,7 +1273,7 @@ const deserializeAws_json1_1ScalingPlan = (output: any, context: __SerdeContext)
         : undefined,
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     ScalingInstructions:
       output.ScalingInstructions !== undefined && output.ScalingInstructions !== null
@@ -1282,7 +1285,7 @@ const deserializeAws_json1_1ScalingPlan = (output: any, context: __SerdeContext)
     StatusMessage: __expectString(output.StatusMessage),
     StatusStartTime:
       output.StatusStartTime !== undefined && output.StatusStartTime !== null
-        ? new Date(Math.round(output.StatusStartTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.StatusStartTime)))
         : undefined,
   } as any;
 };

--- a/clients/client-auto-scaling/protocols/Aws_query.ts
+++ b/clients/client-auto-scaling/protocols/Aws_query.ts
@@ -344,11 +344,13 @@ import {
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
+  expectNonNull as __expectNonNull,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   getArrayIfSingleItem as __getArrayIfSingleItem,
   getValueFromTextNode as __getValueFromTextNode,
   parseBoolean as __parseBoolean,
+  parseRfc3339DateTime as __parseRfc3339DateTime,
   serializeFloat as __serializeFloat,
   strictParseFloat as __strictParseFloat,
   strictParseInt32 as __strictParseInt32,
@@ -7375,10 +7377,10 @@ const deserializeAws_queryActivity = (output: any, context: __SerdeContext): Act
     contents.Cause = __expectString(output["Cause"]);
   }
   if (output["StartTime"] !== undefined) {
-    contents.StartTime = new Date(output["StartTime"]);
+    contents.StartTime = __expectNonNull(__parseRfc3339DateTime(output["StartTime"]));
   }
   if (output["EndTime"] !== undefined) {
-    contents.EndTime = new Date(output["EndTime"]);
+    contents.EndTime = __expectNonNull(__parseRfc3339DateTime(output["EndTime"]));
   }
   if (output["StatusCode"] !== undefined) {
     contents.StatusCode = __expectString(output["StatusCode"]);
@@ -7587,7 +7589,7 @@ const deserializeAws_queryAutoScalingGroup = (output: any, context: __SerdeConte
     contents.Instances = deserializeAws_queryInstances(__getArrayIfSingleItem(output["Instances"]["member"]), context);
   }
   if (output["CreatedTime"] !== undefined) {
-    contents.CreatedTime = new Date(output["CreatedTime"]);
+    contents.CreatedTime = __expectNonNull(__parseRfc3339DateTime(output["CreatedTime"]));
   }
   if (output.SuspendedProcesses === "") {
     contents.SuspendedProcesses = [];
@@ -8453,7 +8455,7 @@ const deserializeAws_queryGetPredictiveScalingForecastAnswer = (
     contents.CapacityForecast = deserializeAws_queryCapacityForecast(output["CapacityForecast"], context);
   }
   if (output["UpdateTime"] !== undefined) {
-    contents.UpdateTime = new Date(output["UpdateTime"]);
+    contents.UpdateTime = __expectNonNull(__parseRfc3339DateTime(output["UpdateTime"]));
   }
   return contents;
 };
@@ -8555,10 +8557,10 @@ const deserializeAws_queryInstanceRefresh = (output: any, context: __SerdeContex
     contents.StatusReason = __expectString(output["StatusReason"]);
   }
   if (output["StartTime"] !== undefined) {
-    contents.StartTime = new Date(output["StartTime"]);
+    contents.StartTime = __expectNonNull(__parseRfc3339DateTime(output["StartTime"]));
   }
   if (output["EndTime"] !== undefined) {
-    contents.EndTime = new Date(output["EndTime"]);
+    contents.EndTime = __expectNonNull(__parseRfc3339DateTime(output["EndTime"]));
   }
   if (output["PercentageComplete"] !== undefined) {
     contents.PercentageComplete = __strictParseInt32(output["PercentageComplete"]) as number;
@@ -8802,7 +8804,7 @@ const deserializeAws_queryLaunchConfiguration = (output: any, context: __SerdeCo
     contents.IamInstanceProfile = __expectString(output["IamInstanceProfile"]);
   }
   if (output["CreatedTime"] !== undefined) {
-    contents.CreatedTime = new Date(output["CreatedTime"]);
+    contents.CreatedTime = __expectNonNull(__parseRfc3339DateTime(output["CreatedTime"]));
   }
   if (output["EbsOptimized"] !== undefined) {
     contents.EbsOptimized = __parseBoolean(output["EbsOptimized"]);
@@ -9315,7 +9317,7 @@ const deserializeAws_queryPredictiveScalingForecastTimestamps = (output: any, co
       if (entry === null) {
         return null as any;
       }
-      return new Date(entry);
+      return __expectNonNull(__parseRfc3339DateTime(entry));
     });
 };
 
@@ -9692,13 +9694,13 @@ const deserializeAws_queryScheduledUpdateGroupAction = (
     contents.ScheduledActionARN = __expectString(output["ScheduledActionARN"]);
   }
   if (output["Time"] !== undefined) {
-    contents.Time = new Date(output["Time"]);
+    contents.Time = __expectNonNull(__parseRfc3339DateTime(output["Time"]));
   }
   if (output["StartTime"] !== undefined) {
-    contents.StartTime = new Date(output["StartTime"]);
+    contents.StartTime = __expectNonNull(__parseRfc3339DateTime(output["StartTime"]));
   }
   if (output["EndTime"] !== undefined) {
-    contents.EndTime = new Date(output["EndTime"]);
+    contents.EndTime = __expectNonNull(__parseRfc3339DateTime(output["EndTime"]));
   }
   if (output["Recurrence"] !== undefined) {
     contents.Recurrence = __expectString(output["Recurrence"]);

--- a/clients/client-backup/protocols/Aws_restJson1.ts
+++ b/clients/client-backup/protocols/Aws_restJson1.ts
@@ -198,9 +198,11 @@ import {
   expectInt32 as __expectInt32,
   expectLong as __expectLong,
   expectNonNull as __expectNonNull,
+  expectNumber as __expectNumber,
   expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
+  parseEpochTimestamp as __parseEpochTimestamp,
 } from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
@@ -2298,7 +2300,7 @@ export const deserializeAws_restJson1CreateBackupPlanCommand = async (
     contents.BackupPlanId = __expectString(data.BackupPlanId);
   }
   if (data.CreationDate !== undefined && data.CreationDate !== null) {
-    contents.CreationDate = new Date(Math.round(data.CreationDate * 1000));
+    contents.CreationDate = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.CreationDate)));
   }
   if (data.VersionId !== undefined && data.VersionId !== null) {
     contents.VersionId = __expectString(data.VersionId);
@@ -2393,7 +2395,7 @@ export const deserializeAws_restJson1CreateBackupSelectionCommand = async (
     contents.BackupPlanId = __expectString(data.BackupPlanId);
   }
   if (data.CreationDate !== undefined && data.CreationDate !== null) {
-    contents.CreationDate = new Date(Math.round(data.CreationDate * 1000));
+    contents.CreationDate = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.CreationDate)));
   }
   if (data.SelectionId !== undefined && data.SelectionId !== null) {
     contents.SelectionId = __expectString(data.SelectionId);
@@ -2491,7 +2493,7 @@ export const deserializeAws_restJson1CreateBackupVaultCommand = async (
     contents.BackupVaultName = __expectString(data.BackupVaultName);
   }
   if (data.CreationDate !== undefined && data.CreationDate !== null) {
-    contents.CreationDate = new Date(Math.round(data.CreationDate * 1000));
+    contents.CreationDate = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.CreationDate)));
   }
   return Promise.resolve(contents);
 };
@@ -2769,7 +2771,7 @@ export const deserializeAws_restJson1DeleteBackupPlanCommand = async (
     contents.BackupPlanId = __expectString(data.BackupPlanId);
   }
   if (data.DeletionDate !== undefined && data.DeletionDate !== null) {
-    contents.DeletionDate = new Date(Math.round(data.DeletionDate * 1000));
+    contents.DeletionDate = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.DeletionDate)));
   }
   if (data.VersionId !== undefined && data.VersionId !== null) {
     contents.VersionId = __expectString(data.VersionId);
@@ -3467,16 +3469,18 @@ export const deserializeAws_restJson1DescribeBackupJobCommand = async (
     contents.BytesTransferred = __expectLong(data.BytesTransferred);
   }
   if (data.CompletionDate !== undefined && data.CompletionDate !== null) {
-    contents.CompletionDate = new Date(Math.round(data.CompletionDate * 1000));
+    contents.CompletionDate = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.CompletionDate)));
   }
   if (data.CreatedBy !== undefined && data.CreatedBy !== null) {
     contents.CreatedBy = deserializeAws_restJson1RecoveryPointCreator(data.CreatedBy, context);
   }
   if (data.CreationDate !== undefined && data.CreationDate !== null) {
-    contents.CreationDate = new Date(Math.round(data.CreationDate * 1000));
+    contents.CreationDate = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.CreationDate)));
   }
   if (data.ExpectedCompletionDate !== undefined && data.ExpectedCompletionDate !== null) {
-    contents.ExpectedCompletionDate = new Date(Math.round(data.ExpectedCompletionDate * 1000));
+    contents.ExpectedCompletionDate = __expectNonNull(
+      __parseEpochTimestamp(__expectNumber(data.ExpectedCompletionDate))
+    );
   }
   if (data.IamRoleArn !== undefined && data.IamRoleArn !== null) {
     contents.IamRoleArn = __expectString(data.IamRoleArn);
@@ -3494,7 +3498,7 @@ export const deserializeAws_restJson1DescribeBackupJobCommand = async (
     contents.ResourceType = __expectString(data.ResourceType);
   }
   if (data.StartBy !== undefined && data.StartBy !== null) {
-    contents.StartBy = new Date(Math.round(data.StartBy * 1000));
+    contents.StartBy = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.StartBy)));
   }
   if (data.State !== undefined && data.State !== null) {
     contents.State = __expectString(data.State);
@@ -3598,7 +3602,7 @@ export const deserializeAws_restJson1DescribeBackupVaultCommand = async (
     contents.BackupVaultName = __expectString(data.BackupVaultName);
   }
   if (data.CreationDate !== undefined && data.CreationDate !== null) {
-    contents.CreationDate = new Date(Math.round(data.CreationDate * 1000));
+    contents.CreationDate = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.CreationDate)));
   }
   if (data.CreatorRequestId !== undefined && data.CreatorRequestId !== null) {
     contents.CreatorRequestId = __expectString(data.CreatorRequestId);
@@ -3772,7 +3776,7 @@ export const deserializeAws_restJson1DescribeFrameworkCommand = async (
   };
   const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CreationTime !== undefined && data.CreationTime !== null) {
-    contents.CreationTime = new Date(Math.round(data.CreationTime * 1000));
+    contents.CreationTime = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.CreationTime)));
   }
   if (data.DeploymentStatus !== undefined && data.DeploymentStatus !== null) {
     contents.DeploymentStatus = __expectString(data.DeploymentStatus);
@@ -3876,7 +3880,7 @@ export const deserializeAws_restJson1DescribeGlobalSettingsCommand = async (
     contents.GlobalSettings = deserializeAws_restJson1GlobalSettings(data.GlobalSettings, context);
   }
   if (data.LastUpdateTime !== undefined && data.LastUpdateTime !== null) {
-    contents.LastUpdateTime = new Date(Math.round(data.LastUpdateTime * 1000));
+    contents.LastUpdateTime = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.LastUpdateTime)));
   }
   return Promise.resolve(contents);
 };
@@ -3941,7 +3945,7 @@ export const deserializeAws_restJson1DescribeProtectedResourceCommand = async (
   };
   const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.LastBackupTime !== undefined && data.LastBackupTime !== null) {
-    contents.LastBackupTime = new Date(Math.round(data.LastBackupTime * 1000));
+    contents.LastBackupTime = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.LastBackupTime)));
   }
   if (data.ResourceArn !== undefined && data.ResourceArn !== null) {
     contents.ResourceArn = __expectString(data.ResourceArn);
@@ -4056,13 +4060,13 @@ export const deserializeAws_restJson1DescribeRecoveryPointCommand = async (
     contents.CalculatedLifecycle = deserializeAws_restJson1CalculatedLifecycle(data.CalculatedLifecycle, context);
   }
   if (data.CompletionDate !== undefined && data.CompletionDate !== null) {
-    contents.CompletionDate = new Date(Math.round(data.CompletionDate * 1000));
+    contents.CompletionDate = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.CompletionDate)));
   }
   if (data.CreatedBy !== undefined && data.CreatedBy !== null) {
     contents.CreatedBy = deserializeAws_restJson1RecoveryPointCreator(data.CreatedBy, context);
   }
   if (data.CreationDate !== undefined && data.CreationDate !== null) {
-    contents.CreationDate = new Date(Math.round(data.CreationDate * 1000));
+    contents.CreationDate = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.CreationDate)));
   }
   if (data.EncryptionKeyArn !== undefined && data.EncryptionKeyArn !== null) {
     contents.EncryptionKeyArn = __expectString(data.EncryptionKeyArn);
@@ -4074,7 +4078,7 @@ export const deserializeAws_restJson1DescribeRecoveryPointCommand = async (
     contents.IsEncrypted = __expectBoolean(data.IsEncrypted);
   }
   if (data.LastRestoreTime !== undefined && data.LastRestoreTime !== null) {
-    contents.LastRestoreTime = new Date(Math.round(data.LastRestoreTime * 1000));
+    contents.LastRestoreTime = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.LastRestoreTime)));
   }
   if (data.Lifecycle !== undefined && data.Lifecycle !== null) {
     contents.Lifecycle = deserializeAws_restJson1Lifecycle(data.Lifecycle, context);
@@ -4403,13 +4407,13 @@ export const deserializeAws_restJson1DescribeRestoreJobCommand = async (
     contents.BackupSizeInBytes = __expectLong(data.BackupSizeInBytes);
   }
   if (data.CompletionDate !== undefined && data.CompletionDate !== null) {
-    contents.CompletionDate = new Date(Math.round(data.CompletionDate * 1000));
+    contents.CompletionDate = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.CompletionDate)));
   }
   if (data.CreatedResourceArn !== undefined && data.CreatedResourceArn !== null) {
     contents.CreatedResourceArn = __expectString(data.CreatedResourceArn);
   }
   if (data.CreationDate !== undefined && data.CreationDate !== null) {
-    contents.CreationDate = new Date(Math.round(data.CreationDate * 1000));
+    contents.CreationDate = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.CreationDate)));
   }
   if (data.ExpectedCompletionTimeMinutes !== undefined && data.ExpectedCompletionTimeMinutes !== null) {
     contents.ExpectedCompletionTimeMinutes = __expectLong(data.ExpectedCompletionTimeMinutes);
@@ -4713,16 +4717,16 @@ export const deserializeAws_restJson1GetBackupPlanCommand = async (
     contents.BackupPlanId = __expectString(data.BackupPlanId);
   }
   if (data.CreationDate !== undefined && data.CreationDate !== null) {
-    contents.CreationDate = new Date(Math.round(data.CreationDate * 1000));
+    contents.CreationDate = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.CreationDate)));
   }
   if (data.CreatorRequestId !== undefined && data.CreatorRequestId !== null) {
     contents.CreatorRequestId = __expectString(data.CreatorRequestId);
   }
   if (data.DeletionDate !== undefined && data.DeletionDate !== null) {
-    contents.DeletionDate = new Date(Math.round(data.DeletionDate * 1000));
+    contents.DeletionDate = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.DeletionDate)));
   }
   if (data.LastExecutionDate !== undefined && data.LastExecutionDate !== null) {
-    contents.LastExecutionDate = new Date(Math.round(data.LastExecutionDate * 1000));
+    contents.LastExecutionDate = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.LastExecutionDate)));
   }
   if (data.VersionId !== undefined && data.VersionId !== null) {
     contents.VersionId = __expectString(data.VersionId);
@@ -4980,7 +4984,7 @@ export const deserializeAws_restJson1GetBackupSelectionCommand = async (
     contents.BackupSelection = deserializeAws_restJson1BackupSelection(data.BackupSelection, context);
   }
   if (data.CreationDate !== undefined && data.CreationDate !== null) {
-    contents.CreationDate = new Date(Math.round(data.CreationDate * 1000));
+    contents.CreationDate = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.CreationDate)));
   }
   if (data.CreatorRequestId !== undefined && data.CreatorRequestId !== null) {
     contents.CreatorRequestId = __expectString(data.CreatorRequestId);
@@ -6695,7 +6699,7 @@ export const deserializeAws_restJson1StartBackupJobCommand = async (
     contents.BackupJobId = __expectString(data.BackupJobId);
   }
   if (data.CreationDate !== undefined && data.CreationDate !== null) {
-    contents.CreationDate = new Date(Math.round(data.CreationDate * 1000));
+    contents.CreationDate = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.CreationDate)));
   }
   if (data.RecoveryPointArn !== undefined && data.RecoveryPointArn !== null) {
     contents.RecoveryPointArn = __expectString(data.RecoveryPointArn);
@@ -6797,7 +6801,7 @@ export const deserializeAws_restJson1StartCopyJobCommand = async (
     contents.CopyJobId = __expectString(data.CopyJobId);
   }
   if (data.CreationDate !== undefined && data.CreationDate !== null) {
-    contents.CreationDate = new Date(Math.round(data.CreationDate * 1000));
+    contents.CreationDate = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.CreationDate)));
   }
   return Promise.resolve(contents);
 };
@@ -7307,7 +7311,7 @@ export const deserializeAws_restJson1UpdateBackupPlanCommand = async (
     contents.BackupPlanId = __expectString(data.BackupPlanId);
   }
   if (data.CreationDate !== undefined && data.CreationDate !== null) {
-    contents.CreationDate = new Date(Math.round(data.CreationDate * 1000));
+    contents.CreationDate = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.CreationDate)));
   }
   if (data.VersionId !== undefined && data.VersionId !== null) {
     contents.VersionId = __expectString(data.VersionId);
@@ -7391,7 +7395,7 @@ export const deserializeAws_restJson1UpdateFrameworkCommand = async (
   };
   const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CreationTime !== undefined && data.CreationTime !== null) {
-    contents.CreationTime = new Date(Math.round(data.CreationTime * 1000));
+    contents.CreationTime = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.CreationTime)));
   }
   if (data.FrameworkArn !== undefined && data.FrameworkArn !== null) {
     contents.FrameworkArn = __expectString(data.FrameworkArn);
@@ -7727,7 +7731,7 @@ export const deserializeAws_restJson1UpdateReportPlanCommand = async (
   };
   const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CreationTime !== undefined && data.CreationTime !== null) {
-    contents.CreationTime = new Date(Math.round(data.CreationTime * 1000));
+    contents.CreationTime = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.CreationTime)));
   }
   if (data.ReportPlanArn !== undefined && data.ReportPlanArn !== null) {
     contents.ReportPlanArn = __expectString(data.ReportPlanArn);
@@ -8490,7 +8494,7 @@ const deserializeAws_restJson1BackupJob = (output: any, context: __SerdeContext)
     BytesTransferred: __expectLong(output.BytesTransferred),
     CompletionDate:
       output.CompletionDate !== undefined && output.CompletionDate !== null
-        ? new Date(Math.round(output.CompletionDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CompletionDate)))
         : undefined,
     CreatedBy:
       output.CreatedBy !== undefined && output.CreatedBy !== null
@@ -8498,11 +8502,11 @@ const deserializeAws_restJson1BackupJob = (output: any, context: __SerdeContext)
         : undefined,
     CreationDate:
       output.CreationDate !== undefined && output.CreationDate !== null
-        ? new Date(Math.round(output.CreationDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationDate)))
         : undefined,
     ExpectedCompletionDate:
       output.ExpectedCompletionDate !== undefined && output.ExpectedCompletionDate !== null
-        ? new Date(Math.round(output.ExpectedCompletionDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.ExpectedCompletionDate)))
         : undefined,
     IamRoleArn: __expectString(output.IamRoleArn),
     PercentDone: __expectString(output.PercentDone),
@@ -8510,7 +8514,9 @@ const deserializeAws_restJson1BackupJob = (output: any, context: __SerdeContext)
     ResourceArn: __expectString(output.ResourceArn),
     ResourceType: __expectString(output.ResourceType),
     StartBy:
-      output.StartBy !== undefined && output.StartBy !== null ? new Date(Math.round(output.StartBy * 1000)) : undefined,
+      output.StartBy !== undefined && output.StartBy !== null
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.StartBy)))
+        : undefined,
     State: __expectString(output.State),
     StatusMessage: __expectString(output.StatusMessage),
   } as any;
@@ -8575,16 +8581,16 @@ const deserializeAws_restJson1BackupPlansListMember = (output: any, context: __S
     BackupPlanName: __expectString(output.BackupPlanName),
     CreationDate:
       output.CreationDate !== undefined && output.CreationDate !== null
-        ? new Date(Math.round(output.CreationDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationDate)))
         : undefined,
     CreatorRequestId: __expectString(output.CreatorRequestId),
     DeletionDate:
       output.DeletionDate !== undefined && output.DeletionDate !== null
-        ? new Date(Math.round(output.DeletionDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.DeletionDate)))
         : undefined,
     LastExecutionDate:
       output.LastExecutionDate !== undefined && output.LastExecutionDate !== null
-        ? new Date(Math.round(output.LastExecutionDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastExecutionDate)))
         : undefined,
     VersionId: __expectString(output.VersionId),
   } as any;
@@ -8700,7 +8706,7 @@ const deserializeAws_restJson1BackupSelectionsListMember = (
     BackupPlanId: __expectString(output.BackupPlanId),
     CreationDate:
       output.CreationDate !== undefined && output.CreationDate !== null
-        ? new Date(Math.round(output.CreationDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationDate)))
         : undefined,
     CreatorRequestId: __expectString(output.CreatorRequestId),
     IamRoleArn: __expectString(output.IamRoleArn),
@@ -8740,7 +8746,7 @@ const deserializeAws_restJson1BackupVaultListMember = (output: any, context: __S
     BackupVaultName: __expectString(output.BackupVaultName),
     CreationDate:
       output.CreationDate !== undefined && output.CreationDate !== null
-        ? new Date(Math.round(output.CreationDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationDate)))
         : undefined,
     CreatorRequestId: __expectString(output.CreatorRequestId),
     EncryptionKeyArn: __expectString(output.EncryptionKeyArn),
@@ -8752,11 +8758,11 @@ const deserializeAws_restJson1CalculatedLifecycle = (output: any, context: __Ser
   return {
     DeleteAt:
       output.DeleteAt !== undefined && output.DeleteAt !== null
-        ? new Date(Math.round(output.DeleteAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.DeleteAt)))
         : undefined,
     MoveToColdStorageAt:
       output.MoveToColdStorageAt !== undefined && output.MoveToColdStorageAt !== null
-        ? new Date(Math.round(output.MoveToColdStorageAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.MoveToColdStorageAt)))
         : undefined,
   } as any;
 };
@@ -8845,7 +8851,7 @@ const deserializeAws_restJson1CopyJob = (output: any, context: __SerdeContext): 
     BackupSizeInBytes: __expectLong(output.BackupSizeInBytes),
     CompletionDate:
       output.CompletionDate !== undefined && output.CompletionDate !== null
-        ? new Date(Math.round(output.CompletionDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CompletionDate)))
         : undefined,
     CopyJobId: __expectString(output.CopyJobId),
     CreatedBy:
@@ -8854,7 +8860,7 @@ const deserializeAws_restJson1CopyJob = (output: any, context: __SerdeContext): 
         : undefined,
     CreationDate:
       output.CreationDate !== undefined && output.CreationDate !== null
-        ? new Date(Math.round(output.CreationDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationDate)))
         : undefined,
     DestinationBackupVaultArn: __expectString(output.DestinationBackupVaultArn),
     DestinationRecoveryPointArn: __expectString(output.DestinationRecoveryPointArn),
@@ -8894,7 +8900,7 @@ const deserializeAws_restJson1Framework = (output: any, context: __SerdeContext)
   return {
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     DeploymentStatus: __expectString(output.DeploymentStatus),
     FrameworkArn: __expectString(output.FrameworkArn),
@@ -8986,7 +8992,7 @@ const deserializeAws_restJson1ProtectedResource = (output: any, context: __Serde
   return {
     LastBackupTime:
       output.LastBackupTime !== undefined && output.LastBackupTime !== null
-        ? new Date(Math.round(output.LastBackupTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastBackupTime)))
         : undefined,
     ResourceArn: __expectString(output.ResourceArn),
     ResourceType: __expectString(output.ResourceType),
@@ -9018,7 +9024,7 @@ const deserializeAws_restJson1RecoveryPointByBackupVault = (
         : undefined,
     CompletionDate:
       output.CompletionDate !== undefined && output.CompletionDate !== null
-        ? new Date(Math.round(output.CompletionDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CompletionDate)))
         : undefined,
     CreatedBy:
       output.CreatedBy !== undefined && output.CreatedBy !== null
@@ -9026,14 +9032,14 @@ const deserializeAws_restJson1RecoveryPointByBackupVault = (
         : undefined,
     CreationDate:
       output.CreationDate !== undefined && output.CreationDate !== null
-        ? new Date(Math.round(output.CreationDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationDate)))
         : undefined,
     EncryptionKeyArn: __expectString(output.EncryptionKeyArn),
     IamRoleArn: __expectString(output.IamRoleArn),
     IsEncrypted: __expectBoolean(output.IsEncrypted),
     LastRestoreTime:
       output.LastRestoreTime !== undefined && output.LastRestoreTime !== null
-        ? new Date(Math.round(output.LastRestoreTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastRestoreTime)))
         : undefined,
     Lifecycle:
       output.Lifecycle !== undefined && output.Lifecycle !== null
@@ -9071,7 +9077,7 @@ const deserializeAws_restJson1RecoveryPointByResource = (
     BackupVaultName: __expectString(output.BackupVaultName),
     CreationDate:
       output.CreationDate !== undefined && output.CreationDate !== null
-        ? new Date(Math.round(output.CreationDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationDate)))
         : undefined,
     EncryptionKeyArn: __expectString(output.EncryptionKeyArn),
     RecoveryPointArn: __expectString(output.RecoveryPointArn),
@@ -9128,11 +9134,11 @@ const deserializeAws_restJson1ReportJob = (output: any, context: __SerdeContext)
   return {
     CompletionTime:
       output.CompletionTime !== undefined && output.CompletionTime !== null
-        ? new Date(Math.round(output.CompletionTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CompletionTime)))
         : undefined,
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     ReportDestination:
       output.ReportDestination !== undefined && output.ReportDestination !== null
@@ -9161,16 +9167,16 @@ const deserializeAws_restJson1ReportPlan = (output: any, context: __SerdeContext
   return {
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     DeploymentStatus: __expectString(output.DeploymentStatus),
     LastAttemptedExecutionTime:
       output.LastAttemptedExecutionTime !== undefined && output.LastAttemptedExecutionTime !== null
-        ? new Date(Math.round(output.LastAttemptedExecutionTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastAttemptedExecutionTime)))
         : undefined,
     LastSuccessfulExecutionTime:
       output.LastSuccessfulExecutionTime !== undefined && output.LastSuccessfulExecutionTime !== null
-        ? new Date(Math.round(output.LastSuccessfulExecutionTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastSuccessfulExecutionTime)))
         : undefined,
     ReportDeliveryChannel:
       output.ReportDeliveryChannel !== undefined && output.ReportDeliveryChannel !== null
@@ -9268,12 +9274,12 @@ const deserializeAws_restJson1RestoreJobsListMember = (output: any, context: __S
     BackupSizeInBytes: __expectLong(output.BackupSizeInBytes),
     CompletionDate:
       output.CompletionDate !== undefined && output.CompletionDate !== null
-        ? new Date(Math.round(output.CompletionDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CompletionDate)))
         : undefined,
     CreatedResourceArn: __expectString(output.CreatedResourceArn),
     CreationDate:
       output.CreationDate !== undefined && output.CreationDate !== null
-        ? new Date(Math.round(output.CreationDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationDate)))
         : undefined,
     ExpectedCompletionTimeMinutes: __expectLong(output.ExpectedCompletionTimeMinutes),
     IamRoleArn: __expectString(output.IamRoleArn),

--- a/clients/client-braket/protocols/Aws_restJson1.ts
+++ b/clients/client-braket/protocols/Aws_restJson1.ts
@@ -33,6 +33,7 @@ import {
   expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
+  parseRfc3339DateTime as __parseRfc3339DateTime,
 } from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
@@ -659,7 +660,7 @@ export const deserializeAws_restJson1GetQuantumTaskCommand = async (
   };
   const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.createdAt !== undefined && data.createdAt !== null) {
-    contents.createdAt = new Date(Math.round(data.createdAt * 1000));
+    contents.createdAt = __expectNonNull(__parseRfc3339DateTime(data.createdAt));
   }
   if (data.deviceArn !== undefined && data.deviceArn !== null) {
     contents.deviceArn = __expectString(data.deviceArn);
@@ -668,7 +669,7 @@ export const deserializeAws_restJson1GetQuantumTaskCommand = async (
     contents.deviceParameters = new __LazyJsonString(data.deviceParameters);
   }
   if (data.endedAt !== undefined && data.endedAt !== null) {
-    contents.endedAt = new Date(Math.round(data.endedAt * 1000));
+    contents.endedAt = __expectNonNull(__parseRfc3339DateTime(data.endedAt));
   }
   if (data.failureReason !== undefined && data.failureReason !== null) {
     contents.failureReason = __expectString(data.failureReason);
@@ -1380,11 +1381,13 @@ const deserializeAws_restJson1QuantumTaskSummary = (output: any, context: __Serd
   return {
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
-        ? new Date(Math.round(output.createdAt * 1000))
+        ? __expectNonNull(__parseRfc3339DateTime(output.createdAt))
         : undefined,
     deviceArn: __expectString(output.deviceArn),
     endedAt:
-      output.endedAt !== undefined && output.endedAt !== null ? new Date(Math.round(output.endedAt * 1000)) : undefined,
+      output.endedAt !== undefined && output.endedAt !== null
+        ? __expectNonNull(__parseRfc3339DateTime(output.endedAt))
+        : undefined,
     outputS3Bucket: __expectString(output.outputS3Bucket),
     outputS3Directory: __expectString(output.outputS3Directory),
     quantumTaskArn: __expectString(output.quantumTaskArn),

--- a/clients/client-budgets/protocols/Aws_json1_1.ts
+++ b/clients/client-budgets/protocols/Aws_json1_1.ts
@@ -120,8 +120,11 @@ import {
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
   expectBoolean as __expectBoolean,
+  expectNonNull as __expectNonNull,
+  expectNumber as __expectNumber,
   expectString as __expectString,
   limitedParseDouble as __limitedParseDouble,
+  parseEpochTimestamp as __parseEpochTimestamp,
   serializeFloat as __serializeFloat,
 } from "@aws-sdk/smithy-client";
 import {
@@ -3055,7 +3058,7 @@ const deserializeAws_json1_1ActionHistory = (output: any, context: __SerdeContex
     Status: __expectString(output.Status),
     Timestamp:
       output.Timestamp !== undefined && output.Timestamp !== null
-        ? new Date(Math.round(output.Timestamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.Timestamp)))
         : undefined,
   } as any;
 };
@@ -3110,7 +3113,7 @@ const deserializeAws_json1_1Budget = (output: any, context: __SerdeContext): Bud
         : undefined,
     LastUpdatedTime:
       output.LastUpdatedTime !== undefined && output.LastUpdatedTime !== null
-        ? new Date(Math.round(output.LastUpdatedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastUpdatedTime)))
         : undefined,
     PlannedBudgetLimits:
       output.PlannedBudgetLimits !== undefined && output.PlannedBudgetLimits !== null
@@ -3657,8 +3660,14 @@ const deserializeAws_json1_1TargetIds = (output: any, context: __SerdeContext): 
 
 const deserializeAws_json1_1TimePeriod = (output: any, context: __SerdeContext): TimePeriod => {
   return {
-    End: output.End !== undefined && output.End !== null ? new Date(Math.round(output.End * 1000)) : undefined,
-    Start: output.Start !== undefined && output.Start !== null ? new Date(Math.round(output.Start * 1000)) : undefined,
+    End:
+      output.End !== undefined && output.End !== null
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.End)))
+        : undefined,
+    Start:
+      output.Start !== undefined && output.Start !== null
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.Start)))
+        : undefined,
   } as any;
 };
 

--- a/clients/client-chime-sdk-identity/protocols/Aws_restJson1.ts
+++ b/clients/client-chime-sdk-identity/protocols/Aws_restJson1.ts
@@ -74,9 +74,11 @@ import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@a
 import {
   expectInt32 as __expectInt32,
   expectNonNull as __expectNonNull,
+  expectNumber as __expectNumber,
   expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
+  parseEpochTimestamp as __parseEpochTimestamp,
 } from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
@@ -1555,7 +1557,9 @@ export const deserializeAws_restJson1GetAppInstanceRetentionSettingsCommand = as
     );
   }
   if (data.InitiateDeletionTimestamp !== undefined && data.InitiateDeletionTimestamp !== null) {
-    contents.InitiateDeletionTimestamp = new Date(Math.round(data.InitiateDeletionTimestamp * 1000));
+    contents.InitiateDeletionTimestamp = __expectNonNull(
+      __parseEpochTimestamp(__expectNumber(data.InitiateDeletionTimestamp))
+    );
   }
   return Promise.resolve(contents);
 };
@@ -1970,7 +1974,9 @@ export const deserializeAws_restJson1PutAppInstanceRetentionSettingsCommand = as
     );
   }
   if (data.InitiateDeletionTimestamp !== undefined && data.InitiateDeletionTimestamp !== null) {
-    contents.InitiateDeletionTimestamp = new Date(Math.round(data.InitiateDeletionTimestamp * 1000));
+    contents.InitiateDeletionTimestamp = __expectNonNull(
+      __parseEpochTimestamp(__expectNumber(data.InitiateDeletionTimestamp))
+    );
   }
   return Promise.resolve(contents);
 };
@@ -2481,11 +2487,11 @@ const deserializeAws_restJson1AppInstance = (output: any, context: __SerdeContex
     AppInstanceArn: __expectString(output.AppInstanceArn),
     CreatedTimestamp:
       output.CreatedTimestamp !== undefined && output.CreatedTimestamp !== null
-        ? new Date(Math.round(output.CreatedTimestamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreatedTimestamp)))
         : undefined,
     LastUpdatedTimestamp:
       output.LastUpdatedTimestamp !== undefined && output.LastUpdatedTimestamp !== null
-        ? new Date(Math.round(output.LastUpdatedTimestamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastUpdatedTimestamp)))
         : undefined,
     Metadata: __expectString(output.Metadata),
     Name: __expectString(output.Name),
@@ -2501,7 +2507,7 @@ const deserializeAws_restJson1AppInstanceAdmin = (output: any, context: __SerdeC
     AppInstanceArn: __expectString(output.AppInstanceArn),
     CreatedTimestamp:
       output.CreatedTimestamp !== undefined && output.CreatedTimestamp !== null
-        ? new Date(Math.round(output.CreatedTimestamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreatedTimestamp)))
         : undefined,
   } as any;
 };
@@ -2568,11 +2574,11 @@ const deserializeAws_restJson1AppInstanceUser = (output: any, context: __SerdeCo
     AppInstanceUserArn: __expectString(output.AppInstanceUserArn),
     CreatedTimestamp:
       output.CreatedTimestamp !== undefined && output.CreatedTimestamp !== null
-        ? new Date(Math.round(output.CreatedTimestamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreatedTimestamp)))
         : undefined,
     LastUpdatedTimestamp:
       output.LastUpdatedTimestamp !== undefined && output.LastUpdatedTimestamp !== null
-        ? new Date(Math.round(output.LastUpdatedTimestamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastUpdatedTimestamp)))
         : undefined,
     Metadata: __expectString(output.Metadata),
     Name: __expectString(output.Name),

--- a/clients/client-chime-sdk-messaging/protocols/Aws_restJson1.ts
+++ b/clients/client-chime-sdk-messaging/protocols/Aws_restJson1.ts
@@ -118,9 +118,11 @@ import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@a
 import {
   expectBoolean as __expectBoolean,
   expectNonNull as __expectNonNull,
+  expectNumber as __expectNumber,
   expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
+  parseEpochTimestamp as __parseEpochTimestamp,
 } from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
@@ -4489,7 +4491,7 @@ const deserializeAws_restJson1AppInstanceUserMembershipSummary = (
   return {
     ReadMarkerTimestamp:
       output.ReadMarkerTimestamp !== undefined && output.ReadMarkerTimestamp !== null
-        ? new Date(Math.round(output.ReadMarkerTimestamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.ReadMarkerTimestamp)))
         : undefined,
     Type: __expectString(output.Type),
   } as any;
@@ -4547,15 +4549,15 @@ const deserializeAws_restJson1Channel = (output: any, context: __SerdeContext): 
         : undefined,
     CreatedTimestamp:
       output.CreatedTimestamp !== undefined && output.CreatedTimestamp !== null
-        ? new Date(Math.round(output.CreatedTimestamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreatedTimestamp)))
         : undefined,
     LastMessageTimestamp:
       output.LastMessageTimestamp !== undefined && output.LastMessageTimestamp !== null
-        ? new Date(Math.round(output.LastMessageTimestamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastMessageTimestamp)))
         : undefined,
     LastUpdatedTimestamp:
       output.LastUpdatedTimestamp !== undefined && output.LastUpdatedTimestamp !== null
-        ? new Date(Math.round(output.LastUpdatedTimestamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastUpdatedTimestamp)))
         : undefined,
     Metadata: __expectString(output.Metadata),
     Mode: __expectString(output.Mode),
@@ -4573,7 +4575,7 @@ const deserializeAws_restJson1ChannelBan = (output: any, context: __SerdeContext
         : undefined,
     CreatedTimestamp:
       output.CreatedTimestamp !== undefined && output.CreatedTimestamp !== null
-        ? new Date(Math.round(output.CreatedTimestamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreatedTimestamp)))
         : undefined,
     Member:
       output.Member !== undefined && output.Member !== null
@@ -4607,7 +4609,7 @@ const deserializeAws_restJson1ChannelMembership = (output: any, context: __Serde
     ChannelArn: __expectString(output.ChannelArn),
     CreatedTimestamp:
       output.CreatedTimestamp !== undefined && output.CreatedTimestamp !== null
-        ? new Date(Math.round(output.CreatedTimestamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreatedTimestamp)))
         : undefined,
     InvitedBy:
       output.InvitedBy !== undefined && output.InvitedBy !== null
@@ -4615,7 +4617,7 @@ const deserializeAws_restJson1ChannelMembership = (output: any, context: __Serde
         : undefined,
     LastUpdatedTimestamp:
       output.LastUpdatedTimestamp !== undefined && output.LastUpdatedTimestamp !== null
-        ? new Date(Math.round(output.LastUpdatedTimestamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastUpdatedTimestamp)))
         : undefined,
     Member:
       output.Member !== undefined && output.Member !== null
@@ -4687,15 +4689,15 @@ const deserializeAws_restJson1ChannelMessage = (output: any, context: __SerdeCon
     Content: __expectString(output.Content),
     CreatedTimestamp:
       output.CreatedTimestamp !== undefined && output.CreatedTimestamp !== null
-        ? new Date(Math.round(output.CreatedTimestamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreatedTimestamp)))
         : undefined,
     LastEditedTimestamp:
       output.LastEditedTimestamp !== undefined && output.LastEditedTimestamp !== null
-        ? new Date(Math.round(output.LastEditedTimestamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastEditedTimestamp)))
         : undefined,
     LastUpdatedTimestamp:
       output.LastUpdatedTimestamp !== undefined && output.LastUpdatedTimestamp !== null
-        ? new Date(Math.round(output.LastUpdatedTimestamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastUpdatedTimestamp)))
         : undefined,
     MessageId: __expectString(output.MessageId),
     Metadata: __expectString(output.Metadata),
@@ -4714,15 +4716,15 @@ const deserializeAws_restJson1ChannelMessageSummary = (output: any, context: __S
     Content: __expectString(output.Content),
     CreatedTimestamp:
       output.CreatedTimestamp !== undefined && output.CreatedTimestamp !== null
-        ? new Date(Math.round(output.CreatedTimestamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreatedTimestamp)))
         : undefined,
     LastEditedTimestamp:
       output.LastEditedTimestamp !== undefined && output.LastEditedTimestamp !== null
-        ? new Date(Math.round(output.LastEditedTimestamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastEditedTimestamp)))
         : undefined,
     LastUpdatedTimestamp:
       output.LastUpdatedTimestamp !== undefined && output.LastUpdatedTimestamp !== null
-        ? new Date(Math.round(output.LastUpdatedTimestamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastUpdatedTimestamp)))
         : undefined,
     MessageId: __expectString(output.MessageId),
     Metadata: __expectString(output.Metadata),
@@ -4784,7 +4786,7 @@ const deserializeAws_restJson1ChannelModerator = (output: any, context: __SerdeC
         : undefined,
     CreatedTimestamp:
       output.CreatedTimestamp !== undefined && output.CreatedTimestamp !== null
-        ? new Date(Math.round(output.CreatedTimestamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreatedTimestamp)))
         : undefined,
     Moderator:
       output.Moderator !== undefined && output.Moderator !== null
@@ -4824,7 +4826,7 @@ const deserializeAws_restJson1ChannelSummary = (output: any, context: __SerdeCon
     ChannelArn: __expectString(output.ChannelArn),
     LastMessageTimestamp:
       output.LastMessageTimestamp !== undefined && output.LastMessageTimestamp !== null
-        ? new Date(Math.round(output.LastMessageTimestamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastMessageTimestamp)))
         : undefined,
     Metadata: __expectString(output.Metadata),
     Mode: __expectString(output.Mode),

--- a/clients/client-chime/protocols/Aws_restJson1.ts
+++ b/clients/client-chime/protocols/Aws_restJson1.ts
@@ -647,9 +647,12 @@ import {
   expectBoolean as __expectBoolean,
   expectInt32 as __expectInt32,
   expectNonNull as __expectNonNull,
+  expectNumber as __expectNumber,
   expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
+  parseEpochTimestamp as __parseEpochTimestamp,
+  parseRfc3339DateTime as __parseRfc3339DateTime,
 } from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
@@ -15858,7 +15861,9 @@ export const deserializeAws_restJson1GetAppInstanceRetentionSettingsCommand = as
     );
   }
   if (data.InitiateDeletionTimestamp !== undefined && data.InitiateDeletionTimestamp !== null) {
-    contents.InitiateDeletionTimestamp = new Date(Math.round(data.InitiateDeletionTimestamp * 1000));
+    contents.InitiateDeletionTimestamp = __expectNonNull(
+      __parseEpochTimestamp(__expectNumber(data.InitiateDeletionTimestamp))
+    );
   }
   return Promise.resolve(contents);
 };
@@ -17081,7 +17086,7 @@ export const deserializeAws_restJson1GetPhoneNumberSettingsCommand = async (
     contents.CallingName = __expectString(data.CallingName);
   }
   if (data.CallingNameUpdatedTimestamp !== undefined && data.CallingNameUpdatedTimestamp !== null) {
-    contents.CallingNameUpdatedTimestamp = new Date(data.CallingNameUpdatedTimestamp);
+    contents.CallingNameUpdatedTimestamp = __expectNonNull(__parseRfc3339DateTime(data.CallingNameUpdatedTimestamp));
   }
   return Promise.resolve(contents);
 };
@@ -17280,7 +17285,7 @@ export const deserializeAws_restJson1GetRetentionSettingsCommand = async (
   };
   const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.InitiateDeletionTimestamp !== undefined && data.InitiateDeletionTimestamp !== null) {
-    contents.InitiateDeletionTimestamp = new Date(data.InitiateDeletionTimestamp);
+    contents.InitiateDeletionTimestamp = __expectNonNull(__parseRfc3339DateTime(data.InitiateDeletionTimestamp));
   }
   if (data.RetentionSettings !== undefined && data.RetentionSettings !== null) {
     contents.RetentionSettings = deserializeAws_restJson1RetentionSettings(data.RetentionSettings, context);
@@ -22234,7 +22239,9 @@ export const deserializeAws_restJson1PutAppInstanceRetentionSettingsCommand = as
     );
   }
   if (data.InitiateDeletionTimestamp !== undefined && data.InitiateDeletionTimestamp !== null) {
-    contents.InitiateDeletionTimestamp = new Date(Math.round(data.InitiateDeletionTimestamp * 1000));
+    contents.InitiateDeletionTimestamp = __expectNonNull(
+      __parseEpochTimestamp(__expectNumber(data.InitiateDeletionTimestamp))
+    );
   }
   return Promise.resolve(contents);
 };
@@ -22555,7 +22562,7 @@ export const deserializeAws_restJson1PutRetentionSettingsCommand = async (
   };
   const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.InitiateDeletionTimestamp !== undefined && data.InitiateDeletionTimestamp !== null) {
-    contents.InitiateDeletionTimestamp = new Date(data.InitiateDeletionTimestamp);
+    contents.InitiateDeletionTimestamp = __expectNonNull(__parseRfc3339DateTime(data.InitiateDeletionTimestamp));
   }
   if (data.RetentionSettings !== undefined && data.RetentionSettings !== null) {
     contents.RetentionSettings = deserializeAws_restJson1RetentionSettings(data.RetentionSettings, context);
@@ -28341,7 +28348,7 @@ const deserializeAws_restJson1Account = (output: any, context: __SerdeContext): 
     AwsAccountId: __expectString(output.AwsAccountId),
     CreatedTimestamp:
       output.CreatedTimestamp !== undefined && output.CreatedTimestamp !== null
-        ? new Date(output.CreatedTimestamp)
+        ? __expectNonNull(__parseRfc3339DateTime(output.CreatedTimestamp))
         : undefined,
     DefaultLicense: __expectString(output.DefaultLicense),
     Name: __expectString(output.Name),
@@ -28389,11 +28396,11 @@ const deserializeAws_restJson1AppInstance = (output: any, context: __SerdeContex
     AppInstanceArn: __expectString(output.AppInstanceArn),
     CreatedTimestamp:
       output.CreatedTimestamp !== undefined && output.CreatedTimestamp !== null
-        ? new Date(Math.round(output.CreatedTimestamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreatedTimestamp)))
         : undefined,
     LastUpdatedTimestamp:
       output.LastUpdatedTimestamp !== undefined && output.LastUpdatedTimestamp !== null
-        ? new Date(Math.round(output.LastUpdatedTimestamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastUpdatedTimestamp)))
         : undefined,
     Metadata: __expectString(output.Metadata),
     Name: __expectString(output.Name),
@@ -28409,7 +28416,7 @@ const deserializeAws_restJson1AppInstanceAdmin = (output: any, context: __SerdeC
     AppInstanceArn: __expectString(output.AppInstanceArn),
     CreatedTimestamp:
       output.CreatedTimestamp !== undefined && output.CreatedTimestamp !== null
-        ? new Date(Math.round(output.CreatedTimestamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreatedTimestamp)))
         : undefined,
   } as any;
 };
@@ -28500,11 +28507,11 @@ const deserializeAws_restJson1AppInstanceUser = (output: any, context: __SerdeCo
     AppInstanceUserArn: __expectString(output.AppInstanceUserArn),
     CreatedTimestamp:
       output.CreatedTimestamp !== undefined && output.CreatedTimestamp !== null
-        ? new Date(Math.round(output.CreatedTimestamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreatedTimestamp)))
         : undefined,
     LastUpdatedTimestamp:
       output.LastUpdatedTimestamp !== undefined && output.LastUpdatedTimestamp !== null
-        ? new Date(Math.round(output.LastUpdatedTimestamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastUpdatedTimestamp)))
         : undefined,
     Metadata: __expectString(output.Metadata),
     Name: __expectString(output.Name),
@@ -28532,7 +28539,7 @@ const deserializeAws_restJson1AppInstanceUserMembershipSummary = (
   return {
     ReadMarkerTimestamp:
       output.ReadMarkerTimestamp !== undefined && output.ReadMarkerTimestamp !== null
-        ? new Date(Math.round(output.ReadMarkerTimestamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.ReadMarkerTimestamp)))
         : undefined,
     Type: __expectString(output.Type),
   } as any;
@@ -28632,14 +28639,14 @@ const deserializeAws_restJson1Bot = (output: any, context: __SerdeContext): Bot 
     BotType: __expectString(output.BotType),
     CreatedTimestamp:
       output.CreatedTimestamp !== undefined && output.CreatedTimestamp !== null
-        ? new Date(output.CreatedTimestamp)
+        ? __expectNonNull(__parseRfc3339DateTime(output.CreatedTimestamp))
         : undefined,
     Disabled: __expectBoolean(output.Disabled),
     DisplayName: __expectString(output.DisplayName),
     SecurityToken: __expectString(output.SecurityToken),
     UpdatedTimestamp:
       output.UpdatedTimestamp !== undefined && output.UpdatedTimestamp !== null
-        ? new Date(output.UpdatedTimestamp)
+        ? __expectNonNull(__parseRfc3339DateTime(output.UpdatedTimestamp))
         : undefined,
     UserId: __expectString(output.UserId),
   } as any;
@@ -28696,15 +28703,15 @@ const deserializeAws_restJson1Channel = (output: any, context: __SerdeContext): 
         : undefined,
     CreatedTimestamp:
       output.CreatedTimestamp !== undefined && output.CreatedTimestamp !== null
-        ? new Date(Math.round(output.CreatedTimestamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreatedTimestamp)))
         : undefined,
     LastMessageTimestamp:
       output.LastMessageTimestamp !== undefined && output.LastMessageTimestamp !== null
-        ? new Date(Math.round(output.LastMessageTimestamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastMessageTimestamp)))
         : undefined,
     LastUpdatedTimestamp:
       output.LastUpdatedTimestamp !== undefined && output.LastUpdatedTimestamp !== null
-        ? new Date(Math.round(output.LastUpdatedTimestamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastUpdatedTimestamp)))
         : undefined,
     Metadata: __expectString(output.Metadata),
     Mode: __expectString(output.Mode),
@@ -28722,7 +28729,7 @@ const deserializeAws_restJson1ChannelBan = (output: any, context: __SerdeContext
         : undefined,
     CreatedTimestamp:
       output.CreatedTimestamp !== undefined && output.CreatedTimestamp !== null
-        ? new Date(Math.round(output.CreatedTimestamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreatedTimestamp)))
         : undefined,
     Member:
       output.Member !== undefined && output.Member !== null
@@ -28756,7 +28763,7 @@ const deserializeAws_restJson1ChannelMembership = (output: any, context: __Serde
     ChannelArn: __expectString(output.ChannelArn),
     CreatedTimestamp:
       output.CreatedTimestamp !== undefined && output.CreatedTimestamp !== null
-        ? new Date(Math.round(output.CreatedTimestamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreatedTimestamp)))
         : undefined,
     InvitedBy:
       output.InvitedBy !== undefined && output.InvitedBy !== null
@@ -28764,7 +28771,7 @@ const deserializeAws_restJson1ChannelMembership = (output: any, context: __Serde
         : undefined,
     LastUpdatedTimestamp:
       output.LastUpdatedTimestamp !== undefined && output.LastUpdatedTimestamp !== null
-        ? new Date(Math.round(output.LastUpdatedTimestamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastUpdatedTimestamp)))
         : undefined,
     Member:
       output.Member !== undefined && output.Member !== null
@@ -28836,15 +28843,15 @@ const deserializeAws_restJson1ChannelMessage = (output: any, context: __SerdeCon
     Content: __expectString(output.Content),
     CreatedTimestamp:
       output.CreatedTimestamp !== undefined && output.CreatedTimestamp !== null
-        ? new Date(Math.round(output.CreatedTimestamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreatedTimestamp)))
         : undefined,
     LastEditedTimestamp:
       output.LastEditedTimestamp !== undefined && output.LastEditedTimestamp !== null
-        ? new Date(Math.round(output.LastEditedTimestamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastEditedTimestamp)))
         : undefined,
     LastUpdatedTimestamp:
       output.LastUpdatedTimestamp !== undefined && output.LastUpdatedTimestamp !== null
-        ? new Date(Math.round(output.LastUpdatedTimestamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastUpdatedTimestamp)))
         : undefined,
     MessageId: __expectString(output.MessageId),
     Metadata: __expectString(output.Metadata),
@@ -28863,15 +28870,15 @@ const deserializeAws_restJson1ChannelMessageSummary = (output: any, context: __S
     Content: __expectString(output.Content),
     CreatedTimestamp:
       output.CreatedTimestamp !== undefined && output.CreatedTimestamp !== null
-        ? new Date(Math.round(output.CreatedTimestamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreatedTimestamp)))
         : undefined,
     LastEditedTimestamp:
       output.LastEditedTimestamp !== undefined && output.LastEditedTimestamp !== null
-        ? new Date(Math.round(output.LastEditedTimestamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastEditedTimestamp)))
         : undefined,
     LastUpdatedTimestamp:
       output.LastUpdatedTimestamp !== undefined && output.LastUpdatedTimestamp !== null
-        ? new Date(Math.round(output.LastUpdatedTimestamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastUpdatedTimestamp)))
         : undefined,
     MessageId: __expectString(output.MessageId),
     Metadata: __expectString(output.Metadata),
@@ -28933,7 +28940,7 @@ const deserializeAws_restJson1ChannelModerator = (output: any, context: __SerdeC
         : undefined,
     CreatedTimestamp:
       output.CreatedTimestamp !== undefined && output.CreatedTimestamp !== null
-        ? new Date(Math.round(output.CreatedTimestamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreatedTimestamp)))
         : undefined,
     Moderator:
       output.Moderator !== undefined && output.Moderator !== null
@@ -28982,7 +28989,7 @@ const deserializeAws_restJson1ChannelSummary = (output: any, context: __SerdeCon
     ChannelArn: __expectString(output.ChannelArn),
     LastMessageTimestamp:
       output.LastMessageTimestamp !== undefined && output.LastMessageTimestamp !== null
-        ? new Date(Math.round(output.LastMessageTimestamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastMessageTimestamp)))
         : undefined,
     Metadata: __expectString(output.Metadata),
     Mode: __expectString(output.Mode),
@@ -29130,7 +29137,7 @@ const deserializeAws_restJson1MediaCapturePipeline = (output: any, context: __Se
   return {
     CreatedTimestamp:
       output.CreatedTimestamp !== undefined && output.CreatedTimestamp !== null
-        ? new Date(output.CreatedTimestamp)
+        ? __expectNonNull(__parseRfc3339DateTime(output.CreatedTimestamp))
         : undefined,
     MediaPipelineId: __expectString(output.MediaPipelineId),
     SinkArn: __expectString(output.SinkArn),
@@ -29140,7 +29147,7 @@ const deserializeAws_restJson1MediaCapturePipeline = (output: any, context: __Se
     Status: __expectString(output.Status),
     UpdatedTimestamp:
       output.UpdatedTimestamp !== undefined && output.UpdatedTimestamp !== null
-        ? new Date(output.UpdatedTimestamp)
+        ? __expectNonNull(__parseRfc3339DateTime(output.UpdatedTimestamp))
         : undefined,
   } as any;
 };
@@ -29326,11 +29333,11 @@ const deserializeAws_restJson1PhoneNumber = (output: any, context: __SerdeContex
     Country: __expectString(output.Country),
     CreatedTimestamp:
       output.CreatedTimestamp !== undefined && output.CreatedTimestamp !== null
-        ? new Date(output.CreatedTimestamp)
+        ? __expectNonNull(__parseRfc3339DateTime(output.CreatedTimestamp))
         : undefined,
     DeletionTimestamp:
       output.DeletionTimestamp !== undefined && output.DeletionTimestamp !== null
-        ? new Date(output.DeletionTimestamp)
+        ? __expectNonNull(__parseRfc3339DateTime(output.DeletionTimestamp))
         : undefined,
     E164PhoneNumber: __expectString(output.E164PhoneNumber),
     PhoneNumberId: __expectString(output.PhoneNumberId),
@@ -29339,7 +29346,7 @@ const deserializeAws_restJson1PhoneNumber = (output: any, context: __SerdeContex
     Type: __expectString(output.Type),
     UpdatedTimestamp:
       output.UpdatedTimestamp !== undefined && output.UpdatedTimestamp !== null
-        ? new Date(output.UpdatedTimestamp)
+        ? __expectNonNull(__parseRfc3339DateTime(output.UpdatedTimestamp))
         : undefined,
   } as any;
 };
@@ -29351,7 +29358,7 @@ const deserializeAws_restJson1PhoneNumberAssociation = (
   return {
     AssociatedTimestamp:
       output.AssociatedTimestamp !== undefined && output.AssociatedTimestamp !== null
-        ? new Date(output.AssociatedTimestamp)
+        ? __expectNonNull(__parseRfc3339DateTime(output.AssociatedTimestamp))
         : undefined,
     Name: __expectString(output.Name),
     Value: __expectString(output.Value),
@@ -29444,7 +29451,7 @@ const deserializeAws_restJson1PhoneNumberOrder = (output: any, context: __SerdeC
   return {
     CreatedTimestamp:
       output.CreatedTimestamp !== undefined && output.CreatedTimestamp !== null
-        ? new Date(output.CreatedTimestamp)
+        ? __expectNonNull(__parseRfc3339DateTime(output.CreatedTimestamp))
         : undefined,
     OrderedPhoneNumbers:
       output.OrderedPhoneNumbers !== undefined && output.OrderedPhoneNumbers !== null
@@ -29455,7 +29462,7 @@ const deserializeAws_restJson1PhoneNumberOrder = (output: any, context: __SerdeC
     Status: __expectString(output.Status),
     UpdatedTimestamp:
       output.UpdatedTimestamp !== undefined && output.UpdatedTimestamp !== null
-        ? new Date(output.UpdatedTimestamp)
+        ? __expectNonNull(__parseRfc3339DateTime(output.UpdatedTimestamp))
         : undefined,
   } as any;
 };
@@ -29505,11 +29512,11 @@ const deserializeAws_restJson1ProxySession = (output: any, context: __SerdeConte
         : undefined,
     CreatedTimestamp:
       output.CreatedTimestamp !== undefined && output.CreatedTimestamp !== null
-        ? new Date(output.CreatedTimestamp)
+        ? __expectNonNull(__parseRfc3339DateTime(output.CreatedTimestamp))
         : undefined,
     EndedTimestamp:
       output.EndedTimestamp !== undefined && output.EndedTimestamp !== null
-        ? new Date(output.EndedTimestamp)
+        ? __expectNonNull(__parseRfc3339DateTime(output.EndedTimestamp))
         : undefined,
     ExpiryMinutes: __expectInt32(output.ExpiryMinutes),
     GeoMatchLevel: __expectString(output.GeoMatchLevel),
@@ -29527,7 +29534,7 @@ const deserializeAws_restJson1ProxySession = (output: any, context: __SerdeConte
     Status: __expectString(output.Status),
     UpdatedTimestamp:
       output.UpdatedTimestamp !== undefined && output.UpdatedTimestamp !== null
-        ? new Date(output.UpdatedTimestamp)
+        ? __expectNonNull(__parseRfc3339DateTime(output.UpdatedTimestamp))
         : undefined,
     VoiceConnectorId: __expectString(output.VoiceConnectorId),
   } as any;
@@ -29563,13 +29570,13 @@ const deserializeAws_restJson1Room = (output: any, context: __SerdeContext): Roo
     CreatedBy: __expectString(output.CreatedBy),
     CreatedTimestamp:
       output.CreatedTimestamp !== undefined && output.CreatedTimestamp !== null
-        ? new Date(output.CreatedTimestamp)
+        ? __expectNonNull(__parseRfc3339DateTime(output.CreatedTimestamp))
         : undefined,
     Name: __expectString(output.Name),
     RoomId: __expectString(output.RoomId),
     UpdatedTimestamp:
       output.UpdatedTimestamp !== undefined && output.UpdatedTimestamp !== null
-        ? new Date(output.UpdatedTimestamp)
+        ? __expectNonNull(__parseRfc3339DateTime(output.UpdatedTimestamp))
         : undefined,
   } as any;
 };
@@ -29596,7 +29603,7 @@ const deserializeAws_restJson1RoomMembership = (output: any, context: __SerdeCon
     RoomId: __expectString(output.RoomId),
     UpdatedTimestamp:
       output.UpdatedTimestamp !== undefined && output.UpdatedTimestamp !== null
-        ? new Date(output.UpdatedTimestamp)
+        ? __expectNonNull(__parseRfc3339DateTime(output.UpdatedTimestamp))
         : undefined,
   } as any;
 };
@@ -29654,7 +29661,7 @@ const deserializeAws_restJson1SipMediaApplication = (output: any, context: __Ser
     AwsRegion: __expectString(output.AwsRegion),
     CreatedTimestamp:
       output.CreatedTimestamp !== undefined && output.CreatedTimestamp !== null
-        ? new Date(output.CreatedTimestamp)
+        ? __expectNonNull(__parseRfc3339DateTime(output.CreatedTimestamp))
         : undefined,
     Endpoints:
       output.Endpoints !== undefined && output.Endpoints !== null
@@ -29664,7 +29671,7 @@ const deserializeAws_restJson1SipMediaApplication = (output: any, context: __Ser
     SipMediaApplicationId: __expectString(output.SipMediaApplicationId),
     UpdatedTimestamp:
       output.UpdatedTimestamp !== undefined && output.UpdatedTimestamp !== null
-        ? new Date(output.UpdatedTimestamp)
+        ? __expectNonNull(__parseRfc3339DateTime(output.UpdatedTimestamp))
         : undefined,
   } as any;
 };
@@ -29728,7 +29735,7 @@ const deserializeAws_restJson1SipRule = (output: any, context: __SerdeContext): 
   return {
     CreatedTimestamp:
       output.CreatedTimestamp !== undefined && output.CreatedTimestamp !== null
-        ? new Date(output.CreatedTimestamp)
+        ? __expectNonNull(__parseRfc3339DateTime(output.CreatedTimestamp))
         : undefined,
     Disabled: __expectBoolean(output.Disabled),
     Name: __expectString(output.Name),
@@ -29741,7 +29748,7 @@ const deserializeAws_restJson1SipRule = (output: any, context: __SerdeContext): 
     TriggerValue: __expectString(output.TriggerValue),
     UpdatedTimestamp:
       output.UpdatedTimestamp !== undefined && output.UpdatedTimestamp !== null
-        ? new Date(output.UpdatedTimestamp)
+        ? __expectNonNull(__parseRfc3339DateTime(output.UpdatedTimestamp))
         : undefined,
   } as any;
 };
@@ -29875,7 +29882,10 @@ const deserializeAws_restJson1Termination = (output: any, context: __SerdeContex
 const deserializeAws_restJson1TerminationHealth = (output: any, context: __SerdeContext): TerminationHealth => {
   return {
     Source: __expectString(output.Source),
-    Timestamp: output.Timestamp !== undefined && output.Timestamp !== null ? new Date(output.Timestamp) : undefined,
+    Timestamp:
+      output.Timestamp !== undefined && output.Timestamp !== null
+        ? __expectNonNull(__parseRfc3339DateTime(output.Timestamp))
+        : undefined,
   } as any;
 };
 
@@ -29887,13 +29897,18 @@ const deserializeAws_restJson1User = (output: any, context: __SerdeContext): Use
         ? deserializeAws_restJson1AlexaForBusinessMetadata(output.AlexaForBusinessMetadata, context)
         : undefined,
     DisplayName: __expectString(output.DisplayName),
-    InvitedOn: output.InvitedOn !== undefined && output.InvitedOn !== null ? new Date(output.InvitedOn) : undefined,
+    InvitedOn:
+      output.InvitedOn !== undefined && output.InvitedOn !== null
+        ? __expectNonNull(__parseRfc3339DateTime(output.InvitedOn))
+        : undefined,
     LicenseType: __expectString(output.LicenseType),
     PersonalPIN: __expectString(output.PersonalPIN),
     PrimaryEmail: __expectString(output.PrimaryEmail),
     PrimaryProvisionedNumber: __expectString(output.PrimaryProvisionedNumber),
     RegisteredOn:
-      output.RegisteredOn !== undefined && output.RegisteredOn !== null ? new Date(output.RegisteredOn) : undefined,
+      output.RegisteredOn !== undefined && output.RegisteredOn !== null
+        ? __expectNonNull(__parseRfc3339DateTime(output.RegisteredOn))
+        : undefined,
     UserId: __expectString(output.UserId),
     UserInvitationStatus: __expectString(output.UserInvitationStatus),
     UserRegistrationStatus: __expectString(output.UserRegistrationStatus),
@@ -29945,14 +29960,14 @@ const deserializeAws_restJson1VoiceConnector = (output: any, context: __SerdeCon
     AwsRegion: __expectString(output.AwsRegion),
     CreatedTimestamp:
       output.CreatedTimestamp !== undefined && output.CreatedTimestamp !== null
-        ? new Date(output.CreatedTimestamp)
+        ? __expectNonNull(__parseRfc3339DateTime(output.CreatedTimestamp))
         : undefined,
     Name: __expectString(output.Name),
     OutboundHostName: __expectString(output.OutboundHostName),
     RequireEncryption: __expectBoolean(output.RequireEncryption),
     UpdatedTimestamp:
       output.UpdatedTimestamp !== undefined && output.UpdatedTimestamp !== null
-        ? new Date(output.UpdatedTimestamp)
+        ? __expectNonNull(__parseRfc3339DateTime(output.UpdatedTimestamp))
         : undefined,
     VoiceConnectorId: __expectString(output.VoiceConnectorId),
   } as any;
@@ -29962,12 +29977,12 @@ const deserializeAws_restJson1VoiceConnectorGroup = (output: any, context: __Ser
   return {
     CreatedTimestamp:
       output.CreatedTimestamp !== undefined && output.CreatedTimestamp !== null
-        ? new Date(output.CreatedTimestamp)
+        ? __expectNonNull(__parseRfc3339DateTime(output.CreatedTimestamp))
         : undefined,
     Name: __expectString(output.Name),
     UpdatedTimestamp:
       output.UpdatedTimestamp !== undefined && output.UpdatedTimestamp !== null
-        ? new Date(output.UpdatedTimestamp)
+        ? __expectNonNull(__parseRfc3339DateTime(output.UpdatedTimestamp))
         : undefined,
     VoiceConnectorGroupId: __expectString(output.VoiceConnectorGroupId),
     VoiceConnectorItems:

--- a/clients/client-cloud9/protocols/Aws_json1_1.ts
+++ b/clients/client-cloud9/protocols/Aws_json1_1.ts
@@ -77,7 +77,13 @@ import {
   UpdateEnvironmentResult,
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
-import { expectInt32 as __expectInt32, expectString as __expectString } from "@aws-sdk/smithy-client";
+import {
+  expectInt32 as __expectInt32,
+  expectNonNull as __expectNonNull,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
+  parseEpochTimestamp as __parseEpochTimestamp,
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   HeaderBag as __HeaderBag,
@@ -1964,7 +1970,7 @@ const deserializeAws_json1_1EnvironmentMember = (output: any, context: __SerdeCo
     environmentId: __expectString(output.environmentId),
     lastAccess:
       output.lastAccess !== undefined && output.lastAccess !== null
-        ? new Date(Math.round(output.lastAccess * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastAccess)))
         : undefined,
     permissions: __expectString(output.permissions),
     userArn: __expectString(output.userArn),

--- a/clients/client-clouddirectory/protocols/Aws_restJson1.ts
+++ b/clients/client-clouddirectory/protocols/Aws_restJson1.ts
@@ -279,8 +279,10 @@ import {
   expectBoolean as __expectBoolean,
   expectInt32 as __expectInt32,
   expectNonNull as __expectNonNull,
+  expectNumber as __expectNumber,
   expectObject as __expectObject,
   expectString as __expectString,
+  parseEpochTimestamp as __parseEpochTimestamp,
 } from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
@@ -12384,7 +12386,7 @@ const deserializeAws_restJson1Directory = (output: any, context: __SerdeContext)
   return {
     CreationDateTime:
       output.CreationDateTime !== undefined && output.CreationDateTime !== null
-        ? new Date(Math.round(output.CreationDateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationDateTime)))
         : undefined,
     DirectoryArn: __expectString(output.DirectoryArn),
     Name: __expectString(output.Name),
@@ -12716,7 +12718,7 @@ const deserializeAws_restJson1TypedAttributeValue = (output: any, context: __Ser
   }
   if (output.DatetimeValue !== undefined && output.DatetimeValue !== null) {
     return {
-      DatetimeValue: new Date(Math.round(output.DatetimeValue * 1000)),
+      DatetimeValue: __expectNonNull(__parseEpochTimestamp(__expectNumber(output.DatetimeValue))),
     };
   }
   if (__expectString(output.NumberValue) !== undefined) {

--- a/clients/client-cloudformation/protocols/Aws_query.ts
+++ b/clients/client-cloudformation/protocols/Aws_query.ts
@@ -351,11 +351,13 @@ import {
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
+  expectNonNull as __expectNonNull,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   getArrayIfSingleItem as __getArrayIfSingleItem,
   getValueFromTextNode as __getValueFromTextNode,
   parseBoolean as __parseBoolean,
+  parseRfc3339DateTime as __parseRfc3339DateTime,
   strictParseInt32 as __strictParseInt32,
 } from "@aws-sdk/smithy-client";
 import {
@@ -7821,7 +7823,7 @@ const deserializeAws_queryChangeSetSummary = (output: any, context: __SerdeConte
     contents.StatusReason = __expectString(output["StatusReason"]);
   }
   if (output["CreationTime"] !== undefined) {
-    contents.CreationTime = new Date(output["CreationTime"]);
+    contents.CreationTime = __expectNonNull(__parseRfc3339DateTime(output["CreationTime"]));
   }
   if (output["Description"] !== undefined) {
     contents.Description = __expectString(output["Description"]);
@@ -8036,7 +8038,7 @@ const deserializeAws_queryDescribeChangeSetOutput = (output: any, context: __Ser
     );
   }
   if (output["CreationTime"] !== undefined) {
-    contents.CreationTime = new Date(output["CreationTime"]);
+    contents.CreationTime = __expectNonNull(__parseRfc3339DateTime(output["CreationTime"]));
   }
   if (output["ExecutionStatus"] !== undefined) {
     contents.ExecutionStatus = __expectString(output["ExecutionStatus"]);
@@ -8152,7 +8154,7 @@ const deserializeAws_queryDescribeStackDriftDetectionStatusOutput = (
     contents.DriftedStackResourceCount = __strictParseInt32(output["DriftedStackResourceCount"]) as number;
   }
   if (output["Timestamp"] !== undefined) {
-    contents.Timestamp = new Date(output["Timestamp"]);
+    contents.Timestamp = __expectNonNull(__parseRfc3339DateTime(output["Timestamp"]));
   }
   return contents;
 };
@@ -8376,10 +8378,10 @@ const deserializeAws_queryDescribeTypeOutput = (output: any, context: __SerdeCon
     contents.DocumentationUrl = __expectString(output["DocumentationUrl"]);
   }
   if (output["LastUpdated"] !== undefined) {
-    contents.LastUpdated = new Date(output["LastUpdated"]);
+    contents.LastUpdated = __expectNonNull(__parseRfc3339DateTime(output["LastUpdated"]));
   }
   if (output["TimeCreated"] !== undefined) {
-    contents.TimeCreated = new Date(output["TimeCreated"]);
+    contents.TimeCreated = __expectNonNull(__parseRfc3339DateTime(output["TimeCreated"]));
   }
   if (output["ConfigurationSchema"] !== undefined) {
     contents.ConfigurationSchema = __expectString(output["ConfigurationSchema"]);
@@ -9679,13 +9681,13 @@ const deserializeAws_queryStack = (output: any, context: __SerdeContext): Stack 
     );
   }
   if (output["CreationTime"] !== undefined) {
-    contents.CreationTime = new Date(output["CreationTime"]);
+    contents.CreationTime = __expectNonNull(__parseRfc3339DateTime(output["CreationTime"]));
   }
   if (output["DeletionTime"] !== undefined) {
-    contents.DeletionTime = new Date(output["DeletionTime"]);
+    contents.DeletionTime = __expectNonNull(__parseRfc3339DateTime(output["DeletionTime"]));
   }
   if (output["LastUpdatedTime"] !== undefined) {
-    contents.LastUpdatedTime = new Date(output["LastUpdatedTime"]);
+    contents.LastUpdatedTime = __expectNonNull(__parseRfc3339DateTime(output["LastUpdatedTime"]));
   }
   if (output["RollbackConfiguration"] !== undefined) {
     contents.RollbackConfiguration = deserializeAws_queryRollbackConfiguration(
@@ -9762,7 +9764,7 @@ const deserializeAws_queryStackDriftInformation = (output: any, context: __Serde
     contents.StackDriftStatus = __expectString(output["StackDriftStatus"]);
   }
   if (output["LastCheckTimestamp"] !== undefined) {
-    contents.LastCheckTimestamp = new Date(output["LastCheckTimestamp"]);
+    contents.LastCheckTimestamp = __expectNonNull(__parseRfc3339DateTime(output["LastCheckTimestamp"]));
   }
   return contents;
 };
@@ -9779,7 +9781,7 @@ const deserializeAws_queryStackDriftInformationSummary = (
     contents.StackDriftStatus = __expectString(output["StackDriftStatus"]);
   }
   if (output["LastCheckTimestamp"] !== undefined) {
-    contents.LastCheckTimestamp = new Date(output["LastCheckTimestamp"]);
+    contents.LastCheckTimestamp = __expectNonNull(__parseRfc3339DateTime(output["LastCheckTimestamp"]));
   }
   return contents;
 };
@@ -9817,7 +9819,7 @@ const deserializeAws_queryStackEvent = (output: any, context: __SerdeContext): S
     contents.ResourceType = __expectString(output["ResourceType"]);
   }
   if (output["Timestamp"] !== undefined) {
-    contents.Timestamp = new Date(output["Timestamp"]);
+    contents.Timestamp = __expectNonNull(__parseRfc3339DateTime(output["Timestamp"]));
   }
   if (output["ResourceStatus"] !== undefined) {
     contents.ResourceStatus = __expectString(output["ResourceStatus"]);
@@ -9899,7 +9901,7 @@ const deserializeAws_queryStackInstance = (output: any, context: __SerdeContext)
     contents.DriftStatus = __expectString(output["DriftStatus"]);
   }
   if (output["LastDriftCheckTimestamp"] !== undefined) {
-    contents.LastDriftCheckTimestamp = new Date(output["LastDriftCheckTimestamp"]);
+    contents.LastDriftCheckTimestamp = __expectNonNull(__parseRfc3339DateTime(output["LastDriftCheckTimestamp"]));
   }
   return contents;
 };
@@ -9985,7 +9987,7 @@ const deserializeAws_queryStackInstanceSummary = (output: any, context: __SerdeC
     contents.DriftStatus = __expectString(output["DriftStatus"]);
   }
   if (output["LastDriftCheckTimestamp"] !== undefined) {
-    contents.LastDriftCheckTimestamp = new Date(output["LastDriftCheckTimestamp"]);
+    contents.LastDriftCheckTimestamp = __expectNonNull(__parseRfc3339DateTime(output["LastDriftCheckTimestamp"]));
   }
   return contents;
 };
@@ -10030,7 +10032,7 @@ const deserializeAws_queryStackResource = (output: any, context: __SerdeContext)
     contents.ResourceType = __expectString(output["ResourceType"]);
   }
   if (output["Timestamp"] !== undefined) {
-    contents.Timestamp = new Date(output["Timestamp"]);
+    contents.Timestamp = __expectNonNull(__parseRfc3339DateTime(output["Timestamp"]));
   }
   if (output["ResourceStatus"] !== undefined) {
     contents.ResourceStatus = __expectString(output["ResourceStatus"]);
@@ -10081,7 +10083,7 @@ const deserializeAws_queryStackResourceDetail = (output: any, context: __SerdeCo
     contents.ResourceType = __expectString(output["ResourceType"]);
   }
   if (output["LastUpdatedTimestamp"] !== undefined) {
-    contents.LastUpdatedTimestamp = new Date(output["LastUpdatedTimestamp"]);
+    contents.LastUpdatedTimestamp = __expectNonNull(__parseRfc3339DateTime(output["LastUpdatedTimestamp"]));
   }
   if (output["ResourceStatus"] !== undefined) {
     contents.ResourceStatus = __expectString(output["ResourceStatus"]);
@@ -10161,7 +10163,7 @@ const deserializeAws_queryStackResourceDrift = (output: any, context: __SerdeCon
     contents.StackResourceDriftStatus = __expectString(output["StackResourceDriftStatus"]);
   }
   if (output["Timestamp"] !== undefined) {
-    contents.Timestamp = new Date(output["Timestamp"]);
+    contents.Timestamp = __expectNonNull(__parseRfc3339DateTime(output["Timestamp"]));
   }
   if (output["ModuleInfo"] !== undefined) {
     contents.ModuleInfo = deserializeAws_queryModuleInfo(output["ModuleInfo"], context);
@@ -10181,7 +10183,7 @@ const deserializeAws_queryStackResourceDriftInformation = (
     contents.StackResourceDriftStatus = __expectString(output["StackResourceDriftStatus"]);
   }
   if (output["LastCheckTimestamp"] !== undefined) {
-    contents.LastCheckTimestamp = new Date(output["LastCheckTimestamp"]);
+    contents.LastCheckTimestamp = __expectNonNull(__parseRfc3339DateTime(output["LastCheckTimestamp"]));
   }
   return contents;
 };
@@ -10198,7 +10200,7 @@ const deserializeAws_queryStackResourceDriftInformationSummary = (
     contents.StackResourceDriftStatus = __expectString(output["StackResourceDriftStatus"]);
   }
   if (output["LastCheckTimestamp"] !== undefined) {
-    contents.LastCheckTimestamp = new Date(output["LastCheckTimestamp"]);
+    contents.LastCheckTimestamp = __expectNonNull(__parseRfc3339DateTime(output["LastCheckTimestamp"]));
   }
   return contents;
 };
@@ -10257,7 +10259,7 @@ const deserializeAws_queryStackResourceSummary = (output: any, context: __SerdeC
     contents.ResourceType = __expectString(output["ResourceType"]);
   }
   if (output["LastUpdatedTimestamp"] !== undefined) {
-    contents.LastUpdatedTimestamp = new Date(output["LastUpdatedTimestamp"]);
+    contents.LastUpdatedTimestamp = __expectNonNull(__parseRfc3339DateTime(output["LastUpdatedTimestamp"]));
   }
   if (output["ResourceStatus"] !== undefined) {
     contents.ResourceStatus = __expectString(output["ResourceStatus"]);
@@ -10399,7 +10401,7 @@ const deserializeAws_queryStackSetDriftDetectionDetails = (
     contents.DriftDetectionStatus = __expectString(output["DriftDetectionStatus"]);
   }
   if (output["LastDriftCheckTimestamp"] !== undefined) {
-    contents.LastDriftCheckTimestamp = new Date(output["LastDriftCheckTimestamp"]);
+    contents.LastDriftCheckTimestamp = __expectNonNull(__parseRfc3339DateTime(output["LastDriftCheckTimestamp"]));
   }
   if (output["TotalStackInstancesCount"] !== undefined) {
     contents.TotalStackInstancesCount = __strictParseInt32(output["TotalStackInstancesCount"]) as number;
@@ -10488,10 +10490,10 @@ const deserializeAws_queryStackSetOperation = (output: any, context: __SerdeCont
     contents.ExecutionRoleName = __expectString(output["ExecutionRoleName"]);
   }
   if (output["CreationTimestamp"] !== undefined) {
-    contents.CreationTimestamp = new Date(output["CreationTimestamp"]);
+    contents.CreationTimestamp = __expectNonNull(__parseRfc3339DateTime(output["CreationTimestamp"]));
   }
   if (output["EndTimestamp"] !== undefined) {
-    contents.EndTimestamp = new Date(output["EndTimestamp"]);
+    contents.EndTimestamp = __expectNonNull(__parseRfc3339DateTime(output["EndTimestamp"]));
   }
   if (output["DeploymentTargets"] !== undefined) {
     contents.DeploymentTargets = deserializeAws_queryDeploymentTargets(output["DeploymentTargets"], context);
@@ -10626,10 +10628,10 @@ const deserializeAws_queryStackSetOperationSummary = (
     contents.Status = __expectString(output["Status"]);
   }
   if (output["CreationTimestamp"] !== undefined) {
-    contents.CreationTimestamp = new Date(output["CreationTimestamp"]);
+    contents.CreationTimestamp = __expectNonNull(__parseRfc3339DateTime(output["CreationTimestamp"]));
   }
   if (output["EndTimestamp"] !== undefined) {
-    contents.EndTimestamp = new Date(output["EndTimestamp"]);
+    contents.EndTimestamp = __expectNonNull(__parseRfc3339DateTime(output["EndTimestamp"]));
   }
   return contents;
 };
@@ -10678,7 +10680,7 @@ const deserializeAws_queryStackSetSummary = (output: any, context: __SerdeContex
     contents.DriftStatus = __expectString(output["DriftStatus"]);
   }
   if (output["LastDriftCheckTimestamp"] !== undefined) {
-    contents.LastDriftCheckTimestamp = new Date(output["LastDriftCheckTimestamp"]);
+    contents.LastDriftCheckTimestamp = __expectNonNull(__parseRfc3339DateTime(output["LastDriftCheckTimestamp"]));
   }
   return contents;
 };
@@ -10718,13 +10720,13 @@ const deserializeAws_queryStackSummary = (output: any, context: __SerdeContext):
     contents.TemplateDescription = __expectString(output["TemplateDescription"]);
   }
   if (output["CreationTime"] !== undefined) {
-    contents.CreationTime = new Date(output["CreationTime"]);
+    contents.CreationTime = __expectNonNull(__parseRfc3339DateTime(output["CreationTime"]));
   }
   if (output["LastUpdatedTime"] !== undefined) {
-    contents.LastUpdatedTime = new Date(output["LastUpdatedTime"]);
+    contents.LastUpdatedTime = __expectNonNull(__parseRfc3339DateTime(output["LastUpdatedTime"]));
   }
   if (output["DeletionTime"] !== undefined) {
-    contents.DeletionTime = new Date(output["DeletionTime"]);
+    contents.DeletionTime = __expectNonNull(__parseRfc3339DateTime(output["DeletionTime"]));
   }
   if (output["StackStatus"] !== undefined) {
     contents.StackStatus = __expectString(output["StackStatus"]);
@@ -10899,7 +10901,7 @@ const deserializeAws_queryTypeConfigurationDetails = (
     contents.Configuration = __expectString(output["Configuration"]);
   }
   if (output["LastUpdated"] !== undefined) {
-    contents.LastUpdated = new Date(output["LastUpdated"]);
+    contents.LastUpdated = __expectNonNull(__parseRfc3339DateTime(output["LastUpdated"]));
   }
   if (output["TypeArn"] !== undefined) {
     contents.TypeArn = __expectString(output["TypeArn"]);
@@ -11019,7 +11021,7 @@ const deserializeAws_queryTypeSummary = (output: any, context: __SerdeContext): 
     contents.TypeArn = __expectString(output["TypeArn"]);
   }
   if (output["LastUpdated"] !== undefined) {
-    contents.LastUpdated = new Date(output["LastUpdated"]);
+    contents.LastUpdated = __expectNonNull(__parseRfc3339DateTime(output["LastUpdated"]));
   }
   if (output["Description"] !== undefined) {
     contents.Description = __expectString(output["Description"]);
@@ -11086,7 +11088,7 @@ const deserializeAws_queryTypeVersionSummary = (output: any, context: __SerdeCon
     contents.Arn = __expectString(output["Arn"]);
   }
   if (output["TimeCreated"] !== undefined) {
-    contents.TimeCreated = new Date(output["TimeCreated"]);
+    contents.TimeCreated = __expectNonNull(__parseRfc3339DateTime(output["TimeCreated"]));
   }
   if (output["Description"] !== undefined) {
     contents.Description = __expectString(output["Description"]);

--- a/clients/client-cloudfront/protocols/Aws_restXml.ts
+++ b/clients/client-cloudfront/protocols/Aws_restXml.ts
@@ -488,6 +488,7 @@ import {
   getArrayIfSingleItem as __getArrayIfSingleItem,
   getValueFromTextNode as __getValueFromTextNode,
   parseBoolean as __parseBoolean,
+  parseRfc3339DateTime as __parseRfc3339DateTime,
   strictParseInt32 as __strictParseInt32,
   strictParseLong as __strictParseLong,
 } from "@aws-sdk/smithy-client";
@@ -15854,7 +15855,7 @@ const deserializeAws_restXmlCachePolicy = (output: any, context: __SerdeContext)
     contents.Id = __expectString(output["Id"]);
   }
   if (output["LastModifiedTime"] !== undefined) {
-    contents.LastModifiedTime = new Date(output["LastModifiedTime"]);
+    contents.LastModifiedTime = __expectNonNull(__parseRfc3339DateTime(output["LastModifiedTime"]));
   }
   if (output["CachePolicyConfig"] !== undefined) {
     contents.CachePolicyConfig = deserializeAws_restXmlCachePolicyConfig(output["CachePolicyConfig"], context);
@@ -16482,7 +16483,7 @@ const deserializeAws_restXmlDistribution = (output: any, context: __SerdeContext
     contents.Status = __expectString(output["Status"]);
   }
   if (output["LastModifiedTime"] !== undefined) {
-    contents.LastModifiedTime = new Date(output["LastModifiedTime"]);
+    contents.LastModifiedTime = __expectNonNull(__parseRfc3339DateTime(output["LastModifiedTime"]));
   }
   if (output["InProgressInvalidationBatches"] !== undefined) {
     contents.InProgressInvalidationBatches = __strictParseInt32(output["InProgressInvalidationBatches"]) as number;
@@ -16704,7 +16705,7 @@ const deserializeAws_restXmlDistributionSummary = (output: any, context: __Serde
     contents.Status = __expectString(output["Status"]);
   }
   if (output["LastModifiedTime"] !== undefined) {
-    contents.LastModifiedTime = new Date(output["LastModifiedTime"]);
+    contents.LastModifiedTime = __expectNonNull(__parseRfc3339DateTime(output["LastModifiedTime"]));
   }
   if (output["DomainName"] !== undefined) {
     contents.DomainName = __expectString(output["DomainName"]);
@@ -16858,7 +16859,7 @@ const deserializeAws_restXmlFieldLevelEncryption = (output: any, context: __Serd
     contents.Id = __expectString(output["Id"]);
   }
   if (output["LastModifiedTime"] !== undefined) {
-    contents.LastModifiedTime = new Date(output["LastModifiedTime"]);
+    contents.LastModifiedTime = __expectNonNull(__parseRfc3339DateTime(output["LastModifiedTime"]));
   }
   if (output["FieldLevelEncryptionConfig"] !== undefined) {
     contents.FieldLevelEncryptionConfig = deserializeAws_restXmlFieldLevelEncryptionConfig(
@@ -16944,7 +16945,7 @@ const deserializeAws_restXmlFieldLevelEncryptionProfile = (
     contents.Id = __expectString(output["Id"]);
   }
   if (output["LastModifiedTime"] !== undefined) {
-    contents.LastModifiedTime = new Date(output["LastModifiedTime"]);
+    contents.LastModifiedTime = __expectNonNull(__parseRfc3339DateTime(output["LastModifiedTime"]));
   }
   if (output["FieldLevelEncryptionProfileConfig"] !== undefined) {
     contents.FieldLevelEncryptionProfileConfig = deserializeAws_restXmlFieldLevelEncryptionProfileConfig(
@@ -17026,7 +17027,7 @@ const deserializeAws_restXmlFieldLevelEncryptionProfileSummary = (
     contents.Id = __expectString(output["Id"]);
   }
   if (output["LastModifiedTime"] !== undefined) {
-    contents.LastModifiedTime = new Date(output["LastModifiedTime"]);
+    contents.LastModifiedTime = __expectNonNull(__parseRfc3339DateTime(output["LastModifiedTime"]));
   }
   if (output["Name"] !== undefined) {
     contents.Name = __expectString(output["Name"]);
@@ -17069,7 +17070,7 @@ const deserializeAws_restXmlFieldLevelEncryptionSummary = (
     contents.Id = __expectString(output["Id"]);
   }
   if (output["LastModifiedTime"] !== undefined) {
-    contents.LastModifiedTime = new Date(output["LastModifiedTime"]);
+    contents.LastModifiedTime = __expectNonNull(__parseRfc3339DateTime(output["LastModifiedTime"]));
   }
   if (output["Comment"] !== undefined) {
     contents.Comment = __expectString(output["Comment"]);
@@ -17279,10 +17280,10 @@ const deserializeAws_restXmlFunctionMetadata = (output: any, context: __SerdeCon
     contents.Stage = __expectString(output["Stage"]);
   }
   if (output["CreatedTime"] !== undefined) {
-    contents.CreatedTime = new Date(output["CreatedTime"]);
+    contents.CreatedTime = __expectNonNull(__parseRfc3339DateTime(output["CreatedTime"]));
   }
   if (output["LastModifiedTime"] !== undefined) {
-    contents.LastModifiedTime = new Date(output["LastModifiedTime"]);
+    contents.LastModifiedTime = __expectNonNull(__parseRfc3339DateTime(output["LastModifiedTime"]));
   }
   return contents;
 };
@@ -17383,7 +17384,7 @@ const deserializeAws_restXmlInvalidation = (output: any, context: __SerdeContext
     contents.Status = __expectString(output["Status"]);
   }
   if (output["CreateTime"] !== undefined) {
-    contents.CreateTime = new Date(output["CreateTime"]);
+    contents.CreateTime = __expectNonNull(__parseRfc3339DateTime(output["CreateTime"]));
   }
   if (output["InvalidationBatch"] !== undefined) {
     contents.InvalidationBatch = deserializeAws_restXmlInvalidationBatch(output["InvalidationBatch"], context);
@@ -17451,7 +17452,7 @@ const deserializeAws_restXmlInvalidationSummary = (output: any, context: __Serde
     contents.Id = __expectString(output["Id"]);
   }
   if (output["CreateTime"] !== undefined) {
-    contents.CreateTime = new Date(output["CreateTime"]);
+    contents.CreateTime = __expectNonNull(__parseRfc3339DateTime(output["CreateTime"]));
   }
   if (output["Status"] !== undefined) {
     contents.Status = __expectString(output["Status"]);
@@ -17480,7 +17481,7 @@ const deserializeAws_restXmlKeyGroup = (output: any, context: __SerdeContext): K
     contents.Id = __expectString(output["Id"]);
   }
   if (output["LastModifiedTime"] !== undefined) {
-    contents.LastModifiedTime = new Date(output["LastModifiedTime"]);
+    contents.LastModifiedTime = __expectNonNull(__parseRfc3339DateTime(output["LastModifiedTime"]));
   }
   if (output["KeyGroupConfig"] !== undefined) {
     contents.KeyGroupConfig = deserializeAws_restXmlKeyGroupConfig(output["KeyGroupConfig"], context);
@@ -17934,7 +17935,7 @@ const deserializeAws_restXmlOriginRequestPolicy = (output: any, context: __Serde
     contents.Id = __expectString(output["Id"]);
   }
   if (output["LastModifiedTime"] !== undefined) {
-    contents.LastModifiedTime = new Date(output["LastModifiedTime"]);
+    contents.LastModifiedTime = __expectNonNull(__parseRfc3339DateTime(output["LastModifiedTime"]));
   }
   if (output["OriginRequestPolicyConfig"] !== undefined) {
     contents.OriginRequestPolicyConfig = deserializeAws_restXmlOriginRequestPolicyConfig(
@@ -18211,7 +18212,7 @@ const deserializeAws_restXmlPublicKey = (output: any, context: __SerdeContext): 
     contents.Id = __expectString(output["Id"]);
   }
   if (output["CreatedTime"] !== undefined) {
-    contents.CreatedTime = new Date(output["CreatedTime"]);
+    contents.CreatedTime = __expectNonNull(__parseRfc3339DateTime(output["CreatedTime"]));
   }
   if (output["PublicKeyConfig"] !== undefined) {
     contents.PublicKeyConfig = deserializeAws_restXmlPublicKeyConfig(output["PublicKeyConfig"], context);
@@ -18295,7 +18296,7 @@ const deserializeAws_restXmlPublicKeySummary = (output: any, context: __SerdeCon
     contents.Name = __expectString(output["Name"]);
   }
   if (output["CreatedTime"] !== undefined) {
-    contents.CreatedTime = new Date(output["CreatedTime"]);
+    contents.CreatedTime = __expectNonNull(__parseRfc3339DateTime(output["CreatedTime"]));
   }
   if (output["EncodedKey"] !== undefined) {
     contents.EncodedKey = __expectString(output["EncodedKey"]);
@@ -18650,7 +18651,7 @@ const deserializeAws_restXmlStreamingDistribution = (output: any, context: __Ser
     contents.Status = __expectString(output["Status"]);
   }
   if (output["LastModifiedTime"] !== undefined) {
-    contents.LastModifiedTime = new Date(output["LastModifiedTime"]);
+    contents.LastModifiedTime = __expectNonNull(__parseRfc3339DateTime(output["LastModifiedTime"]));
   }
   if (output["DomainName"] !== undefined) {
     contents.DomainName = __expectString(output["DomainName"]);
@@ -18774,7 +18775,7 @@ const deserializeAws_restXmlStreamingDistributionSummary = (
     contents.Status = __expectString(output["Status"]);
   }
   if (output["LastModifiedTime"] !== undefined) {
-    contents.LastModifiedTime = new Date(output["LastModifiedTime"]);
+    contents.LastModifiedTime = __expectNonNull(__parseRfc3339DateTime(output["LastModifiedTime"]));
   }
   if (output["DomainName"] !== undefined) {
     contents.DomainName = __expectString(output["DomainName"]);

--- a/clients/client-cloudhsm-v2/protocols/Aws_json1_1.ts
+++ b/clients/client-cloudhsm-v2/protocols/Aws_json1_1.ts
@@ -62,7 +62,13 @@ import {
   UntagResourceResponse,
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
-import { expectBoolean as __expectBoolean, expectString as __expectString } from "@aws-sdk/smithy-client";
+import {
+  expectBoolean as __expectBoolean,
+  expectNonNull as __expectNonNull,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
+  parseEpochTimestamp as __parseEpochTimestamp,
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   HeaderBag as __HeaderBag,
@@ -1919,15 +1925,15 @@ const deserializeAws_json1_1Backup = (output: any, context: __SerdeContext): Bac
     ClusterId: __expectString(output.ClusterId),
     CopyTimestamp:
       output.CopyTimestamp !== undefined && output.CopyTimestamp !== null
-        ? new Date(Math.round(output.CopyTimestamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CopyTimestamp)))
         : undefined,
     CreateTimestamp:
       output.CreateTimestamp !== undefined && output.CreateTimestamp !== null
-        ? new Date(Math.round(output.CreateTimestamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreateTimestamp)))
         : undefined,
     DeleteTimestamp:
       output.DeleteTimestamp !== undefined && output.DeleteTimestamp !== null
-        ? new Date(Math.round(output.DeleteTimestamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.DeleteTimestamp)))
         : undefined,
     NeverExpires: __expectBoolean(output.NeverExpires),
     SourceBackup: __expectString(output.SourceBackup),
@@ -2033,7 +2039,7 @@ const deserializeAws_json1_1Cluster = (output: any, context: __SerdeContext): Cl
     ClusterId: __expectString(output.ClusterId),
     CreateTimestamp:
       output.CreateTimestamp !== undefined && output.CreateTimestamp !== null
-        ? new Date(Math.round(output.CreateTimestamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreateTimestamp)))
         : undefined,
     HsmType: __expectString(output.HsmType),
     Hsms:
@@ -2147,7 +2153,7 @@ const deserializeAws_json1_1DestinationBackup = (output: any, context: __SerdeCo
   return {
     CreateTimestamp:
       output.CreateTimestamp !== undefined && output.CreateTimestamp !== null
-        ? new Date(Math.round(output.CreateTimestamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreateTimestamp)))
         : undefined,
     SourceBackup: __expectString(output.SourceBackup),
     SourceCluster: __expectString(output.SourceCluster),

--- a/clients/client-cloudsearch/protocols/Aws_query.ts
+++ b/clients/client-cloudsearch/protocols/Aws_query.ts
@@ -157,11 +157,13 @@ import {
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
+  expectNonNull as __expectNonNull,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   getArrayIfSingleItem as __getArrayIfSingleItem,
   getValueFromTextNode as __getValueFromTextNode,
   parseBoolean as __parseBoolean,
+  parseRfc3339DateTime as __parseRfc3339DateTime,
   serializeFloat as __serializeFloat,
   strictParseFloat as __strictParseFloat,
   strictParseInt32 as __strictParseInt32,
@@ -4609,10 +4611,10 @@ const deserializeAws_queryOptionStatus = (output: any, context: __SerdeContext):
     PendingDeletion: undefined,
   };
   if (output["CreationDate"] !== undefined) {
-    contents.CreationDate = new Date(output["CreationDate"]);
+    contents.CreationDate = __expectNonNull(__parseRfc3339DateTime(output["CreationDate"]));
   }
   if (output["UpdateDate"] !== undefined) {
-    contents.UpdateDate = new Date(output["UpdateDate"]);
+    contents.UpdateDate = __expectNonNull(__parseRfc3339DateTime(output["UpdateDate"]));
   }
   if (output["UpdateVersion"] !== undefined) {
     contents.UpdateVersion = __strictParseInt32(output["UpdateVersion"]) as number;

--- a/clients/client-cloudtrail/protocols/Aws_json1_1.ts
+++ b/clients/client-cloudtrail/protocols/Aws_json1_1.ts
@@ -118,7 +118,13 @@ import {
   UpdateTrailResponse,
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
-import { expectBoolean as __expectBoolean, expectString as __expectString } from "@aws-sdk/smithy-client";
+import {
+  expectBoolean as __expectBoolean,
+  expectNonNull as __expectNonNull,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
+  parseEpochTimestamp as __parseEpochTimestamp,
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   HeaderBag as __HeaderBag,
@@ -3687,7 +3693,7 @@ const deserializeAws_json1_1Event = (output: any, context: __SerdeContext): Even
     EventSource: __expectString(output.EventSource),
     EventTime:
       output.EventTime !== undefined && output.EventTime !== null
-        ? new Date(Math.round(output.EventTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.EventTime)))
         : undefined,
     ReadOnly: __expectString(output.ReadOnly),
     Resources:
@@ -3791,34 +3797,34 @@ const deserializeAws_json1_1GetTrailStatusResponse = (output: any, context: __Se
     LatestCloudWatchLogsDeliveryError: __expectString(output.LatestCloudWatchLogsDeliveryError),
     LatestCloudWatchLogsDeliveryTime:
       output.LatestCloudWatchLogsDeliveryTime !== undefined && output.LatestCloudWatchLogsDeliveryTime !== null
-        ? new Date(Math.round(output.LatestCloudWatchLogsDeliveryTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LatestCloudWatchLogsDeliveryTime)))
         : undefined,
     LatestDeliveryAttemptSucceeded: __expectString(output.LatestDeliveryAttemptSucceeded),
     LatestDeliveryAttemptTime: __expectString(output.LatestDeliveryAttemptTime),
     LatestDeliveryError: __expectString(output.LatestDeliveryError),
     LatestDeliveryTime:
       output.LatestDeliveryTime !== undefined && output.LatestDeliveryTime !== null
-        ? new Date(Math.round(output.LatestDeliveryTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LatestDeliveryTime)))
         : undefined,
     LatestDigestDeliveryError: __expectString(output.LatestDigestDeliveryError),
     LatestDigestDeliveryTime:
       output.LatestDigestDeliveryTime !== undefined && output.LatestDigestDeliveryTime !== null
-        ? new Date(Math.round(output.LatestDigestDeliveryTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LatestDigestDeliveryTime)))
         : undefined,
     LatestNotificationAttemptSucceeded: __expectString(output.LatestNotificationAttemptSucceeded),
     LatestNotificationAttemptTime: __expectString(output.LatestNotificationAttemptTime),
     LatestNotificationError: __expectString(output.LatestNotificationError),
     LatestNotificationTime:
       output.LatestNotificationTime !== undefined && output.LatestNotificationTime !== null
-        ? new Date(Math.round(output.LatestNotificationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LatestNotificationTime)))
         : undefined,
     StartLoggingTime:
       output.StartLoggingTime !== undefined && output.StartLoggingTime !== null
-        ? new Date(Math.round(output.StartLoggingTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.StartLoggingTime)))
         : undefined,
     StopLoggingTime:
       output.StopLoggingTime !== undefined && output.StopLoggingTime !== null
-        ? new Date(Math.round(output.StopLoggingTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.StopLoggingTime)))
         : undefined,
     TimeLoggingStarted: __expectString(output.TimeLoggingStarted),
     TimeLoggingStopped: __expectString(output.TimeLoggingStopped),
@@ -4171,11 +4177,11 @@ const deserializeAws_json1_1PublicKey = (output: any, context: __SerdeContext): 
     Fingerprint: __expectString(output.Fingerprint),
     ValidityEndTime:
       output.ValidityEndTime !== undefined && output.ValidityEndTime !== null
-        ? new Date(Math.round(output.ValidityEndTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.ValidityEndTime)))
         : undefined,
     ValidityStartTime:
       output.ValidityStartTime !== undefined && output.ValidityStartTime !== null
-        ? new Date(Math.round(output.ValidityStartTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.ValidityStartTime)))
         : undefined,
     Value: output.Value !== undefined && output.Value !== null ? context.base64Decoder(output.Value) : undefined,
   } as any;

--- a/clients/client-cloudwatch-events/protocols/Aws_json1_1.ts
+++ b/clients/client-cloudwatch-events/protocols/Aws_json1_1.ts
@@ -266,7 +266,10 @@ import {
   expectBoolean as __expectBoolean,
   expectInt32 as __expectInt32,
   expectLong as __expectLong,
+  expectNonNull as __expectNonNull,
+  expectNumber as __expectNumber,
   expectString as __expectString,
+  parseEpochTimestamp as __parseEpochTimestamp,
 } from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
@@ -6030,14 +6033,14 @@ const deserializeAws_json1_1ApiDestination = (output: any, context: __SerdeConte
     ConnectionArn: __expectString(output.ConnectionArn),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     HttpMethod: __expectString(output.HttpMethod),
     InvocationEndpoint: __expectString(output.InvocationEndpoint),
     InvocationRateLimitPerSecond: __expectInt32(output.InvocationRateLimitPerSecond),
     LastModifiedTime:
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
-        ? new Date(Math.round(output.LastModifiedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastModifiedTime)))
         : undefined,
     Name: __expectString(output.Name),
   } as any;
@@ -6059,7 +6062,7 @@ const deserializeAws_json1_1Archive = (output: any, context: __SerdeContext): Ar
     ArchiveName: __expectString(output.ArchiveName),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     EventCount: __expectLong(output.EventCount),
     EventSourceArn: __expectString(output.EventSourceArn),
@@ -6171,15 +6174,15 @@ const deserializeAws_json1_1Connection = (output: any, context: __SerdeContext):
     ConnectionState: __expectString(output.ConnectionState),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     LastAuthorizedTime:
       output.LastAuthorizedTime !== undefined && output.LastAuthorizedTime !== null
-        ? new Date(Math.round(output.LastAuthorizedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastAuthorizedTime)))
         : undefined,
     LastModifiedTime:
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
-        ? new Date(Math.round(output.LastModifiedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastModifiedTime)))
         : undefined,
     Name: __expectString(output.Name),
     StateReason: __expectString(output.StateReason),
@@ -6370,11 +6373,11 @@ const deserializeAws_json1_1CreateApiDestinationResponse = (
     ApiDestinationState: __expectString(output.ApiDestinationState),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     LastModifiedTime:
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
-        ? new Date(Math.round(output.LastModifiedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastModifiedTime)))
         : undefined,
   } as any;
 };
@@ -6384,7 +6387,7 @@ const deserializeAws_json1_1CreateArchiveResponse = (output: any, context: __Ser
     ArchiveArn: __expectString(output.ArchiveArn),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     State: __expectString(output.State),
     StateReason: __expectString(output.StateReason),
@@ -6400,11 +6403,11 @@ const deserializeAws_json1_1CreateConnectionResponse = (
     ConnectionState: __expectString(output.ConnectionState),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     LastModifiedTime:
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
-        ? new Date(Math.round(output.LastModifiedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastModifiedTime)))
         : undefined,
   } as any;
 };
@@ -6439,15 +6442,15 @@ const deserializeAws_json1_1DeauthorizeConnectionResponse = (
     ConnectionState: __expectString(output.ConnectionState),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     LastAuthorizedTime:
       output.LastAuthorizedTime !== undefined && output.LastAuthorizedTime !== null
-        ? new Date(Math.round(output.LastAuthorizedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastAuthorizedTime)))
         : undefined,
     LastModifiedTime:
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
-        ? new Date(Math.round(output.LastModifiedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastModifiedTime)))
         : undefined,
   } as any;
 };
@@ -6472,15 +6475,15 @@ const deserializeAws_json1_1DeleteConnectionResponse = (
     ConnectionState: __expectString(output.ConnectionState),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     LastAuthorizedTime:
       output.LastAuthorizedTime !== undefined && output.LastAuthorizedTime !== null
-        ? new Date(Math.round(output.LastAuthorizedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastAuthorizedTime)))
         : undefined,
     LastModifiedTime:
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
-        ? new Date(Math.round(output.LastModifiedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastModifiedTime)))
         : undefined,
   } as any;
 };
@@ -6495,7 +6498,7 @@ const deserializeAws_json1_1DescribeApiDestinationResponse = (
     ConnectionArn: __expectString(output.ConnectionArn),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     Description: __expectString(output.Description),
     HttpMethod: __expectString(output.HttpMethod),
@@ -6503,7 +6506,7 @@ const deserializeAws_json1_1DescribeApiDestinationResponse = (
     InvocationRateLimitPerSecond: __expectInt32(output.InvocationRateLimitPerSecond),
     LastModifiedTime:
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
-        ? new Date(Math.round(output.LastModifiedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastModifiedTime)))
         : undefined,
     Name: __expectString(output.Name),
   } as any;
@@ -6518,7 +6521,7 @@ const deserializeAws_json1_1DescribeArchiveResponse = (
     ArchiveName: __expectString(output.ArchiveName),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     Description: __expectString(output.Description),
     EventCount: __expectLong(output.EventCount),
@@ -6545,16 +6548,16 @@ const deserializeAws_json1_1DescribeConnectionResponse = (
     ConnectionState: __expectString(output.ConnectionState),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     Description: __expectString(output.Description),
     LastAuthorizedTime:
       output.LastAuthorizedTime !== undefined && output.LastAuthorizedTime !== null
-        ? new Date(Math.round(output.LastAuthorizedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastAuthorizedTime)))
         : undefined,
     LastModifiedTime:
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
-        ? new Date(Math.round(output.LastModifiedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastModifiedTime)))
         : undefined,
     Name: __expectString(output.Name),
     SecretArn: __expectString(output.SecretArn),
@@ -6582,11 +6585,11 @@ const deserializeAws_json1_1DescribeEventSourceResponse = (
     CreatedBy: __expectString(output.CreatedBy),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     ExpirationTime:
       output.ExpirationTime !== undefined && output.ExpirationTime !== null
-        ? new Date(Math.round(output.ExpirationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.ExpirationTime)))
         : undefined,
     Name: __expectString(output.Name),
     State: __expectString(output.State),
@@ -6612,26 +6615,26 @@ const deserializeAws_json1_1DescribeReplayResponse = (output: any, context: __Se
         : undefined,
     EventEndTime:
       output.EventEndTime !== undefined && output.EventEndTime !== null
-        ? new Date(Math.round(output.EventEndTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.EventEndTime)))
         : undefined,
     EventLastReplayedTime:
       output.EventLastReplayedTime !== undefined && output.EventLastReplayedTime !== null
-        ? new Date(Math.round(output.EventLastReplayedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.EventLastReplayedTime)))
         : undefined,
     EventSourceArn: __expectString(output.EventSourceArn),
     EventStartTime:
       output.EventStartTime !== undefined && output.EventStartTime !== null
-        ? new Date(Math.round(output.EventStartTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.EventStartTime)))
         : undefined,
     ReplayArn: __expectString(output.ReplayArn),
     ReplayEndTime:
       output.ReplayEndTime !== undefined && output.ReplayEndTime !== null
-        ? new Date(Math.round(output.ReplayEndTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.ReplayEndTime)))
         : undefined,
     ReplayName: __expectString(output.ReplayName),
     ReplayStartTime:
       output.ReplayStartTime !== undefined && output.ReplayStartTime !== null
-        ? new Date(Math.round(output.ReplayStartTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.ReplayStartTime)))
         : undefined,
     State: __expectString(output.State),
     StateReason: __expectString(output.StateReason),
@@ -6712,11 +6715,11 @@ const deserializeAws_json1_1EventSource = (output: any, context: __SerdeContext)
     CreatedBy: __expectString(output.CreatedBy),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     ExpirationTime:
       output.ExpirationTime !== undefined && output.ExpirationTime !== null
-        ? new Date(Math.round(output.ExpirationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.ExpirationTime)))
         : undefined,
     Name: __expectString(output.Name),
     State: __expectString(output.State),
@@ -6994,11 +6997,11 @@ const deserializeAws_json1_1PartnerEventSourceAccount = (
     Account: __expectString(output.Account),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     ExpirationTime:
       output.ExpirationTime !== undefined && output.ExpirationTime !== null
-        ? new Date(Math.round(output.ExpirationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.ExpirationTime)))
         : undefined,
     State: __expectString(output.State),
   } as any;
@@ -7258,25 +7261,25 @@ const deserializeAws_json1_1Replay = (output: any, context: __SerdeContext): Rep
   return {
     EventEndTime:
       output.EventEndTime !== undefined && output.EventEndTime !== null
-        ? new Date(Math.round(output.EventEndTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.EventEndTime)))
         : undefined,
     EventLastReplayedTime:
       output.EventLastReplayedTime !== undefined && output.EventLastReplayedTime !== null
-        ? new Date(Math.round(output.EventLastReplayedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.EventLastReplayedTime)))
         : undefined,
     EventSourceArn: __expectString(output.EventSourceArn),
     EventStartTime:
       output.EventStartTime !== undefined && output.EventStartTime !== null
-        ? new Date(Math.round(output.EventStartTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.EventStartTime)))
         : undefined,
     ReplayEndTime:
       output.ReplayEndTime !== undefined && output.ReplayEndTime !== null
-        ? new Date(Math.round(output.ReplayEndTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.ReplayEndTime)))
         : undefined,
     ReplayName: __expectString(output.ReplayName),
     ReplayStartTime:
       output.ReplayStartTime !== undefined && output.ReplayStartTime !== null
-        ? new Date(Math.round(output.ReplayStartTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.ReplayStartTime)))
         : undefined,
     State: __expectString(output.State),
     StateReason: __expectString(output.StateReason),
@@ -7464,7 +7467,7 @@ const deserializeAws_json1_1StartReplayResponse = (output: any, context: __Serde
     ReplayArn: __expectString(output.ReplayArn),
     ReplayStartTime:
       output.ReplayStartTime !== undefined && output.ReplayStartTime !== null
-        ? new Date(Math.round(output.ReplayStartTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.ReplayStartTime)))
         : undefined,
     State: __expectString(output.State),
     StateReason: __expectString(output.StateReason),
@@ -7603,11 +7606,11 @@ const deserializeAws_json1_1UpdateApiDestinationResponse = (
     ApiDestinationState: __expectString(output.ApiDestinationState),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     LastModifiedTime:
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
-        ? new Date(Math.round(output.LastModifiedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastModifiedTime)))
         : undefined,
   } as any;
 };
@@ -7617,7 +7620,7 @@ const deserializeAws_json1_1UpdateArchiveResponse = (output: any, context: __Ser
     ArchiveArn: __expectString(output.ArchiveArn),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     State: __expectString(output.State),
     StateReason: __expectString(output.StateReason),
@@ -7633,15 +7636,15 @@ const deserializeAws_json1_1UpdateConnectionResponse = (
     ConnectionState: __expectString(output.ConnectionState),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     LastAuthorizedTime:
       output.LastAuthorizedTime !== undefined && output.LastAuthorizedTime !== null
-        ? new Date(Math.round(output.LastAuthorizedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastAuthorizedTime)))
         : undefined,
     LastModifiedTime:
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
-        ? new Date(Math.round(output.LastModifiedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastModifiedTime)))
         : undefined,
   } as any;
 };

--- a/clients/client-cloudwatch/protocols/Aws_query.ts
+++ b/clients/client-cloudwatch/protocols/Aws_query.ts
@@ -178,11 +178,13 @@ import {
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
+  expectNonNull as __expectNonNull,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   getArrayIfSingleItem as __getArrayIfSingleItem,
   getValueFromTextNode as __getValueFromTextNode,
   parseBoolean as __parseBoolean,
+  parseRfc3339DateTime as __parseRfc3339DateTime,
   serializeFloat as __serializeFloat,
   strictParseFloat as __strictParseFloat,
   strictParseInt32 as __strictParseInt32,
@@ -4582,7 +4584,7 @@ const deserializeAws_queryAlarmHistoryItem = (output: any, context: __SerdeConte
     contents.AlarmType = __expectString(output["AlarmType"]);
   }
   if (output["Timestamp"] !== undefined) {
-    contents.Timestamp = new Date(output["Timestamp"]);
+    contents.Timestamp = __expectNonNull(__parseRfc3339DateTime(output["Timestamp"]));
   }
   if (output["HistoryItemType"] !== undefined) {
     contents.HistoryItemType = __expectString(output["HistoryItemType"]);
@@ -4731,7 +4733,9 @@ const deserializeAws_queryCompositeAlarm = (output: any, context: __SerdeContext
     contents.AlarmArn = __expectString(output["AlarmArn"]);
   }
   if (output["AlarmConfigurationUpdatedTimestamp"] !== undefined) {
-    contents.AlarmConfigurationUpdatedTimestamp = new Date(output["AlarmConfigurationUpdatedTimestamp"]);
+    contents.AlarmConfigurationUpdatedTimestamp = __expectNonNull(
+      __parseRfc3339DateTime(output["AlarmConfigurationUpdatedTimestamp"])
+    );
   }
   if (output["AlarmDescription"] !== undefined) {
     contents.AlarmDescription = __expectString(output["AlarmDescription"]);
@@ -4767,7 +4771,7 @@ const deserializeAws_queryCompositeAlarm = (output: any, context: __SerdeContext
     contents.StateReasonData = __expectString(output["StateReasonData"]);
   }
   if (output["StateUpdatedTimestamp"] !== undefined) {
-    contents.StateUpdatedTimestamp = new Date(output["StateUpdatedTimestamp"]);
+    contents.StateUpdatedTimestamp = __expectNonNull(__parseRfc3339DateTime(output["StateUpdatedTimestamp"]));
   }
   if (output["StateValue"] !== undefined) {
     contents.StateValue = __expectString(output["StateValue"]);
@@ -4824,7 +4828,7 @@ const deserializeAws_queryDashboardEntry = (output: any, context: __SerdeContext
     contents.DashboardArn = __expectString(output["DashboardArn"]);
   }
   if (output["LastModified"] !== undefined) {
-    contents.LastModified = new Date(output["LastModified"]);
+    contents.LastModified = __expectNonNull(__parseRfc3339DateTime(output["LastModified"]));
   }
   if (output["Size"] !== undefined) {
     contents.Size = __strictParseLong(output["Size"]) as number;
@@ -4911,7 +4915,7 @@ const deserializeAws_queryDatapoint = (output: any, context: __SerdeContext): Da
     ExtendedStatistics: undefined,
   };
   if (output["Timestamp"] !== undefined) {
-    contents.Timestamp = new Date(output["Timestamp"]);
+    contents.Timestamp = __expectNonNull(__parseRfc3339DateTime(output["Timestamp"]));
   }
   if (output["SampleCount"] !== undefined) {
     contents.SampleCount = __strictParseFloat(output["SampleCount"]) as number;
@@ -5367,10 +5371,10 @@ const deserializeAws_queryGetMetricStreamOutput = (output: any, context: __Serde
     contents.State = __expectString(output["State"]);
   }
   if (output["CreationDate"] !== undefined) {
-    contents.CreationDate = new Date(output["CreationDate"]);
+    contents.CreationDate = __expectNonNull(__parseRfc3339DateTime(output["CreationDate"]));
   }
   if (output["LastUpdateDate"] !== undefined) {
-    contents.LastUpdateDate = new Date(output["LastUpdateDate"]);
+    contents.LastUpdateDate = __expectNonNull(__parseRfc3339DateTime(output["LastUpdateDate"]));
   }
   if (output["OutputFormat"] !== undefined) {
     contents.OutputFormat = __expectString(output["OutputFormat"]);
@@ -5452,7 +5456,7 @@ const deserializeAws_queryInsightRuleContributorDatapoint = (
     ApproximateValue: undefined,
   };
   if (output["Timestamp"] !== undefined) {
-    contents.Timestamp = new Date(output["Timestamp"]);
+    contents.Timestamp = __expectNonNull(__parseRfc3339DateTime(output["Timestamp"]));
   }
   if (output["ApproximateValue"] !== undefined) {
     contents.ApproximateValue = __strictParseFloat(output["ApproximateValue"]) as number;
@@ -5525,7 +5529,7 @@ const deserializeAws_queryInsightRuleMetricDatapoint = (
     Maximum: undefined,
   };
   if (output["Timestamp"] !== undefined) {
-    contents.Timestamp = new Date(output["Timestamp"]);
+    contents.Timestamp = __expectNonNull(__parseRfc3339DateTime(output["Timestamp"]));
   }
   if (output["UniqueContributors"] !== undefined) {
     contents.UniqueContributors = __strictParseFloat(output["UniqueContributors"]) as number;
@@ -5803,7 +5807,9 @@ const deserializeAws_queryMetricAlarm = (output: any, context: __SerdeContext): 
     contents.AlarmDescription = __expectString(output["AlarmDescription"]);
   }
   if (output["AlarmConfigurationUpdatedTimestamp"] !== undefined) {
-    contents.AlarmConfigurationUpdatedTimestamp = new Date(output["AlarmConfigurationUpdatedTimestamp"]);
+    contents.AlarmConfigurationUpdatedTimestamp = __expectNonNull(
+      __parseRfc3339DateTime(output["AlarmConfigurationUpdatedTimestamp"])
+    );
   }
   if (output["ActionsEnabled"] !== undefined) {
     contents.ActionsEnabled = __parseBoolean(output["ActionsEnabled"]);
@@ -5845,7 +5851,7 @@ const deserializeAws_queryMetricAlarm = (output: any, context: __SerdeContext): 
     contents.StateReasonData = __expectString(output["StateReasonData"]);
   }
   if (output["StateUpdatedTimestamp"] !== undefined) {
-    contents.StateUpdatedTimestamp = new Date(output["StateUpdatedTimestamp"]);
+    contents.StateUpdatedTimestamp = __expectNonNull(__parseRfc3339DateTime(output["StateUpdatedTimestamp"]));
   }
   if (output["MetricName"] !== undefined) {
     contents.MetricName = __expectString(output["MetricName"]);
@@ -6088,10 +6094,10 @@ const deserializeAws_queryMetricStreamEntry = (output: any, context: __SerdeCont
     contents.Arn = __expectString(output["Arn"]);
   }
   if (output["CreationDate"] !== undefined) {
-    contents.CreationDate = new Date(output["CreationDate"]);
+    contents.CreationDate = __expectNonNull(__parseRfc3339DateTime(output["CreationDate"]));
   }
   if (output["LastUpdateDate"] !== undefined) {
-    contents.LastUpdateDate = new Date(output["LastUpdateDate"]);
+    contents.LastUpdateDate = __expectNonNull(__parseRfc3339DateTime(output["LastUpdateDate"]));
   }
   if (output["Name"] !== undefined) {
     contents.Name = __expectString(output["Name"]);
@@ -6212,10 +6218,10 @@ const deserializeAws_queryRange = (output: any, context: __SerdeContext): Range 
     EndTime: undefined,
   };
   if (output["StartTime"] !== undefined) {
-    contents.StartTime = new Date(output["StartTime"]);
+    contents.StartTime = __expectNonNull(__parseRfc3339DateTime(output["StartTime"]));
   }
   if (output["EndTime"] !== undefined) {
-    contents.EndTime = new Date(output["EndTime"]);
+    contents.EndTime = __expectNonNull(__parseRfc3339DateTime(output["EndTime"]));
   }
   return contents;
 };
@@ -6312,7 +6318,7 @@ const deserializeAws_queryTimestamps = (output: any, context: __SerdeContext): D
       if (entry === null) {
         return null as any;
       }
-      return new Date(entry);
+      return __expectNonNull(__parseRfc3339DateTime(entry));
     });
 };
 

--- a/clients/client-codeartifact/protocols/Aws_restJson1.ts
+++ b/clients/client-codeartifact/protocols/Aws_restJson1.ts
@@ -130,9 +130,11 @@ import {
   expectInt32 as __expectInt32,
   expectLong as __expectLong,
   expectNonNull as __expectNonNull,
+  expectNumber as __expectNumber,
   expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
+  parseEpochTimestamp as __parseEpochTimestamp,
   strictParseInt32 as __strictParseInt32,
 } from "@aws-sdk/smithy-client";
 import {
@@ -2537,7 +2539,7 @@ export const deserializeAws_restJson1GetAuthorizationTokenCommand = async (
     contents.authorizationToken = __expectString(data.authorizationToken);
   }
   if (data.expiration !== undefined && data.expiration !== null) {
-    contents.expiration = new Date(Math.round(data.expiration * 1000));
+    contents.expiration = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.expiration)));
   }
   return Promise.resolve(contents);
 };
@@ -4676,7 +4678,7 @@ const deserializeAws_restJson1DomainDescription = (output: any, context: __Serde
     assetSizeBytes: __expectLong(output.assetSizeBytes),
     createdTime:
       output.createdTime !== undefined && output.createdTime !== null
-        ? new Date(Math.round(output.createdTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.createdTime)))
         : undefined,
     encryptionKey: __expectString(output.encryptionKey),
     name: __expectString(output.name),
@@ -4692,7 +4694,7 @@ const deserializeAws_restJson1DomainSummary = (output: any, context: __SerdeCont
     arn: __expectString(output.arn),
     createdTime:
       output.createdTime !== undefined && output.createdTime !== null
-        ? new Date(Math.round(output.createdTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.createdTime)))
         : undefined,
     encryptionKey: __expectString(output.encryptionKey),
     name: __expectString(output.name),
@@ -4785,7 +4787,7 @@ const deserializeAws_restJson1PackageVersionDescription = (
     packageName: __expectString(output.packageName),
     publishedTime:
       output.publishedTime !== undefined && output.publishedTime !== null
-        ? new Date(Math.round(output.publishedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.publishedTime)))
         : undefined,
     revision: __expectString(output.revision),
     sourceCodeRepository: __expectString(output.sourceCodeRepository),

--- a/clients/client-codebuild/protocols/Aws_json1_1.ts
+++ b/clients/client-codebuild/protocols/Aws_json1_1.ts
@@ -244,8 +244,11 @@ import {
   expectBoolean as __expectBoolean,
   expectInt32 as __expectInt32,
   expectLong as __expectLong,
+  expectNonNull as __expectNonNull,
+  expectNumber as __expectNumber,
   expectString as __expectString,
   limitedParseDouble as __limitedParseDouble,
+  parseEpochTimestamp as __parseEpochTimestamp,
   serializeFloat as __serializeFloat,
 } from "@aws-sdk/smithy-client";
 import {
@@ -4872,7 +4875,9 @@ const deserializeAws_json1_1Build = (output: any, context: __SerdeContext): Buil
         : undefined,
     encryptionKey: __expectString(output.encryptionKey),
     endTime:
-      output.endTime !== undefined && output.endTime !== null ? new Date(Math.round(output.endTime * 1000)) : undefined,
+      output.endTime !== undefined && output.endTime !== null
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.endTime)))
+        : undefined,
     environment:
       output.environment !== undefined && output.environment !== null
         ? deserializeAws_json1_1ProjectEnvironment(output.environment, context)
@@ -4926,7 +4931,7 @@ const deserializeAws_json1_1Build = (output: any, context: __SerdeContext): Buil
     sourceVersion: __expectString(output.sourceVersion),
     startTime:
       output.startTime !== undefined && output.startTime !== null
-        ? new Date(Math.round(output.startTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.startTime)))
         : undefined,
     timeoutInMinutes: __expectInt32(output.timeoutInMinutes),
     vpcConfig:
@@ -4986,7 +4991,9 @@ const deserializeAws_json1_1BuildBatch = (output: any, context: __SerdeContext):
     debugSessionEnabled: __expectBoolean(output.debugSessionEnabled),
     encryptionKey: __expectString(output.encryptionKey),
     endTime:
-      output.endTime !== undefined && output.endTime !== null ? new Date(Math.round(output.endTime * 1000)) : undefined,
+      output.endTime !== undefined && output.endTime !== null
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.endTime)))
+        : undefined,
     environment:
       output.environment !== undefined && output.environment !== null
         ? deserializeAws_json1_1ProjectEnvironment(output.environment, context)
@@ -5028,7 +5035,7 @@ const deserializeAws_json1_1BuildBatch = (output: any, context: __SerdeContext):
     sourceVersion: __expectString(output.sourceVersion),
     startTime:
       output.startTime !== undefined && output.startTime !== null
-        ? new Date(Math.round(output.startTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.startTime)))
         : undefined,
     vpcConfig:
       output.vpcConfig !== undefined && output.vpcConfig !== null
@@ -5067,12 +5074,14 @@ const deserializeAws_json1_1BuildBatchPhase = (output: any, context: __SerdeCont
         : undefined,
     durationInSeconds: __expectLong(output.durationInSeconds),
     endTime:
-      output.endTime !== undefined && output.endTime !== null ? new Date(Math.round(output.endTime * 1000)) : undefined,
+      output.endTime !== undefined && output.endTime !== null
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.endTime)))
+        : undefined,
     phaseStatus: __expectString(output.phaseStatus),
     phaseType: __expectString(output.phaseType),
     startTime:
       output.startTime !== undefined && output.startTime !== null
-        ? new Date(Math.round(output.startTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.startTime)))
         : undefined,
   } as any;
 };
@@ -5144,12 +5153,14 @@ const deserializeAws_json1_1BuildPhase = (output: any, context: __SerdeContext):
         : undefined,
     durationInSeconds: __expectLong(output.durationInSeconds),
     endTime:
-      output.endTime !== undefined && output.endTime !== null ? new Date(Math.round(output.endTime * 1000)) : undefined,
+      output.endTime !== undefined && output.endTime !== null
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.endTime)))
+        : undefined,
     phaseStatus: __expectString(output.phaseStatus),
     phaseType: __expectString(output.phaseType),
     startTime:
       output.startTime !== undefined && output.startTime !== null
-        ? new Date(Math.round(output.startTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.startTime)))
         : undefined,
   } as any;
 };
@@ -5226,7 +5237,7 @@ const deserializeAws_json1_1BuildSummary = (output: any, context: __SerdeContext
         : undefined,
     requestedOn:
       output.requestedOn !== undefined && output.requestedOn !== null
-        ? new Date(Math.round(output.requestedOn * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.requestedOn)))
         : undefined,
     secondaryArtifacts:
       output.secondaryArtifacts !== undefined && output.secondaryArtifacts !== null
@@ -5249,7 +5260,9 @@ const deserializeAws_json1_1CodeCoverage = (output: any, context: __SerdeContext
     branchesCovered: __expectInt32(output.branchesCovered),
     branchesMissed: __expectInt32(output.branchesMissed),
     expired:
-      output.expired !== undefined && output.expired !== null ? new Date(Math.round(output.expired * 1000)) : undefined,
+      output.expired !== undefined && output.expired !== null
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.expired)))
+        : undefined,
     filePath: __expectString(output.filePath),
     id: __expectString(output.id),
     lineCoveragePercentage: __limitedParseDouble(output.lineCoveragePercentage),
@@ -5830,7 +5843,9 @@ const deserializeAws_json1_1Project = (output: any, context: __SerdeContext): Pr
         : undefined,
     concurrentBuildLimit: __expectInt32(output.concurrentBuildLimit),
     created:
-      output.created !== undefined && output.created !== null ? new Date(Math.round(output.created * 1000)) : undefined,
+      output.created !== undefined && output.created !== null
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.created)))
+        : undefined,
     description: __expectString(output.description),
     encryptionKey: __expectString(output.encryptionKey),
     environment:
@@ -5843,7 +5858,7 @@ const deserializeAws_json1_1Project = (output: any, context: __SerdeContext): Pr
         : undefined,
     lastModified:
       output.lastModified !== undefined && output.lastModified !== null
-        ? new Date(Math.round(output.lastModified * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastModified)))
         : undefined,
     logsConfig:
       output.logsConfig !== undefined && output.logsConfig !== null
@@ -6117,10 +6132,14 @@ const deserializeAws_json1_1Report = (output: any, context: __SerdeContext): Rep
         ? deserializeAws_json1_1CodeCoverageReportSummary(output.codeCoverageSummary, context)
         : undefined,
     created:
-      output.created !== undefined && output.created !== null ? new Date(Math.round(output.created * 1000)) : undefined,
+      output.created !== undefined && output.created !== null
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.created)))
+        : undefined,
     executionId: __expectString(output.executionId),
     expired:
-      output.expired !== undefined && output.expired !== null ? new Date(Math.round(output.expired * 1000)) : undefined,
+      output.expired !== undefined && output.expired !== null
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.expired)))
+        : undefined,
     exportConfig:
       output.exportConfig !== undefined && output.exportConfig !== null
         ? deserializeAws_json1_1ReportExportConfig(output.exportConfig, context)
@@ -6162,14 +6181,16 @@ const deserializeAws_json1_1ReportGroup = (output: any, context: __SerdeContext)
   return {
     arn: __expectString(output.arn),
     created:
-      output.created !== undefined && output.created !== null ? new Date(Math.round(output.created * 1000)) : undefined,
+      output.created !== undefined && output.created !== null
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.created)))
+        : undefined,
     exportConfig:
       output.exportConfig !== undefined && output.exportConfig !== null
         ? deserializeAws_json1_1ReportExportConfig(output.exportConfig, context)
         : undefined,
     lastModified:
       output.lastModified !== undefined && output.lastModified !== null
-        ? new Date(Math.round(output.lastModified * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastModified)))
         : undefined,
     name: __expectString(output.name),
     status: __expectString(output.status),
@@ -6439,7 +6460,9 @@ const deserializeAws_json1_1TestCase = (output: any, context: __SerdeContext): T
   return {
     durationInNanoSeconds: __expectLong(output.durationInNanoSeconds),
     expired:
-      output.expired !== undefined && output.expired !== null ? new Date(Math.round(output.expired * 1000)) : undefined,
+      output.expired !== undefined && output.expired !== null
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.expired)))
+        : undefined,
     message: __expectString(output.message),
     name: __expectString(output.name),
     prefix: __expectString(output.prefix),
@@ -6536,7 +6559,7 @@ const deserializeAws_json1_1Webhook = (output: any, context: __SerdeContext): We
         : undefined,
     lastModifiedSecret:
       output.lastModifiedSecret !== undefined && output.lastModifiedSecret !== null
-        ? new Date(Math.round(output.lastModifiedSecret * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastModifiedSecret)))
         : undefined,
     payloadUrl: __expectString(output.payloadUrl),
     secret: __expectString(output.secret),

--- a/clients/client-codecommit/protocols/Aws_json1_1.ts
+++ b/clients/client-codecommit/protocols/Aws_json1_1.ts
@@ -614,7 +614,10 @@ import {
   expectBoolean as __expectBoolean,
   expectInt32 as __expectInt32,
   expectLong as __expectLong,
+  expectNonNull as __expectNonNull,
+  expectNumber as __expectNumber,
   expectString as __expectString,
+  parseEpochTimestamp as __parseEpochTimestamp,
 } from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
@@ -17760,11 +17763,11 @@ const deserializeAws_json1_1ApprovalRule = (output: any, context: __SerdeContext
     approvalRuleName: __expectString(output.approvalRuleName),
     creationDate:
       output.creationDate !== undefined && output.creationDate !== null
-        ? new Date(Math.round(output.creationDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.creationDate)))
         : undefined,
     lastModifiedDate:
       output.lastModifiedDate !== undefined && output.lastModifiedDate !== null
-        ? new Date(Math.round(output.lastModifiedDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastModifiedDate)))
         : undefined,
     lastModifiedUser: __expectString(output.lastModifiedUser),
     originApprovalRuleTemplate:
@@ -17873,11 +17876,11 @@ const deserializeAws_json1_1ApprovalRuleTemplate = (output: any, context: __Serd
     approvalRuleTemplateName: __expectString(output.approvalRuleTemplateName),
     creationDate:
       output.creationDate !== undefined && output.creationDate !== null
-        ? new Date(Math.round(output.creationDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.creationDate)))
         : undefined,
     lastModifiedDate:
       output.lastModifiedDate !== undefined && output.lastModifiedDate !== null
-        ? new Date(Math.round(output.lastModifiedDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastModifiedDate)))
         : undefined,
     lastModifiedUser: __expectString(output.lastModifiedUser),
     ruleContentSha256: __expectString(output.ruleContentSha256),
@@ -18285,13 +18288,13 @@ const deserializeAws_json1_1Comment = (output: any, context: __SerdeContext): Co
     content: __expectString(output.content),
     creationDate:
       output.creationDate !== undefined && output.creationDate !== null
-        ? new Date(Math.round(output.creationDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.creationDate)))
         : undefined,
     deleted: __expectBoolean(output.deleted),
     inReplyTo: __expectString(output.inReplyTo),
     lastModifiedDate:
       output.lastModifiedDate !== undefined && output.lastModifiedDate !== null
-        ? new Date(Math.round(output.lastModifiedDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastModifiedDate)))
         : undefined,
     reactionCounts:
       output.reactionCounts !== undefined && output.reactionCounts !== null
@@ -20362,12 +20365,12 @@ const deserializeAws_json1_1PullRequest = (output: any, context: __SerdeContext)
     clientRequestToken: __expectString(output.clientRequestToken),
     creationDate:
       output.creationDate !== undefined && output.creationDate !== null
-        ? new Date(Math.round(output.creationDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.creationDate)))
         : undefined,
     description: __expectString(output.description),
     lastActivityDate:
       output.lastActivityDate !== undefined && output.lastActivityDate !== null
-        ? new Date(Math.round(output.lastActivityDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastActivityDate)))
         : undefined,
     pullRequestId: __expectString(output.pullRequestId),
     pullRequestStatus: __expectString(output.pullRequestStatus),
@@ -20445,7 +20448,7 @@ const deserializeAws_json1_1PullRequestEvent = (output: any, context: __SerdeCon
         : undefined,
     eventDate:
       output.eventDate !== undefined && output.eventDate !== null
-        ? new Date(Math.round(output.eventDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.eventDate)))
         : undefined,
     pullRequestCreatedEventMetadata:
       output.pullRequestCreatedEventMetadata !== undefined && output.pullRequestCreatedEventMetadata !== null
@@ -20752,12 +20755,12 @@ const deserializeAws_json1_1RepositoryMetadata = (output: any, context: __SerdeC
     cloneUrlSsh: __expectString(output.cloneUrlSsh),
     creationDate:
       output.creationDate !== undefined && output.creationDate !== null
-        ? new Date(Math.round(output.creationDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.creationDate)))
         : undefined,
     defaultBranch: __expectString(output.defaultBranch),
     lastModifiedDate:
       output.lastModifiedDate !== undefined && output.lastModifiedDate !== null
-        ? new Date(Math.round(output.lastModifiedDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastModifiedDate)))
         : undefined,
     repositoryDescription: __expectString(output.repositoryDescription),
     repositoryId: __expectString(output.repositoryId),

--- a/clients/client-codedeploy/protocols/Aws_json1_1.ts
+++ b/clients/client-codedeploy/protocols/Aws_json1_1.ts
@@ -407,8 +407,11 @@ import {
   expectBoolean as __expectBoolean,
   expectInt32 as __expectInt32,
   expectLong as __expectLong,
+  expectNonNull as __expectNonNull,
+  expectNumber as __expectNumber,
   expectString as __expectString,
   limitedParseDouble as __limitedParseDouble,
+  parseEpochTimestamp as __parseEpochTimestamp,
 } from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
@@ -8807,7 +8810,7 @@ const deserializeAws_json1_1ApplicationInfo = (output: any, context: __SerdeCont
     computePlatform: __expectString(output.computePlatform),
     createTime:
       output.createTime !== undefined && output.createTime !== null
-        ? new Date(Math.round(output.createTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.createTime)))
         : undefined,
     gitHubAccountName: __expectString(output.gitHubAccountName),
     linkedToGitHub: __expectBoolean(output.linkedToGitHub),
@@ -9068,7 +9071,7 @@ const deserializeAws_json1_1CloudFormationTarget = (output: any, context: __Serd
     deploymentId: __expectString(output.deploymentId),
     lastUpdatedAt:
       output.lastUpdatedAt !== undefined && output.lastUpdatedAt !== null
-        ? new Date(Math.round(output.lastUpdatedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastUpdatedAt)))
         : undefined,
     lifecycleEvents:
       output.lifecycleEvents !== undefined && output.lifecycleEvents !== null
@@ -9174,7 +9177,7 @@ const deserializeAws_json1_1DeploymentConfigInfo = (output: any, context: __Serd
     computePlatform: __expectString(output.computePlatform),
     createTime:
       output.createTime !== undefined && output.createTime !== null
-        ? new Date(Math.round(output.createTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.createTime)))
         : undefined,
     deploymentConfigId: __expectString(output.deploymentConfigId),
     deploymentConfigName: __expectString(output.deploymentConfigName),
@@ -9389,12 +9392,12 @@ const deserializeAws_json1_1DeploymentInfo = (output: any, context: __SerdeConte
         : undefined,
     completeTime:
       output.completeTime !== undefined && output.completeTime !== null
-        ? new Date(Math.round(output.completeTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.completeTime)))
         : undefined,
     computePlatform: __expectString(output.computePlatform),
     createTime:
       output.createTime !== undefined && output.createTime !== null
-        ? new Date(Math.round(output.createTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.createTime)))
         : undefined,
     creator: __expectString(output.creator),
     deploymentConfigName: __expectString(output.deploymentConfigName),
@@ -9443,7 +9446,7 @@ const deserializeAws_json1_1DeploymentInfo = (output: any, context: __SerdeConte
         : undefined,
     startTime:
       output.startTime !== undefined && output.startTime !== null
-        ? new Date(Math.round(output.startTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.startTime)))
         : undefined,
     status: __expectString(output.status),
     targetInstances:
@@ -9688,7 +9691,7 @@ const deserializeAws_json1_1ECSTarget = (output: any, context: __SerdeContext): 
     deploymentId: __expectString(output.deploymentId),
     lastUpdatedAt:
       output.lastUpdatedAt !== undefined && output.lastUpdatedAt !== null
-        ? new Date(Math.round(output.lastUpdatedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastUpdatedAt)))
         : undefined,
     lifecycleEvents:
       output.lifecycleEvents !== undefined && output.lifecycleEvents !== null
@@ -9764,15 +9767,15 @@ const deserializeAws_json1_1GenericRevisionInfo = (output: any, context: __Serde
     description: __expectString(output.description),
     firstUsedTime:
       output.firstUsedTime !== undefined && output.firstUsedTime !== null
-        ? new Date(Math.round(output.firstUsedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.firstUsedTime)))
         : undefined,
     lastUsedTime:
       output.lastUsedTime !== undefined && output.lastUsedTime !== null
-        ? new Date(Math.round(output.lastUsedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastUsedTime)))
         : undefined,
     registerTime:
       output.registerTime !== undefined && output.registerTime !== null
-        ? new Date(Math.round(output.registerTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.registerTime)))
         : undefined,
   } as any;
 };
@@ -9975,7 +9978,7 @@ const deserializeAws_json1_1InstanceInfo = (output: any, context: __SerdeContext
   return {
     deregisterTime:
       output.deregisterTime !== undefined && output.deregisterTime !== null
-        ? new Date(Math.round(output.deregisterTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.deregisterTime)))
         : undefined,
     iamSessionArn: __expectString(output.iamSessionArn),
     iamUserArn: __expectString(output.iamUserArn),
@@ -9983,7 +9986,7 @@ const deserializeAws_json1_1InstanceInfo = (output: any, context: __SerdeContext
     instanceName: __expectString(output.instanceName),
     registerTime:
       output.registerTime !== undefined && output.registerTime !== null
-        ? new Date(Math.round(output.registerTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.registerTime)))
         : undefined,
     tags:
       output.tags !== undefined && output.tags !== null
@@ -10068,7 +10071,7 @@ const deserializeAws_json1_1InstanceSummary = (output: any, context: __SerdeCont
     instanceType: __expectString(output.instanceType),
     lastUpdatedAt:
       output.lastUpdatedAt !== undefined && output.lastUpdatedAt !== null
-        ? new Date(Math.round(output.lastUpdatedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastUpdatedAt)))
         : undefined,
     lifecycleEvents:
       output.lifecycleEvents !== undefined && output.lifecycleEvents !== null
@@ -10095,7 +10098,7 @@ const deserializeAws_json1_1InstanceTarget = (output: any, context: __SerdeConte
     instanceLabel: __expectString(output.instanceLabel),
     lastUpdatedAt:
       output.lastUpdatedAt !== undefined && output.lastUpdatedAt !== null
-        ? new Date(Math.round(output.lastUpdatedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastUpdatedAt)))
         : undefined,
     lifecycleEvents:
       output.lifecycleEvents !== undefined && output.lifecycleEvents !== null
@@ -10594,7 +10597,7 @@ const deserializeAws_json1_1LambdaTarget = (output: any, context: __SerdeContext
         : undefined,
     lastUpdatedAt:
       output.lastUpdatedAt !== undefined && output.lastUpdatedAt !== null
-        ? new Date(Math.round(output.lastUpdatedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastUpdatedAt)))
         : undefined,
     lifecycleEvents:
       output.lifecycleEvents !== undefined && output.lifecycleEvents !== null
@@ -10610,11 +10613,13 @@ const deserializeAws_json1_1LastDeploymentInfo = (output: any, context: __SerdeC
   return {
     createTime:
       output.createTime !== undefined && output.createTime !== null
-        ? new Date(Math.round(output.createTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.createTime)))
         : undefined,
     deploymentId: __expectString(output.deploymentId),
     endTime:
-      output.endTime !== undefined && output.endTime !== null ? new Date(Math.round(output.endTime * 1000)) : undefined,
+      output.endTime !== undefined && output.endTime !== null
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.endTime)))
+        : undefined,
     status: __expectString(output.status),
   } as any;
 };
@@ -10626,11 +10631,13 @@ const deserializeAws_json1_1LifecycleEvent = (output: any, context: __SerdeConte
         ? deserializeAws_json1_1Diagnostics(output.diagnostics, context)
         : undefined,
     endTime:
-      output.endTime !== undefined && output.endTime !== null ? new Date(Math.round(output.endTime * 1000)) : undefined,
+      output.endTime !== undefined && output.endTime !== null
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.endTime)))
+        : undefined,
     lifecycleEventName: __expectString(output.lifecycleEventName),
     startTime:
       output.startTime !== undefined && output.startTime !== null
-        ? new Date(Math.round(output.startTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.startTime)))
         : undefined,
     status: __expectString(output.status),
   } as any;

--- a/clients/client-codeguru-reviewer/protocols/Aws_restJson1.ts
+++ b/clients/client-codeguru-reviewer/protocols/Aws_restJson1.ts
@@ -80,9 +80,11 @@ import {
   expectInt32 as __expectInt32,
   expectLong as __expectLong,
   expectNonNull as __expectNonNull,
+  expectNumber as __expectNumber,
   expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
+  parseEpochTimestamp as __parseEpochTimestamp,
 } from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
@@ -2094,11 +2096,11 @@ const deserializeAws_restJson1CodeReview = (output: any, context: __SerdeContext
     CodeReviewArn: __expectString(output.CodeReviewArn),
     CreatedTimeStamp:
       output.CreatedTimeStamp !== undefined && output.CreatedTimeStamp !== null
-        ? new Date(Math.round(output.CreatedTimeStamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreatedTimeStamp)))
         : undefined,
     LastUpdatedTimeStamp:
       output.LastUpdatedTimeStamp !== undefined && output.LastUpdatedTimeStamp !== null
-        ? new Date(Math.round(output.LastUpdatedTimeStamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastUpdatedTimeStamp)))
         : undefined,
     Metrics:
       output.Metrics !== undefined && output.Metrics !== null
@@ -2135,11 +2137,11 @@ const deserializeAws_restJson1CodeReviewSummary = (output: any, context: __Serde
     CodeReviewArn: __expectString(output.CodeReviewArn),
     CreatedTimeStamp:
       output.CreatedTimeStamp !== undefined && output.CreatedTimeStamp !== null
-        ? new Date(Math.round(output.CreatedTimeStamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreatedTimeStamp)))
         : undefined,
     LastUpdatedTimeStamp:
       output.LastUpdatedTimeStamp !== undefined && output.LastUpdatedTimeStamp !== null
-        ? new Date(Math.round(output.LastUpdatedTimeStamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastUpdatedTimeStamp)))
         : undefined,
     MetricsSummary:
       output.MetricsSummary !== undefined && output.MetricsSummary !== null
@@ -2217,11 +2219,11 @@ const deserializeAws_restJson1RecommendationFeedback = (
     CodeReviewArn: __expectString(output.CodeReviewArn),
     CreatedTimeStamp:
       output.CreatedTimeStamp !== undefined && output.CreatedTimeStamp !== null
-        ? new Date(Math.round(output.CreatedTimeStamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreatedTimeStamp)))
         : undefined,
     LastUpdatedTimeStamp:
       output.LastUpdatedTimeStamp !== undefined && output.LastUpdatedTimeStamp !== null
-        ? new Date(Math.round(output.LastUpdatedTimeStamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastUpdatedTimeStamp)))
         : undefined,
     Reactions:
       output.Reactions !== undefined && output.Reactions !== null
@@ -2292,7 +2294,7 @@ const deserializeAws_restJson1RepositoryAssociation = (output: any, context: __S
     ConnectionArn: __expectString(output.ConnectionArn),
     CreatedTimeStamp:
       output.CreatedTimeStamp !== undefined && output.CreatedTimeStamp !== null
-        ? new Date(Math.round(output.CreatedTimeStamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreatedTimeStamp)))
         : undefined,
     KMSKeyDetails:
       output.KMSKeyDetails !== undefined && output.KMSKeyDetails !== null
@@ -2300,7 +2302,7 @@ const deserializeAws_restJson1RepositoryAssociation = (output: any, context: __S
         : undefined,
     LastUpdatedTimeStamp:
       output.LastUpdatedTimeStamp !== undefined && output.LastUpdatedTimeStamp !== null
-        ? new Date(Math.round(output.LastUpdatedTimeStamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastUpdatedTimeStamp)))
         : undefined,
     Name: __expectString(output.Name),
     Owner: __expectString(output.Owner),
@@ -2338,7 +2340,7 @@ const deserializeAws_restJson1RepositoryAssociationSummary = (
     ConnectionArn: __expectString(output.ConnectionArn),
     LastUpdatedTimeStamp:
       output.LastUpdatedTimeStamp !== undefined && output.LastUpdatedTimeStamp !== null
-        ? new Date(Math.round(output.LastUpdatedTimeStamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastUpdatedTimeStamp)))
         : undefined,
     Name: __expectString(output.Name),
     Owner: __expectString(output.Owner),

--- a/clients/client-codeguruprofiler/protocols/Aws_restJson1.ts
+++ b/clients/client-codeguruprofiler/protocols/Aws_restJson1.ts
@@ -96,6 +96,7 @@ import {
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   limitedParseDouble as __limitedParseDouble,
+  parseRfc3339DateTime as __parseRfc3339DateTime,
 } from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
@@ -1047,7 +1048,7 @@ export const deserializeAws_restJson1BatchGetFrameMetricDataCommand = async (
   };
   const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.endTime !== undefined && data.endTime !== null) {
-    contents.endTime = new Date(data.endTime);
+    contents.endTime = __expectNonNull(__parseRfc3339DateTime(data.endTime));
   }
   if (data.endTimes !== undefined && data.endTimes !== null) {
     contents.endTimes = deserializeAws_restJson1ListOfTimestamps(data.endTimes, context);
@@ -1059,7 +1060,7 @@ export const deserializeAws_restJson1BatchGetFrameMetricDataCommand = async (
     contents.resolution = __expectString(data.resolution);
   }
   if (data.startTime !== undefined && data.startTime !== null) {
-    contents.startTime = new Date(data.startTime);
+    contents.startTime = __expectNonNull(__parseRfc3339DateTime(data.startTime));
   }
   if (data.unprocessedEndTimes !== undefined && data.unprocessedEndTimes !== null) {
     contents.unprocessedEndTimes = deserializeAws_restJson1UnprocessedEndTimeMap(data.unprocessedEndTimes, context);
@@ -1787,10 +1788,10 @@ export const deserializeAws_restJson1GetRecommendationsCommand = async (
     contents.anomalies = deserializeAws_restJson1Anomalies(data.anomalies, context);
   }
   if (data.profileEndTime !== undefined && data.profileEndTime !== null) {
-    contents.profileEndTime = new Date(data.profileEndTime);
+    contents.profileEndTime = __expectNonNull(__parseRfc3339DateTime(data.profileEndTime));
   }
   if (data.profileStartTime !== undefined && data.profileStartTime !== null) {
-    contents.profileStartTime = new Date(data.profileStartTime);
+    contents.profileStartTime = __expectNonNull(__parseRfc3339DateTime(data.profileStartTime));
   }
   if (data.profilingGroupName !== undefined && data.profilingGroupName !== null) {
     contents.profilingGroupName = __expectString(data.profilingGroupName);
@@ -3058,7 +3059,10 @@ const deserializeAws_restJson1AgentParameters = (output: any, context: __SerdeCo
 const deserializeAws_restJson1AggregatedProfileTime = (output: any, context: __SerdeContext): AggregatedProfileTime => {
   return {
     period: __expectString(output.period),
-    start: output.start !== undefined && output.start !== null ? new Date(output.start) : undefined,
+    start:
+      output.start !== undefined && output.start !== null
+        ? __expectNonNull(__parseRfc3339DateTime(output.start))
+        : undefined,
   } as any;
 };
 
@@ -3089,9 +3093,15 @@ const deserializeAws_restJson1Anomaly = (output: any, context: __SerdeContext): 
 
 const deserializeAws_restJson1AnomalyInstance = (output: any, context: __SerdeContext): AnomalyInstance => {
   return {
-    endTime: output.endTime !== undefined && output.endTime !== null ? new Date(output.endTime) : undefined,
+    endTime:
+      output.endTime !== undefined && output.endTime !== null
+        ? __expectNonNull(__parseRfc3339DateTime(output.endTime))
+        : undefined,
     id: __expectString(output.id),
-    startTime: output.startTime !== undefined && output.startTime !== null ? new Date(output.startTime) : undefined,
+    startTime:
+      output.startTime !== undefined && output.startTime !== null
+        ? __expectNonNull(__parseRfc3339DateTime(output.startTime))
+        : undefined,
     userFeedback:
       output.userFeedback !== undefined && output.userFeedback !== null
         ? deserializeAws_restJson1UserFeedback(output.userFeedback, context)
@@ -3162,11 +3172,11 @@ const deserializeAws_restJson1FindingsReportSummary = (output: any, context: __S
     id: __expectString(output.id),
     profileEndTime:
       output.profileEndTime !== undefined && output.profileEndTime !== null
-        ? new Date(output.profileEndTime)
+        ? __expectNonNull(__parseRfc3339DateTime(output.profileEndTime))
         : undefined,
     profileStartTime:
       output.profileStartTime !== undefined && output.profileStartTime !== null
-        ? new Date(output.profileStartTime)
+        ? __expectNonNull(__parseRfc3339DateTime(output.profileStartTime))
         : undefined,
     profilingGroupName: __expectString(output.profilingGroupName),
     totalNumberOfFindings: __expectInt32(output.totalNumberOfFindings),
@@ -3292,7 +3302,10 @@ const deserializeAws_restJson1Pattern = (output: any, context: __SerdeContext): 
 
 const deserializeAws_restJson1ProfileTime = (output: any, context: __SerdeContext): ProfileTime => {
   return {
-    start: output.start !== undefined && output.start !== null ? new Date(output.start) : undefined,
+    start:
+      output.start !== undefined && output.start !== null
+        ? __expectNonNull(__parseRfc3339DateTime(output.start))
+        : undefined,
   } as any;
 };
 
@@ -3318,7 +3331,10 @@ const deserializeAws_restJson1ProfilingGroupDescription = (
         : undefined,
     arn: __expectString(output.arn),
     computePlatform: __expectString(output.computePlatform),
-    createdAt: output.createdAt !== undefined && output.createdAt !== null ? new Date(output.createdAt) : undefined,
+    createdAt:
+      output.createdAt !== undefined && output.createdAt !== null
+        ? __expectNonNull(__parseRfc3339DateTime(output.createdAt))
+        : undefined,
     name: __expectString(output.name),
     profilingStatus:
       output.profilingStatus !== undefined && output.profilingStatus !== null
@@ -3328,7 +3344,10 @@ const deserializeAws_restJson1ProfilingGroupDescription = (
       output.tags !== undefined && output.tags !== null
         ? deserializeAws_restJson1TagsMap(output.tags, context)
         : undefined,
-    updatedAt: output.updatedAt !== undefined && output.updatedAt !== null ? new Date(output.updatedAt) : undefined,
+    updatedAt:
+      output.updatedAt !== undefined && output.updatedAt !== null
+        ? __expectNonNull(__parseRfc3339DateTime(output.updatedAt))
+        : undefined,
   } as any;
 };
 
@@ -3361,11 +3380,11 @@ const deserializeAws_restJson1ProfilingStatus = (output: any, context: __SerdeCo
   return {
     latestAgentOrchestratedAt:
       output.latestAgentOrchestratedAt !== undefined && output.latestAgentOrchestratedAt !== null
-        ? new Date(output.latestAgentOrchestratedAt)
+        ? __expectNonNull(__parseRfc3339DateTime(output.latestAgentOrchestratedAt))
         : undefined,
     latestAgentProfileReportedAt:
       output.latestAgentProfileReportedAt !== undefined && output.latestAgentProfileReportedAt !== null
-        ? new Date(output.latestAgentProfileReportedAt)
+        ? __expectNonNull(__parseRfc3339DateTime(output.latestAgentProfileReportedAt))
         : undefined,
     latestAggregatedProfile:
       output.latestAggregatedProfile !== undefined && output.latestAggregatedProfile !== null
@@ -3378,12 +3397,18 @@ const deserializeAws_restJson1Recommendation = (output: any, context: __SerdeCon
   return {
     allMatchesCount: __expectInt32(output.allMatchesCount),
     allMatchesSum: __limitedParseDouble(output.allMatchesSum),
-    endTime: output.endTime !== undefined && output.endTime !== null ? new Date(output.endTime) : undefined,
+    endTime:
+      output.endTime !== undefined && output.endTime !== null
+        ? __expectNonNull(__parseRfc3339DateTime(output.endTime))
+        : undefined,
     pattern:
       output.pattern !== undefined && output.pattern !== null
         ? deserializeAws_restJson1Pattern(output.pattern, context)
         : undefined,
-    startTime: output.startTime !== undefined && output.startTime !== null ? new Date(output.startTime) : undefined,
+    startTime:
+      output.startTime !== undefined && output.startTime !== null
+        ? __expectNonNull(__parseRfc3339DateTime(output.startTime))
+        : undefined,
     topMatches:
       output.topMatches !== undefined && output.topMatches !== null
         ? deserializeAws_restJson1Matches(output.topMatches, context)
@@ -3460,7 +3485,10 @@ const deserializeAws_restJson1ThreadStates = (output: any, context: __SerdeConte
 
 const deserializeAws_restJson1TimestampStructure = (output: any, context: __SerdeContext): TimestampStructure => {
   return {
-    value: output.value !== undefined && output.value !== null ? new Date(output.value) : undefined,
+    value:
+      output.value !== undefined && output.value !== null
+        ? __expectNonNull(__parseRfc3339DateTime(output.value))
+        : undefined,
   } as any;
 };
 

--- a/clients/client-codepipeline/protocols/Aws_json1_1.ts
+++ b/clients/client-codepipeline/protocols/Aws_json1_1.ts
@@ -276,7 +276,10 @@ import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@a
 import {
   expectBoolean as __expectBoolean,
   expectInt32 as __expectInt32,
+  expectNonNull as __expectNonNull,
+  expectNumber as __expectNumber,
   expectString as __expectString,
+  parseEpochTimestamp as __parseEpochTimestamp,
 } from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
@@ -5338,7 +5341,7 @@ const deserializeAws_json1_1ActionExecution = (output: any, context: __SerdeCont
     externalExecutionUrl: __expectString(output.externalExecutionUrl),
     lastStatusChange:
       output.lastStatusChange !== undefined && output.lastStatusChange !== null
-        ? new Date(Math.round(output.lastStatusChange * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastStatusChange)))
         : undefined,
     lastUpdatedBy: __expectString(output.lastUpdatedBy),
     percentComplete: __expectInt32(output.percentComplete),
@@ -5358,7 +5361,7 @@ const deserializeAws_json1_1ActionExecutionDetail = (output: any, context: __Ser
         : undefined,
     lastUpdateTime:
       output.lastUpdateTime !== undefined && output.lastUpdateTime !== null
-        ? new Date(Math.round(output.lastUpdateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastUpdateTime)))
         : undefined,
     output:
       output.output !== undefined && output.output !== null
@@ -5369,7 +5372,7 @@ const deserializeAws_json1_1ActionExecutionDetail = (output: any, context: __Ser
     stageName: __expectString(output.stageName),
     startTime:
       output.startTime !== undefined && output.startTime !== null
-        ? new Date(Math.round(output.startTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.startTime)))
         : undefined,
     status: __expectString(output.status),
   } as any;
@@ -5450,7 +5453,9 @@ const deserializeAws_json1_1ActionNotFoundException = (
 const deserializeAws_json1_1ActionRevision = (output: any, context: __SerdeContext): ActionRevision => {
   return {
     created:
-      output.created !== undefined && output.created !== null ? new Date(Math.round(output.created * 1000)) : undefined,
+      output.created !== undefined && output.created !== null
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.created)))
+        : undefined,
     revisionChangeId: __expectString(output.revisionChangeId),
     revisionId: __expectString(output.revisionId),
   } as any;
@@ -5734,7 +5739,9 @@ const deserializeAws_json1_1ArtifactLocation = (output: any, context: __SerdeCon
 const deserializeAws_json1_1ArtifactRevision = (output: any, context: __SerdeContext): ArtifactRevision => {
   return {
     created:
-      output.created !== undefined && output.created !== null ? new Date(Math.round(output.created * 1000)) : undefined,
+      output.created !== undefined && output.created !== null
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.created)))
+        : undefined,
     name: __expectString(output.name),
     revisionChangeIdentifier: __expectString(output.revisionChangeIdentifier),
     revisionId: __expectString(output.revisionId),
@@ -5939,7 +5946,9 @@ const deserializeAws_json1_1GetPipelineOutput = (output: any, context: __SerdeCo
 const deserializeAws_json1_1GetPipelineStateOutput = (output: any, context: __SerdeContext): GetPipelineStateOutput => {
   return {
     created:
-      output.created !== undefined && output.created !== null ? new Date(Math.round(output.created * 1000)) : undefined,
+      output.created !== undefined && output.created !== null
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.created)))
+        : undefined,
     pipelineName: __expectString(output.pipelineName),
     pipelineVersion: __expectInt32(output.pipelineVersion),
     stageStates:
@@ -5947,7 +5956,9 @@ const deserializeAws_json1_1GetPipelineStateOutput = (output: any, context: __Se
         ? deserializeAws_json1_1StageStateList(output.stageStates, context)
         : undefined,
     updated:
-      output.updated !== undefined && output.updated !== null ? new Date(Math.round(output.updated * 1000)) : undefined,
+      output.updated !== undefined && output.updated !== null
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.updated)))
+        : undefined,
   } as any;
 };
 
@@ -6269,7 +6280,7 @@ const deserializeAws_json1_1ListWebhookItem = (output: any, context: __SerdeCont
     errorMessage: __expectString(output.errorMessage),
     lastTriggered:
       output.lastTriggered !== undefined && output.lastTriggered !== null
-        ? new Date(Math.round(output.lastTriggered * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastTriggered)))
         : undefined,
     tags:
       output.tags !== undefined && output.tags !== null
@@ -6411,7 +6422,7 @@ const deserializeAws_json1_1PipelineExecutionSummary = (
   return {
     lastUpdateTime:
       output.lastUpdateTime !== undefined && output.lastUpdateTime !== null
-        ? new Date(Math.round(output.lastUpdateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastUpdateTime)))
         : undefined,
     pipelineExecutionId: __expectString(output.pipelineExecutionId),
     sourceRevisions:
@@ -6420,7 +6431,7 @@ const deserializeAws_json1_1PipelineExecutionSummary = (
         : undefined,
     startTime:
       output.startTime !== undefined && output.startTime !== null
-        ? new Date(Math.round(output.startTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.startTime)))
         : undefined,
     status: __expectString(output.status),
     stopTrigger:
@@ -6462,10 +6473,14 @@ const deserializeAws_json1_1PipelineList = (output: any, context: __SerdeContext
 const deserializeAws_json1_1PipelineMetadata = (output: any, context: __SerdeContext): PipelineMetadata => {
   return {
     created:
-      output.created !== undefined && output.created !== null ? new Date(Math.round(output.created * 1000)) : undefined,
+      output.created !== undefined && output.created !== null
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.created)))
+        : undefined,
     pipelineArn: __expectString(output.pipelineArn),
     updated:
-      output.updated !== undefined && output.updated !== null ? new Date(Math.round(output.updated * 1000)) : undefined,
+      output.updated !== undefined && output.updated !== null
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.updated)))
+        : undefined,
   } as any;
 };
 
@@ -6504,10 +6519,14 @@ const deserializeAws_json1_1PipelineStageDeclarationList = (
 const deserializeAws_json1_1PipelineSummary = (output: any, context: __SerdeContext): PipelineSummary => {
   return {
     created:
-      output.created !== undefined && output.created !== null ? new Date(Math.round(output.created * 1000)) : undefined,
+      output.created !== undefined && output.created !== null
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.created)))
+        : undefined,
     name: __expectString(output.name),
     updated:
-      output.updated !== undefined && output.updated !== null ? new Date(Math.round(output.updated * 1000)) : undefined,
+      output.updated !== undefined && output.updated !== null
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.updated)))
+        : undefined,
     version: __expectInt32(output.version),
   } as any;
 };
@@ -6581,7 +6600,7 @@ const deserializeAws_json1_1PutApprovalResultOutput = (
   return {
     approvedAt:
       output.approvedAt !== undefined && output.approvedAt !== null
-        ? new Date(Math.round(output.approvedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.approvedAt)))
         : undefined,
   } as any;
 };
@@ -6899,7 +6918,7 @@ const deserializeAws_json1_1TransitionState = (output: any, context: __SerdeCont
     enabled: __expectBoolean(output.enabled),
     lastChangedAt:
       output.lastChangedAt !== undefined && output.lastChangedAt !== null
-        ? new Date(Math.round(output.lastChangedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastChangedAt)))
         : undefined,
     lastChangedBy: __expectString(output.lastChangedBy),
   } as any;

--- a/clients/client-codestar-notifications/protocols/Aws_restJson1.ts
+++ b/clients/client-codestar-notifications/protocols/Aws_restJson1.ts
@@ -49,8 +49,10 @@ import {
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
   expectNonNull as __expectNonNull,
+  expectNumber as __expectNumber,
   expectObject as __expectObject,
   expectString as __expectString,
+  parseEpochTimestamp as __parseEpochTimestamp,
 } from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
@@ -657,7 +659,7 @@ export const deserializeAws_restJson1DescribeNotificationRuleCommand = async (
     contents.CreatedBy = __expectString(data.CreatedBy);
   }
   if (data.CreatedTimestamp !== undefined && data.CreatedTimestamp !== null) {
-    contents.CreatedTimestamp = new Date(Math.round(data.CreatedTimestamp * 1000));
+    contents.CreatedTimestamp = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.CreatedTimestamp)));
   }
   if (data.DetailType !== undefined && data.DetailType !== null) {
     contents.DetailType = __expectString(data.DetailType);
@@ -666,7 +668,7 @@ export const deserializeAws_restJson1DescribeNotificationRuleCommand = async (
     contents.EventTypes = deserializeAws_restJson1EventTypeBatch(data.EventTypes, context);
   }
   if (data.LastModifiedTimestamp !== undefined && data.LastModifiedTimestamp !== null) {
-    contents.LastModifiedTimestamp = new Date(Math.round(data.LastModifiedTimestamp * 1000));
+    contents.LastModifiedTimestamp = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.LastModifiedTimestamp)));
   }
   if (data.Name !== undefined && data.Name !== null) {
     contents.Name = __expectString(data.Name);

--- a/clients/client-codestar/protocols/Aws_json1_1.ts
+++ b/clients/client-codestar/protocols/Aws_json1_1.ts
@@ -90,7 +90,13 @@ import {
   ValidationException,
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
-import { expectBoolean as __expectBoolean, expectString as __expectString } from "@aws-sdk/smithy-client";
+import {
+  expectBoolean as __expectBoolean,
+  expectNonNull as __expectNonNull,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
+  parseEpochTimestamp as __parseEpochTimestamp,
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   HeaderBag as __HeaderBag,
@@ -2184,13 +2190,13 @@ const deserializeAws_json1_1CreateUserProfileResult = (
   return {
     createdTimestamp:
       output.createdTimestamp !== undefined && output.createdTimestamp !== null
-        ? new Date(Math.round(output.createdTimestamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.createdTimestamp)))
         : undefined,
     displayName: __expectString(output.displayName),
     emailAddress: __expectString(output.emailAddress),
     lastModifiedTimestamp:
       output.lastModifiedTimestamp !== undefined && output.lastModifiedTimestamp !== null
-        ? new Date(Math.round(output.lastModifiedTimestamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastModifiedTimestamp)))
         : undefined,
     sshPublicKey: __expectString(output.sshPublicKey),
     userArn: __expectString(output.userArn),
@@ -2219,7 +2225,7 @@ const deserializeAws_json1_1DescribeProjectResult = (output: any, context: __Ser
     clientRequestToken: __expectString(output.clientRequestToken),
     createdTimeStamp:
       output.createdTimeStamp !== undefined && output.createdTimeStamp !== null
-        ? new Date(Math.round(output.createdTimeStamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.createdTimeStamp)))
         : undefined,
     description: __expectString(output.description),
     id: __expectString(output.id),
@@ -2240,13 +2246,13 @@ const deserializeAws_json1_1DescribeUserProfileResult = (
   return {
     createdTimestamp:
       output.createdTimestamp !== undefined && output.createdTimestamp !== null
-        ? new Date(Math.round(output.createdTimestamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.createdTimestamp)))
         : undefined,
     displayName: __expectString(output.displayName),
     emailAddress: __expectString(output.emailAddress),
     lastModifiedTimestamp:
       output.lastModifiedTimestamp !== undefined && output.lastModifiedTimestamp !== null
-        ? new Date(Math.round(output.lastModifiedTimestamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastModifiedTimestamp)))
         : undefined,
     sshPublicKey: __expectString(output.sshPublicKey),
     userArn: __expectString(output.userArn),
@@ -2492,13 +2498,13 @@ const deserializeAws_json1_1UpdateUserProfileResult = (
   return {
     createdTimestamp:
       output.createdTimestamp !== undefined && output.createdTimestamp !== null
-        ? new Date(Math.round(output.createdTimestamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.createdTimestamp)))
         : undefined,
     displayName: __expectString(output.displayName),
     emailAddress: __expectString(output.emailAddress),
     lastModifiedTimestamp:
       output.lastModifiedTimestamp !== undefined && output.lastModifiedTimestamp !== null
-        ? new Date(Math.round(output.lastModifiedTimestamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastModifiedTimestamp)))
         : undefined,
     sshPublicKey: __expectString(output.sshPublicKey),
     userArn: __expectString(output.userArn),

--- a/clients/client-cognito-identity-provider/protocols/Aws_json1_1.ts
+++ b/clients/client-cognito-identity-provider/protocols/Aws_json1_1.ts
@@ -578,7 +578,10 @@ import {
   expectBoolean as __expectBoolean,
   expectInt32 as __expectInt32,
   expectLong as __expectLong,
+  expectNonNull as __expectNonNull,
+  expectNumber as __expectNumber,
   expectString as __expectString,
+  parseEpochTimestamp as __parseEpochTimestamp,
 } from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
@@ -15837,11 +15840,11 @@ const deserializeAws_json1_1AdminGetUserResponse = (output: any, context: __Serd
         : undefined,
     UserCreateDate:
       output.UserCreateDate !== undefined && output.UserCreateDate !== null
-        ? new Date(Math.round(output.UserCreateDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.UserCreateDate)))
         : undefined,
     UserLastModifiedDate:
       output.UserLastModifiedDate !== undefined && output.UserLastModifiedDate !== null
-        ? new Date(Math.round(output.UserLastModifiedDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.UserLastModifiedDate)))
         : undefined,
     UserMFASettingList:
       output.UserMFASettingList !== undefined && output.UserMFASettingList !== null
@@ -16102,7 +16105,7 @@ const deserializeAws_json1_1AuthEventType = (output: any, context: __SerdeContex
         : undefined,
     CreationDate:
       output.CreationDate !== undefined && output.CreationDate !== null
-        ? new Date(Math.round(output.CreationDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationDate)))
         : undefined,
     EventContextData:
       output.EventContextData !== undefined && output.EventContextData !== null
@@ -16514,16 +16517,16 @@ const deserializeAws_json1_1DeviceType = (output: any, context: __SerdeContext):
         : undefined,
     DeviceCreateDate:
       output.DeviceCreateDate !== undefined && output.DeviceCreateDate !== null
-        ? new Date(Math.round(output.DeviceCreateDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.DeviceCreateDate)))
         : undefined,
     DeviceKey: __expectString(output.DeviceKey),
     DeviceLastAuthenticatedDate:
       output.DeviceLastAuthenticatedDate !== undefined && output.DeviceLastAuthenticatedDate !== null
-        ? new Date(Math.round(output.DeviceLastAuthenticatedDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.DeviceLastAuthenticatedDate)))
         : undefined,
     DeviceLastModifiedDate:
       output.DeviceLastModifiedDate !== undefined && output.DeviceLastModifiedDate !== null
-        ? new Date(Math.round(output.DeviceLastModifiedDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.DeviceLastModifiedDate)))
         : undefined,
   } as any;
 };
@@ -16586,7 +16589,7 @@ const deserializeAws_json1_1EventFeedbackType = (output: any, context: __SerdeCo
   return {
     FeedbackDate:
       output.FeedbackDate !== undefined && output.FeedbackDate !== null
-        ? new Date(Math.round(output.FeedbackDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.FeedbackDate)))
         : undefined,
     FeedbackValue: __expectString(output.FeedbackValue),
     Provider: __expectString(output.Provider),
@@ -16775,13 +16778,13 @@ const deserializeAws_json1_1GroupType = (output: any, context: __SerdeContext): 
   return {
     CreationDate:
       output.CreationDate !== undefined && output.CreationDate !== null
-        ? new Date(Math.round(output.CreationDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationDate)))
         : undefined,
     Description: __expectString(output.Description),
     GroupName: __expectString(output.GroupName),
     LastModifiedDate:
       output.LastModifiedDate !== undefined && output.LastModifiedDate !== null
-        ? new Date(Math.round(output.LastModifiedDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastModifiedDate)))
         : undefined,
     Precedence: __expectInt32(output.Precedence),
     RoleArn: __expectString(output.RoleArn),
@@ -16797,7 +16800,7 @@ const deserializeAws_json1_1IdentityProviderType = (output: any, context: __Serd
         : undefined,
     CreationDate:
       output.CreationDate !== undefined && output.CreationDate !== null
-        ? new Date(Math.round(output.CreationDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationDate)))
         : undefined,
     IdpIdentifiers:
       output.IdpIdentifiers !== undefined && output.IdpIdentifiers !== null
@@ -16805,7 +16808,7 @@ const deserializeAws_json1_1IdentityProviderType = (output: any, context: __Serd
         : undefined,
     LastModifiedDate:
       output.LastModifiedDate !== undefined && output.LastModifiedDate !== null
-        ? new Date(Math.round(output.LastModifiedDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastModifiedDate)))
         : undefined,
     ProviderDetails:
       output.ProviderDetails !== undefined && output.ProviderDetails !== null
@@ -17223,11 +17226,11 @@ const deserializeAws_json1_1ProviderDescription = (output: any, context: __Serde
   return {
     CreationDate:
       output.CreationDate !== undefined && output.CreationDate !== null
-        ? new Date(Math.round(output.CreationDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationDate)))
         : undefined,
     LastModifiedDate:
       output.LastModifiedDate !== undefined && output.LastModifiedDate !== null
-        ? new Date(Math.round(output.LastModifiedDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastModifiedDate)))
         : undefined,
     ProviderName: __expectString(output.ProviderName),
     ProviderType: __expectString(output.ProviderType),
@@ -17382,7 +17385,7 @@ const deserializeAws_json1_1RiskConfigurationType = (output: any, context: __Ser
         : undefined,
     LastModifiedDate:
       output.LastModifiedDate !== undefined && output.LastModifiedDate !== null
-        ? new Date(Math.round(output.LastModifiedDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastModifiedDate)))
         : undefined,
     RiskExceptionConfiguration:
       output.RiskExceptionConfiguration !== undefined && output.RiskExceptionConfiguration !== null
@@ -17654,12 +17657,12 @@ const deserializeAws_json1_1UICustomizationType = (output: any, context: __Serde
     ClientId: __expectString(output.ClientId),
     CreationDate:
       output.CreationDate !== undefined && output.CreationDate !== null
-        ? new Date(Math.round(output.CreationDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationDate)))
         : undefined,
     ImageUrl: __expectString(output.ImageUrl),
     LastModifiedDate:
       output.LastModifiedDate !== undefined && output.LastModifiedDate !== null
-        ? new Date(Math.round(output.LastModifiedDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastModifiedDate)))
         : undefined,
     UserPoolId: __expectString(output.UserPoolId),
   } as any;
@@ -17829,12 +17832,12 @@ const deserializeAws_json1_1UserImportJobType = (output: any, context: __SerdeCo
     CloudWatchLogsRoleArn: __expectString(output.CloudWatchLogsRoleArn),
     CompletionDate:
       output.CompletionDate !== undefined && output.CompletionDate !== null
-        ? new Date(Math.round(output.CompletionDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CompletionDate)))
         : undefined,
     CompletionMessage: __expectString(output.CompletionMessage),
     CreationDate:
       output.CreationDate !== undefined && output.CreationDate !== null
-        ? new Date(Math.round(output.CreationDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationDate)))
         : undefined,
     FailedUsers: __expectLong(output.FailedUsers),
     ImportedUsers: __expectLong(output.ImportedUsers),
@@ -17844,7 +17847,7 @@ const deserializeAws_json1_1UserImportJobType = (output: any, context: __SerdeCo
     SkippedUsers: __expectLong(output.SkippedUsers),
     StartDate:
       output.StartDate !== undefined && output.StartDate !== null
-        ? new Date(Math.round(output.StartDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.StartDate)))
         : undefined,
     Status: __expectString(output.Status),
     UserPoolId: __expectString(output.UserPoolId),
@@ -17983,7 +17986,7 @@ const deserializeAws_json1_1UserPoolClientType = (output: any, context: __SerdeC
     ClientSecret: __expectString(output.ClientSecret),
     CreationDate:
       output.CreationDate !== undefined && output.CreationDate !== null
-        ? new Date(Math.round(output.CreationDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationDate)))
         : undefined,
     DefaultRedirectURI: __expectString(output.DefaultRedirectURI),
     EnableTokenRevocation: __expectBoolean(output.EnableTokenRevocation),
@@ -17994,7 +17997,7 @@ const deserializeAws_json1_1UserPoolClientType = (output: any, context: __SerdeC
     IdTokenValidity: __expectInt32(output.IdTokenValidity),
     LastModifiedDate:
       output.LastModifiedDate !== undefined && output.LastModifiedDate !== null
-        ? new Date(Math.round(output.LastModifiedDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastModifiedDate)))
         : undefined,
     LogoutURLs:
       output.LogoutURLs !== undefined && output.LogoutURLs !== null
@@ -18029,7 +18032,7 @@ const deserializeAws_json1_1UserPoolDescriptionType = (
   return {
     CreationDate:
       output.CreationDate !== undefined && output.CreationDate !== null
-        ? new Date(Math.round(output.CreationDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationDate)))
         : undefined,
     Id: __expectString(output.Id),
     LambdaConfig:
@@ -18038,7 +18041,7 @@ const deserializeAws_json1_1UserPoolDescriptionType = (
         : undefined,
     LastModifiedDate:
       output.LastModifiedDate !== undefined && output.LastModifiedDate !== null
-        ? new Date(Math.round(output.LastModifiedDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastModifiedDate)))
         : undefined,
     Name: __expectString(output.Name),
     Status: __expectString(output.Status),
@@ -18107,7 +18110,7 @@ const deserializeAws_json1_1UserPoolType = (output: any, context: __SerdeContext
         : undefined,
     CreationDate:
       output.CreationDate !== undefined && output.CreationDate !== null
-        ? new Date(Math.round(output.CreationDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationDate)))
         : undefined,
     CustomDomain: __expectString(output.CustomDomain),
     DeviceConfiguration:
@@ -18130,7 +18133,7 @@ const deserializeAws_json1_1UserPoolType = (output: any, context: __SerdeContext
         : undefined,
     LastModifiedDate:
       output.LastModifiedDate !== undefined && output.LastModifiedDate !== null
-        ? new Date(Math.round(output.LastModifiedDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastModifiedDate)))
         : undefined,
     MfaConfiguration: __expectString(output.MfaConfiguration),
     Name: __expectString(output.Name),
@@ -18197,11 +18200,11 @@ const deserializeAws_json1_1UserType = (output: any, context: __SerdeContext): U
         : undefined,
     UserCreateDate:
       output.UserCreateDate !== undefined && output.UserCreateDate !== null
-        ? new Date(Math.round(output.UserCreateDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.UserCreateDate)))
         : undefined,
     UserLastModifiedDate:
       output.UserLastModifiedDate !== undefined && output.UserLastModifiedDate !== null
-        ? new Date(Math.round(output.UserLastModifiedDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.UserLastModifiedDate)))
         : undefined,
     UserStatus: __expectString(output.UserStatus),
     Username: __expectString(output.Username),

--- a/clients/client-cognito-identity/protocols/Aws_json1_1.ts
+++ b/clients/client-cognito-identity/protocols/Aws_json1_1.ts
@@ -114,7 +114,13 @@ import {
   UntagResourceResponse,
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
-import { expectBoolean as __expectBoolean, expectString as __expectString } from "@aws-sdk/smithy-client";
+import {
+  expectBoolean as __expectBoolean,
+  expectNonNull as __expectNonNull,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
+  parseEpochTimestamp as __parseEpochTimestamp,
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   HeaderBag as __HeaderBag,
@@ -3253,7 +3259,7 @@ const deserializeAws_json1_1Credentials = (output: any, context: __SerdeContext)
     AccessKeyId: __expectString(output.AccessKeyId),
     Expiration:
       output.Expiration !== undefined && output.Expiration !== null
-        ? new Date(Math.round(output.Expiration * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.Expiration)))
         : undefined,
     SecretKey: __expectString(output.SecretKey),
     SessionToken: __expectString(output.SessionToken),
@@ -3384,12 +3390,12 @@ const deserializeAws_json1_1IdentityDescription = (output: any, context: __Serde
   return {
     CreationDate:
       output.CreationDate !== undefined && output.CreationDate !== null
-        ? new Date(Math.round(output.CreationDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationDate)))
         : undefined,
     IdentityId: __expectString(output.IdentityId),
     LastModifiedDate:
       output.LastModifiedDate !== undefined && output.LastModifiedDate !== null
-        ? new Date(Math.round(output.LastModifiedDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastModifiedDate)))
         : undefined,
     Logins:
       output.Logins !== undefined && output.Logins !== null

--- a/clients/client-cognito-sync/protocols/Aws_restJson1.ts
+++ b/clients/client-cognito-sync/protocols/Aws_restJson1.ts
@@ -64,9 +64,11 @@ import {
   expectInt32 as __expectInt32,
   expectLong as __expectLong,
   expectNonNull as __expectNonNull,
+  expectNumber as __expectNumber,
   expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
+  parseEpochTimestamp as __parseEpochTimestamp,
 } from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
@@ -1244,10 +1246,12 @@ export const deserializeAws_restJson1GetBulkPublishDetailsCommand = async (
   };
   const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.BulkPublishCompleteTime !== undefined && data.BulkPublishCompleteTime !== null) {
-    contents.BulkPublishCompleteTime = new Date(Math.round(data.BulkPublishCompleteTime * 1000));
+    contents.BulkPublishCompleteTime = __expectNonNull(
+      __parseEpochTimestamp(__expectNumber(data.BulkPublishCompleteTime))
+    );
   }
   if (data.BulkPublishStartTime !== undefined && data.BulkPublishStartTime !== null) {
-    contents.BulkPublishStartTime = new Date(Math.round(data.BulkPublishStartTime * 1000));
+    contents.BulkPublishStartTime = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.BulkPublishStartTime)));
   }
   if (data.BulkPublishStatus !== undefined && data.BulkPublishStatus !== null) {
     contents.BulkPublishStatus = __expectString(data.BulkPublishStatus);
@@ -2685,7 +2689,7 @@ const deserializeAws_restJson1Dataset = (output: any, context: __SerdeContext): 
   return {
     CreationDate:
       output.CreationDate !== undefined && output.CreationDate !== null
-        ? new Date(Math.round(output.CreationDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationDate)))
         : undefined,
     DataStorage: __expectLong(output.DataStorage),
     DatasetName: __expectString(output.DatasetName),
@@ -2693,7 +2697,7 @@ const deserializeAws_restJson1Dataset = (output: any, context: __SerdeContext): 
     LastModifiedBy: __expectString(output.LastModifiedBy),
     LastModifiedDate:
       output.LastModifiedDate !== undefined && output.LastModifiedDate !== null
-        ? new Date(Math.round(output.LastModifiedDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastModifiedDate)))
         : undefined,
     NumRecords: __expectLong(output.NumRecords),
   } as any;
@@ -2728,7 +2732,7 @@ const deserializeAws_restJson1IdentityPoolUsage = (output: any, context: __Serde
     IdentityPoolId: __expectString(output.IdentityPoolId),
     LastModifiedDate:
       output.LastModifiedDate !== undefined && output.LastModifiedDate !== null
-        ? new Date(Math.round(output.LastModifiedDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastModifiedDate)))
         : undefined,
     SyncSessionsCount: __expectLong(output.SyncSessionsCount),
   } as any;
@@ -2753,7 +2757,7 @@ const deserializeAws_restJson1IdentityUsage = (output: any, context: __SerdeCont
     IdentityPoolId: __expectString(output.IdentityPoolId),
     LastModifiedDate:
       output.LastModifiedDate !== undefined && output.LastModifiedDate !== null
-        ? new Date(Math.round(output.LastModifiedDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastModifiedDate)))
         : undefined,
   } as any;
 };
@@ -2783,13 +2787,13 @@ const deserializeAws_restJson1_Record = (output: any, context: __SerdeContext): 
   return {
     DeviceLastModifiedDate:
       output.DeviceLastModifiedDate !== undefined && output.DeviceLastModifiedDate !== null
-        ? new Date(Math.round(output.DeviceLastModifiedDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.DeviceLastModifiedDate)))
         : undefined,
     Key: __expectString(output.Key),
     LastModifiedBy: __expectString(output.LastModifiedBy),
     LastModifiedDate:
       output.LastModifiedDate !== undefined && output.LastModifiedDate !== null
-        ? new Date(Math.round(output.LastModifiedDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastModifiedDate)))
         : undefined,
     SyncCount: __expectLong(output.SyncCount),
     Value: __expectString(output.Value),

--- a/clients/client-comprehend/protocols/Aws_json1_1.ts
+++ b/clients/client-comprehend/protocols/Aws_json1_1.ts
@@ -402,9 +402,12 @@ import {
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
   expectInt32 as __expectInt32,
+  expectNonNull as __expectNonNull,
+  expectNumber as __expectNumber,
   expectString as __expectString,
   limitedParseDouble as __limitedParseDouble,
   limitedParseFloat32 as __limitedParseFloat32,
+  parseEpochTimestamp as __parseEpochTimestamp,
 } from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
@@ -8151,7 +8154,9 @@ const deserializeAws_json1_1DocumentClassificationJobProperties = (
     DataAccessRoleArn: __expectString(output.DataAccessRoleArn),
     DocumentClassifierArn: __expectString(output.DocumentClassifierArn),
     EndTime:
-      output.EndTime !== undefined && output.EndTime !== null ? new Date(Math.round(output.EndTime * 1000)) : undefined,
+      output.EndTime !== undefined && output.EndTime !== null
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.EndTime)))
+        : undefined,
     InputDataConfig:
       output.InputDataConfig !== undefined && output.InputDataConfig !== null
         ? deserializeAws_json1_1InputDataConfig(output.InputDataConfig, context)
@@ -8167,7 +8172,7 @@ const deserializeAws_json1_1DocumentClassificationJobProperties = (
         : undefined,
     SubmitTime:
       output.SubmitTime !== undefined && output.SubmitTime !== null
-        ? new Date(Math.round(output.SubmitTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.SubmitTime)))
         : undefined,
     VolumeKmsKeyId: __expectString(output.VolumeKmsKeyId),
     VpcConfig:
@@ -8242,7 +8247,9 @@ const deserializeAws_json1_1DocumentClassifierProperties = (
     DataAccessRoleArn: __expectString(output.DataAccessRoleArn),
     DocumentClassifierArn: __expectString(output.DocumentClassifierArn),
     EndTime:
-      output.EndTime !== undefined && output.EndTime !== null ? new Date(Math.round(output.EndTime * 1000)) : undefined,
+      output.EndTime !== undefined && output.EndTime !== null
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.EndTime)))
+        : undefined,
     InputDataConfig:
       output.InputDataConfig !== undefined && output.InputDataConfig !== null
         ? deserializeAws_json1_1DocumentClassifierInputDataConfig(output.InputDataConfig, context)
@@ -8258,15 +8265,15 @@ const deserializeAws_json1_1DocumentClassifierProperties = (
     Status: __expectString(output.Status),
     SubmitTime:
       output.SubmitTime !== undefined && output.SubmitTime !== null
-        ? new Date(Math.round(output.SubmitTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.SubmitTime)))
         : undefined,
     TrainingEndTime:
       output.TrainingEndTime !== undefined && output.TrainingEndTime !== null
-        ? new Date(Math.round(output.TrainingEndTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.TrainingEndTime)))
         : undefined,
     TrainingStartTime:
       output.TrainingStartTime !== undefined && output.TrainingStartTime !== null
-        ? new Date(Math.round(output.TrainingStartTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.TrainingStartTime)))
         : undefined,
     VolumeKmsKeyId: __expectString(output.VolumeKmsKeyId),
     VpcConfig:
@@ -8311,7 +8318,9 @@ const deserializeAws_json1_1DominantLanguageDetectionJobProperties = (
   return {
     DataAccessRoleArn: __expectString(output.DataAccessRoleArn),
     EndTime:
-      output.EndTime !== undefined && output.EndTime !== null ? new Date(Math.round(output.EndTime * 1000)) : undefined,
+      output.EndTime !== undefined && output.EndTime !== null
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.EndTime)))
+        : undefined,
     InputDataConfig:
       output.InputDataConfig !== undefined && output.InputDataConfig !== null
         ? deserializeAws_json1_1InputDataConfig(output.InputDataConfig, context)
@@ -8327,7 +8336,7 @@ const deserializeAws_json1_1DominantLanguageDetectionJobProperties = (
         : undefined,
     SubmitTime:
       output.SubmitTime !== undefined && output.SubmitTime !== null
-        ? new Date(Math.round(output.SubmitTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.SubmitTime)))
         : undefined,
     VolumeKmsKeyId: __expectString(output.VolumeKmsKeyId),
     VpcConfig:
@@ -8355,7 +8364,7 @@ const deserializeAws_json1_1EndpointProperties = (output: any, context: __SerdeC
   return {
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     CurrentInferenceUnits: __expectInt32(output.CurrentInferenceUnits),
     DataAccessRoleArn: __expectString(output.DataAccessRoleArn),
@@ -8363,7 +8372,7 @@ const deserializeAws_json1_1EndpointProperties = (output: any, context: __SerdeC
     EndpointArn: __expectString(output.EndpointArn),
     LastModifiedTime:
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
-        ? new Date(Math.round(output.LastModifiedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastModifiedTime)))
         : undefined,
     Message: __expectString(output.Message),
     ModelArn: __expectString(output.ModelArn),
@@ -8389,7 +8398,9 @@ const deserializeAws_json1_1EntitiesDetectionJobProperties = (
   return {
     DataAccessRoleArn: __expectString(output.DataAccessRoleArn),
     EndTime:
-      output.EndTime !== undefined && output.EndTime !== null ? new Date(Math.round(output.EndTime * 1000)) : undefined,
+      output.EndTime !== undefined && output.EndTime !== null
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.EndTime)))
+        : undefined,
     EntityRecognizerArn: __expectString(output.EntityRecognizerArn),
     InputDataConfig:
       output.InputDataConfig !== undefined && output.InputDataConfig !== null
@@ -8407,7 +8418,7 @@ const deserializeAws_json1_1EntitiesDetectionJobProperties = (
         : undefined,
     SubmitTime:
       output.SubmitTime !== undefined && output.SubmitTime !== null
-        ? new Date(Math.round(output.SubmitTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.SubmitTime)))
         : undefined,
     VolumeKmsKeyId: __expectString(output.VolumeKmsKeyId),
     VpcConfig:
@@ -8582,7 +8593,9 @@ const deserializeAws_json1_1EntityRecognizerProperties = (
   return {
     DataAccessRoleArn: __expectString(output.DataAccessRoleArn),
     EndTime:
-      output.EndTime !== undefined && output.EndTime !== null ? new Date(Math.round(output.EndTime * 1000)) : undefined,
+      output.EndTime !== undefined && output.EndTime !== null
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.EndTime)))
+        : undefined,
     EntityRecognizerArn: __expectString(output.EntityRecognizerArn),
     InputDataConfig:
       output.InputDataConfig !== undefined && output.InputDataConfig !== null
@@ -8598,15 +8611,15 @@ const deserializeAws_json1_1EntityRecognizerProperties = (
     Status: __expectString(output.Status),
     SubmitTime:
       output.SubmitTime !== undefined && output.SubmitTime !== null
-        ? new Date(Math.round(output.SubmitTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.SubmitTime)))
         : undefined,
     TrainingEndTime:
       output.TrainingEndTime !== undefined && output.TrainingEndTime !== null
-        ? new Date(Math.round(output.TrainingEndTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.TrainingEndTime)))
         : undefined,
     TrainingStartTime:
       output.TrainingStartTime !== undefined && output.TrainingStartTime !== null
-        ? new Date(Math.round(output.TrainingStartTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.TrainingStartTime)))
         : undefined,
     VolumeKmsKeyId: __expectString(output.VolumeKmsKeyId),
     VpcConfig:
@@ -8665,7 +8678,9 @@ const deserializeAws_json1_1EventsDetectionJobProperties = (
   return {
     DataAccessRoleArn: __expectString(output.DataAccessRoleArn),
     EndTime:
-      output.EndTime !== undefined && output.EndTime !== null ? new Date(Math.round(output.EndTime * 1000)) : undefined,
+      output.EndTime !== undefined && output.EndTime !== null
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.EndTime)))
+        : undefined,
     InputDataConfig:
       output.InputDataConfig !== undefined && output.InputDataConfig !== null
         ? deserializeAws_json1_1InputDataConfig(output.InputDataConfig, context)
@@ -8682,7 +8697,7 @@ const deserializeAws_json1_1EventsDetectionJobProperties = (
         : undefined,
     SubmitTime:
       output.SubmitTime !== undefined && output.SubmitTime !== null
-        ? new Date(Math.round(output.SubmitTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.SubmitTime)))
         : undefined,
     TargetEventTypes:
       output.TargetEventTypes !== undefined && output.TargetEventTypes !== null
@@ -8758,7 +8773,9 @@ const deserializeAws_json1_1KeyPhrasesDetectionJobProperties = (
   return {
     DataAccessRoleArn: __expectString(output.DataAccessRoleArn),
     EndTime:
-      output.EndTime !== undefined && output.EndTime !== null ? new Date(Math.round(output.EndTime * 1000)) : undefined,
+      output.EndTime !== undefined && output.EndTime !== null
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.EndTime)))
+        : undefined,
     InputDataConfig:
       output.InputDataConfig !== undefined && output.InputDataConfig !== null
         ? deserializeAws_json1_1InputDataConfig(output.InputDataConfig, context)
@@ -8775,7 +8792,7 @@ const deserializeAws_json1_1KeyPhrasesDetectionJobProperties = (
         : undefined,
     SubmitTime:
       output.SubmitTime !== undefined && output.SubmitTime !== null
-        ? new Date(Math.round(output.SubmitTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.SubmitTime)))
         : undefined,
     VolumeKmsKeyId: __expectString(output.VolumeKmsKeyId),
     VpcConfig:
@@ -9169,7 +9186,9 @@ const deserializeAws_json1_1PiiEntitiesDetectionJobProperties = (
   return {
     DataAccessRoleArn: __expectString(output.DataAccessRoleArn),
     EndTime:
-      output.EndTime !== undefined && output.EndTime !== null ? new Date(Math.round(output.EndTime * 1000)) : undefined,
+      output.EndTime !== undefined && output.EndTime !== null
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.EndTime)))
+        : undefined,
     InputDataConfig:
       output.InputDataConfig !== undefined && output.InputDataConfig !== null
         ? deserializeAws_json1_1InputDataConfig(output.InputDataConfig, context)
@@ -9191,7 +9210,7 @@ const deserializeAws_json1_1PiiEntitiesDetectionJobProperties = (
         : undefined,
     SubmitTime:
       output.SubmitTime !== undefined && output.SubmitTime !== null
-        ? new Date(Math.round(output.SubmitTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.SubmitTime)))
         : undefined,
   } as any;
 };
@@ -9288,7 +9307,9 @@ const deserializeAws_json1_1SentimentDetectionJobProperties = (
   return {
     DataAccessRoleArn: __expectString(output.DataAccessRoleArn),
     EndTime:
-      output.EndTime !== undefined && output.EndTime !== null ? new Date(Math.round(output.EndTime * 1000)) : undefined,
+      output.EndTime !== undefined && output.EndTime !== null
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.EndTime)))
+        : undefined,
     InputDataConfig:
       output.InputDataConfig !== undefined && output.InputDataConfig !== null
         ? deserializeAws_json1_1InputDataConfig(output.InputDataConfig, context)
@@ -9305,7 +9326,7 @@ const deserializeAws_json1_1SentimentDetectionJobProperties = (
         : undefined,
     SubmitTime:
       output.SubmitTime !== undefined && output.SubmitTime !== null
-        ? new Date(Math.round(output.SubmitTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.SubmitTime)))
         : undefined,
     VolumeKmsKeyId: __expectString(output.VolumeKmsKeyId),
     VpcConfig:
@@ -9597,7 +9618,9 @@ const deserializeAws_json1_1TopicsDetectionJobProperties = (
   return {
     DataAccessRoleArn: __expectString(output.DataAccessRoleArn),
     EndTime:
-      output.EndTime !== undefined && output.EndTime !== null ? new Date(Math.round(output.EndTime * 1000)) : undefined,
+      output.EndTime !== undefined && output.EndTime !== null
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.EndTime)))
+        : undefined,
     InputDataConfig:
       output.InputDataConfig !== undefined && output.InputDataConfig !== null
         ? deserializeAws_json1_1InputDataConfig(output.InputDataConfig, context)
@@ -9614,7 +9637,7 @@ const deserializeAws_json1_1TopicsDetectionJobProperties = (
         : undefined,
     SubmitTime:
       output.SubmitTime !== undefined && output.SubmitTime !== null
-        ? new Date(Math.round(output.SubmitTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.SubmitTime)))
         : undefined,
     VolumeKmsKeyId: __expectString(output.VolumeKmsKeyId),
     VpcConfig:

--- a/clients/client-comprehendmedical/protocols/Aws_json1_1.ts
+++ b/clients/client-comprehendmedical/protocols/Aws_json1_1.ts
@@ -138,8 +138,11 @@ import {
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
   expectInt32 as __expectInt32,
+  expectNonNull as __expectNonNull,
+  expectNumber as __expectNumber,
   expectString as __expectString,
   limitedParseFloat32 as __limitedParseFloat32,
+  parseEpochTimestamp as __parseEpochTimestamp,
 } from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
@@ -2532,10 +2535,12 @@ const deserializeAws_json1_1ComprehendMedicalAsyncJobProperties = (
   return {
     DataAccessRoleArn: __expectString(output.DataAccessRoleArn),
     EndTime:
-      output.EndTime !== undefined && output.EndTime !== null ? new Date(Math.round(output.EndTime * 1000)) : undefined,
+      output.EndTime !== undefined && output.EndTime !== null
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.EndTime)))
+        : undefined,
     ExpirationTime:
       output.ExpirationTime !== undefined && output.ExpirationTime !== null
-        ? new Date(Math.round(output.ExpirationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.ExpirationTime)))
         : undefined,
     InputDataConfig:
       output.InputDataConfig !== undefined && output.InputDataConfig !== null
@@ -2555,7 +2560,7 @@ const deserializeAws_json1_1ComprehendMedicalAsyncJobProperties = (
         : undefined,
     SubmitTime:
       output.SubmitTime !== undefined && output.SubmitTime !== null
-        ? new Date(Math.round(output.SubmitTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.SubmitTime)))
         : undefined,
   } as any;
 };

--- a/clients/client-compute-optimizer/protocols/Aws_json1_0.ts
+++ b/clients/client-compute-optimizer/protocols/Aws_json1_0.ts
@@ -138,8 +138,11 @@ import {
   expectBoolean as __expectBoolean,
   expectInt32 as __expectInt32,
   expectLong as __expectLong,
+  expectNonNull as __expectNonNull,
+  expectNumber as __expectNumber,
   expectString as __expectString,
   limitedParseDouble as __limitedParseDouble,
+  parseEpochTimestamp as __parseEpochTimestamp,
 } from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
@@ -2500,7 +2503,7 @@ const deserializeAws_json1_0AccountEnrollmentStatus = (
     accountId: __expectString(output.accountId),
     lastUpdatedTimestamp:
       output.lastUpdatedTimestamp !== undefined && output.lastUpdatedTimestamp !== null
-        ? new Date(Math.round(output.lastUpdatedTimestamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastUpdatedTimestamp)))
         : undefined,
     status: __expectString(output.status),
     statusReason: __expectString(output.statusReason),
@@ -2548,7 +2551,7 @@ const deserializeAws_json1_0AutoScalingGroupRecommendation = (
     finding: __expectString(output.finding),
     lastRefreshTimestamp:
       output.lastRefreshTimestamp !== undefined && output.lastRefreshTimestamp !== null
-        ? new Date(Math.round(output.lastRefreshTimestamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastRefreshTimestamp)))
         : undefined,
     lookBackPeriodInDays: __limitedParseDouble(output.lookBackPeriodInDays),
     recommendationOptions:
@@ -2784,7 +2787,7 @@ const deserializeAws_json1_0GetEnrollmentStatusResponse = (
   return {
     lastUpdatedTimestamp:
       output.lastUpdatedTimestamp !== undefined && output.lastUpdatedTimestamp !== null
-        ? new Date(Math.round(output.lastUpdatedTimestamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastUpdatedTimestamp)))
         : undefined,
     memberAccountsEnrolled: __expectBoolean(output.memberAccountsEnrolled),
     numberOfMemberAccountsOptedIn: __expectInt32(output.numberOfMemberAccountsOptedIn),
@@ -2854,7 +2857,7 @@ const deserializeAws_json1_0InstanceRecommendation = (output: any, context: __Se
     instanceName: __expectString(output.instanceName),
     lastRefreshTimestamp:
       output.lastRefreshTimestamp !== undefined && output.lastRefreshTimestamp !== null
-        ? new Date(Math.round(output.lastRefreshTimestamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastRefreshTimestamp)))
         : undefined,
     lookBackPeriodInDays: __limitedParseDouble(output.lookBackPeriodInDays),
     recommendationOptions:
@@ -3006,7 +3009,7 @@ const deserializeAws_json1_0LambdaFunctionRecommendation = (
     functionVersion: __expectString(output.functionVersion),
     lastRefreshTimestamp:
       output.lastRefreshTimestamp !== undefined && output.lastRefreshTimestamp !== null
-        ? new Date(Math.round(output.lastRefreshTimestamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastRefreshTimestamp)))
         : undefined,
     lookbackPeriodInDays: __limitedParseDouble(output.lookbackPeriodInDays),
     memorySizeRecommendationOptions:
@@ -3187,7 +3190,7 @@ const deserializeAws_json1_0RecommendationExportJob = (
   return {
     creationTimestamp:
       output.creationTimestamp !== undefined && output.creationTimestamp !== null
-        ? new Date(Math.round(output.creationTimestamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.creationTimestamp)))
         : undefined,
     destination:
       output.destination !== undefined && output.destination !== null
@@ -3197,7 +3200,7 @@ const deserializeAws_json1_0RecommendationExportJob = (
     jobId: __expectString(output.jobId),
     lastUpdatedTimestamp:
       output.lastUpdatedTimestamp !== undefined && output.lastUpdatedTimestamp !== null
-        ? new Date(Math.round(output.lastUpdatedTimestamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastUpdatedTimestamp)))
         : undefined,
     resourceType: __expectString(output.resourceType),
     status: __expectString(output.status),
@@ -3364,7 +3367,7 @@ const deserializeAws_json1_0Timestamps = (output: any, context: __SerdeContext):
       if (entry === null) {
         return null as any;
       }
-      return new Date(Math.round(entry * 1000));
+      return __expectNonNull(__parseEpochTimestamp(__expectNumber(entry)));
     });
 };
 
@@ -3418,7 +3421,7 @@ const deserializeAws_json1_0VolumeRecommendation = (output: any, context: __Serd
     finding: __expectString(output.finding),
     lastRefreshTimestamp:
       output.lastRefreshTimestamp !== undefined && output.lastRefreshTimestamp !== null
-        ? new Date(Math.round(output.lastRefreshTimestamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastRefreshTimestamp)))
         : undefined,
     lookBackPeriodInDays: __limitedParseDouble(output.lookBackPeriodInDays),
     utilizationMetrics:

--- a/clients/client-config-service/protocols/Aws_json1_1.ts
+++ b/clients/client-config-service/protocols/Aws_json1_1.ts
@@ -612,7 +612,10 @@ import {
   expectBoolean as __expectBoolean,
   expectInt32 as __expectInt32,
   expectLong as __expectLong,
+  expectNonNull as __expectNonNull,
+  expectNumber as __expectNumber,
   expectString as __expectString,
+  parseEpochTimestamp as __parseEpochTimestamp,
 } from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
@@ -10763,7 +10766,7 @@ const deserializeAws_json1_1AggregatedSourceStatus = (output: any, context: __Se
     LastUpdateStatus: __expectString(output.LastUpdateStatus),
     LastUpdateTime:
       output.LastUpdateTime !== undefined && output.LastUpdateTime !== null
-        ? new Date(Math.round(output.LastUpdateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastUpdateTime)))
         : undefined,
     SourceId: __expectString(output.SourceId),
     SourceType: __expectString(output.SourceType),
@@ -10795,7 +10798,7 @@ const deserializeAws_json1_1AggregateEvaluationResult = (
     ComplianceType: __expectString(output.ComplianceType),
     ConfigRuleInvokedTime:
       output.ConfigRuleInvokedTime !== undefined && output.ConfigRuleInvokedTime !== null
-        ? new Date(Math.round(output.ConfigRuleInvokedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.ConfigRuleInvokedTime)))
         : undefined,
     EvaluationResultIdentifier:
       output.EvaluationResultIdentifier !== undefined && output.EvaluationResultIdentifier !== null
@@ -10803,7 +10806,7 @@ const deserializeAws_json1_1AggregateEvaluationResult = (
         : undefined,
     ResultRecordedTime:
       output.ResultRecordedTime !== undefined && output.ResultRecordedTime !== null
-        ? new Date(Math.round(output.ResultRecordedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.ResultRecordedTime)))
         : undefined,
   } as any;
 };
@@ -10845,7 +10848,7 @@ const deserializeAws_json1_1AggregationAuthorization = (
     AuthorizedAwsRegion: __expectString(output.AuthorizedAwsRegion),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
   } as any;
 };
@@ -10884,13 +10887,13 @@ const deserializeAws_json1_1BaseConfigurationItem = (output: any, context: __Ser
     configuration: __expectString(output.configuration),
     configurationItemCaptureTime:
       output.configurationItemCaptureTime !== undefined && output.configurationItemCaptureTime !== null
-        ? new Date(Math.round(output.configurationItemCaptureTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.configurationItemCaptureTime)))
         : undefined,
     configurationItemStatus: __expectString(output.configurationItemStatus),
     configurationStateId: __expectString(output.configurationStateId),
     resourceCreationTime:
       output.resourceCreationTime !== undefined && output.resourceCreationTime !== null
-        ? new Date(Math.round(output.resourceCreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.resourceCreationTime)))
         : undefined,
     resourceId: __expectString(output.resourceId),
     resourceName: __expectString(output.resourceName),
@@ -11044,7 +11047,7 @@ const deserializeAws_json1_1ComplianceSummary = (output: any, context: __SerdeCo
   return {
     ComplianceSummaryTimestamp:
       output.ComplianceSummaryTimestamp !== undefined && output.ComplianceSummaryTimestamp !== null
-        ? new Date(Math.round(output.ComplianceSummaryTimestamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.ComplianceSummaryTimestamp)))
         : undefined,
     CompliantResourceCount:
       output.CompliantResourceCount !== undefined && output.CompliantResourceCount !== null
@@ -11077,18 +11080,18 @@ const deserializeAws_json1_1ConfigExportDeliveryInfo = (
   return {
     lastAttemptTime:
       output.lastAttemptTime !== undefined && output.lastAttemptTime !== null
-        ? new Date(Math.round(output.lastAttemptTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastAttemptTime)))
         : undefined,
     lastErrorCode: __expectString(output.lastErrorCode),
     lastErrorMessage: __expectString(output.lastErrorMessage),
     lastStatus: __expectString(output.lastStatus),
     lastSuccessfulTime:
       output.lastSuccessfulTime !== undefined && output.lastSuccessfulTime !== null
-        ? new Date(Math.round(output.lastSuccessfulTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastSuccessfulTime)))
         : undefined,
     nextDeliveryTime:
       output.nextDeliveryTime !== undefined && output.nextDeliveryTime !== null
-        ? new Date(Math.round(output.nextDeliveryTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.nextDeliveryTime)))
         : undefined,
   } as any;
 };
@@ -11124,30 +11127,30 @@ const deserializeAws_json1_1ConfigRuleEvaluationStatus = (
     ConfigRuleName: __expectString(output.ConfigRuleName),
     FirstActivatedTime:
       output.FirstActivatedTime !== undefined && output.FirstActivatedTime !== null
-        ? new Date(Math.round(output.FirstActivatedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.FirstActivatedTime)))
         : undefined,
     FirstEvaluationStarted: __expectBoolean(output.FirstEvaluationStarted),
     LastDeactivatedTime:
       output.LastDeactivatedTime !== undefined && output.LastDeactivatedTime !== null
-        ? new Date(Math.round(output.LastDeactivatedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastDeactivatedTime)))
         : undefined,
     LastErrorCode: __expectString(output.LastErrorCode),
     LastErrorMessage: __expectString(output.LastErrorMessage),
     LastFailedEvaluationTime:
       output.LastFailedEvaluationTime !== undefined && output.LastFailedEvaluationTime !== null
-        ? new Date(Math.round(output.LastFailedEvaluationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastFailedEvaluationTime)))
         : undefined,
     LastFailedInvocationTime:
       output.LastFailedInvocationTime !== undefined && output.LastFailedInvocationTime !== null
-        ? new Date(Math.round(output.LastFailedInvocationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastFailedInvocationTime)))
         : undefined,
     LastSuccessfulEvaluationTime:
       output.LastSuccessfulEvaluationTime !== undefined && output.LastSuccessfulEvaluationTime !== null
-        ? new Date(Math.round(output.LastSuccessfulEvaluationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastSuccessfulEvaluationTime)))
         : undefined,
     LastSuccessfulInvocationTime:
       output.LastSuccessfulInvocationTime !== undefined && output.LastSuccessfulInvocationTime !== null
-        ? new Date(Math.round(output.LastSuccessfulInvocationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastSuccessfulInvocationTime)))
         : undefined,
   } as any;
 };
@@ -11196,7 +11199,7 @@ const deserializeAws_json1_1ConfigStreamDeliveryInfo = (
     lastStatus: __expectString(output.lastStatus),
     lastStatusChangeTime:
       output.lastStatusChangeTime !== undefined && output.lastStatusChangeTime !== null
-        ? new Date(Math.round(output.lastStatusChangeTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastStatusChangeTime)))
         : undefined,
   } as any;
 };
@@ -11215,11 +11218,11 @@ const deserializeAws_json1_1ConfigurationAggregator = (
     CreatedBy: __expectString(output.CreatedBy),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     LastUpdatedTime:
       output.LastUpdatedTime !== undefined && output.LastUpdatedTime !== null
-        ? new Date(Math.round(output.LastUpdatedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastUpdatedTime)))
         : undefined,
     OrganizationAggregationSource:
       output.OrganizationAggregationSource !== undefined && output.OrganizationAggregationSource !== null
@@ -11251,7 +11254,7 @@ const deserializeAws_json1_1ConfigurationItem = (output: any, context: __SerdeCo
     configuration: __expectString(output.configuration),
     configurationItemCaptureTime:
       output.configurationItemCaptureTime !== undefined && output.configurationItemCaptureTime !== null
-        ? new Date(Math.round(output.configurationItemCaptureTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.configurationItemCaptureTime)))
         : undefined,
     configurationItemMD5Hash: __expectString(output.configurationItemMD5Hash),
     configurationItemStatus: __expectString(output.configurationItemStatus),
@@ -11266,7 +11269,7 @@ const deserializeAws_json1_1ConfigurationItem = (output: any, context: __SerdeCo
         : undefined,
     resourceCreationTime:
       output.resourceCreationTime !== undefined && output.resourceCreationTime !== null
-        ? new Date(Math.round(output.resourceCreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.resourceCreationTime)))
         : undefined,
     resourceId: __expectString(output.resourceId),
     resourceName: __expectString(output.resourceName),
@@ -11326,16 +11329,16 @@ const deserializeAws_json1_1ConfigurationRecorderStatus = (
     lastErrorMessage: __expectString(output.lastErrorMessage),
     lastStartTime:
       output.lastStartTime !== undefined && output.lastStartTime !== null
-        ? new Date(Math.round(output.lastStartTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastStartTime)))
         : undefined,
     lastStatus: __expectString(output.lastStatus),
     lastStatusChangeTime:
       output.lastStatusChangeTime !== undefined && output.lastStatusChangeTime !== null
-        ? new Date(Math.round(output.lastStatusChangeTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastStatusChangeTime)))
         : undefined,
     lastStopTime:
       output.lastStopTime !== undefined && output.lastStopTime !== null
-        ? new Date(Math.round(output.lastStopTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastStopTime)))
         : undefined,
     name: __expectString(output.name),
     recording: __expectBoolean(output.recording),
@@ -11394,7 +11397,7 @@ const deserializeAws_json1_1ConformancePackDetail = (output: any, context: __Ser
     DeliveryS3KeyPrefix: __expectString(output.DeliveryS3KeyPrefix),
     LastUpdateRequestedTime:
       output.LastUpdateRequestedTime !== undefined && output.LastUpdateRequestedTime !== null
-        ? new Date(Math.round(output.LastUpdateRequestedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastUpdateRequestedTime)))
         : undefined,
   } as any;
 };
@@ -11422,7 +11425,7 @@ const deserializeAws_json1_1ConformancePackEvaluationResult = (
     ComplianceType: __expectString(output.ComplianceType),
     ConfigRuleInvokedTime:
       output.ConfigRuleInvokedTime !== undefined && output.ConfigRuleInvokedTime !== null
-        ? new Date(Math.round(output.ConfigRuleInvokedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.ConfigRuleInvokedTime)))
         : undefined,
     EvaluationResultIdentifier:
       output.EvaluationResultIdentifier !== undefined && output.EvaluationResultIdentifier !== null
@@ -11430,7 +11433,7 @@ const deserializeAws_json1_1ConformancePackEvaluationResult = (
         : undefined,
     ResultRecordedTime:
       output.ResultRecordedTime !== undefined && output.ResultRecordedTime !== null
-        ? new Date(Math.round(output.ResultRecordedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.ResultRecordedTime)))
         : undefined,
   } as any;
 };
@@ -11513,11 +11516,11 @@ const deserializeAws_json1_1ConformancePackStatusDetail = (
     ConformancePackStatusReason: __expectString(output.ConformancePackStatusReason),
     LastUpdateCompletedTime:
       output.LastUpdateCompletedTime !== undefined && output.LastUpdateCompletedTime !== null
-        ? new Date(Math.round(output.LastUpdateCompletedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastUpdateCompletedTime)))
         : undefined,
     LastUpdateRequestedTime:
       output.LastUpdateRequestedTime !== undefined && output.LastUpdateRequestedTime !== null
-        ? new Date(Math.round(output.LastUpdateRequestedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastUpdateRequestedTime)))
         : undefined,
     StackArn: __expectString(output.StackArn),
   } as any;
@@ -12003,7 +12006,7 @@ const deserializeAws_json1_1Evaluation = (output: any, context: __SerdeContext):
     ComplianceType: __expectString(output.ComplianceType),
     OrderingTimestamp:
       output.OrderingTimestamp !== undefined && output.OrderingTimestamp !== null
-        ? new Date(Math.round(output.OrderingTimestamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.OrderingTimestamp)))
         : undefined,
   } as any;
 };
@@ -12014,7 +12017,7 @@ const deserializeAws_json1_1EvaluationResult = (output: any, context: __SerdeCon
     ComplianceType: __expectString(output.ComplianceType),
     ConfigRuleInvokedTime:
       output.ConfigRuleInvokedTime !== undefined && output.ConfigRuleInvokedTime !== null
-        ? new Date(Math.round(output.ConfigRuleInvokedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.ConfigRuleInvokedTime)))
         : undefined,
     EvaluationResultIdentifier:
       output.EvaluationResultIdentifier !== undefined && output.EvaluationResultIdentifier !== null
@@ -12022,7 +12025,7 @@ const deserializeAws_json1_1EvaluationResult = (output: any, context: __SerdeCon
         : undefined,
     ResultRecordedTime:
       output.ResultRecordedTime !== undefined && output.ResultRecordedTime !== null
-        ? new Date(Math.round(output.ResultRecordedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.ResultRecordedTime)))
         : undefined,
     ResultToken: __expectString(output.ResultToken),
   } as any;
@@ -12039,7 +12042,7 @@ const deserializeAws_json1_1EvaluationResultIdentifier = (
         : undefined,
     OrderingTimestamp:
       output.OrderingTimestamp !== undefined && output.OrderingTimestamp !== null
-        ? new Date(Math.round(output.OrderingTimestamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.OrderingTimestamp)))
         : undefined,
   } as any;
 };
@@ -12713,7 +12716,7 @@ const deserializeAws_json1_1MemberAccountStatus = (output: any, context: __Serde
     ErrorMessage: __expectString(output.ErrorMessage),
     LastUpdateTime:
       output.LastUpdateTime !== undefined && output.LastUpdateTime !== null
-        ? new Date(Math.round(output.LastUpdateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastUpdateTime)))
         : undefined,
     MemberAccountRuleStatus: __expectString(output.MemberAccountRuleStatus),
   } as any;
@@ -12900,7 +12903,7 @@ const deserializeAws_json1_1OrganizationConfigRule = (output: any, context: __Se
         : undefined,
     LastUpdateTime:
       output.LastUpdateTime !== undefined && output.LastUpdateTime !== null
-        ? new Date(Math.round(output.LastUpdateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastUpdateTime)))
         : undefined,
     OrganizationConfigRuleArn: __expectString(output.OrganizationConfigRuleArn),
     OrganizationConfigRuleName: __expectString(output.OrganizationConfigRuleName),
@@ -12952,7 +12955,7 @@ const deserializeAws_json1_1OrganizationConfigRuleStatus = (
     ErrorMessage: __expectString(output.ErrorMessage),
     LastUpdateTime:
       output.LastUpdateTime !== undefined && output.LastUpdateTime !== null
-        ? new Date(Math.round(output.LastUpdateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastUpdateTime)))
         : undefined,
     OrganizationConfigRuleName: __expectString(output.OrganizationConfigRuleName),
     OrganizationRuleStatus: __expectString(output.OrganizationRuleStatus),
@@ -13004,7 +13007,7 @@ const deserializeAws_json1_1OrganizationConformancePack = (
         : undefined,
     LastUpdateTime:
       output.LastUpdateTime !== undefined && output.LastUpdateTime !== null
-        ? new Date(Math.round(output.LastUpdateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastUpdateTime)))
         : undefined,
     OrganizationConformancePackArn: __expectString(output.OrganizationConformancePackArn),
     OrganizationConformancePackName: __expectString(output.OrganizationConformancePackName),
@@ -13022,7 +13025,7 @@ const deserializeAws_json1_1OrganizationConformancePackDetailedStatus = (
     ErrorMessage: __expectString(output.ErrorMessage),
     LastUpdateTime:
       output.LastUpdateTime !== undefined && output.LastUpdateTime !== null
-        ? new Date(Math.round(output.LastUpdateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastUpdateTime)))
         : undefined,
     Status: __expectString(output.Status),
   } as any;
@@ -13065,7 +13068,7 @@ const deserializeAws_json1_1OrganizationConformancePackStatus = (
     ErrorMessage: __expectString(output.ErrorMessage),
     LastUpdateTime:
       output.LastUpdateTime !== undefined && output.LastUpdateTime !== null
-        ? new Date(Math.round(output.LastUpdateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastUpdateTime)))
         : undefined,
     OrganizationConformancePackName: __expectString(output.OrganizationConformancePackName),
     Status: __expectString(output.Status),
@@ -13375,7 +13378,7 @@ const deserializeAws_json1_1RemediationException = (output: any, context: __Serd
     ConfigRuleName: __expectString(output.ConfigRuleName),
     ExpirationTime:
       output.ExpirationTime !== undefined && output.ExpirationTime !== null
-        ? new Date(Math.round(output.ExpirationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.ExpirationTime)))
         : undefined,
     Message: __expectString(output.Message),
     ResourceId: __expectString(output.ResourceId),
@@ -13425,11 +13428,11 @@ const deserializeAws_json1_1RemediationExecutionStatus = (
   return {
     InvocationTime:
       output.InvocationTime !== undefined && output.InvocationTime !== null
-        ? new Date(Math.round(output.InvocationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.InvocationTime)))
         : undefined,
     LastUpdatedTime:
       output.LastUpdatedTime !== undefined && output.LastUpdatedTime !== null
-        ? new Date(Math.round(output.LastUpdatedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastUpdatedTime)))
         : undefined,
     ResourceKey:
       output.ResourceKey !== undefined && output.ResourceKey !== null
@@ -13466,12 +13469,12 @@ const deserializeAws_json1_1RemediationExecutionStep = (
     Name: __expectString(output.Name),
     StartTime:
       output.StartTime !== undefined && output.StartTime !== null
-        ? new Date(Math.round(output.StartTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.StartTime)))
         : undefined,
     State: __expectString(output.State),
     StopTime:
       output.StopTime !== undefined && output.StopTime !== null
-        ? new Date(Math.round(output.StopTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.StopTime)))
         : undefined,
   } as any;
 };
@@ -13564,7 +13567,7 @@ const deserializeAws_json1_1ResourceIdentifier = (output: any, context: __SerdeC
   return {
     resourceDeletionTime:
       output.resourceDeletionTime !== undefined && output.resourceDeletionTime !== null
-        ? new Date(Math.round(output.resourceDeletionTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.resourceDeletionTime)))
         : undefined,
     resourceId: __expectString(output.resourceId),
     resourceName: __expectString(output.resourceName),

--- a/clients/client-connect/protocols/Aws_restJson1.ts
+++ b/clients/client-connect/protocols/Aws_restJson1.ts
@@ -408,10 +408,12 @@ import {
   expectBoolean as __expectBoolean,
   expectInt32 as __expectInt32,
   expectNonNull as __expectNonNull,
+  expectNumber as __expectNumber,
   expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   limitedParseDouble as __limitedParseDouble,
+  parseEpochTimestamp as __parseEpochTimestamp,
   serializeFloat as __serializeFloat,
 } from "@aws-sdk/smithy-client";
 import {
@@ -8889,7 +8891,7 @@ export const deserializeAws_restJson1GetCurrentMetricDataCommand = async (
   };
   const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DataSnapshotTime !== undefined && data.DataSnapshotTime !== null) {
-    contents.DataSnapshotTime = new Date(Math.round(data.DataSnapshotTime * 1000));
+    contents.DataSnapshotTime = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.DataSnapshotTime)));
   }
   if (data.MetricResults !== undefined && data.MetricResults !== null) {
     contents.MetricResults = deserializeAws_restJson1CurrentMetricResults(data.MetricResults, context);
@@ -15130,12 +15132,12 @@ const deserializeAws_restJson1Credentials = (output: any, context: __SerdeContex
     AccessToken: __expectString(output.AccessToken),
     AccessTokenExpiration:
       output.AccessTokenExpiration !== undefined && output.AccessTokenExpiration !== null
-        ? new Date(Math.round(output.AccessTokenExpiration * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.AccessTokenExpiration)))
         : undefined,
     RefreshToken: __expectString(output.RefreshToken),
     RefreshTokenExpiration:
       output.RefreshTokenExpiration !== undefined && output.RefreshTokenExpiration !== null
-        ? new Date(Math.round(output.RefreshTokenExpiration * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.RefreshTokenExpiration)))
         : undefined,
   } as any;
 };
@@ -15471,7 +15473,7 @@ const deserializeAws_restJson1Instance = (output: any, context: __SerdeContext):
     Arn: __expectString(output.Arn),
     CreatedTime:
       output.CreatedTime !== undefined && output.CreatedTime !== null
-        ? new Date(Math.round(output.CreatedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreatedTime)))
         : undefined,
     Id: __expectString(output.Id),
     IdentityManagementType: __expectString(output.IdentityManagementType),
@@ -15535,7 +15537,7 @@ const deserializeAws_restJson1InstanceSummary = (output: any, context: __SerdeCo
     Arn: __expectString(output.Arn),
     CreatedTime:
       output.CreatedTime !== undefined && output.CreatedTime !== null
-        ? new Date(Math.round(output.CreatedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreatedTime)))
         : undefined,
     Id: __expectString(output.Id),
     IdentityManagementType: __expectString(output.IdentityManagementType),
@@ -15965,7 +15967,7 @@ const deserializeAws_restJson1SecurityKey = (output: any, context: __SerdeContex
     AssociationId: __expectString(output.AssociationId),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     Key: __expectString(output.Key),
   } as any;

--- a/clients/client-customer-profiles/protocols/Aws_restJson1.ts
+++ b/clients/client-customer-profiles/protocols/Aws_restJson1.ts
@@ -100,9 +100,11 @@ import {
   expectInt32 as __expectInt32,
   expectLong as __expectLong,
   expectNonNull as __expectNonNull,
+  expectNumber as __expectNumber,
   expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
+  parseEpochTimestamp as __parseEpochTimestamp,
 } from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
@@ -1356,7 +1358,7 @@ export const deserializeAws_restJson1CreateDomainCommand = async (
   };
   const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CreatedAt !== undefined && data.CreatedAt !== null) {
-    contents.CreatedAt = new Date(Math.round(data.CreatedAt * 1000));
+    contents.CreatedAt = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.CreatedAt)));
   }
   if (data.DeadLetterQueueUrl !== undefined && data.DeadLetterQueueUrl !== null) {
     contents.DeadLetterQueueUrl = __expectString(data.DeadLetterQueueUrl);
@@ -1371,7 +1373,7 @@ export const deserializeAws_restJson1CreateDomainCommand = async (
     contents.DomainName = __expectString(data.DomainName);
   }
   if (data.LastUpdatedAt !== undefined && data.LastUpdatedAt !== null) {
-    contents.LastUpdatedAt = new Date(Math.round(data.LastUpdatedAt * 1000));
+    contents.LastUpdatedAt = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.LastUpdatedAt)));
   }
   if (data.Matching !== undefined && data.Matching !== null) {
     contents.Matching = deserializeAws_restJson1MatchingResponse(data.Matching, context);
@@ -2081,7 +2083,7 @@ export const deserializeAws_restJson1GetDomainCommand = async (
   };
   const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CreatedAt !== undefined && data.CreatedAt !== null) {
-    contents.CreatedAt = new Date(Math.round(data.CreatedAt * 1000));
+    contents.CreatedAt = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.CreatedAt)));
   }
   if (data.DeadLetterQueueUrl !== undefined && data.DeadLetterQueueUrl !== null) {
     contents.DeadLetterQueueUrl = __expectString(data.DeadLetterQueueUrl);
@@ -2096,7 +2098,7 @@ export const deserializeAws_restJson1GetDomainCommand = async (
     contents.DomainName = __expectString(data.DomainName);
   }
   if (data.LastUpdatedAt !== undefined && data.LastUpdatedAt !== null) {
-    contents.LastUpdatedAt = new Date(Math.round(data.LastUpdatedAt * 1000));
+    contents.LastUpdatedAt = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.LastUpdatedAt)));
   }
   if (data.Matching !== undefined && data.Matching !== null) {
     contents.Matching = deserializeAws_restJson1MatchingResponse(data.Matching, context);
@@ -2197,13 +2199,13 @@ export const deserializeAws_restJson1GetIntegrationCommand = async (
   };
   const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CreatedAt !== undefined && data.CreatedAt !== null) {
-    contents.CreatedAt = new Date(Math.round(data.CreatedAt * 1000));
+    contents.CreatedAt = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.CreatedAt)));
   }
   if (data.DomainName !== undefined && data.DomainName !== null) {
     contents.DomainName = __expectString(data.DomainName);
   }
   if (data.LastUpdatedAt !== undefined && data.LastUpdatedAt !== null) {
-    contents.LastUpdatedAt = new Date(Math.round(data.LastUpdatedAt * 1000));
+    contents.LastUpdatedAt = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.LastUpdatedAt)));
   }
   if (data.ObjectTypeName !== undefined && data.ObjectTypeName !== null) {
     contents.ObjectTypeName = __expectString(data.ObjectTypeName);
@@ -2302,7 +2304,7 @@ export const deserializeAws_restJson1GetMatchesCommand = async (
   };
   const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.MatchGenerationDate !== undefined && data.MatchGenerationDate !== null) {
-    contents.MatchGenerationDate = new Date(Math.round(data.MatchGenerationDate * 1000));
+    contents.MatchGenerationDate = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.MatchGenerationDate)));
   }
   if (data.Matches !== undefined && data.Matches !== null) {
     contents.Matches = deserializeAws_restJson1MatchesList(data.Matches, context);
@@ -2411,7 +2413,7 @@ export const deserializeAws_restJson1GetProfileObjectTypeCommand = async (
     contents.AllowProfileCreation = __expectBoolean(data.AllowProfileCreation);
   }
   if (data.CreatedAt !== undefined && data.CreatedAt !== null) {
-    contents.CreatedAt = new Date(Math.round(data.CreatedAt * 1000));
+    contents.CreatedAt = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.CreatedAt)));
   }
   if (data.Description !== undefined && data.Description !== null) {
     contents.Description = __expectString(data.Description);
@@ -2429,7 +2431,7 @@ export const deserializeAws_restJson1GetProfileObjectTypeCommand = async (
     contents.Keys = deserializeAws_restJson1KeyMap(data.Keys, context);
   }
   if (data.LastUpdatedAt !== undefined && data.LastUpdatedAt !== null) {
-    contents.LastUpdatedAt = new Date(Math.round(data.LastUpdatedAt * 1000));
+    contents.LastUpdatedAt = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.LastUpdatedAt)));
   }
   if (data.ObjectTypeName !== undefined && data.ObjectTypeName !== null) {
     contents.ObjectTypeName = __expectString(data.ObjectTypeName);
@@ -3333,13 +3335,13 @@ export const deserializeAws_restJson1PutIntegrationCommand = async (
   };
   const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CreatedAt !== undefined && data.CreatedAt !== null) {
-    contents.CreatedAt = new Date(Math.round(data.CreatedAt * 1000));
+    contents.CreatedAt = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.CreatedAt)));
   }
   if (data.DomainName !== undefined && data.DomainName !== null) {
     contents.DomainName = __expectString(data.DomainName);
   }
   if (data.LastUpdatedAt !== undefined && data.LastUpdatedAt !== null) {
-    contents.LastUpdatedAt = new Date(Math.round(data.LastUpdatedAt * 1000));
+    contents.LastUpdatedAt = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.LastUpdatedAt)));
   }
   if (data.ObjectTypeName !== undefined && data.ObjectTypeName !== null) {
     contents.ObjectTypeName = __expectString(data.ObjectTypeName);
@@ -3535,7 +3537,7 @@ export const deserializeAws_restJson1PutProfileObjectTypeCommand = async (
     contents.AllowProfileCreation = __expectBoolean(data.AllowProfileCreation);
   }
   if (data.CreatedAt !== undefined && data.CreatedAt !== null) {
-    contents.CreatedAt = new Date(Math.round(data.CreatedAt * 1000));
+    contents.CreatedAt = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.CreatedAt)));
   }
   if (data.Description !== undefined && data.Description !== null) {
     contents.Description = __expectString(data.Description);
@@ -3553,7 +3555,7 @@ export const deserializeAws_restJson1PutProfileObjectTypeCommand = async (
     contents.Keys = deserializeAws_restJson1KeyMap(data.Keys, context);
   }
   if (data.LastUpdatedAt !== undefined && data.LastUpdatedAt !== null) {
-    contents.LastUpdatedAt = new Date(Math.round(data.LastUpdatedAt * 1000));
+    contents.LastUpdatedAt = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.LastUpdatedAt)));
   }
   if (data.ObjectTypeName !== undefined && data.ObjectTypeName !== null) {
     contents.ObjectTypeName = __expectString(data.ObjectTypeName);
@@ -3881,7 +3883,7 @@ export const deserializeAws_restJson1UpdateDomainCommand = async (
   };
   const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CreatedAt !== undefined && data.CreatedAt !== null) {
-    contents.CreatedAt = new Date(Math.round(data.CreatedAt * 1000));
+    contents.CreatedAt = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.CreatedAt)));
   }
   if (data.DeadLetterQueueUrl !== undefined && data.DeadLetterQueueUrl !== null) {
     contents.DeadLetterQueueUrl = __expectString(data.DeadLetterQueueUrl);
@@ -3896,7 +3898,7 @@ export const deserializeAws_restJson1UpdateDomainCommand = async (
     contents.DomainName = __expectString(data.DomainName);
   }
   if (data.LastUpdatedAt !== undefined && data.LastUpdatedAt !== null) {
-    contents.LastUpdatedAt = new Date(Math.round(data.LastUpdatedAt * 1000));
+    contents.LastUpdatedAt = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.LastUpdatedAt)));
   }
   if (data.Matching !== undefined && data.Matching !== null) {
     contents.Matching = deserializeAws_restJson1MatchingResponse(data.Matching, context);
@@ -4695,12 +4697,12 @@ const deserializeAws_restJson1ListDomainItem = (output: any, context: __SerdeCon
   return {
     CreatedAt:
       output.CreatedAt !== undefined && output.CreatedAt !== null
-        ? new Date(Math.round(output.CreatedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreatedAt)))
         : undefined,
     DomainName: __expectString(output.DomainName),
     LastUpdatedAt:
       output.LastUpdatedAt !== undefined && output.LastUpdatedAt !== null
-        ? new Date(Math.round(output.LastUpdatedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastUpdatedAt)))
         : undefined,
     Tags:
       output.Tags !== undefined && output.Tags !== null
@@ -4713,12 +4715,12 @@ const deserializeAws_restJson1ListIntegrationItem = (output: any, context: __Ser
   return {
     CreatedAt:
       output.CreatedAt !== undefined && output.CreatedAt !== null
-        ? new Date(Math.round(output.CreatedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreatedAt)))
         : undefined,
     DomainName: __expectString(output.DomainName),
     LastUpdatedAt:
       output.LastUpdatedAt !== undefined && output.LastUpdatedAt !== null
-        ? new Date(Math.round(output.LastUpdatedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastUpdatedAt)))
         : undefined,
     ObjectTypeName: __expectString(output.ObjectTypeName),
     Tags:
@@ -4747,12 +4749,12 @@ const deserializeAws_restJson1ListProfileObjectTypeItem = (
   return {
     CreatedAt:
       output.CreatedAt !== undefined && output.CreatedAt !== null
-        ? new Date(Math.round(output.CreatedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreatedAt)))
         : undefined,
     Description: __expectString(output.Description),
     LastUpdatedAt:
       output.LastUpdatedAt !== undefined && output.LastUpdatedAt !== null
-        ? new Date(Math.round(output.LastUpdatedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastUpdatedAt)))
         : undefined,
     ObjectTypeName: __expectString(output.ObjectTypeName),
     Tags:

--- a/clients/client-database-migration-service/protocols/Aws_json1_1.ts
+++ b/clients/client-database-migration-service/protocols/Aws_json1_1.ts
@@ -366,7 +366,10 @@ import {
   expectBoolean as __expectBoolean,
   expectInt32 as __expectInt32,
   expectLong as __expectLong,
+  expectNonNull as __expectNonNull,
+  expectNumber as __expectNumber,
   expectString as __expectString,
+  parseEpochTimestamp as __parseEpochTimestamp,
 } from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
@@ -6874,7 +6877,7 @@ const deserializeAws_json1_1Certificate = (output: any, context: __SerdeContext)
     CertificateArn: __expectString(output.CertificateArn),
     CertificateCreationDate:
       output.CertificateCreationDate !== undefined && output.CertificateCreationDate !== null
-        ? new Date(Math.round(output.CertificateCreationDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CertificateCreationDate)))
         : undefined,
     CertificateIdentifier: __expectString(output.CertificateIdentifier),
     CertificateOwner: __expectString(output.CertificateOwner),
@@ -6887,11 +6890,11 @@ const deserializeAws_json1_1Certificate = (output: any, context: __SerdeContext)
     SigningAlgorithm: __expectString(output.SigningAlgorithm),
     ValidFromDate:
       output.ValidFromDate !== undefined && output.ValidFromDate !== null
-        ? new Date(Math.round(output.ValidFromDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.ValidFromDate)))
         : undefined,
     ValidToDate:
       output.ValidToDate !== undefined && output.ValidToDate !== null
-        ? new Date(Math.round(output.ValidToDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.ValidToDate)))
         : undefined,
   } as any;
 };
@@ -7541,7 +7544,10 @@ const deserializeAws_json1_1EndpointSettingsList = (output: any, context: __Serd
 
 const deserializeAws_json1_1Event = (output: any, context: __SerdeContext): Event => {
   return {
-    Date: output.Date !== undefined && output.Date !== null ? new Date(Math.round(output.Date * 1000)) : undefined,
+    Date:
+      output.Date !== undefined && output.Date !== null
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.Date)))
+        : undefined,
     EventCategories:
       output.EventCategories !== undefined && output.EventCategories !== null
         ? deserializeAws_json1_1EventCategoriesList(output.EventCategories, context)
@@ -8034,16 +8040,16 @@ const deserializeAws_json1_1PendingMaintenanceAction = (
     Action: __expectString(output.Action),
     AutoAppliedAfterDate:
       output.AutoAppliedAfterDate !== undefined && output.AutoAppliedAfterDate !== null
-        ? new Date(Math.round(output.AutoAppliedAfterDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.AutoAppliedAfterDate)))
         : undefined,
     CurrentApplyDate:
       output.CurrentApplyDate !== undefined && output.CurrentApplyDate !== null
-        ? new Date(Math.round(output.CurrentApplyDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CurrentApplyDate)))
         : undefined,
     Description: __expectString(output.Description),
     ForcedApplyDate:
       output.ForcedApplyDate !== undefined && output.ForcedApplyDate !== null
-        ? new Date(Math.round(output.ForcedApplyDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.ForcedApplyDate)))
         : undefined,
     OptInStatus: __expectString(output.OptInStatus),
   } as any;
@@ -8174,7 +8180,7 @@ const deserializeAws_json1_1RefreshSchemasStatus = (output: any, context: __Serd
     LastFailureMessage: __expectString(output.LastFailureMessage),
     LastRefreshDate:
       output.LastRefreshDate !== undefined && output.LastRefreshDate !== null
-        ? new Date(Math.round(output.LastRefreshDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastRefreshDate)))
         : undefined,
     ReplicationInstanceArn: __expectString(output.ReplicationInstanceArn),
     Status: __expectString(output.Status),
@@ -8203,11 +8209,11 @@ const deserializeAws_json1_1ReplicationInstance = (output: any, context: __Serde
     EngineVersion: __expectString(output.EngineVersion),
     FreeUntil:
       output.FreeUntil !== undefined && output.FreeUntil !== null
-        ? new Date(Math.round(output.FreeUntil * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.FreeUntil)))
         : undefined,
     InstanceCreateTime:
       output.InstanceCreateTime !== undefined && output.InstanceCreateTime !== null
-        ? new Date(Math.round(output.InstanceCreateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.InstanceCreateTime)))
         : undefined,
     KmsKeyId: __expectString(output.KmsKeyId),
     MultiAZ: __expectBoolean(output.MultiAZ),
@@ -8373,13 +8379,13 @@ const deserializeAws_json1_1ReplicationTask = (output: any, context: __SerdeCont
     ReplicationTaskArn: __expectString(output.ReplicationTaskArn),
     ReplicationTaskCreationDate:
       output.ReplicationTaskCreationDate !== undefined && output.ReplicationTaskCreationDate !== null
-        ? new Date(Math.round(output.ReplicationTaskCreationDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.ReplicationTaskCreationDate)))
         : undefined,
     ReplicationTaskIdentifier: __expectString(output.ReplicationTaskIdentifier),
     ReplicationTaskSettings: __expectString(output.ReplicationTaskSettings),
     ReplicationTaskStartDate:
       output.ReplicationTaskStartDate !== undefined && output.ReplicationTaskStartDate !== null
-        ? new Date(Math.round(output.ReplicationTaskStartDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.ReplicationTaskStartDate)))
         : undefined,
     ReplicationTaskStats:
       output.ReplicationTaskStats !== undefined && output.ReplicationTaskStats !== null
@@ -8407,7 +8413,7 @@ const deserializeAws_json1_1ReplicationTaskAssessmentResult = (
     ReplicationTaskIdentifier: __expectString(output.ReplicationTaskIdentifier),
     ReplicationTaskLastAssessmentDate:
       output.ReplicationTaskLastAssessmentDate !== undefined && output.ReplicationTaskLastAssessmentDate !== null
-        ? new Date(Math.round(output.ReplicationTaskLastAssessmentDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.ReplicationTaskLastAssessmentDate)))
         : undefined,
     S3ObjectUrl: __expectString(output.S3ObjectUrl),
   } as any;
@@ -8443,7 +8449,7 @@ const deserializeAws_json1_1ReplicationTaskAssessmentRun = (
     ReplicationTaskAssessmentRunCreationDate:
       output.ReplicationTaskAssessmentRunCreationDate !== undefined &&
       output.ReplicationTaskAssessmentRunCreationDate !== null
-        ? new Date(Math.round(output.ReplicationTaskAssessmentRunCreationDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.ReplicationTaskAssessmentRunCreationDate)))
         : undefined,
     ResultEncryptionMode: __expectString(output.ResultEncryptionMode),
     ResultKmsKeyArn: __expectString(output.ResultKmsKeyArn),
@@ -8489,7 +8495,7 @@ const deserializeAws_json1_1ReplicationTaskIndividualAssessment = (
     ReplicationTaskIndividualAssessmentStartDate:
       output.ReplicationTaskIndividualAssessmentStartDate !== undefined &&
       output.ReplicationTaskIndividualAssessmentStartDate !== null
-        ? new Date(Math.round(output.ReplicationTaskIndividualAssessmentStartDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.ReplicationTaskIndividualAssessmentStartDate)))
         : undefined,
     Status: __expectString(output.Status),
   } as any;
@@ -8525,24 +8531,24 @@ const deserializeAws_json1_1ReplicationTaskStats = (output: any, context: __Serd
     ElapsedTimeMillis: __expectLong(output.ElapsedTimeMillis),
     FreshStartDate:
       output.FreshStartDate !== undefined && output.FreshStartDate !== null
-        ? new Date(Math.round(output.FreshStartDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.FreshStartDate)))
         : undefined,
     FullLoadFinishDate:
       output.FullLoadFinishDate !== undefined && output.FullLoadFinishDate !== null
-        ? new Date(Math.round(output.FullLoadFinishDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.FullLoadFinishDate)))
         : undefined,
     FullLoadProgressPercent: __expectInt32(output.FullLoadProgressPercent),
     FullLoadStartDate:
       output.FullLoadStartDate !== undefined && output.FullLoadStartDate !== null
-        ? new Date(Math.round(output.FullLoadStartDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.FullLoadStartDate)))
         : undefined,
     StartDate:
       output.StartDate !== undefined && output.StartDate !== null
-        ? new Date(Math.round(output.StartDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.StartDate)))
         : undefined,
     StopDate:
       output.StopDate !== undefined && output.StopDate !== null
-        ? new Date(Math.round(output.StopDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.StopDate)))
         : undefined,
     TablesErrored: __expectInt32(output.TablesErrored),
     TablesLoaded: __expectInt32(output.TablesLoaded),
@@ -8810,19 +8816,19 @@ const deserializeAws_json1_1TableStatistics = (output: any, context: __SerdeCont
     FullLoadCondtnlChkFailedRows: __expectLong(output.FullLoadCondtnlChkFailedRows),
     FullLoadEndTime:
       output.FullLoadEndTime !== undefined && output.FullLoadEndTime !== null
-        ? new Date(Math.round(output.FullLoadEndTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.FullLoadEndTime)))
         : undefined,
     FullLoadErrorRows: __expectLong(output.FullLoadErrorRows),
     FullLoadReloaded: __expectBoolean(output.FullLoadReloaded),
     FullLoadRows: __expectLong(output.FullLoadRows),
     FullLoadStartTime:
       output.FullLoadStartTime !== undefined && output.FullLoadStartTime !== null
-        ? new Date(Math.round(output.FullLoadStartTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.FullLoadStartTime)))
         : undefined,
     Inserts: __expectLong(output.Inserts),
     LastUpdateTime:
       output.LastUpdateTime !== undefined && output.LastUpdateTime !== null
-        ? new Date(Math.round(output.LastUpdateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastUpdateTime)))
         : undefined,
     SchemaName: __expectString(output.SchemaName),
     TableName: __expectString(output.TableName),

--- a/clients/client-databrew/protocols/Aws_restJson1.ts
+++ b/clients/client-databrew/protocols/Aws_restJson1.ts
@@ -105,9 +105,11 @@ import {
   expectInt32 as __expectInt32,
   expectLong as __expectLong,
   expectNonNull as __expectNonNull,
+  expectNumber as __expectNumber,
   expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
+  parseEpochTimestamp as __parseEpochTimestamp,
 } from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
@@ -2330,7 +2332,7 @@ export const deserializeAws_restJson1DescribeDatasetCommand = async (
   };
   const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CreateDate !== undefined && data.CreateDate !== null) {
-    contents.CreateDate = new Date(Math.round(data.CreateDate * 1000));
+    contents.CreateDate = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.CreateDate)));
   }
   if (data.CreatedBy !== undefined && data.CreatedBy !== null) {
     contents.CreatedBy = __expectString(data.CreatedBy);
@@ -2348,7 +2350,7 @@ export const deserializeAws_restJson1DescribeDatasetCommand = async (
     contents.LastModifiedBy = __expectString(data.LastModifiedBy);
   }
   if (data.LastModifiedDate !== undefined && data.LastModifiedDate !== null) {
-    contents.LastModifiedDate = new Date(Math.round(data.LastModifiedDate * 1000));
+    contents.LastModifiedDate = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.LastModifiedDate)));
   }
   if (data.Name !== undefined && data.Name !== null) {
     contents.Name = __expectString(data.Name);
@@ -2448,7 +2450,7 @@ export const deserializeAws_restJson1DescribeJobCommand = async (
   };
   const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CreateDate !== undefined && data.CreateDate !== null) {
-    contents.CreateDate = new Date(Math.round(data.CreateDate * 1000));
+    contents.CreateDate = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.CreateDate)));
   }
   if (data.CreatedBy !== undefined && data.CreatedBy !== null) {
     contents.CreatedBy = __expectString(data.CreatedBy);
@@ -2475,7 +2477,7 @@ export const deserializeAws_restJson1DescribeJobCommand = async (
     contents.LastModifiedBy = __expectString(data.LastModifiedBy);
   }
   if (data.LastModifiedDate !== undefined && data.LastModifiedDate !== null) {
-    contents.LastModifiedDate = new Date(Math.round(data.LastModifiedDate * 1000));
+    contents.LastModifiedDate = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.LastModifiedDate)));
   }
   if (data.LogSubscription !== undefined && data.LogSubscription !== null) {
     contents.LogSubscription = __expectString(data.LogSubscription);
@@ -2597,7 +2599,7 @@ export const deserializeAws_restJson1DescribeJobRunCommand = async (
     contents.Attempt = __expectInt32(data.Attempt);
   }
   if (data.CompletedOn !== undefined && data.CompletedOn !== null) {
-    contents.CompletedOn = new Date(Math.round(data.CompletedOn * 1000));
+    contents.CompletedOn = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.CompletedOn)));
   }
   if (data.DataCatalogOutputs !== undefined && data.DataCatalogOutputs !== null) {
     contents.DataCatalogOutputs = deserializeAws_restJson1DataCatalogOutputList(data.DataCatalogOutputs, context);
@@ -2642,7 +2644,7 @@ export const deserializeAws_restJson1DescribeJobRunCommand = async (
     contents.StartedBy = __expectString(data.StartedBy);
   }
   if (data.StartedOn !== undefined && data.StartedOn !== null) {
-    contents.StartedOn = new Date(Math.round(data.StartedOn * 1000));
+    contents.StartedOn = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.StartedOn)));
   }
   if (data.State !== undefined && data.State !== null) {
     contents.State = __expectString(data.State);
@@ -2721,7 +2723,7 @@ export const deserializeAws_restJson1DescribeProjectCommand = async (
   };
   const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CreateDate !== undefined && data.CreateDate !== null) {
-    contents.CreateDate = new Date(Math.round(data.CreateDate * 1000));
+    contents.CreateDate = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.CreateDate)));
   }
   if (data.CreatedBy !== undefined && data.CreatedBy !== null) {
     contents.CreatedBy = __expectString(data.CreatedBy);
@@ -2733,13 +2735,13 @@ export const deserializeAws_restJson1DescribeProjectCommand = async (
     contents.LastModifiedBy = __expectString(data.LastModifiedBy);
   }
   if (data.LastModifiedDate !== undefined && data.LastModifiedDate !== null) {
-    contents.LastModifiedDate = new Date(Math.round(data.LastModifiedDate * 1000));
+    contents.LastModifiedDate = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.LastModifiedDate)));
   }
   if (data.Name !== undefined && data.Name !== null) {
     contents.Name = __expectString(data.Name);
   }
   if (data.OpenDate !== undefined && data.OpenDate !== null) {
-    contents.OpenDate = new Date(Math.round(data.OpenDate * 1000));
+    contents.OpenDate = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.OpenDate)));
   }
   if (data.OpenedBy !== undefined && data.OpenedBy !== null) {
     contents.OpenedBy = __expectString(data.OpenedBy);
@@ -2835,7 +2837,7 @@ export const deserializeAws_restJson1DescribeRecipeCommand = async (
   };
   const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CreateDate !== undefined && data.CreateDate !== null) {
-    contents.CreateDate = new Date(Math.round(data.CreateDate * 1000));
+    contents.CreateDate = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.CreateDate)));
   }
   if (data.CreatedBy !== undefined && data.CreatedBy !== null) {
     contents.CreatedBy = __expectString(data.CreatedBy);
@@ -2847,7 +2849,7 @@ export const deserializeAws_restJson1DescribeRecipeCommand = async (
     contents.LastModifiedBy = __expectString(data.LastModifiedBy);
   }
   if (data.LastModifiedDate !== undefined && data.LastModifiedDate !== null) {
-    contents.LastModifiedDate = new Date(Math.round(data.LastModifiedDate * 1000));
+    contents.LastModifiedDate = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.LastModifiedDate)));
   }
   if (data.Name !== undefined && data.Name !== null) {
     contents.Name = __expectString(data.Name);
@@ -2859,7 +2861,7 @@ export const deserializeAws_restJson1DescribeRecipeCommand = async (
     contents.PublishedBy = __expectString(data.PublishedBy);
   }
   if (data.PublishedDate !== undefined && data.PublishedDate !== null) {
-    contents.PublishedDate = new Date(Math.round(data.PublishedDate * 1000));
+    contents.PublishedDate = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.PublishedDate)));
   }
   if (data.RecipeVersion !== undefined && data.RecipeVersion !== null) {
     contents.RecipeVersion = __expectString(data.RecipeVersion);
@@ -2942,7 +2944,7 @@ export const deserializeAws_restJson1DescribeScheduleCommand = async (
   };
   const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CreateDate !== undefined && data.CreateDate !== null) {
-    contents.CreateDate = new Date(Math.round(data.CreateDate * 1000));
+    contents.CreateDate = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.CreateDate)));
   }
   if (data.CreatedBy !== undefined && data.CreatedBy !== null) {
     contents.CreatedBy = __expectString(data.CreatedBy);
@@ -2957,7 +2959,7 @@ export const deserializeAws_restJson1DescribeScheduleCommand = async (
     contents.LastModifiedBy = __expectString(data.LastModifiedBy);
   }
   if (data.LastModifiedDate !== undefined && data.LastModifiedDate !== null) {
-    contents.LastModifiedDate = new Date(Math.round(data.LastModifiedDate * 1000));
+    contents.LastModifiedDate = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.LastModifiedDate)));
   }
   if (data.Name !== undefined && data.Name !== null) {
     contents.Name = __expectString(data.Name);
@@ -4173,7 +4175,7 @@ export const deserializeAws_restJson1UpdateProjectCommand = async (
   };
   const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.LastModifiedDate !== undefined && data.LastModifiedDate !== null) {
-    contents.LastModifiedDate = new Date(Math.round(data.LastModifiedDate * 1000));
+    contents.LastModifiedDate = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.LastModifiedDate)));
   }
   if (data.Name !== undefined && data.Name !== null) {
     contents.Name = __expectString(data.Name);
@@ -5294,7 +5296,7 @@ const deserializeAws_restJson1Dataset = (output: any, context: __SerdeContext): 
     AccountId: __expectString(output.AccountId),
     CreateDate:
       output.CreateDate !== undefined && output.CreateDate !== null
-        ? new Date(Math.round(output.CreateDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreateDate)))
         : undefined,
     CreatedBy: __expectString(output.CreatedBy),
     Format: __expectString(output.Format),
@@ -5309,7 +5311,7 @@ const deserializeAws_restJson1Dataset = (output: any, context: __SerdeContext): 
     LastModifiedBy: __expectString(output.LastModifiedBy),
     LastModifiedDate:
       output.LastModifiedDate !== undefined && output.LastModifiedDate !== null
-        ? new Date(Math.round(output.LastModifiedDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastModifiedDate)))
         : undefined,
     Name: __expectString(output.Name),
     PathOptions:
@@ -5431,7 +5433,7 @@ const deserializeAws_restJson1Job = (output: any, context: __SerdeContext): Job 
     AccountId: __expectString(output.AccountId),
     CreateDate:
       output.CreateDate !== undefined && output.CreateDate !== null
-        ? new Date(Math.round(output.CreateDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreateDate)))
         : undefined,
     CreatedBy: __expectString(output.CreatedBy),
     DataCatalogOutputs:
@@ -5452,7 +5454,7 @@ const deserializeAws_restJson1Job = (output: any, context: __SerdeContext): Job 
     LastModifiedBy: __expectString(output.LastModifiedBy),
     LastModifiedDate:
       output.LastModifiedDate !== undefined && output.LastModifiedDate !== null
-        ? new Date(Math.round(output.LastModifiedDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastModifiedDate)))
         : undefined,
     LogSubscription: __expectString(output.LogSubscription),
     MaxCapacity: __expectInt32(output.MaxCapacity),
@@ -5505,7 +5507,7 @@ const deserializeAws_restJson1JobRun = (output: any, context: __SerdeContext): J
     Attempt: __expectInt32(output.Attempt),
     CompletedOn:
       output.CompletedOn !== undefined && output.CompletedOn !== null
-        ? new Date(Math.round(output.CompletedOn * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CompletedOn)))
         : undefined,
     DataCatalogOutputs:
       output.DataCatalogOutputs !== undefined && output.DataCatalogOutputs !== null
@@ -5537,7 +5539,7 @@ const deserializeAws_restJson1JobRun = (output: any, context: __SerdeContext): J
     StartedBy: __expectString(output.StartedBy),
     StartedOn:
       output.StartedOn !== undefined && output.StartedOn !== null
-        ? new Date(Math.round(output.StartedOn * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.StartedOn)))
         : undefined,
     State: __expectString(output.State),
   } as any;
@@ -5673,19 +5675,19 @@ const deserializeAws_restJson1Project = (output: any, context: __SerdeContext): 
     AccountId: __expectString(output.AccountId),
     CreateDate:
       output.CreateDate !== undefined && output.CreateDate !== null
-        ? new Date(Math.round(output.CreateDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreateDate)))
         : undefined,
     CreatedBy: __expectString(output.CreatedBy),
     DatasetName: __expectString(output.DatasetName),
     LastModifiedBy: __expectString(output.LastModifiedBy),
     LastModifiedDate:
       output.LastModifiedDate !== undefined && output.LastModifiedDate !== null
-        ? new Date(Math.round(output.LastModifiedDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastModifiedDate)))
         : undefined,
     Name: __expectString(output.Name),
     OpenDate:
       output.OpenDate !== undefined && output.OpenDate !== null
-        ? new Date(Math.round(output.OpenDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.OpenDate)))
         : undefined,
     OpenedBy: __expectString(output.OpenedBy),
     RecipeName: __expectString(output.RecipeName),
@@ -5717,21 +5719,21 @@ const deserializeAws_restJson1Recipe = (output: any, context: __SerdeContext): R
   return {
     CreateDate:
       output.CreateDate !== undefined && output.CreateDate !== null
-        ? new Date(Math.round(output.CreateDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreateDate)))
         : undefined,
     CreatedBy: __expectString(output.CreatedBy),
     Description: __expectString(output.Description),
     LastModifiedBy: __expectString(output.LastModifiedBy),
     LastModifiedDate:
       output.LastModifiedDate !== undefined && output.LastModifiedDate !== null
-        ? new Date(Math.round(output.LastModifiedDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastModifiedDate)))
         : undefined,
     Name: __expectString(output.Name),
     ProjectName: __expectString(output.ProjectName),
     PublishedBy: __expectString(output.PublishedBy),
     PublishedDate:
       output.PublishedDate !== undefined && output.PublishedDate !== null
-        ? new Date(Math.round(output.PublishedDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.PublishedDate)))
         : undefined,
     RecipeVersion: __expectString(output.RecipeVersion),
     ResourceArn: __expectString(output.ResourceArn),
@@ -5848,7 +5850,7 @@ const deserializeAws_restJson1Schedule = (output: any, context: __SerdeContext):
     AccountId: __expectString(output.AccountId),
     CreateDate:
       output.CreateDate !== undefined && output.CreateDate !== null
-        ? new Date(Math.round(output.CreateDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreateDate)))
         : undefined,
     CreatedBy: __expectString(output.CreatedBy),
     CronExpression: __expectString(output.CronExpression),
@@ -5859,7 +5861,7 @@ const deserializeAws_restJson1Schedule = (output: any, context: __SerdeContext):
     LastModifiedBy: __expectString(output.LastModifiedBy),
     LastModifiedDate:
       output.LastModifiedDate !== undefined && output.LastModifiedDate !== null
-        ? new Date(Math.round(output.LastModifiedDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastModifiedDate)))
         : undefined,
     Name: __expectString(output.Name),
     ResourceArn: __expectString(output.ResourceArn),

--- a/clients/client-dataexchange/protocols/Aws_restJson1.ts
+++ b/clients/client-dataexchange/protocols/Aws_restJson1.ts
@@ -69,6 +69,7 @@ import {
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   limitedParseDouble as __limitedParseDouble,
+  parseRfc3339DateTime as __parseRfc3339DateTime,
 } from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
@@ -952,7 +953,7 @@ export const deserializeAws_restJson1CreateDataSetCommand = async (
     contents.AssetType = __expectString(data.AssetType);
   }
   if (data.CreatedAt !== undefined && data.CreatedAt !== null) {
-    contents.CreatedAt = new Date(data.CreatedAt);
+    contents.CreatedAt = __expectNonNull(__parseRfc3339DateTime(data.CreatedAt));
   }
   if (data.Description !== undefined && data.Description !== null) {
     contents.Description = __expectString(data.Description);
@@ -976,7 +977,7 @@ export const deserializeAws_restJson1CreateDataSetCommand = async (
     contents.Tags = deserializeAws_restJson1MapOf__string(data.Tags, context);
   }
   if (data.UpdatedAt !== undefined && data.UpdatedAt !== null) {
-    contents.UpdatedAt = new Date(data.UpdatedAt);
+    contents.UpdatedAt = __expectNonNull(__parseRfc3339DateTime(data.UpdatedAt));
   }
   return Promise.resolve(contents);
 };
@@ -1073,7 +1074,7 @@ export const deserializeAws_restJson1CreateJobCommand = async (
     contents.Arn = __expectString(data.Arn);
   }
   if (data.CreatedAt !== undefined && data.CreatedAt !== null) {
-    contents.CreatedAt = new Date(data.CreatedAt);
+    contents.CreatedAt = __expectNonNull(__parseRfc3339DateTime(data.CreatedAt));
   }
   if (data.Details !== undefined && data.Details !== null) {
     contents.Details = deserializeAws_restJson1ResponseDetails(data.Details, context);
@@ -1091,7 +1092,7 @@ export const deserializeAws_restJson1CreateJobCommand = async (
     contents.Type = __expectString(data.Type);
   }
   if (data.UpdatedAt !== undefined && data.UpdatedAt !== null) {
-    contents.UpdatedAt = new Date(data.UpdatedAt);
+    contents.UpdatedAt = __expectNonNull(__parseRfc3339DateTime(data.UpdatedAt));
   }
   return Promise.resolve(contents);
 };
@@ -1192,7 +1193,7 @@ export const deserializeAws_restJson1CreateRevisionCommand = async (
     contents.Comment = __expectString(data.Comment);
   }
   if (data.CreatedAt !== undefined && data.CreatedAt !== null) {
-    contents.CreatedAt = new Date(data.CreatedAt);
+    contents.CreatedAt = __expectNonNull(__parseRfc3339DateTime(data.CreatedAt));
   }
   if (data.DataSetId !== undefined && data.DataSetId !== null) {
     contents.DataSetId = __expectString(data.DataSetId);
@@ -1210,7 +1211,7 @@ export const deserializeAws_restJson1CreateRevisionCommand = async (
     contents.Tags = deserializeAws_restJson1MapOf__string(data.Tags, context);
   }
   if (data.UpdatedAt !== undefined && data.UpdatedAt !== null) {
-    contents.UpdatedAt = new Date(data.UpdatedAt);
+    contents.UpdatedAt = __expectNonNull(__parseRfc3339DateTime(data.UpdatedAt));
   }
   return Promise.resolve(contents);
 };
@@ -1588,7 +1589,7 @@ export const deserializeAws_restJson1GetAssetCommand = async (
     contents.AssetType = __expectString(data.AssetType);
   }
   if (data.CreatedAt !== undefined && data.CreatedAt !== null) {
-    contents.CreatedAt = new Date(data.CreatedAt);
+    contents.CreatedAt = __expectNonNull(__parseRfc3339DateTime(data.CreatedAt));
   }
   if (data.DataSetId !== undefined && data.DataSetId !== null) {
     contents.DataSetId = __expectString(data.DataSetId);
@@ -1606,7 +1607,7 @@ export const deserializeAws_restJson1GetAssetCommand = async (
     contents.SourceId = __expectString(data.SourceId);
   }
   if (data.UpdatedAt !== undefined && data.UpdatedAt !== null) {
-    contents.UpdatedAt = new Date(data.UpdatedAt);
+    contents.UpdatedAt = __expectNonNull(__parseRfc3339DateTime(data.UpdatedAt));
   }
   return Promise.resolve(contents);
 };
@@ -1701,7 +1702,7 @@ export const deserializeAws_restJson1GetDataSetCommand = async (
     contents.AssetType = __expectString(data.AssetType);
   }
   if (data.CreatedAt !== undefined && data.CreatedAt !== null) {
-    contents.CreatedAt = new Date(data.CreatedAt);
+    contents.CreatedAt = __expectNonNull(__parseRfc3339DateTime(data.CreatedAt));
   }
   if (data.Description !== undefined && data.Description !== null) {
     contents.Description = __expectString(data.Description);
@@ -1725,7 +1726,7 @@ export const deserializeAws_restJson1GetDataSetCommand = async (
     contents.Tags = deserializeAws_restJson1MapOf__string(data.Tags, context);
   }
   if (data.UpdatedAt !== undefined && data.UpdatedAt !== null) {
-    contents.UpdatedAt = new Date(data.UpdatedAt);
+    contents.UpdatedAt = __expectNonNull(__parseRfc3339DateTime(data.UpdatedAt));
   }
   return Promise.resolve(contents);
 };
@@ -1814,7 +1815,7 @@ export const deserializeAws_restJson1GetJobCommand = async (
     contents.Arn = __expectString(data.Arn);
   }
   if (data.CreatedAt !== undefined && data.CreatedAt !== null) {
-    contents.CreatedAt = new Date(data.CreatedAt);
+    contents.CreatedAt = __expectNonNull(__parseRfc3339DateTime(data.CreatedAt));
   }
   if (data.Details !== undefined && data.Details !== null) {
     contents.Details = deserializeAws_restJson1ResponseDetails(data.Details, context);
@@ -1832,7 +1833,7 @@ export const deserializeAws_restJson1GetJobCommand = async (
     contents.Type = __expectString(data.Type);
   }
   if (data.UpdatedAt !== undefined && data.UpdatedAt !== null) {
-    contents.UpdatedAt = new Date(data.UpdatedAt);
+    contents.UpdatedAt = __expectNonNull(__parseRfc3339DateTime(data.UpdatedAt));
   }
   return Promise.resolve(contents);
 };
@@ -1925,7 +1926,7 @@ export const deserializeAws_restJson1GetRevisionCommand = async (
     contents.Comment = __expectString(data.Comment);
   }
   if (data.CreatedAt !== undefined && data.CreatedAt !== null) {
-    contents.CreatedAt = new Date(data.CreatedAt);
+    contents.CreatedAt = __expectNonNull(__parseRfc3339DateTime(data.CreatedAt));
   }
   if (data.DataSetId !== undefined && data.DataSetId !== null) {
     contents.DataSetId = __expectString(data.DataSetId);
@@ -1943,7 +1944,7 @@ export const deserializeAws_restJson1GetRevisionCommand = async (
     contents.Tags = deserializeAws_restJson1MapOf__string(data.Tags, context);
   }
   if (data.UpdatedAt !== undefined && data.UpdatedAt !== null) {
-    contents.UpdatedAt = new Date(data.UpdatedAt);
+    contents.UpdatedAt = __expectNonNull(__parseRfc3339DateTime(data.UpdatedAt));
   }
   return Promise.resolve(contents);
 };
@@ -2596,7 +2597,7 @@ export const deserializeAws_restJson1UpdateAssetCommand = async (
     contents.AssetType = __expectString(data.AssetType);
   }
   if (data.CreatedAt !== undefined && data.CreatedAt !== null) {
-    contents.CreatedAt = new Date(data.CreatedAt);
+    contents.CreatedAt = __expectNonNull(__parseRfc3339DateTime(data.CreatedAt));
   }
   if (data.DataSetId !== undefined && data.DataSetId !== null) {
     contents.DataSetId = __expectString(data.DataSetId);
@@ -2614,7 +2615,7 @@ export const deserializeAws_restJson1UpdateAssetCommand = async (
     contents.SourceId = __expectString(data.SourceId);
   }
   if (data.UpdatedAt !== undefined && data.UpdatedAt !== null) {
-    contents.UpdatedAt = new Date(data.UpdatedAt);
+    contents.UpdatedAt = __expectNonNull(__parseRfc3339DateTime(data.UpdatedAt));
   }
   return Promise.resolve(contents);
 };
@@ -2724,7 +2725,7 @@ export const deserializeAws_restJson1UpdateDataSetCommand = async (
     contents.AssetType = __expectString(data.AssetType);
   }
   if (data.CreatedAt !== undefined && data.CreatedAt !== null) {
-    contents.CreatedAt = new Date(data.CreatedAt);
+    contents.CreatedAt = __expectNonNull(__parseRfc3339DateTime(data.CreatedAt));
   }
   if (data.Description !== undefined && data.Description !== null) {
     contents.Description = __expectString(data.Description);
@@ -2745,7 +2746,7 @@ export const deserializeAws_restJson1UpdateDataSetCommand = async (
     contents.SourceId = __expectString(data.SourceId);
   }
   if (data.UpdatedAt !== undefined && data.UpdatedAt !== null) {
-    contents.UpdatedAt = new Date(data.UpdatedAt);
+    contents.UpdatedAt = __expectNonNull(__parseRfc3339DateTime(data.UpdatedAt));
   }
   return Promise.resolve(contents);
 };
@@ -2845,7 +2846,7 @@ export const deserializeAws_restJson1UpdateRevisionCommand = async (
     contents.Comment = __expectString(data.Comment);
   }
   if (data.CreatedAt !== undefined && data.CreatedAt !== null) {
-    contents.CreatedAt = new Date(data.CreatedAt);
+    contents.CreatedAt = __expectNonNull(__parseRfc3339DateTime(data.CreatedAt));
   }
   if (data.DataSetId !== undefined && data.DataSetId !== null) {
     contents.DataSetId = __expectString(data.DataSetId);
@@ -2860,7 +2861,7 @@ export const deserializeAws_restJson1UpdateRevisionCommand = async (
     contents.SourceId = __expectString(data.SourceId);
   }
   if (data.UpdatedAt !== undefined && data.UpdatedAt !== null) {
-    contents.UpdatedAt = new Date(data.UpdatedAt);
+    contents.UpdatedAt = __expectNonNull(__parseRfc3339DateTime(data.UpdatedAt));
   }
   return Promise.resolve(contents);
 };
@@ -3303,13 +3304,19 @@ const deserializeAws_restJson1AssetEntry = (output: any, context: __SerdeContext
         ? deserializeAws_restJson1AssetDetails(output.AssetDetails, context)
         : undefined,
     AssetType: __expectString(output.AssetType),
-    CreatedAt: output.CreatedAt !== undefined && output.CreatedAt !== null ? new Date(output.CreatedAt) : undefined,
+    CreatedAt:
+      output.CreatedAt !== undefined && output.CreatedAt !== null
+        ? __expectNonNull(__parseRfc3339DateTime(output.CreatedAt))
+        : undefined,
     DataSetId: __expectString(output.DataSetId),
     Id: __expectString(output.Id),
     Name: __expectString(output.Name),
     RevisionId: __expectString(output.RevisionId),
     SourceId: __expectString(output.SourceId),
-    UpdatedAt: output.UpdatedAt !== undefined && output.UpdatedAt !== null ? new Date(output.UpdatedAt) : undefined,
+    UpdatedAt:
+      output.UpdatedAt !== undefined && output.UpdatedAt !== null
+        ? __expectNonNull(__parseRfc3339DateTime(output.UpdatedAt))
+        : undefined,
   } as any;
 };
 
@@ -3324,7 +3331,10 @@ const deserializeAws_restJson1DataSetEntry = (output: any, context: __SerdeConte
   return {
     Arn: __expectString(output.Arn),
     AssetType: __expectString(output.AssetType),
-    CreatedAt: output.CreatedAt !== undefined && output.CreatedAt !== null ? new Date(output.CreatedAt) : undefined,
+    CreatedAt:
+      output.CreatedAt !== undefined && output.CreatedAt !== null
+        ? __expectNonNull(__parseRfc3339DateTime(output.CreatedAt))
+        : undefined,
     Description: __expectString(output.Description),
     Id: __expectString(output.Id),
     Name: __expectString(output.Name),
@@ -3334,7 +3344,10 @@ const deserializeAws_restJson1DataSetEntry = (output: any, context: __SerdeConte
         ? deserializeAws_restJson1OriginDetails(output.OriginDetails, context)
         : undefined,
     SourceId: __expectString(output.SourceId),
-    UpdatedAt: output.UpdatedAt !== undefined && output.UpdatedAt !== null ? new Date(output.UpdatedAt) : undefined,
+    UpdatedAt:
+      output.UpdatedAt !== undefined && output.UpdatedAt !== null
+        ? __expectNonNull(__parseRfc3339DateTime(output.UpdatedAt))
+        : undefined,
   } as any;
 };
 
@@ -3384,7 +3397,7 @@ const deserializeAws_restJson1ExportAssetToSignedUrlResponseDetails = (
     SignedUrl: __expectString(output.SignedUrl),
     SignedUrlExpiresAt:
       output.SignedUrlExpiresAt !== undefined && output.SignedUrlExpiresAt !== null
-        ? new Date(output.SignedUrlExpiresAt)
+        ? __expectNonNull(__parseRfc3339DateTime(output.SignedUrlExpiresAt))
         : undefined,
   } as any;
 };
@@ -3437,7 +3450,7 @@ const deserializeAws_restJson1ImportAssetFromSignedUrlResponseDetails = (
     SignedUrl: __expectString(output.SignedUrl),
     SignedUrlExpiresAt:
       output.SignedUrlExpiresAt !== undefined && output.SignedUrlExpiresAt !== null
-        ? new Date(output.SignedUrlExpiresAt)
+        ? __expectNonNull(__parseRfc3339DateTime(output.SignedUrlExpiresAt))
         : undefined,
   } as any;
 };
@@ -3459,7 +3472,10 @@ const deserializeAws_restJson1ImportAssetsFromS3ResponseDetails = (
 const deserializeAws_restJson1JobEntry = (output: any, context: __SerdeContext): JobEntry => {
   return {
     Arn: __expectString(output.Arn),
-    CreatedAt: output.CreatedAt !== undefined && output.CreatedAt !== null ? new Date(output.CreatedAt) : undefined,
+    CreatedAt:
+      output.CreatedAt !== undefined && output.CreatedAt !== null
+        ? __expectNonNull(__parseRfc3339DateTime(output.CreatedAt))
+        : undefined,
     Details:
       output.Details !== undefined && output.Details !== null
         ? deserializeAws_restJson1ResponseDetails(output.Details, context)
@@ -3471,7 +3487,10 @@ const deserializeAws_restJson1JobEntry = (output: any, context: __SerdeContext):
     Id: __expectString(output.Id),
     State: __expectString(output.State),
     Type: __expectString(output.Type),
-    UpdatedAt: output.UpdatedAt !== undefined && output.UpdatedAt !== null ? new Date(output.UpdatedAt) : undefined,
+    UpdatedAt:
+      output.UpdatedAt !== undefined && output.UpdatedAt !== null
+        ? __expectNonNull(__parseRfc3339DateTime(output.UpdatedAt))
+        : undefined,
   } as any;
 };
 
@@ -3642,12 +3661,18 @@ const deserializeAws_restJson1RevisionEntry = (output: any, context: __SerdeCont
   return {
     Arn: __expectString(output.Arn),
     Comment: __expectString(output.Comment),
-    CreatedAt: output.CreatedAt !== undefined && output.CreatedAt !== null ? new Date(output.CreatedAt) : undefined,
+    CreatedAt:
+      output.CreatedAt !== undefined && output.CreatedAt !== null
+        ? __expectNonNull(__parseRfc3339DateTime(output.CreatedAt))
+        : undefined,
     DataSetId: __expectString(output.DataSetId),
     Finalized: __expectBoolean(output.Finalized),
     Id: __expectString(output.Id),
     SourceId: __expectString(output.SourceId),
-    UpdatedAt: output.UpdatedAt !== undefined && output.UpdatedAt !== null ? new Date(output.UpdatedAt) : undefined,
+    UpdatedAt:
+      output.UpdatedAt !== undefined && output.UpdatedAt !== null
+        ? __expectNonNull(__parseRfc3339DateTime(output.UpdatedAt))
+        : undefined,
   } as any;
 };
 

--- a/clients/client-datasync/protocols/Aws_json1_1.ts
+++ b/clients/client-datasync/protocols/Aws_json1_1.ts
@@ -164,7 +164,10 @@ import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@a
 import {
   expectInt32 as __expectInt32,
   expectLong as __expectLong,
+  expectNonNull as __expectNonNull,
+  expectNumber as __expectNumber,
   expectString as __expectString,
+  parseEpochTimestamp as __parseEpochTimestamp,
 } from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
@@ -3581,12 +3584,12 @@ const deserializeAws_json1_1DescribeAgentResponse = (output: any, context: __Ser
     AgentArn: __expectString(output.AgentArn),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     EndpointType: __expectString(output.EndpointType),
     LastConnectionTime:
       output.LastConnectionTime !== undefined && output.LastConnectionTime !== null
-        ? new Date(Math.round(output.LastConnectionTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastConnectionTime)))
         : undefined,
     Name: __expectString(output.Name),
     PrivateLinkConfig:
@@ -3604,7 +3607,7 @@ const deserializeAws_json1_1DescribeLocationEfsResponse = (
   return {
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     Ec2Config:
       output.Ec2Config !== undefined && output.Ec2Config !== null
@@ -3622,7 +3625,7 @@ const deserializeAws_json1_1DescribeLocationFsxWindowsResponse = (
   return {
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     Domain: __expectString(output.Domain),
     LocationArn: __expectString(output.LocationArn),
@@ -3642,7 +3645,7 @@ const deserializeAws_json1_1DescribeLocationNfsResponse = (
   return {
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     LocationArn: __expectString(output.LocationArn),
     LocationUri: __expectString(output.LocationUri),
@@ -3669,7 +3672,7 @@ const deserializeAws_json1_1DescribeLocationObjectStorageResponse = (
         : undefined,
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     LocationArn: __expectString(output.LocationArn),
     LocationUri: __expectString(output.LocationUri),
@@ -3689,7 +3692,7 @@ const deserializeAws_json1_1DescribeLocationS3Response = (
         : undefined,
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     LocationArn: __expectString(output.LocationArn),
     LocationUri: __expectString(output.LocationUri),
@@ -3712,7 +3715,7 @@ const deserializeAws_json1_1DescribeLocationSmbResponse = (
         : undefined,
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     Domain: __expectString(output.Domain),
     LocationArn: __expectString(output.LocationArn),
@@ -3753,7 +3756,7 @@ const deserializeAws_json1_1DescribeTaskExecutionResponse = (
         : undefined,
     StartTime:
       output.StartTime !== undefined && output.StartTime !== null
-        ? new Date(Math.round(output.StartTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.StartTime)))
         : undefined,
     Status: __expectString(output.Status),
     TaskExecutionArn: __expectString(output.TaskExecutionArn),
@@ -3765,7 +3768,7 @@ const deserializeAws_json1_1DescribeTaskResponse = (output: any, context: __Serd
     CloudWatchLogGroupArn: __expectString(output.CloudWatchLogGroupArn),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     CurrentTaskExecutionArn: __expectString(output.CurrentTaskExecutionArn),
     DestinationLocationArn: __expectString(output.DestinationLocationArn),

--- a/clients/client-dax/protocols/Aws_json1_1.ts
+++ b/clients/client-dax/protocols/Aws_json1_1.ts
@@ -131,7 +131,13 @@ import {
   UpdateSubnetGroupResponse,
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
-import { expectInt32 as __expectInt32, expectString as __expectString } from "@aws-sdk/smithy-client";
+import {
+  expectInt32 as __expectInt32,
+  expectNonNull as __expectNonNull,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
+  parseEpochTimestamp as __parseEpochTimestamp,
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   HeaderBag as __HeaderBag,
@@ -3359,7 +3365,10 @@ const deserializeAws_json1_1Endpoint = (output: any, context: __SerdeContext): E
 
 const deserializeAws_json1_1Event = (output: any, context: __SerdeContext): Event => {
   return {
-    Date: output.Date !== undefined && output.Date !== null ? new Date(Math.round(output.Date * 1000)) : undefined,
+    Date:
+      output.Date !== undefined && output.Date !== null
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.Date)))
+        : undefined,
     Message: __expectString(output.Message),
     SourceName: __expectString(output.SourceName),
     SourceType: __expectString(output.SourceType),
@@ -3474,7 +3483,7 @@ const deserializeAws_json1_1Node = (output: any, context: __SerdeContext): Node 
         : undefined,
     NodeCreateTime:
       output.NodeCreateTime !== undefined && output.NodeCreateTime !== null
-        ? new Date(Math.round(output.NodeCreateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.NodeCreateTime)))
         : undefined,
     NodeId: __expectString(output.NodeId),
     NodeStatus: __expectString(output.NodeStatus),

--- a/clients/client-detective/protocols/Aws_restJson1.ts
+++ b/clients/client-detective/protocols/Aws_restJson1.ts
@@ -41,6 +41,7 @@ import {
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   limitedParseDouble as __limitedParseDouble,
+  parseRfc3339DateTime as __parseRfc3339DateTime,
 } from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
@@ -1688,7 +1689,9 @@ const deserializeAws_restJson1Graph = (output: any, context: __SerdeContext): Gr
   return {
     Arn: __expectString(output.Arn),
     CreatedTime:
-      output.CreatedTime !== undefined && output.CreatedTime !== null ? new Date(output.CreatedTime) : undefined,
+      output.CreatedTime !== undefined && output.CreatedTime !== null
+        ? __expectNonNull(__parseRfc3339DateTime(output.CreatedTime))
+        : undefined,
   } as any;
 };
 
@@ -1711,20 +1714,24 @@ const deserializeAws_restJson1MemberDetail = (output: any, context: __SerdeConte
     EmailAddress: __expectString(output.EmailAddress),
     GraphArn: __expectString(output.GraphArn),
     InvitedTime:
-      output.InvitedTime !== undefined && output.InvitedTime !== null ? new Date(output.InvitedTime) : undefined,
+      output.InvitedTime !== undefined && output.InvitedTime !== null
+        ? __expectNonNull(__parseRfc3339DateTime(output.InvitedTime))
+        : undefined,
     MasterId: __expectString(output.MasterId),
     PercentOfGraphUtilization: __limitedParseDouble(output.PercentOfGraphUtilization),
     PercentOfGraphUtilizationUpdatedTime:
       output.PercentOfGraphUtilizationUpdatedTime !== undefined && output.PercentOfGraphUtilizationUpdatedTime !== null
-        ? new Date(output.PercentOfGraphUtilizationUpdatedTime)
+        ? __expectNonNull(__parseRfc3339DateTime(output.PercentOfGraphUtilizationUpdatedTime))
         : undefined,
     Status: __expectString(output.Status),
     UpdatedTime:
-      output.UpdatedTime !== undefined && output.UpdatedTime !== null ? new Date(output.UpdatedTime) : undefined,
+      output.UpdatedTime !== undefined && output.UpdatedTime !== null
+        ? __expectNonNull(__parseRfc3339DateTime(output.UpdatedTime))
+        : undefined,
     VolumeUsageInBytes: __expectLong(output.VolumeUsageInBytes),
     VolumeUsageUpdatedTime:
       output.VolumeUsageUpdatedTime !== undefined && output.VolumeUsageUpdatedTime !== null
-        ? new Date(output.VolumeUsageUpdatedTime)
+        ? __expectNonNull(__parseRfc3339DateTime(output.VolumeUsageUpdatedTime))
         : undefined,
   } as any;
 };

--- a/clients/client-device-farm/protocols/Aws_json1_1.ts
+++ b/clients/client-device-farm/protocols/Aws_json1_1.ts
@@ -395,8 +395,11 @@ import {
   expectBoolean as __expectBoolean,
   expectInt32 as __expectInt32,
   expectLong as __expectLong,
+  expectNonNull as __expectNonNull,
+  expectNumber as __expectNumber,
   expectString as __expectString,
   limitedParseDouble as __limitedParseDouble,
+  parseEpochTimestamp as __parseEpochTimestamp,
   serializeFloat as __serializeFloat,
 } from "@aws-sdk/smithy-client";
 import {
@@ -8797,7 +8800,9 @@ const deserializeAws_json1_1CreateTestGridUrlResult = (
 ): CreateTestGridUrlResult => {
   return {
     expires:
-      output.expires !== undefined && output.expires !== null ? new Date(Math.round(output.expires * 1000)) : undefined,
+      output.expires !== undefined && output.expires !== null
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.expires)))
+        : undefined,
     url: __expectString(output.url),
   } as any;
 };
@@ -9386,7 +9391,9 @@ const deserializeAws_json1_1Job = (output: any, context: __SerdeContext): Job =>
         ? deserializeAws_json1_1Counters(output.counters, context)
         : undefined,
     created:
-      output.created !== undefined && output.created !== null ? new Date(Math.round(output.created * 1000)) : undefined,
+      output.created !== undefined && output.created !== null
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.created)))
+        : undefined,
     device:
       output.device !== undefined && output.device !== null
         ? deserializeAws_json1_1Device(output.device, context)
@@ -9400,10 +9407,14 @@ const deserializeAws_json1_1Job = (output: any, context: __SerdeContext): Job =>
     name: __expectString(output.name),
     result: __expectString(output.result),
     started:
-      output.started !== undefined && output.started !== null ? new Date(Math.round(output.started * 1000)) : undefined,
+      output.started !== undefined && output.started !== null
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.started)))
+        : undefined,
     status: __expectString(output.status),
     stopped:
-      output.stopped !== undefined && output.stopped !== null ? new Date(Math.round(output.stopped * 1000)) : undefined,
+      output.stopped !== undefined && output.stopped !== null
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.stopped)))
+        : undefined,
     type: __expectString(output.type),
     videoCapture: __expectBoolean(output.videoCapture),
     videoEndpoint: __expectString(output.videoEndpoint),
@@ -9813,7 +9824,7 @@ const deserializeAws_json1_1OfferingStatus = (output: any, context: __SerdeConte
   return {
     effectiveOn:
       output.effectiveOn !== undefined && output.effectiveOn !== null
-        ? new Date(Math.round(output.effectiveOn * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.effectiveOn)))
         : undefined,
     offering:
       output.offering !== undefined && output.offering !== null
@@ -9847,7 +9858,7 @@ const deserializeAws_json1_1OfferingTransaction = (output: any, context: __Serde
         : undefined,
     createdOn:
       output.createdOn !== undefined && output.createdOn !== null
-        ? new Date(Math.round(output.createdOn * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.createdOn)))
         : undefined,
     offeringPromotionId: __expectString(output.offeringPromotionId),
     offeringStatus:
@@ -9929,7 +9940,9 @@ const deserializeAws_json1_1Project = (output: any, context: __SerdeContext): Pr
   return {
     arn: __expectString(output.arn),
     created:
-      output.created !== undefined && output.created !== null ? new Date(Math.round(output.created * 1000)) : undefined,
+      output.created !== undefined && output.created !== null
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.created)))
+        : undefined,
     defaultJobTimeoutMinutes: __expectInt32(output.defaultJobTimeoutMinutes),
     name: __expectString(output.name),
   } as any;
@@ -10006,7 +10019,9 @@ const deserializeAws_json1_1RemoteAccessSession = (output: any, context: __Serde
     billingMethod: __expectString(output.billingMethod),
     clientId: __expectString(output.clientId),
     created:
-      output.created !== undefined && output.created !== null ? new Date(Math.round(output.created * 1000)) : undefined,
+      output.created !== undefined && output.created !== null
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.created)))
+        : undefined,
     device:
       output.device !== undefined && output.device !== null
         ? deserializeAws_json1_1Device(output.device, context)
@@ -10028,10 +10043,14 @@ const deserializeAws_json1_1RemoteAccessSession = (output: any, context: __Serde
     result: __expectString(output.result),
     skipAppResign: __expectBoolean(output.skipAppResign),
     started:
-      output.started !== undefined && output.started !== null ? new Date(Math.round(output.started * 1000)) : undefined,
+      output.started !== undefined && output.started !== null
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.started)))
+        : undefined,
     status: __expectString(output.status),
     stopped:
-      output.stopped !== undefined && output.stopped !== null ? new Date(Math.round(output.stopped * 1000)) : undefined,
+      output.stopped !== undefined && output.stopped !== null
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.stopped)))
+        : undefined,
   } as any;
 };
 
@@ -10092,7 +10111,9 @@ const deserializeAws_json1_1Run = (output: any, context: __SerdeContext): Run =>
         ? deserializeAws_json1_1Counters(output.counters, context)
         : undefined,
     created:
-      output.created !== undefined && output.created !== null ? new Date(Math.round(output.created * 1000)) : undefined,
+      output.created !== undefined && output.created !== null
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.created)))
+        : undefined,
     customerArtifactPaths:
       output.customerArtifactPaths !== undefined && output.customerArtifactPaths !== null
         ? deserializeAws_json1_1CustomerArtifactPaths(output.customerArtifactPaths, context)
@@ -10130,10 +10151,14 @@ const deserializeAws_json1_1Run = (output: any, context: __SerdeContext): Run =>
     seed: __expectInt32(output.seed),
     skipAppResign: __expectBoolean(output.skipAppResign),
     started:
-      output.started !== undefined && output.started !== null ? new Date(Math.round(output.started * 1000)) : undefined,
+      output.started !== undefined && output.started !== null
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.started)))
+        : undefined,
     status: __expectString(output.status),
     stopped:
-      output.stopped !== undefined && output.stopped !== null ? new Date(Math.round(output.stopped * 1000)) : undefined,
+      output.stopped !== undefined && output.stopped !== null
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.stopped)))
+        : undefined,
     testSpecArn: __expectString(output.testSpecArn),
     totalJobs: __expectInt32(output.totalJobs),
     type: __expectString(output.type),
@@ -10240,7 +10265,9 @@ const deserializeAws_json1_1Suite = (output: any, context: __SerdeContext): Suit
         ? deserializeAws_json1_1Counters(output.counters, context)
         : undefined,
     created:
-      output.created !== undefined && output.created !== null ? new Date(Math.round(output.created * 1000)) : undefined,
+      output.created !== undefined && output.created !== null
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.created)))
+        : undefined,
     deviceMinutes:
       output.deviceMinutes !== undefined && output.deviceMinutes !== null
         ? deserializeAws_json1_1DeviceMinutes(output.deviceMinutes, context)
@@ -10249,10 +10276,14 @@ const deserializeAws_json1_1Suite = (output: any, context: __SerdeContext): Suit
     name: __expectString(output.name),
     result: __expectString(output.result),
     started:
-      output.started !== undefined && output.started !== null ? new Date(Math.round(output.started * 1000)) : undefined,
+      output.started !== undefined && output.started !== null
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.started)))
+        : undefined,
     status: __expectString(output.status),
     stopped:
-      output.stopped !== undefined && output.stopped !== null ? new Date(Math.round(output.stopped * 1000)) : undefined,
+      output.stopped !== undefined && output.stopped !== null
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.stopped)))
+        : undefined,
     type: __expectString(output.type),
   } as any;
 };
@@ -10312,7 +10343,9 @@ const deserializeAws_json1_1Test = (output: any, context: __SerdeContext): Test 
         ? deserializeAws_json1_1Counters(output.counters, context)
         : undefined,
     created:
-      output.created !== undefined && output.created !== null ? new Date(Math.round(output.created * 1000)) : undefined,
+      output.created !== undefined && output.created !== null
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.created)))
+        : undefined,
     deviceMinutes:
       output.deviceMinutes !== undefined && output.deviceMinutes !== null
         ? deserializeAws_json1_1DeviceMinutes(output.deviceMinutes, context)
@@ -10321,10 +10354,14 @@ const deserializeAws_json1_1Test = (output: any, context: __SerdeContext): Test 
     name: __expectString(output.name),
     result: __expectString(output.result),
     started:
-      output.started !== undefined && output.started !== null ? new Date(Math.round(output.started * 1000)) : undefined,
+      output.started !== undefined && output.started !== null
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.started)))
+        : undefined,
     status: __expectString(output.status),
     stopped:
-      output.stopped !== undefined && output.stopped !== null ? new Date(Math.round(output.stopped * 1000)) : undefined,
+      output.stopped !== undefined && output.stopped !== null
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.stopped)))
+        : undefined,
     type: __expectString(output.type),
   } as any;
 };
@@ -10333,7 +10370,9 @@ const deserializeAws_json1_1TestGridProject = (output: any, context: __SerdeCont
   return {
     arn: __expectString(output.arn),
     created:
-      output.created !== undefined && output.created !== null ? new Date(Math.round(output.created * 1000)) : undefined,
+      output.created !== undefined && output.created !== null
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.created)))
+        : undefined,
     description: __expectString(output.description),
     name: __expectString(output.name),
     vpcConfig:
@@ -10359,8 +10398,13 @@ const deserializeAws_json1_1TestGridSession = (output: any, context: __SerdeCont
     arn: __expectString(output.arn),
     billingMinutes: __limitedParseDouble(output.billingMinutes),
     created:
-      output.created !== undefined && output.created !== null ? new Date(Math.round(output.created * 1000)) : undefined,
-    ended: output.ended !== undefined && output.ended !== null ? new Date(Math.round(output.ended * 1000)) : undefined,
+      output.created !== undefined && output.created !== null
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.created)))
+        : undefined,
+    ended:
+      output.ended !== undefined && output.ended !== null
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.ended)))
+        : undefined,
     seleniumProperties: __expectString(output.seleniumProperties),
     status: __expectString(output.status),
   } as any;
@@ -10372,7 +10416,9 @@ const deserializeAws_json1_1TestGridSessionAction = (output: any, context: __Ser
     duration: __expectLong(output.duration),
     requestMethod: __expectString(output.requestMethod),
     started:
-      output.started !== undefined && output.started !== null ? new Date(Math.round(output.started * 1000)) : undefined,
+      output.started !== undefined && output.started !== null
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.started)))
+        : undefined,
     statusCode: __expectString(output.statusCode),
   } as any;
 };
@@ -10602,7 +10648,9 @@ const deserializeAws_json1_1Upload = (output: any, context: __SerdeContext): Upl
     category: __expectString(output.category),
     contentType: __expectString(output.contentType),
     created:
-      output.created !== undefined && output.created !== null ? new Date(Math.round(output.created * 1000)) : undefined,
+      output.created !== undefined && output.created !== null
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.created)))
+        : undefined,
     message: __expectString(output.message),
     metadata: __expectString(output.metadata),
     name: __expectString(output.name),

--- a/clients/client-devops-guru/protocols/Aws_restJson1.ts
+++ b/clients/client-devops-guru/protocols/Aws_restJson1.ts
@@ -132,10 +132,12 @@ import {
   expectInt32 as __expectInt32,
   expectLong as __expectLong,
   expectNonNull as __expectNonNull,
+  expectNumber as __expectNumber,
   expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   limitedParseDouble as __limitedParseDouble,
+  parseEpochTimestamp as __parseEpochTimestamp,
   strictParseInt32 as __strictParseInt32,
 } from "@aws-sdk/smithy-client";
 import {
@@ -3079,11 +3081,11 @@ const deserializeAws_restJson1AnomalyReportedTimeRange = (
   return {
     CloseTime:
       output.CloseTime !== undefined && output.CloseTime !== null
-        ? new Date(Math.round(output.CloseTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CloseTime)))
         : undefined,
     OpenTime:
       output.OpenTime !== undefined && output.OpenTime !== null
-        ? new Date(Math.round(output.OpenTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.OpenTime)))
         : undefined,
   } as any;
 };
@@ -3100,10 +3102,12 @@ const deserializeAws_restJson1AnomalySourceDetails = (output: any, context: __Se
 const deserializeAws_restJson1AnomalyTimeRange = (output: any, context: __SerdeContext): AnomalyTimeRange => {
   return {
     EndTime:
-      output.EndTime !== undefined && output.EndTime !== null ? new Date(Math.round(output.EndTime * 1000)) : undefined,
+      output.EndTime !== undefined && output.EndTime !== null
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.EndTime)))
+        : undefined,
     StartTime:
       output.StartTime !== undefined && output.StartTime !== null
-        ? new Date(Math.round(output.StartTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.StartTime)))
         : undefined,
   } as any;
 };
@@ -3263,10 +3267,12 @@ const deserializeAws_restJson1CostEstimationTimeRange = (
 ): CostEstimationTimeRange => {
   return {
     EndTime:
-      output.EndTime !== undefined && output.EndTime !== null ? new Date(Math.round(output.EndTime * 1000)) : undefined,
+      output.EndTime !== undefined && output.EndTime !== null
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.EndTime)))
+        : undefined,
     StartTime:
       output.StartTime !== undefined && output.StartTime !== null
-        ? new Date(Math.round(output.StartTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.StartTime)))
         : undefined,
   } as any;
 };
@@ -3286,7 +3292,10 @@ const deserializeAws_restJson1Event = (output: any, context: __SerdeContext): Ev
       output.Resources !== undefined && output.Resources !== null
         ? deserializeAws_restJson1EventResources(output.Resources, context)
         : undefined,
-    Time: output.Time !== undefined && output.Time !== null ? new Date(Math.round(output.Time * 1000)) : undefined,
+    Time:
+      output.Time !== undefined && output.Time !== null
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.Time)))
+        : undefined,
   } as any;
 };
 
@@ -3338,10 +3347,12 @@ const deserializeAws_restJson1InsightHealth = (output: any, context: __SerdeCont
 const deserializeAws_restJson1InsightTimeRange = (output: any, context: __SerdeContext): InsightTimeRange => {
   return {
     EndTime:
-      output.EndTime !== undefined && output.EndTime !== null ? new Date(Math.round(output.EndTime * 1000)) : undefined,
+      output.EndTime !== undefined && output.EndTime !== null
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.EndTime)))
+        : undefined,
     StartTime:
       output.StartTime !== undefined && output.StartTime !== null
-        ? new Date(Math.round(output.StartTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.StartTime)))
         : undefined,
   } as any;
 };
@@ -3377,10 +3388,12 @@ const deserializeAws_restJson1OpsCenterIntegration = (output: any, context: __Se
 const deserializeAws_restJson1PredictionTimeRange = (output: any, context: __SerdeContext): PredictionTimeRange => {
   return {
     EndTime:
-      output.EndTime !== undefined && output.EndTime !== null ? new Date(Math.round(output.EndTime * 1000)) : undefined,
+      output.EndTime !== undefined && output.EndTime !== null
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.EndTime)))
+        : undefined,
     StartTime:
       output.StartTime !== undefined && output.StartTime !== null
-        ? new Date(Math.round(output.StartTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.StartTime)))
         : undefined,
   } as any;
 };
@@ -3428,7 +3441,7 @@ const deserializeAws_restJson1ProactiveAnomaly = (output: any, context: __SerdeC
     Status: __expectString(output.Status),
     UpdateTime:
       output.UpdateTime !== undefined && output.UpdateTime !== null
-        ? new Date(Math.round(output.UpdateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.UpdateTime)))
         : undefined,
   } as any;
 };
@@ -3465,7 +3478,7 @@ const deserializeAws_restJson1ProactiveAnomalySummary = (
     Status: __expectString(output.Status),
     UpdateTime:
       output.UpdateTime !== undefined && output.UpdateTime !== null
-        ? new Date(Math.round(output.UpdateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.UpdateTime)))
         : undefined,
   } as any;
 };

--- a/clients/client-direct-connect/protocols/Aws_json1_1.ts
+++ b/clients/client-direct-connect/protocols/Aws_json1_1.ts
@@ -311,7 +311,10 @@ import {
   expectBoolean as __expectBoolean,
   expectInt32 as __expectInt32,
   expectLong as __expectLong,
+  expectNonNull as __expectNonNull,
+  expectNumber as __expectNumber,
   expectString as __expectString,
+  parseEpochTimestamp as __parseEpochTimestamp,
 } from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
@@ -6058,7 +6061,7 @@ const deserializeAws_json1_1Connection = (output: any, context: __SerdeContext):
     lagId: __expectString(output.lagId),
     loaIssueTime:
       output.loaIssueTime !== undefined && output.loaIssueTime !== null
-        ? new Date(Math.round(output.loaIssueTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.loaIssueTime)))
         : undefined,
     location: __expectString(output.location),
     macSecCapable: __expectBoolean(output.macSecCapable),
@@ -6497,7 +6500,7 @@ const deserializeAws_json1_1Interconnect = (output: any, context: __SerdeContext
     lagId: __expectString(output.lagId),
     loaIssueTime:
       output.loaIssueTime !== undefined && output.loaIssueTime !== null
-        ? new Date(Math.round(output.loaIssueTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.loaIssueTime)))
         : undefined,
     location: __expectString(output.location),
     providerName: __expectString(output.providerName),
@@ -6880,11 +6883,13 @@ const deserializeAws_json1_1VirtualInterfaceTestHistory = (
         ? deserializeAws_json1_1BGPPeerIdList(output.bgpPeers, context)
         : undefined,
     endTime:
-      output.endTime !== undefined && output.endTime !== null ? new Date(Math.round(output.endTime * 1000)) : undefined,
+      output.endTime !== undefined && output.endTime !== null
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.endTime)))
+        : undefined,
     ownerAccount: __expectString(output.ownerAccount),
     startTime:
       output.startTime !== undefined && output.startTime !== null
-        ? new Date(Math.round(output.startTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.startTime)))
         : undefined,
     status: __expectString(output.status),
     testDurationInMinutes: __expectInt32(output.testDurationInMinutes),

--- a/clients/client-directory-service/protocols/Aws_json1_1.ts
+++ b/clients/client-directory-service/protocols/Aws_json1_1.ts
@@ -342,7 +342,10 @@ import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@a
 import {
   expectBoolean as __expectBoolean,
   expectInt32 as __expectInt32,
+  expectNonNull as __expectNonNull,
+  expectNumber as __expectNumber,
   expectString as __expectString,
+  parseEpochTimestamp as __parseEpochTimestamp,
 } from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
@@ -8328,11 +8331,11 @@ const deserializeAws_json1_1Certificate = (output: any, context: __SerdeContext)
     CommonName: __expectString(output.CommonName),
     ExpiryDateTime:
       output.ExpiryDateTime !== undefined && output.ExpiryDateTime !== null
-        ? new Date(Math.round(output.ExpiryDateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.ExpiryDateTime)))
         : undefined,
     RegisteredDateTime:
       output.RegisteredDateTime !== undefined && output.RegisteredDateTime !== null
-        ? new Date(Math.round(output.RegisteredDateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.RegisteredDateTime)))
         : undefined,
     State: __expectString(output.State),
     StateReason: __expectString(output.StateReason),
@@ -8366,7 +8369,7 @@ const deserializeAws_json1_1CertificateInfo = (output: any, context: __SerdeCont
     CommonName: __expectString(output.CommonName),
     ExpiryDateTime:
       output.ExpiryDateTime !== undefined && output.ExpiryDateTime !== null
-        ? new Date(Math.round(output.ExpiryDateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.ExpiryDateTime)))
         : undefined,
     State: __expectString(output.State),
     Type: __expectString(output.Type),
@@ -8411,7 +8414,7 @@ const deserializeAws_json1_1ClientAuthenticationSettingInfo = (
   return {
     LastUpdatedDateTime:
       output.LastUpdatedDateTime !== undefined && output.LastUpdatedDateTime !== null
-        ? new Date(Math.round(output.LastUpdatedDateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastUpdatedDateTime)))
         : undefined,
     Status: __expectString(output.Status),
     Type: __expectString(output.Type),
@@ -8782,7 +8785,7 @@ const deserializeAws_json1_1DirectoryDescription = (output: any, context: __Serd
     Edition: __expectString(output.Edition),
     LaunchTime:
       output.LaunchTime !== undefined && output.LaunchTime !== null
-        ? new Date(Math.round(output.LaunchTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LaunchTime)))
         : undefined,
     Name: __expectString(output.Name),
     OwnerDirectoryDescription:
@@ -8807,7 +8810,7 @@ const deserializeAws_json1_1DirectoryDescription = (output: any, context: __Serd
     Stage: __expectString(output.Stage),
     StageLastUpdatedDateTime:
       output.StageLastUpdatedDateTime !== undefined && output.StageLastUpdatedDateTime !== null
-        ? new Date(Math.round(output.StageLastUpdatedDateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.StageLastUpdatedDateTime)))
         : undefined,
     StageReason: __expectString(output.StageReason),
     Type: __expectString(output.Type),
@@ -8949,12 +8952,12 @@ const deserializeAws_json1_1DomainController = (output: any, context: __SerdeCon
     DomainControllerId: __expectString(output.DomainControllerId),
     LaunchTime:
       output.LaunchTime !== undefined && output.LaunchTime !== null
-        ? new Date(Math.round(output.LaunchTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LaunchTime)))
         : undefined,
     Status: __expectString(output.Status),
     StatusLastUpdatedDateTime:
       output.StatusLastUpdatedDateTime !== undefined && output.StatusLastUpdatedDateTime !== null
-        ? new Date(Math.round(output.StatusLastUpdatedDateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.StatusLastUpdatedDateTime)))
         : undefined,
     StatusReason: __expectString(output.StatusReason),
     SubnetId: __expectString(output.SubnetId),
@@ -9026,7 +9029,7 @@ const deserializeAws_json1_1EventTopic = (output: any, context: __SerdeContext):
   return {
     CreatedDateTime:
       output.CreatedDateTime !== undefined && output.CreatedDateTime !== null
-        ? new Date(Math.round(output.CreatedDateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreatedDateTime)))
         : undefined,
     DirectoryId: __expectString(output.DirectoryId),
     Status: __expectString(output.Status),
@@ -9162,7 +9165,7 @@ const deserializeAws_json1_1IpRouteInfo = (output: any, context: __SerdeContext)
   return {
     AddedDateTime:
       output.AddedDateTime !== undefined && output.AddedDateTime !== null
-        ? new Date(Math.round(output.AddedDateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.AddedDateTime)))
         : undefined,
     CidrIp: __expectString(output.CidrIp),
     Description: __expectString(output.Description),
@@ -9199,7 +9202,7 @@ const deserializeAws_json1_1LDAPSSettingInfo = (output: any, context: __SerdeCon
     LDAPSStatusReason: __expectString(output.LDAPSStatusReason),
     LastUpdatedDateTime:
       output.LastUpdatedDateTime !== undefined && output.LastUpdatedDateTime !== null
-        ? new Date(Math.round(output.LastUpdatedDateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastUpdatedDateTime)))
         : undefined,
   } as any;
 };
@@ -9278,7 +9281,7 @@ const deserializeAws_json1_1LogSubscription = (output: any, context: __SerdeCont
     LogGroupName: __expectString(output.LogGroupName),
     SubscriptionCreatedDateTime:
       output.SubscriptionCreatedDateTime !== undefined && output.SubscriptionCreatedDateTime !== null
-        ? new Date(Math.round(output.SubscriptionCreatedDateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.SubscriptionCreatedDateTime)))
         : undefined,
   } as any;
 };
@@ -9356,18 +9359,18 @@ const deserializeAws_json1_1RegionDescription = (output: any, context: __SerdeCo
     DirectoryId: __expectString(output.DirectoryId),
     LastUpdatedDateTime:
       output.LastUpdatedDateTime !== undefined && output.LastUpdatedDateTime !== null
-        ? new Date(Math.round(output.LastUpdatedDateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastUpdatedDateTime)))
         : undefined,
     LaunchTime:
       output.LaunchTime !== undefined && output.LaunchTime !== null
-        ? new Date(Math.round(output.LaunchTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LaunchTime)))
         : undefined,
     RegionName: __expectString(output.RegionName),
     RegionType: __expectString(output.RegionType),
     Status: __expectString(output.Status),
     StatusLastUpdatedDateTime:
       output.StatusLastUpdatedDateTime !== undefined && output.StatusLastUpdatedDateTime !== null
-        ? new Date(Math.round(output.StatusLastUpdatedDateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.StatusLastUpdatedDateTime)))
         : undefined,
     VpcSettings:
       output.VpcSettings !== undefined && output.VpcSettings !== null
@@ -9467,14 +9470,14 @@ const deserializeAws_json1_1SchemaExtensionInfo = (output: any, context: __Serde
     DirectoryId: __expectString(output.DirectoryId),
     EndDateTime:
       output.EndDateTime !== undefined && output.EndDateTime !== null
-        ? new Date(Math.round(output.EndDateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.EndDateTime)))
         : undefined,
     SchemaExtensionId: __expectString(output.SchemaExtensionId),
     SchemaExtensionStatus: __expectString(output.SchemaExtensionStatus),
     SchemaExtensionStatusReason: __expectString(output.SchemaExtensionStatusReason),
     StartDateTime:
       output.StartDateTime !== undefined && output.StartDateTime !== null
-        ? new Date(Math.round(output.StartDateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.StartDateTime)))
         : undefined,
   } as any;
 };
@@ -9523,11 +9526,11 @@ const deserializeAws_json1_1SharedDirectory = (output: any, context: __SerdeCont
   return {
     CreatedDateTime:
       output.CreatedDateTime !== undefined && output.CreatedDateTime !== null
-        ? new Date(Math.round(output.CreatedDateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreatedDateTime)))
         : undefined,
     LastUpdatedDateTime:
       output.LastUpdatedDateTime !== undefined && output.LastUpdatedDateTime !== null
-        ? new Date(Math.round(output.LastUpdatedDateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastUpdatedDateTime)))
         : undefined,
     OwnerAccountId: __expectString(output.OwnerAccountId),
     OwnerDirectoryId: __expectString(output.OwnerDirectoryId),
@@ -9562,7 +9565,7 @@ const deserializeAws_json1_1Snapshot = (output: any, context: __SerdeContext): S
     SnapshotId: __expectString(output.SnapshotId),
     StartTime:
       output.StartTime !== undefined && output.StartTime !== null
-        ? new Date(Math.round(output.StartTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.StartTime)))
         : undefined,
     Status: __expectString(output.Status),
     Type: __expectString(output.Type),
@@ -9650,18 +9653,18 @@ const deserializeAws_json1_1Trust = (output: any, context: __SerdeContext): Trus
   return {
     CreatedDateTime:
       output.CreatedDateTime !== undefined && output.CreatedDateTime !== null
-        ? new Date(Math.round(output.CreatedDateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreatedDateTime)))
         : undefined,
     DirectoryId: __expectString(output.DirectoryId),
     LastUpdatedDateTime:
       output.LastUpdatedDateTime !== undefined && output.LastUpdatedDateTime !== null
-        ? new Date(Math.round(output.LastUpdatedDateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastUpdatedDateTime)))
         : undefined,
     RemoteDomainName: __expectString(output.RemoteDomainName),
     SelectiveAuth: __expectString(output.SelectiveAuth),
     StateLastUpdatedDateTime:
       output.StateLastUpdatedDateTime !== undefined && output.StateLastUpdatedDateTime !== null
-        ? new Date(Math.round(output.StateLastUpdatedDateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.StateLastUpdatedDateTime)))
         : undefined,
     TrustDirection: __expectString(output.TrustDirection),
     TrustId: __expectString(output.TrustId),

--- a/clients/client-dlm/protocols/Aws_restJson1.ts
+++ b/clients/client-dlm/protocols/Aws_restJson1.ts
@@ -53,9 +53,11 @@ import {
   expectBoolean as __expectBoolean,
   expectInt32 as __expectInt32,
   expectNonNull as __expectNonNull,
+  expectNumber as __expectNumber,
   expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
+  parseEpochTimestamp as __parseEpochTimestamp,
 } from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
@@ -1557,11 +1559,11 @@ const deserializeAws_restJson1LifecyclePolicy = (output: any, context: __SerdeCo
   return {
     DateCreated:
       output.DateCreated !== undefined && output.DateCreated !== null
-        ? new Date(Math.round(output.DateCreated * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.DateCreated)))
         : undefined,
     DateModified:
       output.DateModified !== undefined && output.DateModified !== null
-        ? new Date(Math.round(output.DateModified * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.DateModified)))
         : undefined,
     Description: __expectString(output.Description),
     ExecutionRoleArn: __expectString(output.ExecutionRoleArn),

--- a/clients/client-docdb/protocols/Aws_query.ts
+++ b/clients/client-docdb/protocols/Aws_query.ts
@@ -365,11 +365,13 @@ import {
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
+  expectNonNull as __expectNonNull,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   getArrayIfSingleItem as __getArrayIfSingleItem,
   getValueFromTextNode as __getValueFromTextNode,
   parseBoolean as __parseBoolean,
+  parseRfc3339DateTime as __parseRfc3339DateTime,
   strictParseInt32 as __strictParseInt32,
 } from "@aws-sdk/smithy-client";
 import {
@@ -7777,10 +7779,10 @@ const deserializeAws_queryCertificate = (output: any, context: __SerdeContext): 
     contents.Thumbprint = __expectString(output["Thumbprint"]);
   }
   if (output["ValidFrom"] !== undefined) {
-    contents.ValidFrom = new Date(output["ValidFrom"]);
+    contents.ValidFrom = __expectNonNull(__parseRfc3339DateTime(output["ValidFrom"]));
   }
   if (output["ValidTill"] !== undefined) {
-    contents.ValidTill = new Date(output["ValidTill"]);
+    contents.ValidTill = __expectNonNull(__parseRfc3339DateTime(output["ValidTill"]));
   }
   if (output["CertificateArn"] !== undefined) {
     contents.CertificateArn = __expectString(output["CertificateArn"]);
@@ -8011,7 +8013,7 @@ const deserializeAws_queryDBCluster = (output: any, context: __SerdeContext): DB
     contents.PercentProgress = __expectString(output["PercentProgress"]);
   }
   if (output["EarliestRestorableTime"] !== undefined) {
-    contents.EarliestRestorableTime = new Date(output["EarliestRestorableTime"]);
+    contents.EarliestRestorableTime = __expectNonNull(__parseRfc3339DateTime(output["EarliestRestorableTime"]));
   }
   if (output["Endpoint"] !== undefined) {
     contents.Endpoint = __expectString(output["Endpoint"]);
@@ -8029,7 +8031,7 @@ const deserializeAws_queryDBCluster = (output: any, context: __SerdeContext): DB
     contents.EngineVersion = __expectString(output["EngineVersion"]);
   }
   if (output["LatestRestorableTime"] !== undefined) {
-    contents.LatestRestorableTime = new Date(output["LatestRestorableTime"]);
+    contents.LatestRestorableTime = __expectNonNull(__parseRfc3339DateTime(output["LatestRestorableTime"]));
   }
   if (output["Port"] !== undefined) {
     contents.Port = __strictParseInt32(output["Port"]) as number;
@@ -8104,7 +8106,7 @@ const deserializeAws_queryDBCluster = (output: any, context: __SerdeContext): DB
     );
   }
   if (output["ClusterCreateTime"] !== undefined) {
-    contents.ClusterCreateTime = new Date(output["ClusterCreateTime"]);
+    contents.ClusterCreateTime = __expectNonNull(__parseRfc3339DateTime(output["ClusterCreateTime"]));
   }
   if (output.EnabledCloudwatchLogsExports === "") {
     contents.EnabledCloudwatchLogsExports = [];
@@ -8396,7 +8398,7 @@ const deserializeAws_queryDBClusterSnapshot = (output: any, context: __SerdeCont
     contents.DBClusterIdentifier = __expectString(output["DBClusterIdentifier"]);
   }
   if (output["SnapshotCreateTime"] !== undefined) {
-    contents.SnapshotCreateTime = new Date(output["SnapshotCreateTime"]);
+    contents.SnapshotCreateTime = __expectNonNull(__parseRfc3339DateTime(output["SnapshotCreateTime"]));
   }
   if (output["Engine"] !== undefined) {
     contents.Engine = __expectString(output["Engine"]);
@@ -8411,7 +8413,7 @@ const deserializeAws_queryDBClusterSnapshot = (output: any, context: __SerdeCont
     contents.VpcId = __expectString(output["VpcId"]);
   }
   if (output["ClusterCreateTime"] !== undefined) {
-    contents.ClusterCreateTime = new Date(output["ClusterCreateTime"]);
+    contents.ClusterCreateTime = __expectNonNull(__parseRfc3339DateTime(output["ClusterCreateTime"]));
   }
   if (output["MasterUsername"] !== undefined) {
     contents.MasterUsername = __expectString(output["MasterUsername"]);
@@ -8689,7 +8691,7 @@ const deserializeAws_queryDBInstance = (output: any, context: __SerdeContext): D
     contents.Endpoint = deserializeAws_queryEndpoint(output["Endpoint"], context);
   }
   if (output["InstanceCreateTime"] !== undefined) {
-    contents.InstanceCreateTime = new Date(output["InstanceCreateTime"]);
+    contents.InstanceCreateTime = __expectNonNull(__parseRfc3339DateTime(output["InstanceCreateTime"]));
   }
   if (output["PreferredBackupWindow"] !== undefined) {
     contents.PreferredBackupWindow = __expectString(output["PreferredBackupWindow"]);
@@ -8725,7 +8727,7 @@ const deserializeAws_queryDBInstance = (output: any, context: __SerdeContext): D
     );
   }
   if (output["LatestRestorableTime"] !== undefined) {
-    contents.LatestRestorableTime = new Date(output["LatestRestorableTime"]);
+    contents.LatestRestorableTime = __expectNonNull(__parseRfc3339DateTime(output["LatestRestorableTime"]));
   }
   if (output["EngineVersion"] !== undefined) {
     contents.EngineVersion = __expectString(output["EngineVersion"]);
@@ -9243,7 +9245,7 @@ const deserializeAws_queryEvent = (output: any, context: __SerdeContext): Event 
     );
   }
   if (output["Date"] !== undefined) {
-    contents.Date = new Date(output["Date"]);
+    contents.Date = __expectNonNull(__parseRfc3339DateTime(output["Date"]));
   }
   if (output["SourceArn"] !== undefined) {
     contents.SourceArn = __expectString(output["SourceArn"]);
@@ -10110,16 +10112,16 @@ const deserializeAws_queryPendingMaintenanceAction = (
     contents.Action = __expectString(output["Action"]);
   }
   if (output["AutoAppliedAfterDate"] !== undefined) {
-    contents.AutoAppliedAfterDate = new Date(output["AutoAppliedAfterDate"]);
+    contents.AutoAppliedAfterDate = __expectNonNull(__parseRfc3339DateTime(output["AutoAppliedAfterDate"]));
   }
   if (output["ForcedApplyDate"] !== undefined) {
-    contents.ForcedApplyDate = new Date(output["ForcedApplyDate"]);
+    contents.ForcedApplyDate = __expectNonNull(__parseRfc3339DateTime(output["ForcedApplyDate"]));
   }
   if (output["OptInStatus"] !== undefined) {
     contents.OptInStatus = __expectString(output["OptInStatus"]);
   }
   if (output["CurrentApplyDate"] !== undefined) {
-    contents.CurrentApplyDate = new Date(output["CurrentApplyDate"]);
+    contents.CurrentApplyDate = __expectNonNull(__parseRfc3339DateTime(output["CurrentApplyDate"]));
   }
   if (output["Description"] !== undefined) {
     contents.Description = __expectString(output["Description"]);

--- a/clients/client-dynamodb-streams/protocols/Aws_json1_0.ts
+++ b/clients/client-dynamodb-streams/protocols/Aws_json1_0.ts
@@ -30,7 +30,10 @@ import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@a
 import {
   expectBoolean as __expectBoolean,
   expectLong as __expectLong,
+  expectNonNull as __expectNonNull,
+  expectNumber as __expectNumber,
   expectString as __expectString,
+  parseEpochTimestamp as __parseEpochTimestamp,
 } from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
@@ -753,7 +756,7 @@ const deserializeAws_json1_0StreamDescription = (output: any, context: __SerdeCo
   return {
     CreationRequestDateTime:
       output.CreationRequestDateTime !== undefined && output.CreationRequestDateTime !== null
-        ? new Date(Math.round(output.CreationRequestDateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationRequestDateTime)))
         : undefined,
     KeySchema:
       output.KeySchema !== undefined && output.KeySchema !== null
@@ -787,7 +790,7 @@ const deserializeAws_json1_0StreamRecord = (output: any, context: __SerdeContext
   return {
     ApproximateCreationDateTime:
       output.ApproximateCreationDateTime !== undefined && output.ApproximateCreationDateTime !== null
-        ? new Date(Math.round(output.ApproximateCreationDateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.ApproximateCreationDateTime)))
         : undefined,
     Keys:
       output.Keys !== undefined && output.Keys !== null

--- a/clients/client-dynamodb/protocols/Aws_json1_0.ts
+++ b/clients/client-dynamodb/protocols/Aws_json1_0.ts
@@ -326,8 +326,11 @@ import {
   expectBoolean as __expectBoolean,
   expectInt32 as __expectInt32,
   expectLong as __expectLong,
+  expectNonNull as __expectNonNull,
+  expectNumber as __expectNumber,
   expectString as __expectString,
   limitedParseDouble as __limitedParseDouble,
+  parseEpochTimestamp as __parseEpochTimestamp,
   serializeFloat as __serializeFloat,
 } from "@aws-sdk/smithy-client";
 import {
@@ -7564,7 +7567,7 @@ const deserializeAws_json1_0ArchivalSummary = (output: any, context: __SerdeCont
     ArchivalBackupArn: __expectString(output.ArchivalBackupArn),
     ArchivalDateTime:
       output.ArchivalDateTime !== undefined && output.ArchivalDateTime !== null
-        ? new Date(Math.round(output.ArchivalDateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.ArchivalDateTime)))
         : undefined,
     ArchivalReason: __expectString(output.ArchivalReason),
   } as any;
@@ -7741,11 +7744,11 @@ const deserializeAws_json1_0BackupDetails = (output: any, context: __SerdeContex
     BackupArn: __expectString(output.BackupArn),
     BackupCreationDateTime:
       output.BackupCreationDateTime !== undefined && output.BackupCreationDateTime !== null
-        ? new Date(Math.round(output.BackupCreationDateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.BackupCreationDateTime)))
         : undefined,
     BackupExpiryDateTime:
       output.BackupExpiryDateTime !== undefined && output.BackupExpiryDateTime !== null
-        ? new Date(Math.round(output.BackupExpiryDateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.BackupExpiryDateTime)))
         : undefined,
     BackupName: __expectString(output.BackupName),
     BackupSizeBytes: __expectLong(output.BackupSizeBytes),
@@ -7785,11 +7788,11 @@ const deserializeAws_json1_0BackupSummary = (output: any, context: __SerdeContex
     BackupArn: __expectString(output.BackupArn),
     BackupCreationDateTime:
       output.BackupCreationDateTime !== undefined && output.BackupCreationDateTime !== null
-        ? new Date(Math.round(output.BackupCreationDateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.BackupCreationDateTime)))
         : undefined,
     BackupExpiryDateTime:
       output.BackupExpiryDateTime !== undefined && output.BackupExpiryDateTime !== null
-        ? new Date(Math.round(output.BackupExpiryDateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.BackupExpiryDateTime)))
         : undefined,
     BackupName: __expectString(output.BackupName),
     BackupSizeBytes: __expectLong(output.BackupSizeBytes),
@@ -7921,7 +7924,7 @@ const deserializeAws_json1_0BillingModeSummary = (output: any, context: __SerdeC
     BillingMode: __expectString(output.BillingMode),
     LastUpdateToPayPerRequestDateTime:
       output.LastUpdateToPayPerRequestDateTime !== undefined && output.LastUpdateToPayPerRequestDateTime !== null
-        ? new Date(Math.round(output.LastUpdateToPayPerRequestDateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastUpdateToPayPerRequestDateTime)))
         : undefined,
   } as any;
 };
@@ -8175,7 +8178,7 @@ const deserializeAws_json1_0DescribeContributorInsightsOutput = (
     IndexName: __expectString(output.IndexName),
     LastUpdateDateTime:
       output.LastUpdateDateTime !== undefined && output.LastUpdateDateTime !== null
-        ? new Date(Math.round(output.LastUpdateDateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastUpdateDateTime)))
         : undefined,
     TableName: __expectString(output.TableName),
   } as any;
@@ -8342,14 +8345,16 @@ const deserializeAws_json1_0ExportDescription = (output: any, context: __SerdeCo
     BilledSizeBytes: __expectLong(output.BilledSizeBytes),
     ClientToken: __expectString(output.ClientToken),
     EndTime:
-      output.EndTime !== undefined && output.EndTime !== null ? new Date(Math.round(output.EndTime * 1000)) : undefined,
+      output.EndTime !== undefined && output.EndTime !== null
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.EndTime)))
+        : undefined,
     ExportArn: __expectString(output.ExportArn),
     ExportFormat: __expectString(output.ExportFormat),
     ExportManifest: __expectString(output.ExportManifest),
     ExportStatus: __expectString(output.ExportStatus),
     ExportTime:
       output.ExportTime !== undefined && output.ExportTime !== null
-        ? new Date(Math.round(output.ExportTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.ExportTime)))
         : undefined,
     FailureCode: __expectString(output.FailureCode),
     FailureMessage: __expectString(output.FailureMessage),
@@ -8361,7 +8366,7 @@ const deserializeAws_json1_0ExportDescription = (output: any, context: __SerdeCo
     S3SseKmsKeyId: __expectString(output.S3SseKmsKeyId),
     StartTime:
       output.StartTime !== undefined && output.StartTime !== null
-        ? new Date(Math.round(output.StartTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.StartTime)))
         : undefined,
     TableArn: __expectString(output.TableArn),
     TableId: __expectString(output.TableId),
@@ -8540,7 +8545,7 @@ const deserializeAws_json1_0GlobalTableDescription = (output: any, context: __Se
   return {
     CreationDateTime:
       output.CreationDateTime !== undefined && output.CreationDateTime !== null
-        ? new Date(Math.round(output.CreationDateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationDateTime)))
         : undefined,
     GlobalTableArn: __expectString(output.GlobalTableArn),
     GlobalTableName: __expectString(output.GlobalTableName),
@@ -9030,11 +9035,11 @@ const deserializeAws_json1_0PointInTimeRecoveryDescription = (
   return {
     EarliestRestorableDateTime:
       output.EarliestRestorableDateTime !== undefined && output.EarliestRestorableDateTime !== null
-        ? new Date(Math.round(output.EarliestRestorableDateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.EarliestRestorableDateTime)))
         : undefined,
     LatestRestorableDateTime:
       output.LatestRestorableDateTime !== undefined && output.LatestRestorableDateTime !== null
-        ? new Date(Math.round(output.LatestRestorableDateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LatestRestorableDateTime)))
         : undefined,
     PointInTimeRecoveryStatus: __expectString(output.PointInTimeRecoveryStatus),
   } as any;
@@ -9073,11 +9078,11 @@ const deserializeAws_json1_0ProvisionedThroughputDescription = (
   return {
     LastDecreaseDateTime:
       output.LastDecreaseDateTime !== undefined && output.LastDecreaseDateTime !== null
-        ? new Date(Math.round(output.LastDecreaseDateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastDecreaseDateTime)))
         : undefined,
     LastIncreaseDateTime:
       output.LastIncreaseDateTime !== undefined && output.LastIncreaseDateTime !== null
-        ? new Date(Math.round(output.LastIncreaseDateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastIncreaseDateTime)))
         : undefined,
     NumberOfDecreasesToday: __expectLong(output.NumberOfDecreasesToday),
     ReadCapacityUnits: __expectLong(output.ReadCapacityUnits),
@@ -9239,7 +9244,7 @@ const deserializeAws_json1_0ReplicaDescription = (output: any, context: __SerdeC
     RegionName: __expectString(output.RegionName),
     ReplicaInaccessibleDateTime:
       output.ReplicaInaccessibleDateTime !== undefined && output.ReplicaInaccessibleDateTime !== null
-        ? new Date(Math.round(output.ReplicaInaccessibleDateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.ReplicaInaccessibleDateTime)))
         : undefined,
     ReplicaStatus: __expectString(output.ReplicaStatus),
     ReplicaStatusDescription: __expectString(output.ReplicaStatusDescription),
@@ -9465,7 +9470,7 @@ const deserializeAws_json1_0RestoreSummary = (output: any, context: __SerdeConte
   return {
     RestoreDateTime:
       output.RestoreDateTime !== undefined && output.RestoreDateTime !== null
-        ? new Date(Math.round(output.RestoreDateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.RestoreDateTime)))
         : undefined,
     RestoreInProgress: __expectBoolean(output.RestoreInProgress),
     SourceBackupArn: __expectString(output.SourceBackupArn),
@@ -9546,7 +9551,7 @@ const deserializeAws_json1_0SourceTableDetails = (output: any, context: __SerdeC
     TableArn: __expectString(output.TableArn),
     TableCreationDateTime:
       output.TableCreationDateTime !== undefined && output.TableCreationDateTime !== null
-        ? new Date(Math.round(output.TableCreationDateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.TableCreationDateTime)))
         : undefined,
     TableId: __expectString(output.TableId),
     TableName: __expectString(output.TableName),
@@ -9586,7 +9591,7 @@ const deserializeAws_json1_0SSEDescription = (output: any, context: __SerdeConte
   return {
     InaccessibleEncryptionDateTime:
       output.InaccessibleEncryptionDateTime !== undefined && output.InaccessibleEncryptionDateTime !== null
-        ? new Date(Math.round(output.InaccessibleEncryptionDateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.InaccessibleEncryptionDateTime)))
         : undefined,
     KMSMasterKeyArn: __expectString(output.KMSMasterKeyArn),
     SSEType: __expectString(output.SSEType),
@@ -9651,7 +9656,7 @@ const deserializeAws_json1_0TableDescription = (output: any, context: __SerdeCon
         : undefined,
     CreationDateTime:
       output.CreationDateTime !== undefined && output.CreationDateTime !== null
-        ? new Date(Math.round(output.CreationDateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationDateTime)))
         : undefined,
     GlobalSecondaryIndexes:
       output.GlobalSecondaryIndexes !== undefined && output.GlobalSecondaryIndexes !== null

--- a/clients/client-ebs/protocols/Aws_restJson1.ts
+++ b/clients/client-ebs/protocols/Aws_restJson1.ts
@@ -22,9 +22,11 @@ import {
   expectInt32 as __expectInt32,
   expectLong as __expectLong,
   expectNonNull as __expectNonNull,
+  expectNumber as __expectNumber,
   expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
+  parseEpochTimestamp as __parseEpochTimestamp,
   strictParseInt32 as __strictParseInt32,
 } from "@aws-sdk/smithy-client";
 import {
@@ -493,7 +495,7 @@ export const deserializeAws_restJson1ListChangedBlocksCommand = async (
     contents.ChangedBlocks = deserializeAws_restJson1ChangedBlocks(data.ChangedBlocks, context);
   }
   if (data.ExpiryTime !== undefined && data.ExpiryTime !== null) {
-    contents.ExpiryTime = new Date(Math.round(data.ExpiryTime * 1000));
+    contents.ExpiryTime = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.ExpiryTime)));
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
@@ -604,7 +606,7 @@ export const deserializeAws_restJson1ListSnapshotBlocksCommand = async (
     contents.Blocks = deserializeAws_restJson1Blocks(data.Blocks, context);
   }
   if (data.ExpiryTime !== undefined && data.ExpiryTime !== null) {
-    contents.ExpiryTime = new Date(Math.round(data.ExpiryTime * 1000));
+    contents.ExpiryTime = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.ExpiryTime)));
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
@@ -831,7 +833,7 @@ export const deserializeAws_restJson1StartSnapshotCommand = async (
     contents.SnapshotId = __expectString(data.SnapshotId);
   }
   if (data.StartTime !== undefined && data.StartTime !== null) {
-    contents.StartTime = new Date(Math.round(data.StartTime * 1000));
+    contents.StartTime = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.StartTime)));
   }
   if (data.Status !== undefined && data.Status !== null) {
     contents.Status = __expectString(data.Status);

--- a/clients/client-ec2/protocols/Aws_ec2.ts
+++ b/clients/client-ec2/protocols/Aws_ec2.ts
@@ -3004,11 +3004,13 @@ import {
 } from "../models/models_5";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
+  expectNonNull as __expectNonNull,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   getArrayIfSingleItem as __getArrayIfSingleItem,
   getValueFromTextNode as __getValueFromTextNode,
   parseBoolean as __parseBoolean,
+  parseRfc3339DateTime as __parseRfc3339DateTime,
   serializeFloat as __serializeFloat,
   strictParseFloat as __strictParseFloat,
   strictParseInt32 as __strictParseInt32,
@@ -51319,7 +51321,7 @@ const deserializeAws_ec2BundleTask = (output: any, context: __SerdeContext): Bun
     contents.Progress = __expectString(output["progress"]);
   }
   if (output["startTime"] !== undefined) {
-    contents.StartTime = new Date(output["startTime"]);
+    contents.StartTime = __expectNonNull(__parseRfc3339DateTime(output["startTime"]));
   }
   if (output["state"] !== undefined) {
     contents.State = __expectString(output["state"]);
@@ -51328,7 +51330,7 @@ const deserializeAws_ec2BundleTask = (output: any, context: __SerdeContext): Bun
     contents.Storage = deserializeAws_ec2Storage(output["storage"], context);
   }
   if (output["updateTime"] !== undefined) {
-    contents.UpdateTime = new Date(output["updateTime"]);
+    contents.UpdateTime = __expectNonNull(__parseRfc3339DateTime(output["updateTime"]));
   }
   return contents;
 };
@@ -51682,10 +51684,10 @@ const deserializeAws_ec2CapacityReservation = (output: any, context: __SerdeCont
     contents.State = __expectString(output["state"]);
   }
   if (output["startDate"] !== undefined) {
-    contents.StartDate = new Date(output["startDate"]);
+    contents.StartDate = __expectNonNull(__parseRfc3339DateTime(output["startDate"]));
   }
   if (output["endDate"] !== undefined) {
-    contents.EndDate = new Date(output["endDate"]);
+    contents.EndDate = __expectNonNull(__parseRfc3339DateTime(output["endDate"]));
   }
   if (output["endDateType"] !== undefined) {
     contents.EndDateType = __expectString(output["endDateType"]);
@@ -51694,7 +51696,7 @@ const deserializeAws_ec2CapacityReservation = (output: any, context: __SerdeCont
     contents.InstanceMatchCriteria = __expectString(output["instanceMatchCriteria"]);
   }
   if (output["createDate"] !== undefined) {
-    contents.CreateDate = new Date(output["createDate"]);
+    contents.CreateDate = __expectNonNull(__parseRfc3339DateTime(output["createDate"]));
   }
   if (output.tagSet === "") {
     contents.Tags = [];
@@ -55058,19 +55060,19 @@ const deserializeAws_ec2DescribeFastSnapshotRestoreSuccessItem = (
     contents.OwnerAlias = __expectString(output["ownerAlias"]);
   }
   if (output["enablingTime"] !== undefined) {
-    contents.EnablingTime = new Date(output["enablingTime"]);
+    contents.EnablingTime = __expectNonNull(__parseRfc3339DateTime(output["enablingTime"]));
   }
   if (output["optimizingTime"] !== undefined) {
-    contents.OptimizingTime = new Date(output["optimizingTime"]);
+    contents.OptimizingTime = __expectNonNull(__parseRfc3339DateTime(output["optimizingTime"]));
   }
   if (output["enabledTime"] !== undefined) {
-    contents.EnabledTime = new Date(output["enabledTime"]);
+    contents.EnabledTime = __expectNonNull(__parseRfc3339DateTime(output["enabledTime"]));
   }
   if (output["disablingTime"] !== undefined) {
-    contents.DisablingTime = new Date(output["disablingTime"]);
+    contents.DisablingTime = __expectNonNull(__parseRfc3339DateTime(output["disablingTime"]));
   }
   if (output["disabledTime"] !== undefined) {
-    contents.DisabledTime = new Date(output["disabledTime"]);
+    contents.DisabledTime = __expectNonNull(__parseRfc3339DateTime(output["disabledTime"]));
   }
   return contents;
 };
@@ -55135,7 +55137,7 @@ const deserializeAws_ec2DescribeFleetHistoryResult = (
     );
   }
   if (output["lastEvaluatedTime"] !== undefined) {
-    contents.LastEvaluatedTime = new Date(output["lastEvaluatedTime"]);
+    contents.LastEvaluatedTime = __expectNonNull(__parseRfc3339DateTime(output["lastEvaluatedTime"]));
   }
   if (output["nextToken"] !== undefined) {
     contents.NextToken = __expectString(output["nextToken"]);
@@ -55144,7 +55146,7 @@ const deserializeAws_ec2DescribeFleetHistoryResult = (
     contents.FleetId = __expectString(output["fleetId"]);
   }
   if (output["startTime"] !== undefined) {
-    contents.StartTime = new Date(output["startTime"]);
+    contents.StartTime = __expectNonNull(__parseRfc3339DateTime(output["startTime"]));
   }
   return contents;
 };
@@ -56577,7 +56579,7 @@ const deserializeAws_ec2DescribeSpotFleetRequestHistoryResponse = (
     );
   }
   if (output["lastEvaluatedTime"] !== undefined) {
-    contents.LastEvaluatedTime = new Date(output["lastEvaluatedTime"]);
+    contents.LastEvaluatedTime = __expectNonNull(__parseRfc3339DateTime(output["lastEvaluatedTime"]));
   }
   if (output["nextToken"] !== undefined) {
     contents.NextToken = __expectString(output["nextToken"]);
@@ -56586,7 +56588,7 @@ const deserializeAws_ec2DescribeSpotFleetRequestHistoryResponse = (
     contents.SpotFleetRequestId = __expectString(output["spotFleetRequestId"]);
   }
   if (output["startTime"] !== undefined) {
-    contents.StartTime = new Date(output["startTime"]);
+    contents.StartTime = __expectNonNull(__parseRfc3339DateTime(output["startTime"]));
   }
   return contents;
 };
@@ -57680,19 +57682,19 @@ const deserializeAws_ec2DisableFastSnapshotRestoreSuccessItem = (
     contents.OwnerAlias = __expectString(output["ownerAlias"]);
   }
   if (output["enablingTime"] !== undefined) {
-    contents.EnablingTime = new Date(output["enablingTime"]);
+    contents.EnablingTime = __expectNonNull(__parseRfc3339DateTime(output["enablingTime"]));
   }
   if (output["optimizingTime"] !== undefined) {
-    contents.OptimizingTime = new Date(output["optimizingTime"]);
+    contents.OptimizingTime = __expectNonNull(__parseRfc3339DateTime(output["optimizingTime"]));
   }
   if (output["enabledTime"] !== undefined) {
-    contents.EnabledTime = new Date(output["enabledTime"]);
+    contents.EnabledTime = __expectNonNull(__parseRfc3339DateTime(output["enabledTime"]));
   }
   if (output["disablingTime"] !== undefined) {
-    contents.DisablingTime = new Date(output["disablingTime"]);
+    contents.DisablingTime = __expectNonNull(__parseRfc3339DateTime(output["disablingTime"]));
   }
   if (output["disabledTime"] !== undefined) {
-    contents.DisabledTime = new Date(output["disabledTime"]);
+    contents.DisabledTime = __expectNonNull(__parseRfc3339DateTime(output["disabledTime"]));
   }
   return contents;
 };
@@ -58090,7 +58092,7 @@ const deserializeAws_ec2EbsInstanceBlockDevice = (output: any, context: __SerdeC
     VolumeId: undefined,
   };
   if (output["attachTime"] !== undefined) {
-    contents.AttachTime = new Date(output["attachTime"]);
+    contents.AttachTime = __expectNonNull(__parseRfc3339DateTime(output["attachTime"]));
   }
   if (output["deleteOnTermination"] !== undefined) {
     contents.DeleteOnTermination = __parseBoolean(output["deleteOnTermination"]);
@@ -58330,8 +58332,8 @@ const deserializeAws_ec2ElasticInferenceAcceleratorAssociation = (
     );
   }
   if (output["elasticInferenceAcceleratorAssociationTime"] !== undefined) {
-    contents.ElasticInferenceAcceleratorAssociationTime = new Date(
-      output["elasticInferenceAcceleratorAssociationTime"]
+    contents.ElasticInferenceAcceleratorAssociationTime = __expectNonNull(
+      __parseRfc3339DateTime(output["elasticInferenceAcceleratorAssociationTime"])
     );
   }
   return contents;
@@ -58517,19 +58519,19 @@ const deserializeAws_ec2EnableFastSnapshotRestoreSuccessItem = (
     contents.OwnerAlias = __expectString(output["ownerAlias"]);
   }
   if (output["enablingTime"] !== undefined) {
-    contents.EnablingTime = new Date(output["enablingTime"]);
+    contents.EnablingTime = __expectNonNull(__parseRfc3339DateTime(output["enablingTime"]));
   }
   if (output["optimizingTime"] !== undefined) {
-    contents.OptimizingTime = new Date(output["optimizingTime"]);
+    contents.OptimizingTime = __expectNonNull(__parseRfc3339DateTime(output["optimizingTime"]));
   }
   if (output["enabledTime"] !== undefined) {
-    contents.EnabledTime = new Date(output["enabledTime"]);
+    contents.EnabledTime = __expectNonNull(__parseRfc3339DateTime(output["enabledTime"]));
   }
   if (output["disablingTime"] !== undefined) {
-    contents.DisablingTime = new Date(output["disablingTime"]);
+    contents.DisablingTime = __expectNonNull(__parseRfc3339DateTime(output["disablingTime"]));
   }
   if (output["disabledTime"] !== undefined) {
-    contents.DisabledTime = new Date(output["disabledTime"]);
+    contents.DisabledTime = __expectNonNull(__parseRfc3339DateTime(output["disabledTime"]));
   }
   return contents;
 };
@@ -59203,7 +59205,7 @@ const deserializeAws_ec2FleetData = (output: any, context: __SerdeContext): Flee
     contents.ActivityStatus = __expectString(output["activityStatus"]);
   }
   if (output["createTime"] !== undefined) {
-    contents.CreateTime = new Date(output["createTime"]);
+    contents.CreateTime = __expectNonNull(__parseRfc3339DateTime(output["createTime"]));
   }
   if (output["fleetId"] !== undefined) {
     contents.FleetId = __expectString(output["fleetId"]);
@@ -59245,10 +59247,10 @@ const deserializeAws_ec2FleetData = (output: any, context: __SerdeContext): Flee
     contents.Type = __expectString(output["type"]);
   }
   if (output["validFrom"] !== undefined) {
-    contents.ValidFrom = new Date(output["validFrom"]);
+    contents.ValidFrom = __expectNonNull(__parseRfc3339DateTime(output["validFrom"]));
   }
   if (output["validUntil"] !== undefined) {
-    contents.ValidUntil = new Date(output["validUntil"]);
+    contents.ValidUntil = __expectNonNull(__parseRfc3339DateTime(output["validUntil"]));
   }
   if (output["replaceUnhealthyInstances"] !== undefined) {
     contents.ReplaceUnhealthyInstances = __parseBoolean(output["replaceUnhealthyInstances"]);
@@ -59456,7 +59458,7 @@ const deserializeAws_ec2FlowLog = (output: any, context: __SerdeContext): FlowLo
     MaxAggregationInterval: undefined,
   };
   if (output["creationTime"] !== undefined) {
-    contents.CreationTime = new Date(output["creationTime"]);
+    contents.CreationTime = __expectNonNull(__parseRfc3339DateTime(output["creationTime"]));
   }
   if (output["deliverLogsErrorMessage"] !== undefined) {
     contents.DeliverLogsErrorMessage = __expectString(output["deliverLogsErrorMessage"]);
@@ -59597,10 +59599,10 @@ const deserializeAws_ec2FpgaImage = (output: any, context: __SerdeContext): Fpga
     contents.State = deserializeAws_ec2FpgaImageState(output["state"], context);
   }
   if (output["createTime"] !== undefined) {
-    contents.CreateTime = new Date(output["createTime"]);
+    contents.CreateTime = __expectNonNull(__parseRfc3339DateTime(output["createTime"]));
   }
   if (output["updateTime"] !== undefined) {
-    contents.UpdateTime = new Date(output["updateTime"]);
+    contents.UpdateTime = __expectNonNull(__parseRfc3339DateTime(output["updateTime"]));
   }
   if (output["ownerId"] !== undefined) {
     contents.OwnerId = __expectString(output["ownerId"]);
@@ -59834,7 +59836,7 @@ const deserializeAws_ec2GetConsoleOutputResult = (output: any, context: __SerdeC
     contents.Output = __expectString(output["output"]);
   }
   if (output["timestamp"] !== undefined) {
-    contents.Timestamp = new Date(output["timestamp"]);
+    contents.Timestamp = __expectNonNull(__parseRfc3339DateTime(output["timestamp"]));
   }
   return contents;
 };
@@ -60037,7 +60039,7 @@ const deserializeAws_ec2GetPasswordDataResult = (output: any, context: __SerdeCo
     contents.PasswordData = __expectString(output["passwordData"]);
   }
   if (output["timestamp"] !== undefined) {
-    contents.Timestamp = new Date(output["timestamp"]);
+    contents.Timestamp = __expectNonNull(__parseRfc3339DateTime(output["timestamp"]));
   }
   return contents;
 };
@@ -60064,7 +60066,9 @@ const deserializeAws_ec2GetReservedInstancesExchangeQuoteResult = (
     contents.IsValidExchange = __parseBoolean(output["isValidExchange"]);
   }
   if (output["outputReservedInstancesWillExpireAt"] !== undefined) {
-    contents.OutputReservedInstancesWillExpireAt = new Date(output["outputReservedInstancesWillExpireAt"]);
+    contents.OutputReservedInstancesWillExpireAt = __expectNonNull(
+      __parseRfc3339DateTime(output["outputReservedInstancesWillExpireAt"])
+    );
   }
   if (output["paymentDue"] !== undefined) {
     contents.PaymentDue = __expectString(output["paymentDue"]);
@@ -60417,7 +60421,7 @@ const deserializeAws_ec2HistoryRecord = (output: any, context: __SerdeContext): 
     contents.EventType = __expectString(output["eventType"]);
   }
   if (output["timestamp"] !== undefined) {
-    contents.Timestamp = new Date(output["timestamp"]);
+    contents.Timestamp = __expectNonNull(__parseRfc3339DateTime(output["timestamp"]));
   }
   return contents;
 };
@@ -60435,7 +60439,7 @@ const deserializeAws_ec2HistoryRecordEntry = (output: any, context: __SerdeConte
     contents.EventType = __expectString(output["eventType"]);
   }
   if (output["timestamp"] !== undefined) {
-    contents.Timestamp = new Date(output["timestamp"]);
+    contents.Timestamp = __expectNonNull(__parseRfc3339DateTime(output["timestamp"]));
   }
   return contents;
 };
@@ -60516,10 +60520,10 @@ const deserializeAws_ec2Host = (output: any, context: __SerdeContext): Host => {
     contents.State = __expectString(output["state"]);
   }
   if (output["allocationTime"] !== undefined) {
-    contents.AllocationTime = new Date(output["allocationTime"]);
+    contents.AllocationTime = __expectNonNull(__parseRfc3339DateTime(output["allocationTime"]));
   }
   if (output["releaseTime"] !== undefined) {
-    contents.ReleaseTime = new Date(output["releaseTime"]);
+    contents.ReleaseTime = __expectNonNull(__parseRfc3339DateTime(output["releaseTime"]));
   }
   if (output.tagSet === "") {
     contents.Tags = [];
@@ -60683,7 +60687,7 @@ const deserializeAws_ec2HostReservation = (output: any, context: __SerdeContext)
     contents.Duration = __strictParseInt32(output["duration"]) as number;
   }
   if (output["end"] !== undefined) {
-    contents.End = new Date(output["end"]);
+    contents.End = __expectNonNull(__parseRfc3339DateTime(output["end"]));
   }
   if (output.hostIdSet === "") {
     contents.HostIdSet = [];
@@ -60710,7 +60714,7 @@ const deserializeAws_ec2HostReservation = (output: any, context: __SerdeContext)
     contents.PaymentOption = __expectString(output["paymentOption"]);
   }
   if (output["start"] !== undefined) {
-    contents.Start = new Date(output["start"]);
+    contents.Start = __expectNonNull(__parseRfc3339DateTime(output["start"]));
   }
   if (output["state"] !== undefined) {
     contents.State = __expectString(output["state"]);
@@ -60776,7 +60780,7 @@ const deserializeAws_ec2IamInstanceProfileAssociation = (
     contents.State = __expectString(output["state"]);
   }
   if (output["timestamp"] !== undefined) {
-    contents.Timestamp = new Date(output["timestamp"]);
+    contents.Timestamp = __expectNonNull(__parseRfc3339DateTime(output["timestamp"]));
   }
   return contents;
 };
@@ -60833,7 +60837,7 @@ const deserializeAws_ec2IdFormat = (output: any, context: __SerdeContext): IdFor
     UseLongIds: undefined,
   };
   if (output["deadline"] !== undefined) {
-    contents.Deadline = new Date(output["deadline"]);
+    contents.Deadline = __expectNonNull(__parseRfc3339DateTime(output["deadline"]));
   }
   if (output["resource"] !== undefined) {
     contents.Resource = __expectString(output["resource"]);
@@ -61646,7 +61650,7 @@ const deserializeAws_ec2Instance = (output: any, context: __SerdeContext): Insta
     contents.KeyName = __expectString(output["keyName"]);
   }
   if (output["launchTime"] !== undefined) {
-    contents.LaunchTime = new Date(output["launchTime"]);
+    contents.LaunchTime = __expectNonNull(__parseRfc3339DateTime(output["launchTime"]));
   }
   if (output["monitoring"] !== undefined) {
     contents.Monitoring = deserializeAws_ec2Monitoring(output["monitoring"], context);
@@ -62508,7 +62512,7 @@ const deserializeAws_ec2InstanceNetworkInterfaceAttachment = (
     NetworkCardIndex: undefined,
   };
   if (output["attachTime"] !== undefined) {
-    contents.AttachTime = new Date(output["attachTime"]);
+    contents.AttachTime = __expectNonNull(__parseRfc3339DateTime(output["attachTime"]));
   }
   if (output["attachmentId"] !== undefined) {
     contents.AttachmentId = __expectString(output["attachmentId"]);
@@ -62797,7 +62801,7 @@ const deserializeAws_ec2InstanceStatusDetails = (output: any, context: __SerdeCo
     Status: undefined,
   };
   if (output["impairedSince"] !== undefined) {
-    contents.ImpairedSince = new Date(output["impairedSince"]);
+    contents.ImpairedSince = __expectNonNull(__parseRfc3339DateTime(output["impairedSince"]));
   }
   if (output["name"] !== undefined) {
     contents.Name = __expectString(output["name"]);
@@ -62838,13 +62842,13 @@ const deserializeAws_ec2InstanceStatusEvent = (output: any, context: __SerdeCont
     contents.Description = __expectString(output["description"]);
   }
   if (output["notAfter"] !== undefined) {
-    contents.NotAfter = new Date(output["notAfter"]);
+    contents.NotAfter = __expectNonNull(__parseRfc3339DateTime(output["notAfter"]));
   }
   if (output["notBefore"] !== undefined) {
-    contents.NotBefore = new Date(output["notBefore"]);
+    contents.NotBefore = __expectNonNull(__parseRfc3339DateTime(output["notBefore"]));
   }
   if (output["notBeforeDeadline"] !== undefined) {
-    contents.NotBeforeDeadline = new Date(output["notBeforeDeadline"]);
+    contents.NotBeforeDeadline = __expectNonNull(__parseRfc3339DateTime(output["notBeforeDeadline"]));
   }
   return contents;
 };
@@ -63831,7 +63835,7 @@ const deserializeAws_ec2LaunchTemplate = (output: any, context: __SerdeContext):
     contents.LaunchTemplateName = __expectString(output["launchTemplateName"]);
   }
   if (output["createTime"] !== undefined) {
-    contents.CreateTime = new Date(output["createTime"]);
+    contents.CreateTime = __expectNonNull(__parseRfc3339DateTime(output["createTime"]));
   }
   if (output["createdBy"] !== undefined) {
     contents.CreatedBy = __expectString(output["createdBy"]);
@@ -64422,7 +64426,7 @@ const deserializeAws_ec2LaunchTemplateSpotMarketOptions = (
     contents.BlockDurationMinutes = __strictParseInt32(output["blockDurationMinutes"]) as number;
   }
   if (output["validUntil"] !== undefined) {
-    contents.ValidUntil = new Date(output["validUntil"]);
+    contents.ValidUntil = __expectNonNull(__parseRfc3339DateTime(output["validUntil"]));
   }
   if (output["instanceInterruptionBehavior"] !== undefined) {
     contents.InstanceInterruptionBehavior = __expectString(output["instanceInterruptionBehavior"]);
@@ -64488,7 +64492,7 @@ const deserializeAws_ec2LaunchTemplateVersion = (output: any, context: __SerdeCo
     contents.VersionDescription = __expectString(output["versionDescription"]);
   }
   if (output["createTime"] !== undefined) {
-    contents.CreateTime = new Date(output["createTime"]);
+    contents.CreateTime = __expectNonNull(__parseRfc3339DateTime(output["createTime"]));
   }
   if (output["createdBy"] !== undefined) {
     contents.CreatedBy = __expectString(output["createdBy"]);
@@ -65642,10 +65646,10 @@ const deserializeAws_ec2NatGateway = (output: any, context: __SerdeContext): Nat
     ConnectivityType: undefined,
   };
   if (output["createTime"] !== undefined) {
-    contents.CreateTime = new Date(output["createTime"]);
+    contents.CreateTime = __expectNonNull(__parseRfc3339DateTime(output["createTime"]));
   }
   if (output["deleteTime"] !== undefined) {
-    contents.DeleteTime = new Date(output["deleteTime"]);
+    contents.DeleteTime = __expectNonNull(__parseRfc3339DateTime(output["deleteTime"]));
   }
   if (output["failureCode"] !== undefined) {
     contents.FailureCode = __expectString(output["failureCode"]);
@@ -65995,7 +65999,7 @@ const deserializeAws_ec2NetworkInsightsAnalysis = (output: any, context: __Serde
     );
   }
   if (output["startDate"] !== undefined) {
-    contents.StartDate = new Date(output["startDate"]);
+    contents.StartDate = __expectNonNull(__parseRfc3339DateTime(output["startDate"]));
   }
   if (output["status"] !== undefined) {
     contents.Status = __expectString(output["status"]);
@@ -66085,7 +66089,7 @@ const deserializeAws_ec2NetworkInsightsPath = (output: any, context: __SerdeCont
     contents.NetworkInsightsPathArn = __expectString(output["networkInsightsPathArn"]);
   }
   if (output["createdDate"] !== undefined) {
-    contents.CreatedDate = new Date(output["createdDate"]);
+    contents.CreatedDate = __expectNonNull(__parseRfc3339DateTime(output["createdDate"]));
   }
   if (output["source"] !== undefined) {
     contents.Source = __expectString(output["source"]);
@@ -66308,7 +66312,7 @@ const deserializeAws_ec2NetworkInterfaceAttachment = (
     Status: undefined,
   };
   if (output["attachTime"] !== undefined) {
-    contents.AttachTime = new Date(output["attachTime"]);
+    contents.AttachTime = __expectNonNull(__parseRfc3339DateTime(output["attachTime"]));
   }
   if (output["attachmentId"] !== undefined) {
     contents.AttachmentId = __expectString(output["attachmentId"]);
@@ -67352,13 +67356,13 @@ const deserializeAws_ec2ProvisionedBandwidth = (output: any, context: __SerdeCon
     Status: undefined,
   };
   if (output["provisionTime"] !== undefined) {
-    contents.ProvisionTime = new Date(output["provisionTime"]);
+    contents.ProvisionTime = __expectNonNull(__parseRfc3339DateTime(output["provisionTime"]));
   }
   if (output["provisioned"] !== undefined) {
     contents.Provisioned = __expectString(output["provisioned"]);
   }
   if (output["requestTime"] !== undefined) {
-    contents.RequestTime = new Date(output["requestTime"]);
+    contents.RequestTime = __expectNonNull(__parseRfc3339DateTime(output["requestTime"]));
   }
   if (output["requested"] !== undefined) {
     contents.Requested = __expectString(output["requested"]);
@@ -68106,7 +68110,7 @@ const deserializeAws_ec2ReservedInstances = (output: any, context: __SerdeContex
     contents.Duration = __strictParseLong(output["duration"]) as number;
   }
   if (output["end"] !== undefined) {
-    contents.End = new Date(output["end"]);
+    contents.End = __expectNonNull(__parseRfc3339DateTime(output["end"]));
   }
   if (output["fixedPrice"] !== undefined) {
     contents.FixedPrice = __strictParseFloat(output["fixedPrice"]) as number;
@@ -68124,7 +68128,7 @@ const deserializeAws_ec2ReservedInstances = (output: any, context: __SerdeContex
     contents.ReservedInstancesId = __expectString(output["reservedInstancesId"]);
   }
   if (output["start"] !== undefined) {
-    contents.Start = new Date(output["start"]);
+    contents.Start = __expectNonNull(__parseRfc3339DateTime(output["start"]));
   }
   if (output["state"] !== undefined) {
     contents.State = __expectString(output["state"]);
@@ -68232,7 +68236,7 @@ const deserializeAws_ec2ReservedInstancesListing = (output: any, context: __Serd
     contents.ClientToken = __expectString(output["clientToken"]);
   }
   if (output["createDate"] !== undefined) {
-    contents.CreateDate = new Date(output["createDate"]);
+    contents.CreateDate = __expectNonNull(__parseRfc3339DateTime(output["createDate"]));
   }
   if (output.instanceCounts === "") {
     contents.InstanceCounts = [];
@@ -68271,7 +68275,7 @@ const deserializeAws_ec2ReservedInstancesListing = (output: any, context: __Serd
     contents.Tags = deserializeAws_ec2TagList(__getArrayIfSingleItem(output["tagSet"]["item"]), context);
   }
   if (output["updateDate"] !== undefined) {
-    contents.UpdateDate = new Date(output["updateDate"]);
+    contents.UpdateDate = __expectNonNull(__parseRfc3339DateTime(output["updateDate"]));
   }
   return contents;
 };
@@ -68309,10 +68313,10 @@ const deserializeAws_ec2ReservedInstancesModification = (
     contents.ClientToken = __expectString(output["clientToken"]);
   }
   if (output["createDate"] !== undefined) {
-    contents.CreateDate = new Date(output["createDate"]);
+    contents.CreateDate = __expectNonNull(__parseRfc3339DateTime(output["createDate"]));
   }
   if (output["effectiveDate"] !== undefined) {
-    contents.EffectiveDate = new Date(output["effectiveDate"]);
+    contents.EffectiveDate = __expectNonNull(__parseRfc3339DateTime(output["effectiveDate"]));
   }
   if (output.modificationResultSet === "") {
     contents.ModificationResults = [];
@@ -68342,7 +68346,7 @@ const deserializeAws_ec2ReservedInstancesModification = (
     contents.StatusMessage = __expectString(output["statusMessage"]);
   }
   if (output["updateDate"] !== undefined) {
-    contents.UpdateDate = new Date(output["updateDate"]);
+    contents.UpdateDate = __expectNonNull(__parseRfc3339DateTime(output["updateDate"]));
   }
   return contents;
 };
@@ -69141,7 +69145,7 @@ const deserializeAws_ec2ScheduledInstance = (output: any, context: __SerdeContex
     contents.AvailabilityZone = __expectString(output["availabilityZone"]);
   }
   if (output["createDate"] !== undefined) {
-    contents.CreateDate = new Date(output["createDate"]);
+    contents.CreateDate = __expectNonNull(__parseRfc3339DateTime(output["createDate"]));
   }
   if (output["hourlyPrice"] !== undefined) {
     contents.HourlyPrice = __expectString(output["hourlyPrice"]);
@@ -69156,13 +69160,13 @@ const deserializeAws_ec2ScheduledInstance = (output: any, context: __SerdeContex
     contents.NetworkPlatform = __expectString(output["networkPlatform"]);
   }
   if (output["nextSlotStartTime"] !== undefined) {
-    contents.NextSlotStartTime = new Date(output["nextSlotStartTime"]);
+    contents.NextSlotStartTime = __expectNonNull(__parseRfc3339DateTime(output["nextSlotStartTime"]));
   }
   if (output["platform"] !== undefined) {
     contents.Platform = __expectString(output["platform"]);
   }
   if (output["previousSlotEndTime"] !== undefined) {
-    contents.PreviousSlotEndTime = new Date(output["previousSlotEndTime"]);
+    contents.PreviousSlotEndTime = __expectNonNull(__parseRfc3339DateTime(output["previousSlotEndTime"]));
   }
   if (output["recurrence"] !== undefined) {
     contents.Recurrence = deserializeAws_ec2ScheduledInstanceRecurrence(output["recurrence"], context);
@@ -69174,10 +69178,10 @@ const deserializeAws_ec2ScheduledInstance = (output: any, context: __SerdeContex
     contents.SlotDurationInHours = __strictParseInt32(output["slotDurationInHours"]) as number;
   }
   if (output["termEndDate"] !== undefined) {
-    contents.TermEndDate = new Date(output["termEndDate"]);
+    contents.TermEndDate = __expectNonNull(__parseRfc3339DateTime(output["termEndDate"]));
   }
   if (output["termStartDate"] !== undefined) {
-    contents.TermStartDate = new Date(output["termStartDate"]);
+    contents.TermStartDate = __expectNonNull(__parseRfc3339DateTime(output["termStartDate"]));
   }
   if (output["totalScheduledInstanceHours"] !== undefined) {
     contents.TotalScheduledInstanceHours = __strictParseInt32(output["totalScheduledInstanceHours"]) as number;
@@ -69211,7 +69215,7 @@ const deserializeAws_ec2ScheduledInstanceAvailability = (
     contents.AvailableInstanceCount = __strictParseInt32(output["availableInstanceCount"]) as number;
   }
   if (output["firstSlotStartTime"] !== undefined) {
-    contents.FirstSlotStartTime = new Date(output["firstSlotStartTime"]);
+    contents.FirstSlotStartTime = __expectNonNull(__parseRfc3339DateTime(output["firstSlotStartTime"]));
   }
   if (output["hourlyPrice"] !== undefined) {
     contents.HourlyPrice = __expectString(output["hourlyPrice"]);
@@ -69827,7 +69831,7 @@ const deserializeAws_ec2Snapshot = (output: any, context: __SerdeContext): Snaps
     contents.SnapshotId = __expectString(output["snapshotId"]);
   }
   if (output["startTime"] !== undefined) {
-    contents.StartTime = new Date(output["startTime"]);
+    contents.StartTime = __expectNonNull(__parseRfc3339DateTime(output["startTime"]));
   }
   if (output["status"] !== undefined) {
     contents.State = __expectString(output["status"]);
@@ -69949,7 +69953,7 @@ const deserializeAws_ec2SnapshotInfo = (output: any, context: __SerdeContext): S
     contents.VolumeSize = __strictParseInt32(output["volumeSize"]) as number;
   }
   if (output["startTime"] !== undefined) {
-    contents.StartTime = new Date(output["startTime"]);
+    contents.StartTime = __expectNonNull(__parseRfc3339DateTime(output["startTime"]));
   }
   if (output["progress"] !== undefined) {
     contents.Progress = __expectString(output["progress"]);
@@ -70205,7 +70209,7 @@ const deserializeAws_ec2SpotFleetRequestConfig = (output: any, context: __SerdeC
     contents.ActivityStatus = __expectString(output["activityStatus"]);
   }
   if (output["createTime"] !== undefined) {
-    contents.CreateTime = new Date(output["createTime"]);
+    contents.CreateTime = __expectNonNull(__parseRfc3339DateTime(output["createTime"]));
   }
   if (output["spotFleetRequestConfig"] !== undefined) {
     contents.SpotFleetRequestConfig = deserializeAws_ec2SpotFleetRequestConfigData(
@@ -70326,10 +70330,10 @@ const deserializeAws_ec2SpotFleetRequestConfigData = (
     contents.Type = __expectString(output["type"]);
   }
   if (output["validFrom"] !== undefined) {
-    contents.ValidFrom = new Date(output["validFrom"]);
+    contents.ValidFrom = __expectNonNull(__parseRfc3339DateTime(output["validFrom"]));
   }
   if (output["validUntil"] !== undefined) {
-    contents.ValidUntil = new Date(output["validUntil"]);
+    contents.ValidUntil = __expectNonNull(__parseRfc3339DateTime(output["validUntil"]));
   }
   if (output["replaceUnhealthyInstances"] !== undefined) {
     contents.ReplaceUnhealthyInstances = __parseBoolean(output["replaceUnhealthyInstances"]);
@@ -70438,7 +70442,7 @@ const deserializeAws_ec2SpotInstanceRequest = (output: any, context: __SerdeCont
     contents.BlockDurationMinutes = __strictParseInt32(output["blockDurationMinutes"]) as number;
   }
   if (output["createTime"] !== undefined) {
-    contents.CreateTime = new Date(output["createTime"]);
+    contents.CreateTime = __expectNonNull(__parseRfc3339DateTime(output["createTime"]));
   }
   if (output["fault"] !== undefined) {
     contents.Fault = deserializeAws_ec2SpotInstanceStateFault(output["fault"], context);
@@ -70480,10 +70484,10 @@ const deserializeAws_ec2SpotInstanceRequest = (output: any, context: __SerdeCont
     contents.Type = __expectString(output["type"]);
   }
   if (output["validFrom"] !== undefined) {
-    contents.ValidFrom = new Date(output["validFrom"]);
+    contents.ValidFrom = __expectNonNull(__parseRfc3339DateTime(output["validFrom"]));
   }
   if (output["validUntil"] !== undefined) {
-    contents.ValidUntil = new Date(output["validUntil"]);
+    contents.ValidUntil = __expectNonNull(__parseRfc3339DateTime(output["validUntil"]));
   }
   if (output["instanceInterruptionBehavior"] !== undefined) {
     contents.InstanceInterruptionBehavior = __expectString(output["instanceInterruptionBehavior"]);
@@ -70529,7 +70533,7 @@ const deserializeAws_ec2SpotInstanceStatus = (output: any, context: __SerdeConte
     contents.Message = __expectString(output["message"]);
   }
   if (output["updateTime"] !== undefined) {
-    contents.UpdateTime = new Date(output["updateTime"]);
+    contents.UpdateTime = __expectNonNull(__parseRfc3339DateTime(output["updateTime"]));
   }
   return contents;
 };
@@ -70627,7 +70631,7 @@ const deserializeAws_ec2SpotPrice = (output: any, context: __SerdeContext): Spot
     contents.SpotPrice = __expectString(output["spotPrice"]);
   }
   if (output["timestamp"] !== undefined) {
-    contents.Timestamp = new Date(output["timestamp"]);
+    contents.Timestamp = __expectNonNull(__parseRfc3339DateTime(output["timestamp"]));
   }
   return contents;
 };
@@ -70851,7 +70855,7 @@ const deserializeAws_ec2StoreImageTaskResult = (output: any, context: __SerdeCon
     contents.AmiId = __expectString(output["amiId"]);
   }
   if (output["taskStartTime"] !== undefined) {
-    contents.TaskStartTime = new Date(output["taskStartTime"]);
+    contents.TaskStartTime = __expectNonNull(__parseRfc3339DateTime(output["taskStartTime"]));
   }
   if (output["bucket"] !== undefined) {
     contents.Bucket = __expectString(output["bucket"]);
@@ -71781,7 +71785,7 @@ const deserializeAws_ec2TransitGateway = (output: any, context: __SerdeContext):
     contents.Description = __expectString(output["description"]);
   }
   if (output["creationTime"] !== undefined) {
-    contents.CreationTime = new Date(output["creationTime"]);
+    contents.CreationTime = __expectNonNull(__parseRfc3339DateTime(output["creationTime"]));
   }
   if (output["options"] !== undefined) {
     contents.Options = deserializeAws_ec2TransitGatewayOptions(output["options"], context);
@@ -71862,7 +71866,7 @@ const deserializeAws_ec2TransitGatewayAttachment = (output: any, context: __Serd
     contents.Association = deserializeAws_ec2TransitGatewayAttachmentAssociation(output["association"], context);
   }
   if (output["creationTime"] !== undefined) {
-    contents.CreationTime = new Date(output["creationTime"]);
+    contents.CreationTime = __expectNonNull(__parseRfc3339DateTime(output["creationTime"]));
   }
   if (output.tagSet === "") {
     contents.Tags = [];
@@ -72001,7 +72005,7 @@ const deserializeAws_ec2TransitGatewayConnect = (output: any, context: __SerdeCo
     contents.State = __expectString(output["state"]);
   }
   if (output["creationTime"] !== undefined) {
-    contents.CreationTime = new Date(output["creationTime"]);
+    contents.CreationTime = __expectNonNull(__parseRfc3339DateTime(output["creationTime"]));
   }
   if (output["options"] !== undefined) {
     contents.Options = deserializeAws_ec2TransitGatewayConnectOptions(output["options"], context);
@@ -72061,7 +72065,7 @@ const deserializeAws_ec2TransitGatewayConnectPeer = (
     contents.State = __expectString(output["state"]);
   }
   if (output["creationTime"] !== undefined) {
-    contents.CreationTime = new Date(output["creationTime"]);
+    contents.CreationTime = __expectNonNull(__parseRfc3339DateTime(output["creationTime"]));
   }
   if (output["connectPeerConfiguration"] !== undefined) {
     contents.ConnectPeerConfiguration = deserializeAws_ec2TransitGatewayConnectPeerConfiguration(
@@ -72237,7 +72241,7 @@ const deserializeAws_ec2TransitGatewayMulticastDomain = (
     contents.State = __expectString(output["state"]);
   }
   if (output["creationTime"] !== undefined) {
-    contents.CreationTime = new Date(output["creationTime"]);
+    contents.CreationTime = __expectNonNull(__parseRfc3339DateTime(output["creationTime"]));
   }
   if (output.tagSet === "") {
     contents.Tags = [];
@@ -72573,7 +72577,7 @@ const deserializeAws_ec2TransitGatewayPeeringAttachment = (
     contents.State = __expectString(output["state"]);
   }
   if (output["creationTime"] !== undefined) {
-    contents.CreationTime = new Date(output["creationTime"]);
+    contents.CreationTime = __expectNonNull(__parseRfc3339DateTime(output["creationTime"]));
   }
   if (output.tagSet === "") {
     contents.Tags = [];
@@ -72802,7 +72806,7 @@ const deserializeAws_ec2TransitGatewayRouteTable = (output: any, context: __Serd
     contents.DefaultPropagationRouteTable = __parseBoolean(output["defaultPropagationRouteTable"]);
   }
   if (output["creationTime"] !== undefined) {
-    contents.CreationTime = new Date(output["creationTime"]);
+    contents.CreationTime = __expectNonNull(__parseRfc3339DateTime(output["creationTime"]));
   }
   if (output.tagSet === "") {
     contents.Tags = [];
@@ -72945,7 +72949,7 @@ const deserializeAws_ec2TransitGatewayVpcAttachment = (
     );
   }
   if (output["creationTime"] !== undefined) {
-    contents.CreationTime = new Date(output["creationTime"]);
+    contents.CreationTime = __expectNonNull(__parseRfc3339DateTime(output["creationTime"]));
   }
   if (output["options"] !== undefined) {
     contents.Options = deserializeAws_ec2TransitGatewayVpcAttachmentOptions(output["options"], context);
@@ -73538,7 +73542,7 @@ const deserializeAws_ec2VgwTelemetry = (output: any, context: __SerdeContext): V
     contents.AcceptedRouteCount = __strictParseInt32(output["acceptedRouteCount"]) as number;
   }
   if (output["lastStatusChange"] !== undefined) {
-    contents.LastStatusChange = new Date(output["lastStatusChange"]);
+    contents.LastStatusChange = __expectNonNull(__parseRfc3339DateTime(output["lastStatusChange"]));
   }
   if (output["outsideIpAddress"] !== undefined) {
     contents.OutsideIpAddress = __expectString(output["outsideIpAddress"]);
@@ -73612,7 +73616,7 @@ const deserializeAws_ec2Volume = (output: any, context: __SerdeContext): Volume 
     contents.AvailabilityZone = __expectString(output["availabilityZone"]);
   }
   if (output["createTime"] !== undefined) {
-    contents.CreateTime = new Date(output["createTime"]);
+    contents.CreateTime = __expectNonNull(__parseRfc3339DateTime(output["createTime"]));
   }
   if (output["encrypted"] !== undefined) {
     contents.Encrypted = __parseBoolean(output["encrypted"]);
@@ -73669,7 +73673,7 @@ const deserializeAws_ec2VolumeAttachment = (output: any, context: __SerdeContext
     DeleteOnTermination: undefined,
   };
   if (output["attachTime"] !== undefined) {
-    contents.AttachTime = new Date(output["attachTime"]);
+    contents.AttachTime = __expectNonNull(__parseRfc3339DateTime(output["attachTime"]));
   }
   if (output["device"] !== undefined) {
     contents.Device = __expectString(output["device"]);
@@ -73773,10 +73777,10 @@ const deserializeAws_ec2VolumeModification = (output: any, context: __SerdeConte
     contents.Progress = __strictParseLong(output["progress"]) as number;
   }
   if (output["startTime"] !== undefined) {
-    contents.StartTime = new Date(output["startTime"]);
+    contents.StartTime = __expectNonNull(__parseRfc3339DateTime(output["startTime"]));
   }
   if (output["endTime"] !== undefined) {
-    contents.EndTime = new Date(output["endTime"]);
+    contents.EndTime = __expectNonNull(__parseRfc3339DateTime(output["endTime"]));
   }
   return contents;
 };
@@ -73900,10 +73904,10 @@ const deserializeAws_ec2VolumeStatusEvent = (output: any, context: __SerdeContex
     contents.EventType = __expectString(output["eventType"]);
   }
   if (output["notAfter"] !== undefined) {
-    contents.NotAfter = new Date(output["notAfter"]);
+    contents.NotAfter = __expectNonNull(__parseRfc3339DateTime(output["notAfter"]));
   }
   if (output["notBefore"] !== undefined) {
-    contents.NotBefore = new Date(output["notBefore"]);
+    contents.NotBefore = __expectNonNull(__parseRfc3339DateTime(output["notBefore"]));
   }
   if (output["instanceId"] !== undefined) {
     contents.InstanceId = __expectString(output["instanceId"]);
@@ -74256,7 +74260,7 @@ const deserializeAws_ec2VpcEndpoint = (output: any, context: __SerdeContext): Vp
     contents.DnsEntries = deserializeAws_ec2DnsEntrySet(__getArrayIfSingleItem(output["dnsEntrySet"]["item"]), context);
   }
   if (output["creationTimestamp"] !== undefined) {
-    contents.CreationTimestamp = new Date(output["creationTimestamp"]);
+    contents.CreationTimestamp = __expectNonNull(__parseRfc3339DateTime(output["creationTimestamp"]));
   }
   if (output.tagSet === "") {
     contents.Tags = [];
@@ -74297,7 +74301,7 @@ const deserializeAws_ec2VpcEndpointConnection = (output: any, context: __SerdeCo
     contents.VpcEndpointState = __expectString(output["vpcEndpointState"]);
   }
   if (output["creationTimestamp"] !== undefined) {
-    contents.CreationTimestamp = new Date(output["creationTimestamp"]);
+    contents.CreationTimestamp = __expectNonNull(__parseRfc3339DateTime(output["creationTimestamp"]));
   }
   if (output.dnsEntrySet === "") {
     contents.DnsEntries = [];
@@ -74415,7 +74419,7 @@ const deserializeAws_ec2VpcPeeringConnection = (output: any, context: __SerdeCon
     contents.AccepterVpcInfo = deserializeAws_ec2VpcPeeringConnectionVpcInfo(output["accepterVpcInfo"], context);
   }
   if (output["expirationTime"] !== undefined) {
-    contents.ExpirationTime = new Date(output["expirationTime"]);
+    contents.ExpirationTime = __expectNonNull(__parseRfc3339DateTime(output["expirationTime"]));
   }
   if (output["requesterVpcInfo"] !== undefined) {
     contents.RequesterVpcInfo = deserializeAws_ec2VpcPeeringConnectionVpcInfo(output["requesterVpcInfo"], context);

--- a/clients/client-ecr-public/protocols/Aws_json1_1.ts
+++ b/clients/client-ecr-public/protocols/Aws_json1_1.ts
@@ -151,7 +151,10 @@ import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@a
 import {
   expectBoolean as __expectBoolean,
   expectLong as __expectLong,
+  expectNonNull as __expectNonNull,
+  expectNumber as __expectNumber,
   expectString as __expectString,
+  parseEpochTimestamp as __parseEpochTimestamp,
 } from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
@@ -3068,7 +3071,7 @@ const deserializeAws_json1_1AuthorizationData = (output: any, context: __SerdeCo
     authorizationToken: __expectString(output.authorizationToken),
     expiresAt:
       output.expiresAt !== undefined && output.expiresAt !== null
-        ? new Date(Math.round(output.expiresAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.expiresAt)))
         : undefined,
   } as any;
 };
@@ -3287,7 +3290,7 @@ const deserializeAws_json1_1ImageDetail = (output: any, context: __SerdeContext)
     imageManifestMediaType: __expectString(output.imageManifestMediaType),
     imagePushedAt:
       output.imagePushedAt !== undefined && output.imagePushedAt !== null
-        ? new Date(Math.round(output.imagePushedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.imagePushedAt)))
         : undefined,
     imageSizeInBytes: __expectLong(output.imageSizeInBytes),
     imageTags:
@@ -3378,7 +3381,7 @@ const deserializeAws_json1_1ImageTagDetail = (output: any, context: __SerdeConte
   return {
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
-        ? new Date(Math.round(output.createdAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.createdAt)))
         : undefined,
     imageDetail:
       output.imageDetail !== undefined && output.imageDetail !== null
@@ -3592,7 +3595,7 @@ const deserializeAws_json1_1ReferencedImageDetail = (output: any, context: __Ser
     imageManifestMediaType: __expectString(output.imageManifestMediaType),
     imagePushedAt:
       output.imagePushedAt !== undefined && output.imagePushedAt !== null
-        ? new Date(Math.round(output.imagePushedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.imagePushedAt)))
         : undefined,
     imageSizeInBytes: __expectLong(output.imageSizeInBytes),
   } as any;
@@ -3670,7 +3673,7 @@ const deserializeAws_json1_1Repository = (output: any, context: __SerdeContext):
   return {
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
-        ? new Date(Math.round(output.createdAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.createdAt)))
         : undefined,
     registryId: __expectString(output.registryId),
     repositoryArn: __expectString(output.repositoryArn),

--- a/clients/client-ecr/protocols/Aws_json1_1.ts
+++ b/clients/client-ecr/protocols/Aws_json1_1.ts
@@ -217,7 +217,10 @@ import {
   expectBoolean as __expectBoolean,
   expectInt32 as __expectInt32,
   expectLong as __expectLong,
+  expectNonNull as __expectNonNull,
+  expectNumber as __expectNumber,
   expectString as __expectString,
+  parseEpochTimestamp as __parseEpochTimestamp,
 } from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
@@ -4448,7 +4451,7 @@ const deserializeAws_json1_1AuthorizationData = (output: any, context: __SerdeCo
     authorizationToken: __expectString(output.authorizationToken),
     expiresAt:
       output.expiresAt !== undefined && output.expiresAt !== null
-        ? new Date(Math.round(output.expiresAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.expiresAt)))
         : undefined,
     proxyEndpoint: __expectString(output.proxyEndpoint),
   } as any;
@@ -4541,7 +4544,7 @@ const deserializeAws_json1_1DeleteLifecyclePolicyResponse = (
   return {
     lastEvaluatedAt:
       output.lastEvaluatedAt !== undefined && output.lastEvaluatedAt !== null
-        ? new Date(Math.round(output.lastEvaluatedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastEvaluatedAt)))
         : undefined,
     lifecyclePolicyText: __expectString(output.lifecyclePolicyText),
     registryId: __expectString(output.registryId),
@@ -4725,7 +4728,7 @@ const deserializeAws_json1_1GetLifecyclePolicyResponse = (
   return {
     lastEvaluatedAt:
       output.lastEvaluatedAt !== undefined && output.lastEvaluatedAt !== null
-        ? new Date(Math.round(output.lastEvaluatedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastEvaluatedAt)))
         : undefined,
     lifecyclePolicyText: __expectString(output.lifecyclePolicyText),
     registryId: __expectString(output.registryId),
@@ -4783,7 +4786,7 @@ const deserializeAws_json1_1ImageDetail = (output: any, context: __SerdeContext)
     imageManifestMediaType: __expectString(output.imageManifestMediaType),
     imagePushedAt:
       output.imagePushedAt !== undefined && output.imagePushedAt !== null
-        ? new Date(Math.round(output.imagePushedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.imagePushedAt)))
         : undefined,
     imageScanFindingsSummary:
       output.imageScanFindingsSummary !== undefined && output.imageScanFindingsSummary !== null
@@ -4916,11 +4919,11 @@ const deserializeAws_json1_1ImageScanFindings = (output: any, context: __SerdeCo
         : undefined,
     imageScanCompletedAt:
       output.imageScanCompletedAt !== undefined && output.imageScanCompletedAt !== null
-        ? new Date(Math.round(output.imageScanCompletedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.imageScanCompletedAt)))
         : undefined,
     vulnerabilitySourceUpdatedAt:
       output.vulnerabilitySourceUpdatedAt !== undefined && output.vulnerabilitySourceUpdatedAt !== null
-        ? new Date(Math.round(output.vulnerabilitySourceUpdatedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.vulnerabilitySourceUpdatedAt)))
         : undefined,
   } as any;
 };
@@ -4936,11 +4939,11 @@ const deserializeAws_json1_1ImageScanFindingsSummary = (
         : undefined,
     imageScanCompletedAt:
       output.imageScanCompletedAt !== undefined && output.imageScanCompletedAt !== null
-        ? new Date(Math.round(output.imageScanCompletedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.imageScanCompletedAt)))
         : undefined,
     vulnerabilitySourceUpdatedAt:
       output.vulnerabilitySourceUpdatedAt !== undefined && output.vulnerabilitySourceUpdatedAt !== null
-        ? new Date(Math.round(output.vulnerabilitySourceUpdatedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.vulnerabilitySourceUpdatedAt)))
         : undefined,
   } as any;
 };
@@ -5150,7 +5153,7 @@ const deserializeAws_json1_1LifecyclePolicyPreviewResult = (
     imageDigest: __expectString(output.imageDigest),
     imagePushedAt:
       output.imagePushedAt !== undefined && output.imagePushedAt !== null
-        ? new Date(Math.round(output.imagePushedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.imagePushedAt)))
         : undefined,
     imageTags:
       output.imageTags !== undefined && output.imageTags !== null
@@ -5361,7 +5364,7 @@ const deserializeAws_json1_1Repository = (output: any, context: __SerdeContext):
   return {
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
-        ? new Date(Math.round(output.createdAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.createdAt)))
         : undefined,
     encryptionConfiguration:
       output.encryptionConfiguration !== undefined && output.encryptionConfiguration !== null

--- a/clients/client-ecs/protocols/Aws_json1_1.ts
+++ b/clients/client-ecs/protocols/Aws_json1_1.ts
@@ -349,8 +349,11 @@ import {
   expectBoolean as __expectBoolean,
   expectInt32 as __expectInt32,
   expectLong as __expectLong,
+  expectNonNull as __expectNonNull,
+  expectNumber as __expectNumber,
   expectString as __expectString,
   limitedParseDouble as __limitedParseDouble,
+  parseEpochTimestamp as __parseEpochTimestamp,
   serializeFloat as __serializeFloat,
 } from "@aws-sdk/smithy-client";
 import {
@@ -8329,7 +8332,7 @@ const deserializeAws_json1_1ContainerInstance = (output: any, context: __SerdeCo
     pendingTasksCount: __expectInt32(output.pendingTasksCount),
     registeredAt:
       output.registeredAt !== undefined && output.registeredAt !== null
-        ? new Date(Math.round(output.registeredAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.registeredAt)))
         : undefined,
     registeredResources:
       output.registeredResources !== undefined && output.registeredResources !== null
@@ -8520,7 +8523,7 @@ const deserializeAws_json1_1Deployment = (output: any, context: __SerdeContext):
         : undefined,
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
-        ? new Date(Math.round(output.createdAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.createdAt)))
         : undefined,
     desiredCount: __expectInt32(output.desiredCount),
     failedTasks: __expectInt32(output.failedTasks),
@@ -8539,7 +8542,7 @@ const deserializeAws_json1_1Deployment = (output: any, context: __SerdeContext):
     taskDefinition: __expectString(output.taskDefinition),
     updatedAt:
       output.updatedAt !== undefined && output.updatedAt !== null
-        ? new Date(Math.round(output.updatedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.updatedAt)))
         : undefined,
   } as any;
 };
@@ -9259,7 +9262,7 @@ const deserializeAws_json1_1ManagedAgent = (output: any, context: __SerdeContext
   return {
     lastStartedAt:
       output.lastStartedAt !== undefined && output.lastStartedAt !== null
-        ? new Date(Math.round(output.lastStartedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastStartedAt)))
         : undefined,
     lastStatus: __expectString(output.lastStatus),
     name: __expectString(output.name),
@@ -9667,7 +9670,7 @@ const deserializeAws_json1_1Service = (output: any, context: __SerdeContext): Se
     clusterArn: __expectString(output.clusterArn),
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
-        ? new Date(Math.round(output.createdAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.createdAt)))
         : undefined,
     createdBy: __expectString(output.createdBy),
     deploymentConfiguration:
@@ -9734,7 +9737,7 @@ const deserializeAws_json1_1ServiceEvent = (output: any, context: __SerdeContext
   return {
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
-        ? new Date(Math.round(output.createdAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.createdAt)))
         : undefined,
     id: __expectString(output.id),
     message: __expectString(output.message),
@@ -9983,7 +9986,7 @@ const deserializeAws_json1_1Task = (output: any, context: __SerdeContext): Task 
     connectivity: __expectString(output.connectivity),
     connectivityAt:
       output.connectivityAt !== undefined && output.connectivityAt !== null
-        ? new Date(Math.round(output.connectivityAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.connectivityAt)))
         : undefined,
     containerInstanceArn: __expectString(output.containerInstanceArn),
     containers:
@@ -9993,7 +9996,7 @@ const deserializeAws_json1_1Task = (output: any, context: __SerdeContext): Task 
     cpu: __expectString(output.cpu),
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
-        ? new Date(Math.round(output.createdAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.createdAt)))
         : undefined,
     desiredStatus: __expectString(output.desiredStatus),
     enableExecuteCommand: __expectBoolean(output.enableExecuteCommand),
@@ -10003,7 +10006,7 @@ const deserializeAws_json1_1Task = (output: any, context: __SerdeContext): Task 
         : undefined,
     executionStoppedAt:
       output.executionStoppedAt !== undefined && output.executionStoppedAt !== null
-        ? new Date(Math.round(output.executionStoppedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.executionStoppedAt)))
         : undefined,
     group: __expectString(output.group),
     healthStatus: __expectString(output.healthStatus),
@@ -10021,26 +10024,26 @@ const deserializeAws_json1_1Task = (output: any, context: __SerdeContext): Task 
     platformVersion: __expectString(output.platformVersion),
     pullStartedAt:
       output.pullStartedAt !== undefined && output.pullStartedAt !== null
-        ? new Date(Math.round(output.pullStartedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.pullStartedAt)))
         : undefined,
     pullStoppedAt:
       output.pullStoppedAt !== undefined && output.pullStoppedAt !== null
-        ? new Date(Math.round(output.pullStoppedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.pullStoppedAt)))
         : undefined,
     startedAt:
       output.startedAt !== undefined && output.startedAt !== null
-        ? new Date(Math.round(output.startedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.startedAt)))
         : undefined,
     startedBy: __expectString(output.startedBy),
     stopCode: __expectString(output.stopCode),
     stoppedAt:
       output.stoppedAt !== undefined && output.stoppedAt !== null
-        ? new Date(Math.round(output.stoppedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.stoppedAt)))
         : undefined,
     stoppedReason: __expectString(output.stoppedReason),
     stoppingAt:
       output.stoppingAt !== undefined && output.stoppingAt !== null
-        ? new Date(Math.round(output.stoppingAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.stoppingAt)))
         : undefined,
     tags:
       output.tags !== undefined && output.tags !== null ? deserializeAws_json1_1Tags(output.tags, context) : undefined,
@@ -10063,7 +10066,7 @@ const deserializeAws_json1_1TaskDefinition = (output: any, context: __SerdeConte
     cpu: __expectString(output.cpu),
     deregisteredAt:
       output.deregisteredAt !== undefined && output.deregisteredAt !== null
-        ? new Date(Math.round(output.deregisteredAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.deregisteredAt)))
         : undefined,
     ephemeralStorage:
       output.ephemeralStorage !== undefined && output.ephemeralStorage !== null
@@ -10089,7 +10092,7 @@ const deserializeAws_json1_1TaskDefinition = (output: any, context: __SerdeConte
         : undefined,
     registeredAt:
       output.registeredAt !== undefined && output.registeredAt !== null
-        ? new Date(Math.round(output.registeredAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.registeredAt)))
         : undefined,
     registeredBy: __expectString(output.registeredBy),
     requiresAttributes:
@@ -10177,7 +10180,7 @@ const deserializeAws_json1_1TaskSet = (output: any, context: __SerdeContext): Ta
     computedDesiredCount: __expectInt32(output.computedDesiredCount),
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
-        ? new Date(Math.round(output.createdAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.createdAt)))
         : undefined,
     externalId: __expectString(output.externalId),
     id: __expectString(output.id),
@@ -10205,7 +10208,7 @@ const deserializeAws_json1_1TaskSet = (output: any, context: __SerdeContext): Ta
     stabilityStatus: __expectString(output.stabilityStatus),
     stabilityStatusAt:
       output.stabilityStatusAt !== undefined && output.stabilityStatusAt !== null
-        ? new Date(Math.round(output.stabilityStatusAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.stabilityStatusAt)))
         : undefined,
     startedBy: __expectString(output.startedBy),
     status: __expectString(output.status),
@@ -10215,7 +10218,7 @@ const deserializeAws_json1_1TaskSet = (output: any, context: __SerdeContext): Ta
     taskSetArn: __expectString(output.taskSetArn),
     updatedAt:
       output.updatedAt !== undefined && output.updatedAt !== null
-        ? new Date(Math.round(output.updatedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.updatedAt)))
         : undefined,
   } as any;
 };

--- a/clients/client-efs/protocols/Aws_restJson1.ts
+++ b/clients/client-efs/protocols/Aws_restJson1.ts
@@ -115,10 +115,12 @@ import {
   expectInt32 as __expectInt32,
   expectLong as __expectLong,
   expectNonNull as __expectNonNull,
+  expectNumber as __expectNumber,
   expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   limitedParseDouble as __limitedParseDouble,
+  parseEpochTimestamp as __parseEpochTimestamp,
   serializeFloat as __serializeFloat,
 } from "@aws-sdk/smithy-client";
 import {
@@ -1162,7 +1164,7 @@ export const deserializeAws_restJson1CreateFileSystemCommand = async (
     contents.AvailabilityZoneName = __expectString(data.AvailabilityZoneName);
   }
   if (data.CreationTime !== undefined && data.CreationTime !== null) {
-    contents.CreationTime = new Date(Math.round(data.CreationTime * 1000));
+    contents.CreationTime = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.CreationTime)));
   }
   if (data.CreationToken !== undefined && data.CreationToken !== null) {
     contents.CreationToken = __expectString(data.CreationToken);
@@ -3269,7 +3271,7 @@ export const deserializeAws_restJson1UpdateFileSystemCommand = async (
     contents.AvailabilityZoneName = __expectString(data.AvailabilityZoneName);
   }
   if (data.CreationTime !== undefined && data.CreationTime !== null) {
-    contents.CreationTime = new Date(Math.round(data.CreationTime * 1000));
+    contents.CreationTime = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.CreationTime)));
   }
   if (data.CreationToken !== undefined && data.CreationToken !== null) {
     contents.CreationToken = __expectString(data.CreationToken);
@@ -4164,7 +4166,7 @@ const deserializeAws_restJson1FileSystemDescription = (output: any, context: __S
     AvailabilityZoneName: __expectString(output.AvailabilityZoneName),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     CreationToken: __expectString(output.CreationToken),
     Encrypted: __expectBoolean(output.Encrypted),
@@ -4207,7 +4209,7 @@ const deserializeAws_restJson1FileSystemSize = (output: any, context: __SerdeCon
   return {
     Timestamp:
       output.Timestamp !== undefined && output.Timestamp !== null
-        ? new Date(Math.round(output.Timestamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.Timestamp)))
         : undefined,
     Value: __expectLong(output.Value),
     ValueInIA: __expectLong(output.ValueInIA),

--- a/clients/client-eks/protocols/Aws_restJson1.ts
+++ b/clients/client-eks/protocols/Aws_restJson1.ts
@@ -133,9 +133,11 @@ import {
   expectBoolean as __expectBoolean,
   expectInt32 as __expectInt32,
   expectNonNull as __expectNonNull,
+  expectNumber as __expectNumber,
   expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
+  parseEpochTimestamp as __parseEpochTimestamp,
 } from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
@@ -4764,7 +4766,7 @@ const deserializeAws_restJson1Addon = (output: any, context: __SerdeContext): Ad
     clusterName: __expectString(output.clusterName),
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
-        ? new Date(Math.round(output.createdAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.createdAt)))
         : undefined,
     health:
       output.health !== undefined && output.health !== null
@@ -4772,7 +4774,7 @@ const deserializeAws_restJson1Addon = (output: any, context: __SerdeContext): Ad
         : undefined,
     modifiedAt:
       output.modifiedAt !== undefined && output.modifiedAt !== null
-        ? new Date(Math.round(output.modifiedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.modifiedAt)))
         : undefined,
     serviceAccountRoleArn: __expectString(output.serviceAccountRoleArn),
     status: __expectString(output.status),
@@ -4894,7 +4896,7 @@ const deserializeAws_restJson1Cluster = (output: any, context: __SerdeContext): 
     clientRequestToken: __expectString(output.clientRequestToken),
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
-        ? new Date(Math.round(output.createdAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.createdAt)))
         : undefined,
     encryptionConfig:
       output.encryptionConfig !== undefined && output.encryptionConfig !== null
@@ -5002,7 +5004,7 @@ const deserializeAws_restJson1FargateProfile = (output: any, context: __SerdeCon
     clusterName: __expectString(output.clusterName),
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
-        ? new Date(Math.round(output.createdAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.createdAt)))
         : undefined,
     fargateProfileArn: __expectString(output.fargateProfileArn),
     fargateProfileName: __expectString(output.fargateProfileName),
@@ -5212,7 +5214,7 @@ const deserializeAws_restJson1Nodegroup = (output: any, context: __SerdeContext)
     clusterName: __expectString(output.clusterName),
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
-        ? new Date(Math.round(output.createdAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.createdAt)))
         : undefined,
     diskSize: __expectInt32(output.diskSize),
     health:
@@ -5233,7 +5235,7 @@ const deserializeAws_restJson1Nodegroup = (output: any, context: __SerdeContext)
         : undefined,
     modifiedAt:
       output.modifiedAt !== undefined && output.modifiedAt !== null
-        ? new Date(Math.round(output.modifiedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.modifiedAt)))
         : undefined,
     nodeRole: __expectString(output.nodeRole),
     nodegroupArn: __expectString(output.nodegroupArn),
@@ -5415,7 +5417,7 @@ const deserializeAws_restJson1Update = (output: any, context: __SerdeContext): U
   return {
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
-        ? new Date(Math.round(output.createdAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.createdAt)))
         : undefined,
     errors:
       output.errors !== undefined && output.errors !== null

--- a/clients/client-elastic-beanstalk/protocols/Aws_query.ts
+++ b/clients/client-elastic-beanstalk/protocols/Aws_query.ts
@@ -313,11 +313,13 @@ import {
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
+  expectNonNull as __expectNonNull,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   getArrayIfSingleItem as __getArrayIfSingleItem,
   getValueFromTextNode as __getValueFromTextNode,
   parseBoolean as __parseBoolean,
+  parseRfc3339DateTime as __parseRfc3339DateTime,
   strictParseFloat as __strictParseFloat,
   strictParseInt32 as __strictParseInt32,
   strictParseLong as __strictParseLong,
@@ -5487,10 +5489,10 @@ const deserializeAws_queryApplicationDescription = (output: any, context: __Serd
     contents.Description = __expectString(output["Description"]);
   }
   if (output["DateCreated"] !== undefined) {
-    contents.DateCreated = new Date(output["DateCreated"]);
+    contents.DateCreated = __expectNonNull(__parseRfc3339DateTime(output["DateCreated"]));
   }
   if (output["DateUpdated"] !== undefined) {
-    contents.DateUpdated = new Date(output["DateUpdated"]);
+    contents.DateUpdated = __expectNonNull(__parseRfc3339DateTime(output["DateUpdated"]));
   }
   if (output.Versions === "") {
     contents.Versions = [];
@@ -5668,10 +5670,10 @@ const deserializeAws_queryApplicationVersionDescription = (
     contents.SourceBundle = deserializeAws_queryS3Location(output["SourceBundle"], context);
   }
   if (output["DateCreated"] !== undefined) {
-    contents.DateCreated = new Date(output["DateCreated"]);
+    contents.DateCreated = __expectNonNull(__parseRfc3339DateTime(output["DateCreated"]));
   }
   if (output["DateUpdated"] !== undefined) {
-    contents.DateUpdated = new Date(output["DateUpdated"]);
+    contents.DateUpdated = __expectNonNull(__parseRfc3339DateTime(output["DateUpdated"]));
   }
   if (output["Status"] !== undefined) {
     contents.Status = __expectString(output["Status"]);
@@ -6059,10 +6061,10 @@ const deserializeAws_queryConfigurationSettingsDescription = (
     contents.DeploymentStatus = __expectString(output["DeploymentStatus"]);
   }
   if (output["DateCreated"] !== undefined) {
-    contents.DateCreated = new Date(output["DateCreated"]);
+    contents.DateCreated = __expectNonNull(__parseRfc3339DateTime(output["DateCreated"]));
   }
   if (output["DateUpdated"] !== undefined) {
-    contents.DateUpdated = new Date(output["DateUpdated"]);
+    contents.DateUpdated = __expectNonNull(__parseRfc3339DateTime(output["DateUpdated"]));
   }
   if (output.OptionSettings === "") {
     contents.OptionSettings = [];
@@ -6262,7 +6264,7 @@ const deserializeAws_queryDeployment = (output: any, context: __SerdeContext): D
     contents.Status = __expectString(output["Status"]);
   }
   if (output["DeploymentTime"] !== undefined) {
-    contents.DeploymentTime = new Date(output["DeploymentTime"]);
+    contents.DeploymentTime = __expectNonNull(__parseRfc3339DateTime(output["DeploymentTime"]));
   }
   return contents;
 };
@@ -6319,7 +6321,7 @@ const deserializeAws_queryDescribeEnvironmentHealthResult = (
     contents.InstancesHealth = deserializeAws_queryInstanceHealthSummary(output["InstancesHealth"], context);
   }
   if (output["RefreshedAt"] !== undefined) {
-    contents.RefreshedAt = new Date(output["RefreshedAt"]);
+    contents.RefreshedAt = __expectNonNull(__parseRfc3339DateTime(output["RefreshedAt"]));
   }
   return contents;
 };
@@ -6388,7 +6390,7 @@ const deserializeAws_queryDescribeInstancesHealthResult = (
     );
   }
   if (output["RefreshedAt"] !== undefined) {
-    contents.RefreshedAt = new Date(output["RefreshedAt"]);
+    contents.RefreshedAt = __expectNonNull(__parseRfc3339DateTime(output["RefreshedAt"]));
   }
   if (output["NextToken"] !== undefined) {
     contents.NextToken = __expectString(output["NextToken"]);
@@ -6477,10 +6479,10 @@ const deserializeAws_queryEnvironmentDescription = (output: any, context: __Serd
     contents.CNAME = __expectString(output["CNAME"]);
   }
   if (output["DateCreated"] !== undefined) {
-    contents.DateCreated = new Date(output["DateCreated"]);
+    contents.DateCreated = __expectNonNull(__parseRfc3339DateTime(output["DateCreated"]));
   }
   if (output["DateUpdated"] !== undefined) {
-    contents.DateUpdated = new Date(output["DateUpdated"]);
+    contents.DateUpdated = __expectNonNull(__parseRfc3339DateTime(output["DateUpdated"]));
   }
   if (output["Status"] !== undefined) {
     contents.Status = __expectString(output["Status"]);
@@ -6572,7 +6574,7 @@ const deserializeAws_queryEnvironmentInfoDescription = (
     contents.Ec2InstanceId = __expectString(output["Ec2InstanceId"]);
   }
   if (output["SampleTimestamp"] !== undefined) {
-    contents.SampleTimestamp = new Date(output["SampleTimestamp"]);
+    contents.SampleTimestamp = __expectNonNull(__parseRfc3339DateTime(output["SampleTimestamp"]));
   }
   if (output["Message"] !== undefined) {
     contents.Message = __expectString(output["Message"]);
@@ -6756,7 +6758,7 @@ const deserializeAws_queryEventDescription = (output: any, context: __SerdeConte
     Severity: undefined,
   };
   if (output["EventDate"] !== undefined) {
-    contents.EventDate = new Date(output["EventDate"]);
+    contents.EventDate = __expectNonNull(__parseRfc3339DateTime(output["EventDate"]));
   }
   if (output["Message"] !== undefined) {
     contents.Message = __expectString(output["Message"]);
@@ -7172,7 +7174,7 @@ const deserializeAws_queryManagedAction = (output: any, context: __SerdeContext)
     contents.Status = __expectString(output["Status"]);
   }
   if (output["WindowStartTime"] !== undefined) {
-    contents.WindowStartTime = new Date(output["WindowStartTime"]);
+    contents.WindowStartTime = __expectNonNull(__parseRfc3339DateTime(output["WindowStartTime"]));
   }
   return contents;
 };
@@ -7210,10 +7212,10 @@ const deserializeAws_queryManagedActionHistoryItem = (
     contents.FailureDescription = __expectString(output["FailureDescription"]);
   }
   if (output["ExecutedTime"] !== undefined) {
-    contents.ExecutedTime = new Date(output["ExecutedTime"]);
+    contents.ExecutedTime = __expectNonNull(__parseRfc3339DateTime(output["ExecutedTime"]));
   }
   if (output["FinishedTime"] !== undefined) {
-    contents.FinishedTime = new Date(output["FinishedTime"]);
+    contents.FinishedTime = __expectNonNull(__parseRfc3339DateTime(output["FinishedTime"]));
   }
   return contents;
 };
@@ -7408,10 +7410,10 @@ const deserializeAws_queryPlatformDescription = (output: any, context: __SerdeCo
     contents.PlatformStatus = __expectString(output["PlatformStatus"]);
   }
   if (output["DateCreated"] !== undefined) {
-    contents.DateCreated = new Date(output["DateCreated"]);
+    contents.DateCreated = __expectNonNull(__parseRfc3339DateTime(output["DateCreated"]));
   }
   if (output["DateUpdated"] !== undefined) {
-    contents.DateUpdated = new Date(output["DateUpdated"]);
+    contents.DateUpdated = __expectNonNull(__parseRfc3339DateTime(output["DateUpdated"]));
   }
   if (output["PlatformCategory"] !== undefined) {
     contents.PlatformCategory = __expectString(output["PlatformCategory"]);
@@ -7832,7 +7834,7 @@ const deserializeAws_querySingleInstanceHealth = (output: any, context: __SerdeC
     contents.Causes = deserializeAws_queryCauses(__getArrayIfSingleItem(output["Causes"]["member"]), context);
   }
   if (output["LaunchedAt"] !== undefined) {
-    contents.LaunchedAt = new Date(output["LaunchedAt"]);
+    contents.LaunchedAt = __expectNonNull(__parseRfc3339DateTime(output["LaunchedAt"]));
   }
   if (output["ApplicationMetrics"] !== undefined) {
     contents.ApplicationMetrics = deserializeAws_queryApplicationMetrics(output["ApplicationMetrics"], context);

--- a/clients/client-elastic-load-balancing-v2/protocols/Aws_query.ts
+++ b/clients/client-elastic-load-balancing-v2/protocols/Aws_query.ts
@@ -214,11 +214,13 @@ import {
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
+  expectNonNull as __expectNonNull,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   getArrayIfSingleItem as __getArrayIfSingleItem,
   getValueFromTextNode as __getValueFromTextNode,
   parseBoolean as __parseBoolean,
+  parseRfc3339DateTime as __parseRfc3339DateTime,
   strictParseInt32 as __strictParseInt32,
   strictParseLong as __strictParseLong,
 } from "@aws-sdk/smithy-client";
@@ -6722,7 +6724,7 @@ const deserializeAws_queryLoadBalancer = (output: any, context: __SerdeContext):
     contents.CanonicalHostedZoneId = __expectString(output["CanonicalHostedZoneId"]);
   }
   if (output["CreatedTime"] !== undefined) {
-    contents.CreatedTime = new Date(output["CreatedTime"]);
+    contents.CreatedTime = __expectNonNull(__parseRfc3339DateTime(output["CreatedTime"]));
   }
   if (output["LoadBalancerName"] !== undefined) {
     contents.LoadBalancerName = __expectString(output["LoadBalancerName"]);

--- a/clients/client-elastic-load-balancing/protocols/Aws_query.ts
+++ b/clients/client-elastic-load-balancing/protocols/Aws_query.ts
@@ -209,11 +209,13 @@ import {
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
+  expectNonNull as __expectNonNull,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   getArrayIfSingleItem as __getArrayIfSingleItem,
   getValueFromTextNode as __getValueFromTextNode,
   parseBoolean as __parseBoolean,
+  parseRfc3339DateTime as __parseRfc3339DateTime,
   strictParseInt32 as __strictParseInt32,
   strictParseLong as __strictParseLong,
 } from "@aws-sdk/smithy-client";
@@ -4870,7 +4872,7 @@ const deserializeAws_queryLoadBalancerDescription = (output: any, context: __Ser
     );
   }
   if (output["CreatedTime"] !== undefined) {
-    contents.CreatedTime = new Date(output["CreatedTime"]);
+    contents.CreatedTime = __expectNonNull(__parseRfc3339DateTime(output["CreatedTime"]));
   }
   if (output["Scheme"] !== undefined) {
     contents.Scheme = __expectString(output["Scheme"]);

--- a/clients/client-elasticache/protocols/Aws_query.ts
+++ b/clients/client-elasticache/protocols/Aws_query.ts
@@ -448,11 +448,13 @@ import {
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
+  expectNonNull as __expectNonNull,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   getArrayIfSingleItem as __getArrayIfSingleItem,
   getValueFromTextNode as __getValueFromTextNode,
   parseBoolean as __parseBoolean,
+  parseRfc3339DateTime as __parseRfc3339DateTime,
   strictParseFloat as __strictParseFloat,
   strictParseInt32 as __strictParseInt32,
 } from "@aws-sdk/smithy-client";
@@ -10912,7 +10914,7 @@ const deserializeAws_queryCacheCluster = (output: any, context: __SerdeContext):
     contents.PreferredOutpostArn = __expectString(output["PreferredOutpostArn"]);
   }
   if (output["CacheClusterCreateTime"] !== undefined) {
-    contents.CacheClusterCreateTime = new Date(output["CacheClusterCreateTime"]);
+    contents.CacheClusterCreateTime = __expectNonNull(__parseRfc3339DateTime(output["CacheClusterCreateTime"]));
   }
   if (output["PreferredMaintenanceWindow"] !== undefined) {
     contents.PreferredMaintenanceWindow = __expectString(output["PreferredMaintenanceWindow"]);
@@ -10984,7 +10986,7 @@ const deserializeAws_queryCacheCluster = (output: any, context: __SerdeContext):
     contents.AuthTokenEnabled = __parseBoolean(output["AuthTokenEnabled"]);
   }
   if (output["AuthTokenLastModifiedDate"] !== undefined) {
-    contents.AuthTokenLastModifiedDate = new Date(output["AuthTokenLastModifiedDate"]);
+    contents.AuthTokenLastModifiedDate = __expectNonNull(__parseRfc3339DateTime(output["AuthTokenLastModifiedDate"]));
   }
   if (output["TransitEncryptionEnabled"] !== undefined) {
     contents.TransitEncryptionEnabled = __parseBoolean(output["TransitEncryptionEnabled"]);
@@ -11151,7 +11153,7 @@ const deserializeAws_queryCacheNode = (output: any, context: __SerdeContext): Ca
     contents.CacheNodeStatus = __expectString(output["CacheNodeStatus"]);
   }
   if (output["CacheNodeCreateTime"] !== undefined) {
-    contents.CacheNodeCreateTime = new Date(output["CacheNodeCreateTime"]);
+    contents.CacheNodeCreateTime = __expectNonNull(__parseRfc3339DateTime(output["CacheNodeCreateTime"]));
   }
   if (output["Endpoint"] !== undefined) {
     contents.Endpoint = deserializeAws_queryEndpoint(output["Endpoint"], context);
@@ -11310,22 +11312,24 @@ const deserializeAws_queryCacheNodeUpdateStatus = (output: any, context: __Serde
     contents.NodeUpdateStatus = __expectString(output["NodeUpdateStatus"]);
   }
   if (output["NodeDeletionDate"] !== undefined) {
-    contents.NodeDeletionDate = new Date(output["NodeDeletionDate"]);
+    contents.NodeDeletionDate = __expectNonNull(__parseRfc3339DateTime(output["NodeDeletionDate"]));
   }
   if (output["NodeUpdateStartDate"] !== undefined) {
-    contents.NodeUpdateStartDate = new Date(output["NodeUpdateStartDate"]);
+    contents.NodeUpdateStartDate = __expectNonNull(__parseRfc3339DateTime(output["NodeUpdateStartDate"]));
   }
   if (output["NodeUpdateEndDate"] !== undefined) {
-    contents.NodeUpdateEndDate = new Date(output["NodeUpdateEndDate"]);
+    contents.NodeUpdateEndDate = __expectNonNull(__parseRfc3339DateTime(output["NodeUpdateEndDate"]));
   }
   if (output["NodeUpdateInitiatedBy"] !== undefined) {
     contents.NodeUpdateInitiatedBy = __expectString(output["NodeUpdateInitiatedBy"]);
   }
   if (output["NodeUpdateInitiatedDate"] !== undefined) {
-    contents.NodeUpdateInitiatedDate = new Date(output["NodeUpdateInitiatedDate"]);
+    contents.NodeUpdateInitiatedDate = __expectNonNull(__parseRfc3339DateTime(output["NodeUpdateInitiatedDate"]));
   }
   if (output["NodeUpdateStatusModifiedDate"] !== undefined) {
-    contents.NodeUpdateStatusModifiedDate = new Date(output["NodeUpdateStatusModifiedDate"]);
+    contents.NodeUpdateStatusModifiedDate = __expectNonNull(
+      __parseRfc3339DateTime(output["NodeUpdateStatusModifiedDate"])
+    );
   }
   return contents;
 };
@@ -12283,7 +12287,7 @@ const deserializeAws_queryEvent = (output: any, context: __SerdeContext): Event 
     contents.Message = __expectString(output["Message"]);
   }
   if (output["Date"] !== undefined) {
-    contents.Date = new Date(output["Date"]);
+    contents.Date = __expectNonNull(__parseRfc3339DateTime(output["Date"]));
   }
   return contents;
 };
@@ -13029,22 +13033,24 @@ const deserializeAws_queryNodeGroupMemberUpdateStatus = (
     contents.NodeUpdateStatus = __expectString(output["NodeUpdateStatus"]);
   }
   if (output["NodeDeletionDate"] !== undefined) {
-    contents.NodeDeletionDate = new Date(output["NodeDeletionDate"]);
+    contents.NodeDeletionDate = __expectNonNull(__parseRfc3339DateTime(output["NodeDeletionDate"]));
   }
   if (output["NodeUpdateStartDate"] !== undefined) {
-    contents.NodeUpdateStartDate = new Date(output["NodeUpdateStartDate"]);
+    contents.NodeUpdateStartDate = __expectNonNull(__parseRfc3339DateTime(output["NodeUpdateStartDate"]));
   }
   if (output["NodeUpdateEndDate"] !== undefined) {
-    contents.NodeUpdateEndDate = new Date(output["NodeUpdateEndDate"]);
+    contents.NodeUpdateEndDate = __expectNonNull(__parseRfc3339DateTime(output["NodeUpdateEndDate"]));
   }
   if (output["NodeUpdateInitiatedBy"] !== undefined) {
     contents.NodeUpdateInitiatedBy = __expectString(output["NodeUpdateInitiatedBy"]);
   }
   if (output["NodeUpdateInitiatedDate"] !== undefined) {
-    contents.NodeUpdateInitiatedDate = new Date(output["NodeUpdateInitiatedDate"]);
+    contents.NodeUpdateInitiatedDate = __expectNonNull(__parseRfc3339DateTime(output["NodeUpdateInitiatedDate"]));
   }
   if (output["NodeUpdateStatusModifiedDate"] !== undefined) {
-    contents.NodeUpdateStatusModifiedDate = new Date(output["NodeUpdateStatusModifiedDate"]);
+    contents.NodeUpdateStatusModifiedDate = __expectNonNull(
+      __parseRfc3339DateTime(output["NodeUpdateStatusModifiedDate"])
+    );
   }
   return contents;
 };
@@ -13178,10 +13184,10 @@ const deserializeAws_queryNodeSnapshot = (output: any, context: __SerdeContext):
     contents.CacheSize = __expectString(output["CacheSize"]);
   }
   if (output["CacheNodeCreateTime"] !== undefined) {
-    contents.CacheNodeCreateTime = new Date(output["CacheNodeCreateTime"]);
+    contents.CacheNodeCreateTime = __expectNonNull(__parseRfc3339DateTime(output["CacheNodeCreateTime"]));
   }
   if (output["SnapshotCreateTime"] !== undefined) {
-    contents.SnapshotCreateTime = new Date(output["SnapshotCreateTime"]);
+    contents.SnapshotCreateTime = __expectNonNull(__parseRfc3339DateTime(output["SnapshotCreateTime"]));
   }
   return contents;
 };
@@ -13581,7 +13587,7 @@ const deserializeAws_queryReplicationGroup = (output: any, context: __SerdeConte
     contents.AuthTokenEnabled = __parseBoolean(output["AuthTokenEnabled"]);
   }
   if (output["AuthTokenLastModifiedDate"] !== undefined) {
-    contents.AuthTokenLastModifiedDate = new Date(output["AuthTokenLastModifiedDate"]);
+    contents.AuthTokenLastModifiedDate = __expectNonNull(__parseRfc3339DateTime(output["AuthTokenLastModifiedDate"]));
   }
   if (output["TransitEncryptionEnabled"] !== undefined) {
     contents.TransitEncryptionEnabled = __parseBoolean(output["TransitEncryptionEnabled"]);
@@ -13629,7 +13635,7 @@ const deserializeAws_queryReplicationGroup = (output: any, context: __SerdeConte
     );
   }
   if (output["ReplicationGroupCreateTime"] !== undefined) {
-    contents.ReplicationGroupCreateTime = new Date(output["ReplicationGroupCreateTime"]);
+    contents.ReplicationGroupCreateTime = __expectNonNull(__parseRfc3339DateTime(output["ReplicationGroupCreateTime"]));
   }
   return contents;
 };
@@ -13796,7 +13802,7 @@ const deserializeAws_queryReservedCacheNode = (output: any, context: __SerdeCont
     contents.CacheNodeType = __expectString(output["CacheNodeType"]);
   }
   if (output["StartTime"] !== undefined) {
-    contents.StartTime = new Date(output["StartTime"]);
+    contents.StartTime = __expectNonNull(__parseRfc3339DateTime(output["StartTime"]));
   }
   if (output["Duration"] !== undefined) {
     contents.Duration = __strictParseInt32(output["Duration"]) as number;
@@ -14090,16 +14096,18 @@ const deserializeAws_queryServiceUpdate = (output: any, context: __SerdeContext)
     contents.ServiceUpdateName = __expectString(output["ServiceUpdateName"]);
   }
   if (output["ServiceUpdateReleaseDate"] !== undefined) {
-    contents.ServiceUpdateReleaseDate = new Date(output["ServiceUpdateReleaseDate"]);
+    contents.ServiceUpdateReleaseDate = __expectNonNull(__parseRfc3339DateTime(output["ServiceUpdateReleaseDate"]));
   }
   if (output["ServiceUpdateEndDate"] !== undefined) {
-    contents.ServiceUpdateEndDate = new Date(output["ServiceUpdateEndDate"]);
+    contents.ServiceUpdateEndDate = __expectNonNull(__parseRfc3339DateTime(output["ServiceUpdateEndDate"]));
   }
   if (output["ServiceUpdateSeverity"] !== undefined) {
     contents.ServiceUpdateSeverity = __expectString(output["ServiceUpdateSeverity"]);
   }
   if (output["ServiceUpdateRecommendedApplyByDate"] !== undefined) {
-    contents.ServiceUpdateRecommendedApplyByDate = new Date(output["ServiceUpdateRecommendedApplyByDate"]);
+    contents.ServiceUpdateRecommendedApplyByDate = __expectNonNull(
+      __parseRfc3339DateTime(output["ServiceUpdateRecommendedApplyByDate"])
+    );
   }
   if (output["ServiceUpdateStatus"] !== undefined) {
     contents.ServiceUpdateStatus = __expectString(output["ServiceUpdateStatus"]);
@@ -14246,7 +14254,7 @@ const deserializeAws_querySnapshot = (output: any, context: __SerdeContext): Sna
     contents.PreferredOutpostArn = __expectString(output["PreferredOutpostArn"]);
   }
   if (output["CacheClusterCreateTime"] !== undefined) {
-    contents.CacheClusterCreateTime = new Date(output["CacheClusterCreateTime"]);
+    contents.CacheClusterCreateTime = __expectNonNull(__parseRfc3339DateTime(output["CacheClusterCreateTime"]));
   }
   if (output["PreferredMaintenanceWindow"] !== undefined) {
     contents.PreferredMaintenanceWindow = __expectString(output["PreferredMaintenanceWindow"]);
@@ -14593,7 +14601,7 @@ const deserializeAws_queryUpdateAction = (output: any, context: __SerdeContext):
     contents.ServiceUpdateName = __expectString(output["ServiceUpdateName"]);
   }
   if (output["ServiceUpdateReleaseDate"] !== undefined) {
-    contents.ServiceUpdateReleaseDate = new Date(output["ServiceUpdateReleaseDate"]);
+    contents.ServiceUpdateReleaseDate = __expectNonNull(__parseRfc3339DateTime(output["ServiceUpdateReleaseDate"]));
   }
   if (output["ServiceUpdateSeverity"] !== undefined) {
     contents.ServiceUpdateSeverity = __expectString(output["ServiceUpdateSeverity"]);
@@ -14602,13 +14610,15 @@ const deserializeAws_queryUpdateAction = (output: any, context: __SerdeContext):
     contents.ServiceUpdateStatus = __expectString(output["ServiceUpdateStatus"]);
   }
   if (output["ServiceUpdateRecommendedApplyByDate"] !== undefined) {
-    contents.ServiceUpdateRecommendedApplyByDate = new Date(output["ServiceUpdateRecommendedApplyByDate"]);
+    contents.ServiceUpdateRecommendedApplyByDate = __expectNonNull(
+      __parseRfc3339DateTime(output["ServiceUpdateRecommendedApplyByDate"])
+    );
   }
   if (output["ServiceUpdateType"] !== undefined) {
     contents.ServiceUpdateType = __expectString(output["ServiceUpdateType"]);
   }
   if (output["UpdateActionAvailableDate"] !== undefined) {
-    contents.UpdateActionAvailableDate = new Date(output["UpdateActionAvailableDate"]);
+    contents.UpdateActionAvailableDate = __expectNonNull(__parseRfc3339DateTime(output["UpdateActionAvailableDate"]));
   }
   if (output["UpdateActionStatus"] !== undefined) {
     contents.UpdateActionStatus = __expectString(output["UpdateActionStatus"]);
@@ -14617,7 +14627,9 @@ const deserializeAws_queryUpdateAction = (output: any, context: __SerdeContext):
     contents.NodesUpdated = __expectString(output["NodesUpdated"]);
   }
   if (output["UpdateActionStatusModifiedDate"] !== undefined) {
-    contents.UpdateActionStatusModifiedDate = new Date(output["UpdateActionStatusModifiedDate"]);
+    contents.UpdateActionStatusModifiedDate = __expectNonNull(
+      __parseRfc3339DateTime(output["UpdateActionStatusModifiedDate"])
+    );
   }
   if (output["SlaMet"] !== undefined) {
     contents.SlaMet = __expectString(output["SlaMet"]);

--- a/clients/client-elasticsearch-service/protocols/Aws_restJson1.ts
+++ b/clients/client-elasticsearch-service/protocols/Aws_restJson1.ts
@@ -214,10 +214,12 @@ import {
   expectInt32 as __expectInt32,
   expectLong as __expectLong,
   expectNonNull as __expectNonNull,
+  expectNumber as __expectNumber,
   expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   limitedParseDouble as __limitedParseDouble,
+  parseEpochTimestamp as __parseEpochTimestamp,
 } from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
@@ -5628,7 +5630,9 @@ const deserializeAws_restJson1AutoTuneMaintenanceSchedule = (
         ? deserializeAws_restJson1Duration(output.Duration, context)
         : undefined,
     StartAt:
-      output.StartAt !== undefined && output.StartAt !== null ? new Date(Math.round(output.StartAt * 1000)) : undefined,
+      output.StartAt !== undefined && output.StartAt !== null
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.StartAt)))
+        : undefined,
   } as any;
 };
 
@@ -5681,14 +5685,14 @@ const deserializeAws_restJson1AutoTuneStatus = (output: any, context: __SerdeCon
   return {
     CreationDate:
       output.CreationDate !== undefined && output.CreationDate !== null
-        ? new Date(Math.round(output.CreationDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationDate)))
         : undefined,
     ErrorMessage: __expectString(output.ErrorMessage),
     PendingDeletion: __expectBoolean(output.PendingDeletion),
     State: __expectString(output.State),
     UpdateDate:
       output.UpdateDate !== undefined && output.UpdateDate !== null
-        ? new Date(Math.round(output.UpdateDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.UpdateDate)))
         : undefined,
     UpdateVersion: __expectInt32(output.UpdateVersion),
   } as any;
@@ -5807,7 +5811,7 @@ const deserializeAws_restJson1DomainPackageDetails = (output: any, context: __Se
         : undefined,
     LastUpdated:
       output.LastUpdated !== undefined && output.LastUpdated !== null
-        ? new Date(Math.round(output.LastUpdated * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastUpdated)))
         : undefined,
     PackageID: __expectString(output.PackageID),
     PackageName: __expectString(output.PackageName),
@@ -6318,13 +6322,13 @@ const deserializeAws_restJson1OptionStatus = (output: any, context: __SerdeConte
   return {
     CreationDate:
       output.CreationDate !== undefined && output.CreationDate !== null
-        ? new Date(Math.round(output.CreationDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationDate)))
         : undefined,
     PendingDeletion: __expectBoolean(output.PendingDeletion),
     State: __expectString(output.State),
     UpdateDate:
       output.UpdateDate !== undefined && output.UpdateDate !== null
-        ? new Date(Math.round(output.UpdateDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.UpdateDate)))
         : undefined,
     UpdateVersion: __expectInt32(output.UpdateVersion),
   } as any;
@@ -6381,7 +6385,7 @@ const deserializeAws_restJson1PackageDetails = (output: any, context: __SerdeCon
     AvailablePackageVersion: __expectString(output.AvailablePackageVersion),
     CreatedAt:
       output.CreatedAt !== undefined && output.CreatedAt !== null
-        ? new Date(Math.round(output.CreatedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreatedAt)))
         : undefined,
     ErrorDetails:
       output.ErrorDetails !== undefined && output.ErrorDetails !== null
@@ -6389,7 +6393,7 @@ const deserializeAws_restJson1PackageDetails = (output: any, context: __SerdeCon
         : undefined,
     LastUpdatedAt:
       output.LastUpdatedAt !== undefined && output.LastUpdatedAt !== null
-        ? new Date(Math.round(output.LastUpdatedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastUpdatedAt)))
         : undefined,
     PackageDescription: __expectString(output.PackageDescription),
     PackageID: __expectString(output.PackageID),
@@ -6415,7 +6419,7 @@ const deserializeAws_restJson1PackageVersionHistory = (output: any, context: __S
     CommitMessage: __expectString(output.CommitMessage),
     CreatedAt:
       output.CreatedAt !== undefined && output.CreatedAt !== null
-        ? new Date(Math.round(output.CreatedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreatedAt)))
         : undefined,
     PackageVersion: __expectString(output.PackageVersion),
   } as any;
@@ -6473,7 +6477,7 @@ const deserializeAws_restJson1ReservedElasticsearchInstance = (
     ReservedElasticsearchInstanceOfferingId: __expectString(output.ReservedElasticsearchInstanceOfferingId),
     StartTime:
       output.StartTime !== undefined && output.StartTime !== null
-        ? new Date(Math.round(output.StartTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.StartTime)))
         : undefined,
     State: __expectString(output.State),
     UsagePrice: __limitedParseDouble(output.UsagePrice),
@@ -6554,7 +6558,10 @@ const deserializeAws_restJson1ScheduledAutoTuneDetails = (
   return {
     Action: __expectString(output.Action),
     ActionType: __expectString(output.ActionType),
-    Date: output.Date !== undefined && output.Date !== null ? new Date(Math.round(output.Date * 1000)) : undefined,
+    Date:
+      output.Date !== undefined && output.Date !== null
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.Date)))
+        : undefined,
     Severity: __expectString(output.Severity),
   } as any;
 };
@@ -6566,7 +6573,7 @@ const deserializeAws_restJson1ServiceSoftwareOptions = (
   return {
     AutomatedUpdateDate:
       output.AutomatedUpdateDate !== undefined && output.AutomatedUpdateDate !== null
-        ? new Date(Math.round(output.AutomatedUpdateDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.AutomatedUpdateDate)))
         : undefined,
     Cancellable: __expectBoolean(output.Cancellable),
     CurrentVersion: __expectString(output.CurrentVersion),
@@ -6673,7 +6680,7 @@ const deserializeAws_restJson1UpgradeHistory = (output: any, context: __SerdeCon
   return {
     StartTimestamp:
       output.StartTimestamp !== undefined && output.StartTimestamp !== null
-        ? new Date(Math.round(output.StartTimestamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.StartTimestamp)))
         : undefined,
     StepsList:
       output.StepsList !== undefined && output.StepsList !== null

--- a/clients/client-emr-containers/protocols/Aws_restJson1.ts
+++ b/clients/client-emr-containers/protocols/Aws_restJson1.ts
@@ -61,9 +61,11 @@ import {
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
   expectNonNull as __expectNonNull,
+  expectNumber as __expectNumber,
   expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
+  parseEpochTimestamp as __parseEpochTimestamp,
 } from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
@@ -1984,7 +1986,7 @@ const deserializeAws_restJson1Endpoint = (output: any, context: __SerdeContext):
         : undefined,
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
-        ? new Date(Math.round(output.createdAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.createdAt)))
         : undefined,
     executionRoleArn: __expectString(output.executionRoleArn),
     failureReason: __expectString(output.failureReason),
@@ -2049,14 +2051,14 @@ const deserializeAws_restJson1JobRun = (output: any, context: __SerdeContext): J
         : undefined,
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
-        ? new Date(Math.round(output.createdAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.createdAt)))
         : undefined,
     createdBy: __expectString(output.createdBy),
     executionRoleArn: __expectString(output.executionRoleArn),
     failureReason: __expectString(output.failureReason),
     finishedAt:
       output.finishedAt !== undefined && output.finishedAt !== null
-        ? new Date(Math.round(output.finishedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.finishedAt)))
         : undefined,
     id: __expectString(output.id),
     jobDriver:
@@ -2170,7 +2172,7 @@ const deserializeAws_restJson1VirtualCluster = (output: any, context: __SerdeCon
         : undefined,
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
-        ? new Date(Math.round(output.createdAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.createdAt)))
         : undefined,
     id: __expectString(output.id),
     name: __expectString(output.name),

--- a/clients/client-emr/protocols/Aws_json1_1.ts
+++ b/clients/client-emr/protocols/Aws_json1_1.ts
@@ -336,8 +336,11 @@ import {
   expectBoolean as __expectBoolean,
   expectInt32 as __expectInt32,
   expectLong as __expectLong,
+  expectNonNull as __expectNonNull,
+  expectNumber as __expectNumber,
   expectString as __expectString,
   limitedParseDouble as __limitedParseDouble,
+  parseEpochTimestamp as __parseEpochTimestamp,
   serializeFloat as __serializeFloat,
 } from "@aws-sdk/smithy-client";
 import {
@@ -5781,7 +5784,7 @@ const deserializeAws_json1_1BlockPublicAccessConfigurationMetadata = (
     CreatedByArn: __expectString(output.CreatedByArn),
     CreationDateTime:
       output.CreationDateTime !== undefined && output.CreationDateTime !== null
-        ? new Date(Math.round(output.CreationDateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationDateTime)))
         : undefined,
   } as any;
 };
@@ -5976,15 +5979,15 @@ const deserializeAws_json1_1ClusterTimeline = (output: any, context: __SerdeCont
   return {
     CreationDateTime:
       output.CreationDateTime !== undefined && output.CreationDateTime !== null
-        ? new Date(Math.round(output.CreationDateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationDateTime)))
         : undefined,
     EndDateTime:
       output.EndDateTime !== undefined && output.EndDateTime !== null
-        ? new Date(Math.round(output.EndDateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.EndDateTime)))
         : undefined,
     ReadyDateTime:
       output.ReadyDateTime !== undefined && output.ReadyDateTime !== null
-        ? new Date(Math.round(output.ReadyDateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.ReadyDateTime)))
         : undefined,
   } as any;
 };
@@ -6053,7 +6056,7 @@ const deserializeAws_json1_1CreateSecurityConfigurationOutput = (
   return {
     CreationDateTime:
       output.CreationDateTime !== undefined && output.CreationDateTime !== null
-        ? new Date(Math.round(output.CreationDateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationDateTime)))
         : undefined,
     Name: __expectString(output.Name),
   } as any;
@@ -6124,7 +6127,7 @@ const deserializeAws_json1_1DescribeSecurityConfigurationOutput = (
   return {
     CreationDateTime:
       output.CreationDateTime !== undefined && output.CreationDateTime !== null
-        ? new Date(Math.round(output.CreationDateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationDateTime)))
         : undefined,
     Name: __expectString(output.Name),
     SecurityConfiguration: __expectString(output.SecurityConfiguration),
@@ -6429,15 +6432,15 @@ const deserializeAws_json1_1InstanceFleetTimeline = (output: any, context: __Ser
   return {
     CreationDateTime:
       output.CreationDateTime !== undefined && output.CreationDateTime !== null
-        ? new Date(Math.round(output.CreationDateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationDateTime)))
         : undefined,
     EndDateTime:
       output.EndDateTime !== undefined && output.EndDateTime !== null
-        ? new Date(Math.round(output.EndDateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.EndDateTime)))
         : undefined,
     ReadyDateTime:
       output.ReadyDateTime !== undefined && output.ReadyDateTime !== null
-        ? new Date(Math.round(output.ReadyDateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.ReadyDateTime)))
         : undefined,
   } as any;
 };
@@ -6489,12 +6492,12 @@ const deserializeAws_json1_1InstanceGroupDetail = (output: any, context: __Serde
     BidPrice: __expectString(output.BidPrice),
     CreationDateTime:
       output.CreationDateTime !== undefined && output.CreationDateTime !== null
-        ? new Date(Math.round(output.CreationDateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationDateTime)))
         : undefined,
     CustomAmiId: __expectString(output.CustomAmiId),
     EndDateTime:
       output.EndDateTime !== undefined && output.EndDateTime !== null
-        ? new Date(Math.round(output.EndDateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.EndDateTime)))
         : undefined,
     InstanceGroupId: __expectString(output.InstanceGroupId),
     InstanceRequestCount: __expectInt32(output.InstanceRequestCount),
@@ -6506,11 +6509,11 @@ const deserializeAws_json1_1InstanceGroupDetail = (output: any, context: __Serde
     Name: __expectString(output.Name),
     ReadyDateTime:
       output.ReadyDateTime !== undefined && output.ReadyDateTime !== null
-        ? new Date(Math.round(output.ReadyDateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.ReadyDateTime)))
         : undefined,
     StartDateTime:
       output.StartDateTime !== undefined && output.StartDateTime !== null
-        ? new Date(Math.round(output.StartDateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.StartDateTime)))
         : undefined,
     State: __expectString(output.State),
   } as any;
@@ -6577,15 +6580,15 @@ const deserializeAws_json1_1InstanceGroupTimeline = (output: any, context: __Ser
   return {
     CreationDateTime:
       output.CreationDateTime !== undefined && output.CreationDateTime !== null
-        ? new Date(Math.round(output.CreationDateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationDateTime)))
         : undefined,
     EndDateTime:
       output.EndDateTime !== undefined && output.EndDateTime !== null
-        ? new Date(Math.round(output.EndDateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.EndDateTime)))
         : undefined,
     ReadyDateTime:
       output.ReadyDateTime !== undefined && output.ReadyDateTime !== null
-        ? new Date(Math.round(output.ReadyDateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.ReadyDateTime)))
         : undefined,
   } as any;
 };
@@ -6643,15 +6646,15 @@ const deserializeAws_json1_1InstanceTimeline = (output: any, context: __SerdeCon
   return {
     CreationDateTime:
       output.CreationDateTime !== undefined && output.CreationDateTime !== null
-        ? new Date(Math.round(output.CreationDateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationDateTime)))
         : undefined,
     EndDateTime:
       output.EndDateTime !== undefined && output.EndDateTime !== null
-        ? new Date(Math.round(output.EndDateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.EndDateTime)))
         : undefined,
     ReadyDateTime:
       output.ReadyDateTime !== undefined && output.ReadyDateTime !== null
-        ? new Date(Math.round(output.ReadyDateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.ReadyDateTime)))
         : undefined,
   } as any;
 };
@@ -6768,20 +6771,20 @@ const deserializeAws_json1_1JobFlowExecutionStatusDetail = (
   return {
     CreationDateTime:
       output.CreationDateTime !== undefined && output.CreationDateTime !== null
-        ? new Date(Math.round(output.CreationDateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationDateTime)))
         : undefined,
     EndDateTime:
       output.EndDateTime !== undefined && output.EndDateTime !== null
-        ? new Date(Math.round(output.EndDateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.EndDateTime)))
         : undefined,
     LastStateChangeReason: __expectString(output.LastStateChangeReason),
     ReadyDateTime:
       output.ReadyDateTime !== undefined && output.ReadyDateTime !== null
-        ? new Date(Math.round(output.ReadyDateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.ReadyDateTime)))
         : undefined,
     StartDateTime:
       output.StartDateTime !== undefined && output.StartDateTime !== null
-        ? new Date(Math.round(output.StartDateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.StartDateTime)))
         : undefined,
     State: __expectString(output.State),
   } as any;
@@ -7008,7 +7011,9 @@ const deserializeAws_json1_1NotebookExecution = (output: any, context: __SerdeCo
     Arn: __expectString(output.Arn),
     EditorId: __expectString(output.EditorId),
     EndTime:
-      output.EndTime !== undefined && output.EndTime !== null ? new Date(Math.round(output.EndTime * 1000)) : undefined,
+      output.EndTime !== undefined && output.EndTime !== null
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.EndTime)))
+        : undefined,
     ExecutionEngine:
       output.ExecutionEngine !== undefined && output.ExecutionEngine !== null
         ? deserializeAws_json1_1ExecutionEngineConfig(output.ExecutionEngine, context)
@@ -7021,7 +7026,7 @@ const deserializeAws_json1_1NotebookExecution = (output: any, context: __SerdeCo
     OutputNotebookURI: __expectString(output.OutputNotebookURI),
     StartTime:
       output.StartTime !== undefined && output.StartTime !== null
-        ? new Date(Math.round(output.StartTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.StartTime)))
         : undefined,
     Status: __expectString(output.Status),
     Tags:
@@ -7038,12 +7043,14 @@ const deserializeAws_json1_1NotebookExecutionSummary = (
   return {
     EditorId: __expectString(output.EditorId),
     EndTime:
-      output.EndTime !== undefined && output.EndTime !== null ? new Date(Math.round(output.EndTime * 1000)) : undefined,
+      output.EndTime !== undefined && output.EndTime !== null
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.EndTime)))
+        : undefined,
     NotebookExecutionId: __expectString(output.NotebookExecutionId),
     NotebookExecutionName: __expectString(output.NotebookExecutionName),
     StartTime:
       output.StartTime !== undefined && output.StartTime !== null
-        ? new Date(Math.round(output.StartTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.StartTime)))
         : undefined,
     Status: __expectString(output.Status),
   } as any;
@@ -7290,7 +7297,7 @@ const deserializeAws_json1_1SecurityConfigurationSummary = (
   return {
     CreationDateTime:
       output.CreationDateTime !== undefined && output.CreationDateTime !== null
-        ? new Date(Math.round(output.CreationDateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationDateTime)))
         : undefined,
     Name: __expectString(output.Name),
   } as any;
@@ -7300,14 +7307,14 @@ const deserializeAws_json1_1SessionMappingDetail = (output: any, context: __Serd
   return {
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     IdentityId: __expectString(output.IdentityId),
     IdentityName: __expectString(output.IdentityName),
     IdentityType: __expectString(output.IdentityType),
     LastModifiedTime:
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
-        ? new Date(Math.round(output.LastModifiedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastModifiedTime)))
         : undefined,
     SessionPolicyArn: __expectString(output.SessionPolicyArn),
     StudioId: __expectString(output.StudioId),
@@ -7318,7 +7325,7 @@ const deserializeAws_json1_1SessionMappingSummary = (output: any, context: __Ser
   return {
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     IdentityId: __expectString(output.IdentityId),
     IdentityName: __expectString(output.IdentityName),
@@ -7463,16 +7470,16 @@ const deserializeAws_json1_1StepExecutionStatusDetail = (
   return {
     CreationDateTime:
       output.CreationDateTime !== undefined && output.CreationDateTime !== null
-        ? new Date(Math.round(output.CreationDateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationDateTime)))
         : undefined,
     EndDateTime:
       output.EndDateTime !== undefined && output.EndDateTime !== null
-        ? new Date(Math.round(output.EndDateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.EndDateTime)))
         : undefined,
     LastStateChangeReason: __expectString(output.LastStateChangeReason),
     StartDateTime:
       output.StartDateTime !== undefined && output.StartDateTime !== null
-        ? new Date(Math.round(output.StartDateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.StartDateTime)))
         : undefined,
     State: __expectString(output.State),
   } as any;
@@ -7545,15 +7552,15 @@ const deserializeAws_json1_1StepTimeline = (output: any, context: __SerdeContext
   return {
     CreationDateTime:
       output.CreationDateTime !== undefined && output.CreationDateTime !== null
-        ? new Date(Math.round(output.CreationDateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationDateTime)))
         : undefined,
     EndDateTime:
       output.EndDateTime !== undefined && output.EndDateTime !== null
-        ? new Date(Math.round(output.EndDateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.EndDateTime)))
         : undefined,
     StartDateTime:
       output.StartDateTime !== undefined && output.StartDateTime !== null
-        ? new Date(Math.round(output.StartDateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.StartDateTime)))
         : undefined,
   } as any;
 };
@@ -7586,7 +7593,7 @@ const deserializeAws_json1_1Studio = (output: any, context: __SerdeContext): Stu
     AuthMode: __expectString(output.AuthMode),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     DefaultS3Location: __expectString(output.DefaultS3Location),
     Description: __expectString(output.Description),
@@ -7614,7 +7621,7 @@ const deserializeAws_json1_1StudioSummary = (output: any, context: __SerdeContex
   return {
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     Description: __expectString(output.Description),
     Name: __expectString(output.Name),

--- a/clients/client-eventbridge/protocols/Aws_json1_1.ts
+++ b/clients/client-eventbridge/protocols/Aws_json1_1.ts
@@ -266,7 +266,10 @@ import {
   expectBoolean as __expectBoolean,
   expectInt32 as __expectInt32,
   expectLong as __expectLong,
+  expectNonNull as __expectNonNull,
+  expectNumber as __expectNumber,
   expectString as __expectString,
+  parseEpochTimestamp as __parseEpochTimestamp,
 } from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
@@ -6030,14 +6033,14 @@ const deserializeAws_json1_1ApiDestination = (output: any, context: __SerdeConte
     ConnectionArn: __expectString(output.ConnectionArn),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     HttpMethod: __expectString(output.HttpMethod),
     InvocationEndpoint: __expectString(output.InvocationEndpoint),
     InvocationRateLimitPerSecond: __expectInt32(output.InvocationRateLimitPerSecond),
     LastModifiedTime:
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
-        ? new Date(Math.round(output.LastModifiedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastModifiedTime)))
         : undefined,
     Name: __expectString(output.Name),
   } as any;
@@ -6059,7 +6062,7 @@ const deserializeAws_json1_1Archive = (output: any, context: __SerdeContext): Ar
     ArchiveName: __expectString(output.ArchiveName),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     EventCount: __expectLong(output.EventCount),
     EventSourceArn: __expectString(output.EventSourceArn),
@@ -6171,15 +6174,15 @@ const deserializeAws_json1_1Connection = (output: any, context: __SerdeContext):
     ConnectionState: __expectString(output.ConnectionState),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     LastAuthorizedTime:
       output.LastAuthorizedTime !== undefined && output.LastAuthorizedTime !== null
-        ? new Date(Math.round(output.LastAuthorizedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastAuthorizedTime)))
         : undefined,
     LastModifiedTime:
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
-        ? new Date(Math.round(output.LastModifiedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastModifiedTime)))
         : undefined,
     Name: __expectString(output.Name),
     StateReason: __expectString(output.StateReason),
@@ -6370,11 +6373,11 @@ const deserializeAws_json1_1CreateApiDestinationResponse = (
     ApiDestinationState: __expectString(output.ApiDestinationState),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     LastModifiedTime:
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
-        ? new Date(Math.round(output.LastModifiedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastModifiedTime)))
         : undefined,
   } as any;
 };
@@ -6384,7 +6387,7 @@ const deserializeAws_json1_1CreateArchiveResponse = (output: any, context: __Ser
     ArchiveArn: __expectString(output.ArchiveArn),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     State: __expectString(output.State),
     StateReason: __expectString(output.StateReason),
@@ -6400,11 +6403,11 @@ const deserializeAws_json1_1CreateConnectionResponse = (
     ConnectionState: __expectString(output.ConnectionState),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     LastModifiedTime:
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
-        ? new Date(Math.round(output.LastModifiedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastModifiedTime)))
         : undefined,
   } as any;
 };
@@ -6439,15 +6442,15 @@ const deserializeAws_json1_1DeauthorizeConnectionResponse = (
     ConnectionState: __expectString(output.ConnectionState),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     LastAuthorizedTime:
       output.LastAuthorizedTime !== undefined && output.LastAuthorizedTime !== null
-        ? new Date(Math.round(output.LastAuthorizedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastAuthorizedTime)))
         : undefined,
     LastModifiedTime:
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
-        ? new Date(Math.round(output.LastModifiedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastModifiedTime)))
         : undefined,
   } as any;
 };
@@ -6472,15 +6475,15 @@ const deserializeAws_json1_1DeleteConnectionResponse = (
     ConnectionState: __expectString(output.ConnectionState),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     LastAuthorizedTime:
       output.LastAuthorizedTime !== undefined && output.LastAuthorizedTime !== null
-        ? new Date(Math.round(output.LastAuthorizedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastAuthorizedTime)))
         : undefined,
     LastModifiedTime:
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
-        ? new Date(Math.round(output.LastModifiedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastModifiedTime)))
         : undefined,
   } as any;
 };
@@ -6495,7 +6498,7 @@ const deserializeAws_json1_1DescribeApiDestinationResponse = (
     ConnectionArn: __expectString(output.ConnectionArn),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     Description: __expectString(output.Description),
     HttpMethod: __expectString(output.HttpMethod),
@@ -6503,7 +6506,7 @@ const deserializeAws_json1_1DescribeApiDestinationResponse = (
     InvocationRateLimitPerSecond: __expectInt32(output.InvocationRateLimitPerSecond),
     LastModifiedTime:
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
-        ? new Date(Math.round(output.LastModifiedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastModifiedTime)))
         : undefined,
     Name: __expectString(output.Name),
   } as any;
@@ -6518,7 +6521,7 @@ const deserializeAws_json1_1DescribeArchiveResponse = (
     ArchiveName: __expectString(output.ArchiveName),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     Description: __expectString(output.Description),
     EventCount: __expectLong(output.EventCount),
@@ -6545,16 +6548,16 @@ const deserializeAws_json1_1DescribeConnectionResponse = (
     ConnectionState: __expectString(output.ConnectionState),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     Description: __expectString(output.Description),
     LastAuthorizedTime:
       output.LastAuthorizedTime !== undefined && output.LastAuthorizedTime !== null
-        ? new Date(Math.round(output.LastAuthorizedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastAuthorizedTime)))
         : undefined,
     LastModifiedTime:
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
-        ? new Date(Math.round(output.LastModifiedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastModifiedTime)))
         : undefined,
     Name: __expectString(output.Name),
     SecretArn: __expectString(output.SecretArn),
@@ -6582,11 +6585,11 @@ const deserializeAws_json1_1DescribeEventSourceResponse = (
     CreatedBy: __expectString(output.CreatedBy),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     ExpirationTime:
       output.ExpirationTime !== undefined && output.ExpirationTime !== null
-        ? new Date(Math.round(output.ExpirationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.ExpirationTime)))
         : undefined,
     Name: __expectString(output.Name),
     State: __expectString(output.State),
@@ -6612,26 +6615,26 @@ const deserializeAws_json1_1DescribeReplayResponse = (output: any, context: __Se
         : undefined,
     EventEndTime:
       output.EventEndTime !== undefined && output.EventEndTime !== null
-        ? new Date(Math.round(output.EventEndTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.EventEndTime)))
         : undefined,
     EventLastReplayedTime:
       output.EventLastReplayedTime !== undefined && output.EventLastReplayedTime !== null
-        ? new Date(Math.round(output.EventLastReplayedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.EventLastReplayedTime)))
         : undefined,
     EventSourceArn: __expectString(output.EventSourceArn),
     EventStartTime:
       output.EventStartTime !== undefined && output.EventStartTime !== null
-        ? new Date(Math.round(output.EventStartTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.EventStartTime)))
         : undefined,
     ReplayArn: __expectString(output.ReplayArn),
     ReplayEndTime:
       output.ReplayEndTime !== undefined && output.ReplayEndTime !== null
-        ? new Date(Math.round(output.ReplayEndTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.ReplayEndTime)))
         : undefined,
     ReplayName: __expectString(output.ReplayName),
     ReplayStartTime:
       output.ReplayStartTime !== undefined && output.ReplayStartTime !== null
-        ? new Date(Math.round(output.ReplayStartTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.ReplayStartTime)))
         : undefined,
     State: __expectString(output.State),
     StateReason: __expectString(output.StateReason),
@@ -6712,11 +6715,11 @@ const deserializeAws_json1_1EventSource = (output: any, context: __SerdeContext)
     CreatedBy: __expectString(output.CreatedBy),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     ExpirationTime:
       output.ExpirationTime !== undefined && output.ExpirationTime !== null
-        ? new Date(Math.round(output.ExpirationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.ExpirationTime)))
         : undefined,
     Name: __expectString(output.Name),
     State: __expectString(output.State),
@@ -6994,11 +6997,11 @@ const deserializeAws_json1_1PartnerEventSourceAccount = (
     Account: __expectString(output.Account),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     ExpirationTime:
       output.ExpirationTime !== undefined && output.ExpirationTime !== null
-        ? new Date(Math.round(output.ExpirationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.ExpirationTime)))
         : undefined,
     State: __expectString(output.State),
   } as any;
@@ -7258,25 +7261,25 @@ const deserializeAws_json1_1Replay = (output: any, context: __SerdeContext): Rep
   return {
     EventEndTime:
       output.EventEndTime !== undefined && output.EventEndTime !== null
-        ? new Date(Math.round(output.EventEndTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.EventEndTime)))
         : undefined,
     EventLastReplayedTime:
       output.EventLastReplayedTime !== undefined && output.EventLastReplayedTime !== null
-        ? new Date(Math.round(output.EventLastReplayedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.EventLastReplayedTime)))
         : undefined,
     EventSourceArn: __expectString(output.EventSourceArn),
     EventStartTime:
       output.EventStartTime !== undefined && output.EventStartTime !== null
-        ? new Date(Math.round(output.EventStartTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.EventStartTime)))
         : undefined,
     ReplayEndTime:
       output.ReplayEndTime !== undefined && output.ReplayEndTime !== null
-        ? new Date(Math.round(output.ReplayEndTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.ReplayEndTime)))
         : undefined,
     ReplayName: __expectString(output.ReplayName),
     ReplayStartTime:
       output.ReplayStartTime !== undefined && output.ReplayStartTime !== null
-        ? new Date(Math.round(output.ReplayStartTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.ReplayStartTime)))
         : undefined,
     State: __expectString(output.State),
     StateReason: __expectString(output.StateReason),
@@ -7464,7 +7467,7 @@ const deserializeAws_json1_1StartReplayResponse = (output: any, context: __Serde
     ReplayArn: __expectString(output.ReplayArn),
     ReplayStartTime:
       output.ReplayStartTime !== undefined && output.ReplayStartTime !== null
-        ? new Date(Math.round(output.ReplayStartTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.ReplayStartTime)))
         : undefined,
     State: __expectString(output.State),
     StateReason: __expectString(output.StateReason),
@@ -7603,11 +7606,11 @@ const deserializeAws_json1_1UpdateApiDestinationResponse = (
     ApiDestinationState: __expectString(output.ApiDestinationState),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     LastModifiedTime:
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
-        ? new Date(Math.round(output.LastModifiedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastModifiedTime)))
         : undefined,
   } as any;
 };
@@ -7617,7 +7620,7 @@ const deserializeAws_json1_1UpdateArchiveResponse = (output: any, context: __Ser
     ArchiveArn: __expectString(output.ArchiveArn),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     State: __expectString(output.State),
     StateReason: __expectString(output.StateReason),
@@ -7633,15 +7636,15 @@ const deserializeAws_json1_1UpdateConnectionResponse = (
     ConnectionState: __expectString(output.ConnectionState),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     LastAuthorizedTime:
       output.LastAuthorizedTime !== undefined && output.LastAuthorizedTime !== null
-        ? new Date(Math.round(output.LastAuthorizedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastAuthorizedTime)))
         : undefined,
     LastModifiedTime:
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
-        ? new Date(Math.round(output.LastModifiedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastModifiedTime)))
         : undefined,
   } as any;
 };

--- a/clients/client-finspace-data/protocols/Aws_restJson1.ts
+++ b/clients/client-finspace-data/protocols/Aws_restJson1.ts
@@ -18,9 +18,11 @@ import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@a
 import {
   expectLong as __expectLong,
   expectNonNull as __expectNonNull,
+  expectNumber as __expectNumber,
   expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
+  parseEpochTimestamp as __parseEpochTimestamp,
 } from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
@@ -473,7 +475,7 @@ const deserializeAws_restJson1ChangesetInfo = (output: any, context: __SerdeCont
         : undefined,
     createTimestamp:
       output.createTimestamp !== undefined && output.createTimestamp !== null
-        ? new Date(Math.round(output.createTimestamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.createTimestamp)))
         : undefined,
     datasetId: __expectString(output.datasetId),
     errorInfo:

--- a/clients/client-firehose/protocols/Aws_json1_1.ts
+++ b/clients/client-firehose/protocols/Aws_json1_1.ts
@@ -132,8 +132,11 @@ import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@a
 import {
   expectBoolean as __expectBoolean,
   expectInt32 as __expectInt32,
+  expectNonNull as __expectNonNull,
+  expectNumber as __expectNumber,
   expectString as __expectString,
   limitedParseDouble as __limitedParseDouble,
+  parseEpochTimestamp as __parseEpochTimestamp,
   serializeFloat as __serializeFloat,
 } from "@aws-sdk/smithy-client";
 import {
@@ -2535,7 +2538,7 @@ const deserializeAws_json1_1DeliveryStreamDescription = (
   return {
     CreateTimestamp:
       output.CreateTimestamp !== undefined && output.CreateTimestamp !== null
-        ? new Date(Math.round(output.CreateTimestamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreateTimestamp)))
         : undefined,
     DeliveryStreamARN: __expectString(output.DeliveryStreamARN),
     DeliveryStreamEncryptionConfiguration:
@@ -2560,7 +2563,7 @@ const deserializeAws_json1_1DeliveryStreamDescription = (
     HasMoreDestinations: __expectBoolean(output.HasMoreDestinations),
     LastUpdateTimestamp:
       output.LastUpdateTimestamp !== undefined && output.LastUpdateTimestamp !== null
-        ? new Date(Math.round(output.LastUpdateTimestamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastUpdateTimestamp)))
         : undefined,
     Source:
       output.Source !== undefined && output.Source !== null
@@ -2949,7 +2952,7 @@ const deserializeAws_json1_1KinesisStreamSourceDescription = (
   return {
     DeliveryStartTimestamp:
       output.DeliveryStartTimestamp !== undefined && output.DeliveryStartTimestamp !== null
-        ? new Date(Math.round(output.DeliveryStartTimestamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.DeliveryStartTimestamp)))
         : undefined,
     KinesisStreamARN: __expectString(output.KinesisStreamARN),
     RoleARN: __expectString(output.RoleARN),

--- a/clients/client-fis/protocols/Aws_restJson1.ts
+++ b/clients/client-fis/protocols/Aws_restJson1.ts
@@ -65,9 +65,11 @@ import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@a
 import {
   expectBoolean as __expectBoolean,
   expectNonNull as __expectNonNull,
+  expectNumber as __expectNumber,
   expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
+  parseEpochTimestamp as __parseEpochTimestamp,
 } from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
@@ -1822,16 +1824,18 @@ const deserializeAws_restJson1Experiment = (output: any, context: __SerdeContext
         : undefined,
     creationTime:
       output.creationTime !== undefined && output.creationTime !== null
-        ? new Date(Math.round(output.creationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.creationTime)))
         : undefined,
     endTime:
-      output.endTime !== undefined && output.endTime !== null ? new Date(Math.round(output.endTime * 1000)) : undefined,
+      output.endTime !== undefined && output.endTime !== null
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.endTime)))
+        : undefined,
     experimentTemplateId: __expectString(output.experimentTemplateId),
     id: __expectString(output.id),
     roleArn: __expectString(output.roleArn),
     startTime:
       output.startTime !== undefined && output.startTime !== null
-        ? new Date(Math.round(output.startTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.startTime)))
         : undefined,
     state:
       output.state !== undefined && output.state !== null
@@ -1973,7 +1977,7 @@ const deserializeAws_restJson1ExperimentSummary = (output: any, context: __Serde
   return {
     creationTime:
       output.creationTime !== undefined && output.creationTime !== null
-        ? new Date(Math.round(output.creationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.creationTime)))
         : undefined,
     experimentTemplateId: __expectString(output.experimentTemplateId),
     id: __expectString(output.id),
@@ -2079,13 +2083,13 @@ const deserializeAws_restJson1ExperimentTemplate = (output: any, context: __Serd
         : undefined,
     creationTime:
       output.creationTime !== undefined && output.creationTime !== null
-        ? new Date(Math.round(output.creationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.creationTime)))
         : undefined,
     description: __expectString(output.description),
     id: __expectString(output.id),
     lastUpdateTime:
       output.lastUpdateTime !== undefined && output.lastUpdateTime !== null
-        ? new Date(Math.round(output.lastUpdateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastUpdateTime)))
         : undefined,
     roleArn: __expectString(output.roleArn),
     stopConditions:
@@ -2218,13 +2222,13 @@ const deserializeAws_restJson1ExperimentTemplateSummary = (
   return {
     creationTime:
       output.creationTime !== undefined && output.creationTime !== null
-        ? new Date(Math.round(output.creationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.creationTime)))
         : undefined,
     description: __expectString(output.description),
     id: __expectString(output.id),
     lastUpdateTime:
       output.lastUpdateTime !== undefined && output.lastUpdateTime !== null
-        ? new Date(Math.round(output.lastUpdateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastUpdateTime)))
         : undefined,
     tags:
       output.tags !== undefined && output.tags !== null

--- a/clients/client-fms/protocols/Aws_json1_1.ts
+++ b/clients/client-fms/protocols/Aws_json1_1.ts
@@ -169,7 +169,10 @@ import {
   expectBoolean as __expectBoolean,
   expectInt32 as __expectInt32,
   expectLong as __expectLong,
+  expectNonNull as __expectNonNull,
+  expectNumber as __expectNumber,
   expectString as __expectString,
+  parseEpochTimestamp as __parseEpochTimestamp,
 } from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
@@ -3038,11 +3041,11 @@ const deserializeAws_json1_1AppsListData = (output: any, context: __SerdeContext
         : undefined,
     CreateTime:
       output.CreateTime !== undefined && output.CreateTime !== null
-        ? new Date(Math.round(output.CreateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreateTime)))
         : undefined,
     LastUpdateTime:
       output.LastUpdateTime !== undefined && output.LastUpdateTime !== null
-        ? new Date(Math.round(output.LastUpdateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastUpdateTime)))
         : undefined,
     ListId: __expectString(output.ListId),
     ListName: __expectString(output.ListName),
@@ -3933,7 +3936,7 @@ const deserializeAws_json1_1PolicyComplianceDetail = (output: any, context: __Se
     EvaluationLimitExceeded: __expectBoolean(output.EvaluationLimitExceeded),
     ExpiredAt:
       output.ExpiredAt !== undefined && output.ExpiredAt !== null
-        ? new Date(Math.round(output.ExpiredAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.ExpiredAt)))
         : undefined,
     IssueInfoMap:
       output.IssueInfoMap !== undefined && output.IssueInfoMap !== null
@@ -3961,7 +3964,7 @@ const deserializeAws_json1_1PolicyComplianceStatus = (output: any, context: __Se
         : undefined,
     LastUpdated:
       output.LastUpdated !== undefined && output.LastUpdated !== null
-        ? new Date(Math.round(output.LastUpdated * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastUpdated)))
         : undefined,
     MemberAccount: __expectString(output.MemberAccount),
     PolicyId: __expectString(output.PolicyId),
@@ -4090,11 +4093,11 @@ const deserializeAws_json1_1ProtocolsListData = (output: any, context: __SerdeCo
   return {
     CreateTime:
       output.CreateTime !== undefined && output.CreateTime !== null
-        ? new Date(Math.round(output.CreateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreateTime)))
         : undefined,
     LastUpdateTime:
       output.LastUpdateTime !== undefined && output.LastUpdateTime !== null
-        ? new Date(Math.round(output.LastUpdateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastUpdateTime)))
         : undefined,
     ListId: __expectString(output.ListId),
     ListName: __expectString(output.ListName),

--- a/clients/client-forecast/protocols/Aws_json1_1.ts
+++ b/clients/client-forecast/protocols/Aws_json1_1.ts
@@ -184,8 +184,11 @@ import {
   expectBoolean as __expectBoolean,
   expectInt32 as __expectInt32,
   expectLong as __expectLong,
+  expectNonNull as __expectNonNull,
+  expectNumber as __expectNumber,
   expectString as __expectString,
   limitedParseDouble as __limitedParseDouble,
+  parseEpochTimestamp as __parseEpochTimestamp,
   serializeFloat as __serializeFloat,
 } from "@aws-sdk/smithy-client";
 import {
@@ -4029,13 +4032,13 @@ const deserializeAws_json1_1DatasetGroupSummary = (output: any, context: __Serde
   return {
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     DatasetGroupArn: __expectString(output.DatasetGroupArn),
     DatasetGroupName: __expectString(output.DatasetGroupName),
     LastModificationTime:
       output.LastModificationTime !== undefined && output.LastModificationTime !== null
-        ? new Date(Math.round(output.LastModificationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastModificationTime)))
         : undefined,
   } as any;
 };
@@ -4058,7 +4061,7 @@ const deserializeAws_json1_1DatasetImportJobSummary = (
   return {
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     DataSource:
       output.DataSource !== undefined && output.DataSource !== null
@@ -4068,7 +4071,7 @@ const deserializeAws_json1_1DatasetImportJobSummary = (
     DatasetImportJobName: __expectString(output.DatasetImportJobName),
     LastModificationTime:
       output.LastModificationTime !== undefined && output.LastModificationTime !== null
-        ? new Date(Math.round(output.LastModificationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastModificationTime)))
         : undefined,
     Message: __expectString(output.Message),
     Status: __expectString(output.Status),
@@ -4090,7 +4093,7 @@ const deserializeAws_json1_1DatasetSummary = (output: any, context: __SerdeConte
   return {
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     DatasetArn: __expectString(output.DatasetArn),
     DatasetName: __expectString(output.DatasetName),
@@ -4098,7 +4101,7 @@ const deserializeAws_json1_1DatasetSummary = (output: any, context: __SerdeConte
     Domain: __expectString(output.Domain),
     LastModificationTime:
       output.LastModificationTime !== undefined && output.LastModificationTime !== null
-        ? new Date(Math.round(output.LastModificationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastModificationTime)))
         : undefined,
   } as any;
 };
@@ -4119,7 +4122,7 @@ const deserializeAws_json1_1DescribeDatasetGroupResponse = (
   return {
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     DatasetArns:
       output.DatasetArns !== undefined && output.DatasetArns !== null
@@ -4130,7 +4133,7 @@ const deserializeAws_json1_1DescribeDatasetGroupResponse = (
     Domain: __expectString(output.Domain),
     LastModificationTime:
       output.LastModificationTime !== undefined && output.LastModificationTime !== null
-        ? new Date(Math.round(output.LastModificationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastModificationTime)))
         : undefined,
     Status: __expectString(output.Status),
   } as any;
@@ -4143,7 +4146,7 @@ const deserializeAws_json1_1DescribeDatasetImportJobResponse = (
   return {
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     DataSize: __limitedParseDouble(output.DataSize),
     DataSource:
@@ -4161,7 +4164,7 @@ const deserializeAws_json1_1DescribeDatasetImportJobResponse = (
     GeolocationFormat: __expectString(output.GeolocationFormat),
     LastModificationTime:
       output.LastModificationTime !== undefined && output.LastModificationTime !== null
-        ? new Date(Math.round(output.LastModificationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastModificationTime)))
         : undefined,
     Message: __expectString(output.Message),
     Status: __expectString(output.Status),
@@ -4178,7 +4181,7 @@ const deserializeAws_json1_1DescribeDatasetResponse = (
   return {
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     DataFrequency: __expectString(output.DataFrequency),
     DatasetArn: __expectString(output.DatasetArn),
@@ -4191,7 +4194,7 @@ const deserializeAws_json1_1DescribeDatasetResponse = (
         : undefined,
     LastModificationTime:
       output.LastModificationTime !== undefined && output.LastModificationTime !== null
-        ? new Date(Math.round(output.LastModificationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastModificationTime)))
         : undefined,
     Schema:
       output.Schema !== undefined && output.Schema !== null
@@ -4208,7 +4211,7 @@ const deserializeAws_json1_1DescribeForecastExportJobResponse = (
   return {
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     Destination:
       output.Destination !== undefined && output.Destination !== null
@@ -4219,7 +4222,7 @@ const deserializeAws_json1_1DescribeForecastExportJobResponse = (
     ForecastExportJobName: __expectString(output.ForecastExportJobName),
     LastModificationTime:
       output.LastModificationTime !== undefined && output.LastModificationTime !== null
-        ? new Date(Math.round(output.LastModificationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastModificationTime)))
         : undefined,
     Message: __expectString(output.Message),
     Status: __expectString(output.Status),
@@ -4233,7 +4236,7 @@ const deserializeAws_json1_1DescribeForecastResponse = (
   return {
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     DatasetGroupArn: __expectString(output.DatasetGroupArn),
     EstimatedTimeRemainingInMinutes: __expectLong(output.EstimatedTimeRemainingInMinutes),
@@ -4245,7 +4248,7 @@ const deserializeAws_json1_1DescribeForecastResponse = (
         : undefined,
     LastModificationTime:
       output.LastModificationTime !== undefined && output.LastModificationTime !== null
-        ? new Date(Math.round(output.LastModificationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastModificationTime)))
         : undefined,
     Message: __expectString(output.Message),
     PredictorArn: __expectString(output.PredictorArn),
@@ -4260,7 +4263,7 @@ const deserializeAws_json1_1DescribePredictorBacktestExportJobResponse = (
   return {
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     Destination:
       output.Destination !== undefined && output.Destination !== null
@@ -4268,7 +4271,7 @@ const deserializeAws_json1_1DescribePredictorBacktestExportJobResponse = (
         : undefined,
     LastModificationTime:
       output.LastModificationTime !== undefined && output.LastModificationTime !== null
-        ? new Date(Math.round(output.LastModificationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastModificationTime)))
         : undefined,
     Message: __expectString(output.Message),
     PredictorArn: __expectString(output.PredictorArn),
@@ -4291,7 +4294,7 @@ const deserializeAws_json1_1DescribePredictorResponse = (
     AutoMLOverrideStrategy: __expectString(output.AutoMLOverrideStrategy),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     DatasetImportJobArns:
       output.DatasetImportJobArns !== undefined && output.DatasetImportJobArns !== null
@@ -4325,7 +4328,7 @@ const deserializeAws_json1_1DescribePredictorResponse = (
         : undefined,
     LastModificationTime:
       output.LastModificationTime !== undefined && output.LastModificationTime !== null
-        ? new Date(Math.round(output.LastModificationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastModificationTime)))
         : undefined,
     Message: __expectString(output.Message),
     PerformAutoML: __expectBoolean(output.PerformAutoML),
@@ -4499,7 +4502,7 @@ const deserializeAws_json1_1ForecastExportJobSummary = (
   return {
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     Destination:
       output.Destination !== undefined && output.Destination !== null
@@ -4509,7 +4512,7 @@ const deserializeAws_json1_1ForecastExportJobSummary = (
     ForecastExportJobName: __expectString(output.ForecastExportJobName),
     LastModificationTime:
       output.LastModificationTime !== undefined && output.LastModificationTime !== null
-        ? new Date(Math.round(output.LastModificationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastModificationTime)))
         : undefined,
     Message: __expectString(output.Message),
     Status: __expectString(output.Status),
@@ -4531,14 +4534,14 @@ const deserializeAws_json1_1ForecastSummary = (output: any, context: __SerdeCont
   return {
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     DatasetGroupArn: __expectString(output.DatasetGroupArn),
     ForecastArn: __expectString(output.ForecastArn),
     ForecastName: __expectString(output.ForecastName),
     LastModificationTime:
       output.LastModificationTime !== undefined && output.LastModificationTime !== null
-        ? new Date(Math.round(output.LastModificationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastModificationTime)))
         : undefined,
     Message: __expectString(output.Message),
     PredictorArn: __expectString(output.PredictorArn),
@@ -4780,7 +4783,7 @@ const deserializeAws_json1_1PredictorBacktestExportJobSummary = (
   return {
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     Destination:
       output.Destination !== undefined && output.Destination !== null
@@ -4788,7 +4791,7 @@ const deserializeAws_json1_1PredictorBacktestExportJobSummary = (
         : undefined,
     LastModificationTime:
       output.LastModificationTime !== undefined && output.LastModificationTime !== null
-        ? new Date(Math.round(output.LastModificationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastModificationTime)))
         : undefined,
     Message: __expectString(output.Message),
     PredictorBacktestExportJobArn: __expectString(output.PredictorBacktestExportJobArn),
@@ -4856,12 +4859,12 @@ const deserializeAws_json1_1PredictorSummary = (output: any, context: __SerdeCon
   return {
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     DatasetGroupArn: __expectString(output.DatasetGroupArn),
     LastModificationTime:
       output.LastModificationTime !== undefined && output.LastModificationTime !== null
-        ? new Date(Math.round(output.LastModificationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastModificationTime)))
         : undefined,
     Message: __expectString(output.Message),
     PredictorArn: __expectString(output.PredictorArn),
@@ -5014,11 +5017,11 @@ const deserializeAws_json1_1TestWindowSummary = (output: any, context: __SerdeCo
     Status: __expectString(output.Status),
     TestWindowEnd:
       output.TestWindowEnd !== undefined && output.TestWindowEnd !== null
-        ? new Date(Math.round(output.TestWindowEnd * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.TestWindowEnd)))
         : undefined,
     TestWindowStart:
       output.TestWindowStart !== undefined && output.TestWindowStart !== null
-        ? new Date(Math.round(output.TestWindowStart * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.TestWindowStart)))
         : undefined,
   } as any;
 };
@@ -5085,11 +5088,11 @@ const deserializeAws_json1_1WindowSummary = (output: any, context: __SerdeContex
         : undefined,
     TestWindowEnd:
       output.TestWindowEnd !== undefined && output.TestWindowEnd !== null
-        ? new Date(Math.round(output.TestWindowEnd * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.TestWindowEnd)))
         : undefined,
     TestWindowStart:
       output.TestWindowStart !== undefined && output.TestWindowStart !== null
-        ? new Date(Math.round(output.TestWindowStart * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.TestWindowStart)))
         : undefined,
   } as any;
 };

--- a/clients/client-fsx/protocols/Aws_json1_1.ts
+++ b/clients/client-fsx/protocols/Aws_json1_1.ts
@@ -213,7 +213,10 @@ import {
   expectBoolean as __expectBoolean,
   expectInt32 as __expectInt32,
   expectLong as __expectLong,
+  expectNonNull as __expectNonNull,
+  expectNumber as __expectNumber,
   expectString as __expectString,
+  parseEpochTimestamp as __parseEpochTimestamp,
 } from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
@@ -4568,7 +4571,7 @@ const deserializeAws_json1_1AdministrativeAction = (output: any, context: __Serd
     ProgressPercent: __expectInt32(output.ProgressPercent),
     RequestTime:
       output.RequestTime !== undefined && output.RequestTime !== null
-        ? new Date(Math.round(output.RequestTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.RequestTime)))
         : undefined,
     Status: __expectString(output.Status),
     TargetFileSystemValues:
@@ -4637,7 +4640,7 @@ const deserializeAws_json1_1Backup = (output: any, context: __SerdeContext): Bac
     BackupId: __expectString(output.BackupId),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     DirectoryInformation:
       output.DirectoryInformation !== undefined && output.DirectoryInformation !== null
@@ -4854,10 +4857,12 @@ const deserializeAws_json1_1DataRepositoryTask = (output: any, context: __SerdeC
   return {
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     EndTime:
-      output.EndTime !== undefined && output.EndTime !== null ? new Date(Math.round(output.EndTime * 1000)) : undefined,
+      output.EndTime !== undefined && output.EndTime !== null
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.EndTime)))
+        : undefined,
     FailureDetails:
       output.FailureDetails !== undefined && output.FailureDetails !== null
         ? deserializeAws_json1_1DataRepositoryTaskFailureDetails(output.FailureDetails, context)
@@ -4875,7 +4880,7 @@ const deserializeAws_json1_1DataRepositoryTask = (output: any, context: __SerdeC
     ResourceARN: __expectString(output.ResourceARN),
     StartTime:
       output.StartTime !== undefined && output.StartTime !== null
-        ? new Date(Math.round(output.StartTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.StartTime)))
         : undefined,
     Status:
       output.Status !== undefined && output.Status !== null
@@ -4954,7 +4959,7 @@ const deserializeAws_json1_1DataRepositoryTaskStatus = (
     FailedCount: __expectLong(output.FailedCount),
     LastUpdatedTime:
       output.LastUpdatedTime !== undefined && output.LastUpdatedTime !== null
-        ? new Date(Math.round(output.LastUpdatedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastUpdatedTime)))
         : undefined,
     SucceededCount: __expectLong(output.SucceededCount),
     TotalCount: __expectLong(output.TotalCount),
@@ -5162,7 +5167,7 @@ const deserializeAws_json1_1FileSystem = (output: any, context: __SerdeContext):
         : undefined,
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     DNSName: __expectString(output.DNSName),
     FailureDetails:
@@ -5550,7 +5555,7 @@ const deserializeAws_json1_1StorageVirtualMachine = (output: any, context: __Ser
         : undefined,
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     Endpoints:
       output.Endpoints !== undefined && output.Endpoints !== null
@@ -5731,7 +5736,7 @@ const deserializeAws_json1_1Volume = (output: any, context: __SerdeContext): Vol
   return {
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     FileSystemId: __expectString(output.FileSystemId),
     Lifecycle: __expectString(output.Lifecycle),

--- a/clients/client-gamelift/protocols/Aws_json1_1.ts
+++ b/clients/client-gamelift/protocols/Aws_json1_1.ts
@@ -529,9 +529,12 @@ import {
   expectBoolean as __expectBoolean,
   expectInt32 as __expectInt32,
   expectLong as __expectLong,
+  expectNonNull as __expectNonNull,
+  expectNumber as __expectNumber,
   expectString as __expectString,
   limitedParseDouble as __limitedParseDouble,
   limitedParseFloat32 as __limitedParseFloat32,
+  parseEpochTimestamp as __parseEpochTimestamp,
   serializeFloat as __serializeFloat,
 } from "@aws-sdk/smithy-client";
 import {
@@ -11560,12 +11563,12 @@ const deserializeAws_json1_1Alias = (output: any, context: __SerdeContext): Alia
     AliasId: __expectString(output.AliasId),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     Description: __expectString(output.Description),
     LastUpdatedTime:
       output.LastUpdatedTime !== undefined && output.LastUpdatedTime !== null
-        ? new Date(Math.round(output.LastUpdatedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastUpdatedTime)))
         : undefined,
     Name: __expectString(output.Name),
     RoutingStrategy:
@@ -11613,7 +11616,7 @@ const deserializeAws_json1_1Build = (output: any, context: __SerdeContext): Buil
     BuildId: __expectString(output.BuildId),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     Name: __expectString(output.Name),
     OperatingSystem: __expectString(output.OperatingSystem),
@@ -12269,7 +12272,7 @@ const deserializeAws_json1_1Event = (output: any, context: __SerdeContext): Even
     EventId: __expectString(output.EventId),
     EventTime:
       output.EventTime !== undefined && output.EventTime !== null
-        ? new Date(Math.round(output.EventTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.EventTime)))
         : undefined,
     Message: __expectString(output.Message),
     PreSignedLogUrl: __expectString(output.PreSignedLogUrl),
@@ -12318,7 +12321,7 @@ const deserializeAws_json1_1FleetAttributes = (output: any, context: __SerdeCont
         : undefined,
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     Description: __expectString(output.Description),
     FleetArn: __expectString(output.FleetArn),
@@ -12352,7 +12355,7 @@ const deserializeAws_json1_1FleetAttributes = (output: any, context: __SerdeCont
         : undefined,
     TerminationTime:
       output.TerminationTime !== undefined && output.TerminationTime !== null
-        ? new Date(Math.round(output.TerminationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.TerminationTime)))
         : undefined,
   } as any;
 };
@@ -12464,15 +12467,15 @@ const deserializeAws_json1_1GameServer = (output: any, context: __SerdeContext):
     InstanceId: __expectString(output.InstanceId),
     LastClaimTime:
       output.LastClaimTime !== undefined && output.LastClaimTime !== null
-        ? new Date(Math.round(output.LastClaimTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastClaimTime)))
         : undefined,
     LastHealthCheckTime:
       output.LastHealthCheckTime !== undefined && output.LastHealthCheckTime !== null
-        ? new Date(Math.round(output.LastHealthCheckTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastHealthCheckTime)))
         : undefined,
     RegistrationTime:
       output.RegistrationTime !== undefined && output.RegistrationTime !== null
-        ? new Date(Math.round(output.RegistrationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.RegistrationTime)))
         : undefined,
     UtilizationStatus: __expectString(output.UtilizationStatus),
   } as any;
@@ -12484,7 +12487,7 @@ const deserializeAws_json1_1GameServerGroup = (output: any, context: __SerdeCont
     BalancingStrategy: __expectString(output.BalancingStrategy),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     GameServerGroupArn: __expectString(output.GameServerGroupArn),
     GameServerGroupName: __expectString(output.GameServerGroupName),
@@ -12495,7 +12498,7 @@ const deserializeAws_json1_1GameServerGroup = (output: any, context: __SerdeCont
         : undefined,
     LastUpdatedTime:
       output.LastUpdatedTime !== undefined && output.LastUpdatedTime !== null
-        ? new Date(Math.round(output.LastUpdatedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastUpdatedTime)))
         : undefined,
     RoleArn: __expectString(output.RoleArn),
     Status: __expectString(output.Status),
@@ -12567,7 +12570,7 @@ const deserializeAws_json1_1GameSession = (output: any, context: __SerdeContext)
   return {
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     CreatorId: __expectString(output.CreatorId),
     CurrentPlayerSessionCount: __expectInt32(output.CurrentPlayerSessionCount),
@@ -12591,7 +12594,7 @@ const deserializeAws_json1_1GameSession = (output: any, context: __SerdeContext)
     StatusReason: __expectString(output.StatusReason),
     TerminationTime:
       output.TerminationTime !== undefined && output.TerminationTime !== null
-        ? new Date(Math.round(output.TerminationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.TerminationTime)))
         : undefined,
   } as any;
 };
@@ -12657,7 +12660,9 @@ const deserializeAws_json1_1GameSessionPlacement = (output: any, context: __Serd
   return {
     DnsName: __expectString(output.DnsName),
     EndTime:
-      output.EndTime !== undefined && output.EndTime !== null ? new Date(Math.round(output.EndTime * 1000)) : undefined,
+      output.EndTime !== undefined && output.EndTime !== null
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.EndTime)))
+        : undefined,
     GameProperties:
       output.GameProperties !== undefined && output.GameProperties !== null
         ? deserializeAws_json1_1GamePropertyList(output.GameProperties, context)
@@ -12683,7 +12688,7 @@ const deserializeAws_json1_1GameSessionPlacement = (output: any, context: __Serd
     Port: __expectInt32(output.Port),
     StartTime:
       output.StartTime !== undefined && output.StartTime !== null
-        ? new Date(Math.round(output.StartTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.StartTime)))
         : undefined,
     Status: __expectString(output.Status),
   } as any;
@@ -12783,7 +12788,7 @@ const deserializeAws_json1_1Instance = (output: any, context: __SerdeContext): I
   return {
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     DnsName: __expectString(output.DnsName),
     FleetArn: __expectString(output.FleetArn),
@@ -13082,7 +13087,7 @@ const deserializeAws_json1_1MatchmakingConfiguration = (
     ConfigurationArn: __expectString(output.ConfigurationArn),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     CustomEventData: __expectString(output.CustomEventData),
     Description: __expectString(output.Description),
@@ -13122,7 +13127,7 @@ const deserializeAws_json1_1MatchmakingRuleSet = (output: any, context: __SerdeC
   return {
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     RuleSetArn: __expectString(output.RuleSetArn),
     RuleSetBody: __expectString(output.RuleSetBody),
@@ -13146,7 +13151,9 @@ const deserializeAws_json1_1MatchmakingTicket = (output: any, context: __SerdeCo
     ConfigurationArn: __expectString(output.ConfigurationArn),
     ConfigurationName: __expectString(output.ConfigurationName),
     EndTime:
-      output.EndTime !== undefined && output.EndTime !== null ? new Date(Math.round(output.EndTime * 1000)) : undefined,
+      output.EndTime !== undefined && output.EndTime !== null
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.EndTime)))
+        : undefined,
     EstimatedWaitTime: __expectInt32(output.EstimatedWaitTime),
     GameSessionConnectionInfo:
       output.GameSessionConnectionInfo !== undefined && output.GameSessionConnectionInfo !== null
@@ -13158,7 +13165,7 @@ const deserializeAws_json1_1MatchmakingTicket = (output: any, context: __SerdeCo
         : undefined,
     StartTime:
       output.StartTime !== undefined && output.StartTime !== null
-        ? new Date(Math.round(output.StartTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.StartTime)))
         : undefined,
     Status: __expectString(output.Status),
     StatusMessage: __expectString(output.StatusMessage),
@@ -13301,7 +13308,7 @@ const deserializeAws_json1_1PlayerSession = (output: any, context: __SerdeContex
   return {
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     DnsName: __expectString(output.DnsName),
     FleetArn: __expectString(output.FleetArn),
@@ -13315,7 +13322,7 @@ const deserializeAws_json1_1PlayerSession = (output: any, context: __SerdeContex
     Status: __expectString(output.Status),
     TerminationTime:
       output.TerminationTime !== undefined && output.TerminationTime !== null
-        ? new Date(Math.round(output.TerminationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.TerminationTime)))
         : undefined,
   } as any;
 };
@@ -13494,7 +13501,7 @@ const deserializeAws_json1_1Script = (output: any, context: __SerdeContext): Scr
   return {
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     Name: __expectString(output.Name),
     ScriptArn: __expectString(output.ScriptArn),
@@ -13855,11 +13862,11 @@ const deserializeAws_json1_1VpcPeeringAuthorization = (
   return {
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     ExpirationTime:
       output.ExpirationTime !== undefined && output.ExpirationTime !== null
-        ? new Date(Math.round(output.ExpirationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.ExpirationTime)))
         : undefined,
     GameLiftAwsAccountId: __expectString(output.GameLiftAwsAccountId),
     PeerVpcAwsAccountId: __expectString(output.PeerVpcAwsAccountId),

--- a/clients/client-global-accelerator/protocols/Aws_json1_1.ts
+++ b/clients/client-global-accelerator/protocols/Aws_json1_1.ts
@@ -273,8 +273,11 @@ import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@a
 import {
   expectBoolean as __expectBoolean,
   expectInt32 as __expectInt32,
+  expectNonNull as __expectNonNull,
+  expectNumber as __expectNumber,
   expectString as __expectString,
   limitedParseFloat32 as __limitedParseFloat32,
+  parseEpochTimestamp as __parseEpochTimestamp,
   serializeFloat as __serializeFloat,
 } from "@aws-sdk/smithy-client";
 import {
@@ -5606,7 +5609,7 @@ const deserializeAws_json1_1Accelerator = (output: any, context: __SerdeContext)
     AcceleratorArn: __expectString(output.AcceleratorArn),
     CreatedTime:
       output.CreatedTime !== undefined && output.CreatedTime !== null
-        ? new Date(Math.round(output.CreatedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreatedTime)))
         : undefined,
     DnsName: __expectString(output.DnsName),
     Enabled: __expectBoolean(output.Enabled),
@@ -5617,7 +5620,7 @@ const deserializeAws_json1_1Accelerator = (output: any, context: __SerdeContext)
         : undefined,
     LastModifiedTime:
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
-        ? new Date(Math.round(output.LastModifiedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastModifiedTime)))
         : undefined,
     Name: __expectString(output.Name),
     Status: __expectString(output.Status),
@@ -5726,7 +5729,7 @@ const deserializeAws_json1_1ByoipCidrEvent = (output: any, context: __SerdeConte
     Message: __expectString(output.Message),
     Timestamp:
       output.Timestamp !== undefined && output.Timestamp !== null
-        ? new Date(Math.round(output.Timestamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.Timestamp)))
         : undefined,
   } as any;
 };
@@ -5845,7 +5848,7 @@ const deserializeAws_json1_1CustomRoutingAccelerator = (
     AcceleratorArn: __expectString(output.AcceleratorArn),
     CreatedTime:
       output.CreatedTime !== undefined && output.CreatedTime !== null
-        ? new Date(Math.round(output.CreatedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreatedTime)))
         : undefined,
     DnsName: __expectString(output.DnsName),
     Enabled: __expectBoolean(output.Enabled),
@@ -5856,7 +5859,7 @@ const deserializeAws_json1_1CustomRoutingAccelerator = (
         : undefined,
     LastModifiedTime:
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
-        ? new Date(Math.round(output.LastModifiedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastModifiedTime)))
         : undefined,
     Name: __expectString(output.Name),
     Status: __expectString(output.Status),

--- a/clients/client-glue/protocols/Aws_json1_1.ts
+++ b/clients/client-glue/protocols/Aws_json1_1.ts
@@ -831,8 +831,11 @@ import {
   expectBoolean as __expectBoolean,
   expectInt32 as __expectInt32,
   expectLong as __expectLong,
+  expectNonNull as __expectNonNull,
+  expectNumber as __expectNumber,
   expectString as __expectString,
   limitedParseDouble as __limitedParseDouble,
+  parseEpochTimestamp as __parseEpochTimestamp,
   serializeFloat as __serializeFloat,
 } from "@aws-sdk/smithy-client";
 import {
@@ -20885,7 +20888,7 @@ const deserializeAws_json1_1Blueprint = (output: any, context: __SerdeContext): 
     BlueprintServiceLocation: __expectString(output.BlueprintServiceLocation),
     CreatedOn:
       output.CreatedOn !== undefined && output.CreatedOn !== null
-        ? new Date(Math.round(output.CreatedOn * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreatedOn)))
         : undefined,
     Description: __expectString(output.Description),
     ErrorMessage: __expectString(output.ErrorMessage),
@@ -20895,7 +20898,7 @@ const deserializeAws_json1_1Blueprint = (output: any, context: __SerdeContext): 
         : undefined,
     LastModifiedOn:
       output.LastModifiedOn !== undefined && output.LastModifiedOn !== null
-        ? new Date(Math.round(output.LastModifiedOn * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastModifiedOn)))
         : undefined,
     Name: __expectString(output.Name),
     ParameterSpec: __expectString(output.ParameterSpec),
@@ -20926,7 +20929,7 @@ const deserializeAws_json1_1BlueprintRun = (output: any, context: __SerdeContext
     BlueprintName: __expectString(output.BlueprintName),
     CompletedOn:
       output.CompletedOn !== undefined && output.CompletedOn !== null
-        ? new Date(Math.round(output.CompletedOn * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CompletedOn)))
         : undefined,
     ErrorMessage: __expectString(output.ErrorMessage),
     Parameters: __expectString(output.Parameters),
@@ -20935,7 +20938,7 @@ const deserializeAws_json1_1BlueprintRun = (output: any, context: __SerdeContext
     RunId: __expectString(output.RunId),
     StartedOn:
       output.StartedOn !== undefined && output.StartedOn !== null
-        ? new Date(Math.round(output.StartedOn * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.StartedOn)))
         : undefined,
     State: __expectString(output.State),
     WorkflowName: __expectString(output.WorkflowName),
@@ -21002,7 +21005,7 @@ const deserializeAws_json1_1CatalogImportStatus = (output: any, context: __Serde
     ImportCompleted: __expectBoolean(output.ImportCompleted),
     ImportTime:
       output.ImportTime !== undefined && output.ImportTime !== null
-        ? new Date(Math.round(output.ImportTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.ImportTime)))
         : undefined,
     ImportedBy: __expectString(output.ImportedBy),
   } as any;
@@ -21205,7 +21208,7 @@ const deserializeAws_json1_1ColumnStatistics = (output: any, context: __SerdeCon
   return {
     AnalyzedTime:
       output.AnalyzedTime !== undefined && output.AnalyzedTime !== null
-        ? new Date(Math.round(output.AnalyzedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.AnalyzedTime)))
         : undefined,
     ColumnName: __expectString(output.ColumnName),
     ColumnType: __expectString(output.ColumnType),
@@ -21371,13 +21374,13 @@ const deserializeAws_json1_1Connection = (output: any, context: __SerdeContext):
     ConnectionType: __expectString(output.ConnectionType),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     Description: __expectString(output.Description),
     LastUpdatedBy: __expectString(output.LastUpdatedBy),
     LastUpdatedTime:
       output.LastUpdatedTime !== undefined && output.LastUpdatedTime !== null
-        ? new Date(Math.round(output.LastUpdatedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastUpdatedTime)))
         : undefined,
     MatchCriteria:
       output.MatchCriteria !== undefined && output.MatchCriteria !== null
@@ -21443,14 +21446,14 @@ const deserializeAws_json1_1Crawl = (output: any, context: __SerdeContext): Craw
   return {
     CompletedOn:
       output.CompletedOn !== undefined && output.CompletedOn !== null
-        ? new Date(Math.round(output.CompletedOn * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CompletedOn)))
         : undefined,
     ErrorMessage: __expectString(output.ErrorMessage),
     LogGroup: __expectString(output.LogGroup),
     LogStream: __expectString(output.LogStream),
     StartedOn:
       output.StartedOn !== undefined && output.StartedOn !== null
-        ? new Date(Math.round(output.StartedOn * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.StartedOn)))
         : undefined,
     State: __expectString(output.State),
   } as any;
@@ -21467,7 +21470,7 @@ const deserializeAws_json1_1Crawler = (output: any, context: __SerdeContext): Cr
     CrawlerSecurityConfiguration: __expectString(output.CrawlerSecurityConfiguration),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     DatabaseName: __expectString(output.DatabaseName),
     Description: __expectString(output.Description),
@@ -21477,7 +21480,7 @@ const deserializeAws_json1_1Crawler = (output: any, context: __SerdeContext): Cr
         : undefined,
     LastUpdated:
       output.LastUpdated !== undefined && output.LastUpdated !== null
-        ? new Date(Math.round(output.LastUpdated * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastUpdated)))
         : undefined,
     LineageConfiguration:
       output.LineageConfiguration !== undefined && output.LineageConfiguration !== null
@@ -21668,7 +21671,7 @@ const deserializeAws_json1_1CreateDevEndpointResponse = (
     AvailabilityZone: __expectString(output.AvailabilityZone),
     CreatedTimestamp:
       output.CreatedTimestamp !== undefined && output.CreatedTimestamp !== null
-        ? new Date(Math.round(output.CreatedTimestamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreatedTimestamp)))
         : undefined,
     EndpointName: __expectString(output.EndpointName),
     ExtraJarsS3Path: __expectString(output.ExtraJarsS3Path),
@@ -21769,7 +21772,7 @@ const deserializeAws_json1_1CreateSecurityConfigurationResponse = (
   return {
     CreatedTimestamp:
       output.CreatedTimestamp !== undefined && output.CreatedTimestamp !== null
-        ? new Date(Math.round(output.CreatedTimestamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreatedTimestamp)))
         : undefined,
     Name: __expectString(output.Name),
   } as any;
@@ -21804,7 +21807,7 @@ const deserializeAws_json1_1CsvClassifier = (output: any, context: __SerdeContex
     ContainsHeader: __expectString(output.ContainsHeader),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     Delimiter: __expectString(output.Delimiter),
     DisableValueTrimming: __expectBoolean(output.DisableValueTrimming),
@@ -21814,7 +21817,7 @@ const deserializeAws_json1_1CsvClassifier = (output: any, context: __SerdeContex
         : undefined,
     LastUpdated:
       output.LastUpdated !== undefined && output.LastUpdated !== null
-        ? new Date(Math.round(output.LastUpdated * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastUpdated)))
         : undefined,
     Name: __expectString(output.Name),
     QuoteSymbol: __expectString(output.QuoteSymbol),
@@ -21864,7 +21867,7 @@ const deserializeAws_json1_1Database = (output: any, context: __SerdeContext): D
         : undefined,
     CreateTime:
       output.CreateTime !== undefined && output.CreateTime !== null
-        ? new Date(Math.round(output.CreateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreateTime)))
         : undefined,
     Description: __expectString(output.Description),
     LocationUri: __expectString(output.LocationUri),
@@ -21927,11 +21930,11 @@ const deserializeAws_json1_1DateColumnStatisticsData = (
   return {
     MaximumValue:
       output.MaximumValue !== undefined && output.MaximumValue !== null
-        ? new Date(Math.round(output.MaximumValue * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.MaximumValue)))
         : undefined,
     MinimumValue:
       output.MinimumValue !== undefined && output.MinimumValue !== null
-        ? new Date(Math.round(output.MinimumValue * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.MinimumValue)))
         : undefined,
     NumberOfDistinctValues: __expectLong(output.NumberOfDistinctValues),
     NumberOfNulls: __expectLong(output.NumberOfNulls),
@@ -22128,7 +22131,7 @@ const deserializeAws_json1_1DevEndpoint = (output: any, context: __SerdeContext)
     AvailabilityZone: __expectString(output.AvailabilityZone),
     CreatedTimestamp:
       output.CreatedTimestamp !== undefined && output.CreatedTimestamp !== null
-        ? new Date(Math.round(output.CreatedTimestamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreatedTimestamp)))
         : undefined,
     EndpointName: __expectString(output.EndpointName),
     ExtraJarsS3Path: __expectString(output.ExtraJarsS3Path),
@@ -22137,7 +22140,7 @@ const deserializeAws_json1_1DevEndpoint = (output: any, context: __SerdeContext)
     GlueVersion: __expectString(output.GlueVersion),
     LastModifiedTimestamp:
       output.LastModifiedTimestamp !== undefined && output.LastModifiedTimestamp !== null
-        ? new Date(Math.round(output.LastModifiedTimestamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastModifiedTimestamp)))
         : undefined,
     LastUpdateStatus: __expectString(output.LastUpdateStatus),
     NumberOfNodes: __expectInt32(output.NumberOfNodes),
@@ -22663,13 +22666,13 @@ const deserializeAws_json1_1GetMLTaskRunResponse = (output: any, context: __Serd
   return {
     CompletedOn:
       output.CompletedOn !== undefined && output.CompletedOn !== null
-        ? new Date(Math.round(output.CompletedOn * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CompletedOn)))
         : undefined,
     ErrorString: __expectString(output.ErrorString),
     ExecutionTime: __expectInt32(output.ExecutionTime),
     LastModifiedOn:
       output.LastModifiedOn !== undefined && output.LastModifiedOn !== null
-        ? new Date(Math.round(output.LastModifiedOn * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastModifiedOn)))
         : undefined,
     LogGroupName: __expectString(output.LogGroupName),
     Properties:
@@ -22678,7 +22681,7 @@ const deserializeAws_json1_1GetMLTaskRunResponse = (output: any, context: __Serd
         : undefined,
     StartedOn:
       output.StartedOn !== undefined && output.StartedOn !== null
-        ? new Date(Math.round(output.StartedOn * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.StartedOn)))
         : undefined,
     Status: __expectString(output.Status),
     TaskRunId: __expectString(output.TaskRunId),
@@ -22700,7 +22703,7 @@ const deserializeAws_json1_1GetMLTransformResponse = (output: any, context: __Se
   return {
     CreatedOn:
       output.CreatedOn !== undefined && output.CreatedOn !== null
-        ? new Date(Math.round(output.CreatedOn * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreatedOn)))
         : undefined,
     Description: __expectString(output.Description),
     EvaluationMetrics:
@@ -22715,7 +22718,7 @@ const deserializeAws_json1_1GetMLTransformResponse = (output: any, context: __Se
     LabelCount: __expectInt32(output.LabelCount),
     LastModifiedOn:
       output.LastModifiedOn !== undefined && output.LastModifiedOn !== null
-        ? new Date(Math.round(output.LastModifiedOn * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastModifiedOn)))
         : undefined,
     MaxCapacity: __limitedParseDouble(output.MaxCapacity),
     MaxRetries: __expectInt32(output.MaxRetries),
@@ -22835,13 +22838,13 @@ const deserializeAws_json1_1GetResourcePolicyResponse = (
   return {
     CreateTime:
       output.CreateTime !== undefined && output.CreateTime !== null
-        ? new Date(Math.round(output.CreateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreateTime)))
         : undefined,
     PolicyHash: __expectString(output.PolicyHash),
     PolicyInJson: __expectString(output.PolicyInJson),
     UpdateTime:
       output.UpdateTime !== undefined && output.UpdateTime !== null
-        ? new Date(Math.round(output.UpdateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.UpdateTime)))
         : undefined,
   } as any;
 };
@@ -23090,13 +23093,13 @@ const deserializeAws_json1_1GluePolicy = (output: any, context: __SerdeContext):
   return {
     CreateTime:
       output.CreateTime !== undefined && output.CreateTime !== null
-        ? new Date(Math.round(output.CreateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreateTime)))
         : undefined,
     PolicyHash: __expectString(output.PolicyHash),
     PolicyInJson: __expectString(output.PolicyInJson),
     UpdateTime:
       output.UpdateTime !== undefined && output.UpdateTime !== null
-        ? new Date(Math.round(output.UpdateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.UpdateTime)))
         : undefined,
   } as any;
 };
@@ -23126,13 +23129,13 @@ const deserializeAws_json1_1GrokClassifier = (output: any, context: __SerdeConte
     Classification: __expectString(output.Classification),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     CustomPatterns: __expectString(output.CustomPatterns),
     GrokPattern: __expectString(output.GrokPattern),
     LastUpdated:
       output.LastUpdated !== undefined && output.LastUpdated !== null
-        ? new Date(Math.round(output.LastUpdated * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastUpdated)))
         : undefined,
     Name: __expectString(output.Name),
     Version: __expectLong(output.Version),
@@ -23233,7 +23236,7 @@ const deserializeAws_json1_1Job = (output: any, context: __SerdeContext): Job =>
         : undefined,
     CreatedOn:
       output.CreatedOn !== undefined && output.CreatedOn !== null
-        ? new Date(Math.round(output.CreatedOn * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreatedOn)))
         : undefined,
     DefaultArguments:
       output.DefaultArguments !== undefined && output.DefaultArguments !== null
@@ -23247,7 +23250,7 @@ const deserializeAws_json1_1Job = (output: any, context: __SerdeContext): Job =>
     GlueVersion: __expectString(output.GlueVersion),
     LastModifiedOn:
       output.LastModifiedOn !== undefined && output.LastModifiedOn !== null
-        ? new Date(Math.round(output.LastModifiedOn * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastModifiedOn)))
         : undefined,
     LogUri: __expectString(output.LogUri),
     MaxCapacity: __limitedParseDouble(output.MaxCapacity),
@@ -23337,7 +23340,7 @@ const deserializeAws_json1_1JobRun = (output: any, context: __SerdeContext): Job
     Attempt: __expectInt32(output.Attempt),
     CompletedOn:
       output.CompletedOn !== undefined && output.CompletedOn !== null
-        ? new Date(Math.round(output.CompletedOn * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CompletedOn)))
         : undefined,
     ErrorMessage: __expectString(output.ErrorMessage),
     ExecutionTime: __expectInt32(output.ExecutionTime),
@@ -23347,7 +23350,7 @@ const deserializeAws_json1_1JobRun = (output: any, context: __SerdeContext): Job
     JobRunState: __expectString(output.JobRunState),
     LastModifiedOn:
       output.LastModifiedOn !== undefined && output.LastModifiedOn !== null
-        ? new Date(Math.round(output.LastModifiedOn * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastModifiedOn)))
         : undefined,
     LogGroupName: __expectString(output.LogGroupName),
     MaxCapacity: __limitedParseDouble(output.MaxCapacity),
@@ -23364,7 +23367,7 @@ const deserializeAws_json1_1JobRun = (output: any, context: __SerdeContext): Job
     SecurityConfiguration: __expectString(output.SecurityConfiguration),
     StartedOn:
       output.StartedOn !== undefined && output.StartedOn !== null
-        ? new Date(Math.round(output.StartedOn * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.StartedOn)))
         : undefined,
     Timeout: __expectInt32(output.Timeout),
     TriggerName: __expectString(output.TriggerName),
@@ -23387,12 +23390,12 @@ const deserializeAws_json1_1JsonClassifier = (output: any, context: __SerdeConte
   return {
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     JsonPath: __expectString(output.JsonPath),
     LastUpdated:
       output.LastUpdated !== undefined && output.LastUpdated !== null
-        ? new Date(Math.round(output.LastUpdated * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastUpdated)))
         : undefined,
     Name: __expectString(output.Name),
     Version: __expectLong(output.Version),
@@ -23433,7 +23436,7 @@ const deserializeAws_json1_1LastActiveDefinition = (output: any, context: __Serd
     Description: __expectString(output.Description),
     LastModifiedOn:
       output.LastModifiedOn !== undefined && output.LastModifiedOn !== null
-        ? new Date(Math.round(output.LastModifiedOn * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastModifiedOn)))
         : undefined,
     ParameterSpec: __expectString(output.ParameterSpec),
   } as any;
@@ -23447,7 +23450,7 @@ const deserializeAws_json1_1LastCrawlInfo = (output: any, context: __SerdeContex
     MessagePrefix: __expectString(output.MessagePrefix),
     StartTime:
       output.StartTime !== undefined && output.StartTime !== null
-        ? new Date(Math.round(output.StartTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.StartTime)))
         : undefined,
     Status: __expectString(output.Status),
   } as any;
@@ -23667,7 +23670,7 @@ const deserializeAws_json1_1MLTransform = (output: any, context: __SerdeContext)
   return {
     CreatedOn:
       output.CreatedOn !== undefined && output.CreatedOn !== null
-        ? new Date(Math.round(output.CreatedOn * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreatedOn)))
         : undefined,
     Description: __expectString(output.Description),
     EvaluationMetrics:
@@ -23682,7 +23685,7 @@ const deserializeAws_json1_1MLTransform = (output: any, context: __SerdeContext)
     LabelCount: __expectInt32(output.LabelCount),
     LastModifiedOn:
       output.LastModifiedOn !== undefined && output.LastModifiedOn !== null
-        ? new Date(Math.round(output.LastModifiedOn * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastModifiedOn)))
         : undefined,
     MaxCapacity: __limitedParseDouble(output.MaxCapacity),
     MaxRetries: __expectInt32(output.MaxRetries),
@@ -23887,16 +23890,16 @@ const deserializeAws_json1_1Partition = (output: any, context: __SerdeContext): 
     CatalogId: __expectString(output.CatalogId),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     DatabaseName: __expectString(output.DatabaseName),
     LastAccessTime:
       output.LastAccessTime !== undefined && output.LastAccessTime !== null
-        ? new Date(Math.round(output.LastAccessTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastAccessTime)))
         : undefined,
     LastAnalyzedTime:
       output.LastAnalyzedTime !== undefined && output.LastAnalyzedTime !== null
-        ? new Date(Math.round(output.LastAnalyzedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastAnalyzedTime)))
         : undefined,
     Parameters:
       output.Parameters !== undefined && output.Parameters !== null
@@ -24442,7 +24445,7 @@ const deserializeAws_json1_1SecurityConfiguration = (output: any, context: __Ser
   return {
     CreatedTimeStamp:
       output.CreatedTimeStamp !== undefined && output.CreatedTimeStamp !== null
-        ? new Date(Math.round(output.CreatedTimeStamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreatedTimeStamp)))
         : undefined,
     EncryptionConfiguration:
       output.EncryptionConfiguration !== undefined && output.EncryptionConfiguration !== null
@@ -24683,7 +24686,7 @@ const deserializeAws_json1_1Table = (output: any, context: __SerdeContext): Tabl
     CatalogId: __expectString(output.CatalogId),
     CreateTime:
       output.CreateTime !== undefined && output.CreateTime !== null
-        ? new Date(Math.round(output.CreateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreateTime)))
         : undefined,
     CreatedBy: __expectString(output.CreatedBy),
     DatabaseName: __expectString(output.DatabaseName),
@@ -24691,11 +24694,11 @@ const deserializeAws_json1_1Table = (output: any, context: __SerdeContext): Tabl
     IsRegisteredWithLakeFormation: __expectBoolean(output.IsRegisteredWithLakeFormation),
     LastAccessTime:
       output.LastAccessTime !== undefined && output.LastAccessTime !== null
-        ? new Date(Math.round(output.LastAccessTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastAccessTime)))
         : undefined,
     LastAnalyzedTime:
       output.LastAnalyzedTime !== undefined && output.LastAnalyzedTime !== null
-        ? new Date(Math.round(output.LastAnalyzedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastAnalyzedTime)))
         : undefined,
     Name: __expectString(output.Name),
     Owner: __expectString(output.Owner),
@@ -24719,7 +24722,7 @@ const deserializeAws_json1_1Table = (output: any, context: __SerdeContext): Tabl
         : undefined,
     UpdateTime:
       output.UpdateTime !== undefined && output.UpdateTime !== null
-        ? new Date(Math.round(output.UpdateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.UpdateTime)))
         : undefined,
     ViewExpandedText: __expectString(output.ViewExpandedText),
     ViewOriginalText: __expectString(output.ViewOriginalText),
@@ -24818,13 +24821,13 @@ const deserializeAws_json1_1TaskRun = (output: any, context: __SerdeContext): Ta
   return {
     CompletedOn:
       output.CompletedOn !== undefined && output.CompletedOn !== null
-        ? new Date(Math.round(output.CompletedOn * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CompletedOn)))
         : undefined,
     ErrorString: __expectString(output.ErrorString),
     ExecutionTime: __expectInt32(output.ExecutionTime),
     LastModifiedOn:
       output.LastModifiedOn !== undefined && output.LastModifiedOn !== null
-        ? new Date(Math.round(output.LastModifiedOn * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastModifiedOn)))
         : undefined,
     LogGroupName: __expectString(output.LogGroupName),
     Properties:
@@ -24833,7 +24836,7 @@ const deserializeAws_json1_1TaskRun = (output: any, context: __SerdeContext): Ta
         : undefined,
     StartedOn:
       output.StartedOn !== undefined && output.StartedOn !== null
-        ? new Date(Math.round(output.StartedOn * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.StartedOn)))
         : undefined,
     Status: __expectString(output.Status),
     TaskRunId: __expectString(output.TaskRunId),
@@ -25128,7 +25131,7 @@ const deserializeAws_json1_1UserDefinedFunction = (output: any, context: __Serde
     ClassName: __expectString(output.ClassName),
     CreateTime:
       output.CreateTime !== undefined && output.CreateTime !== null
-        ? new Date(Math.round(output.CreateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreateTime)))
         : undefined,
     DatabaseName: __expectString(output.DatabaseName),
     FunctionName: __expectString(output.FunctionName),
@@ -25186,7 +25189,7 @@ const deserializeAws_json1_1Workflow = (output: any, context: __SerdeContext): W
         : undefined,
     CreatedOn:
       output.CreatedOn !== undefined && output.CreatedOn !== null
-        ? new Date(Math.round(output.CreatedOn * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreatedOn)))
         : undefined,
     DefaultRunProperties:
       output.DefaultRunProperties !== undefined && output.DefaultRunProperties !== null
@@ -25199,7 +25202,7 @@ const deserializeAws_json1_1Workflow = (output: any, context: __SerdeContext): W
         : undefined,
     LastModifiedOn:
       output.LastModifiedOn !== undefined && output.LastModifiedOn !== null
-        ? new Date(Math.round(output.LastModifiedOn * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastModifiedOn)))
         : undefined,
     LastRun:
       output.LastRun !== undefined && output.LastRun !== null
@@ -25238,7 +25241,7 @@ const deserializeAws_json1_1WorkflowRun = (output: any, context: __SerdeContext)
   return {
     CompletedOn:
       output.CompletedOn !== undefined && output.CompletedOn !== null
-        ? new Date(Math.round(output.CompletedOn * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CompletedOn)))
         : undefined,
     ErrorMessage: __expectString(output.ErrorMessage),
     Graph:
@@ -25249,7 +25252,7 @@ const deserializeAws_json1_1WorkflowRun = (output: any, context: __SerdeContext)
     PreviousRunId: __expectString(output.PreviousRunId),
     StartedOn:
       output.StartedOn !== undefined && output.StartedOn !== null
-        ? new Date(Math.round(output.StartedOn * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.StartedOn)))
         : undefined,
     StartingEventBatchCondition:
       output.StartingEventBatchCondition !== undefined && output.StartingEventBatchCondition !== null
@@ -25321,11 +25324,11 @@ const deserializeAws_json1_1XMLClassifier = (output: any, context: __SerdeContex
     Classification: __expectString(output.Classification),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     LastUpdated:
       output.LastUpdated !== undefined && output.LastUpdated !== null
-        ? new Date(Math.round(output.LastUpdated * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastUpdated)))
         : undefined,
     Name: __expectString(output.Name),
     RowTag: __expectString(output.RowTag),

--- a/clients/client-greengrassv2/protocols/Aws_restJson1.ts
+++ b/clients/client-greengrassv2/protocols/Aws_restJson1.ts
@@ -106,10 +106,12 @@ import {
   expectInt32 as __expectInt32,
   expectLong as __expectLong,
   expectNonNull as __expectNonNull,
+  expectNumber as __expectNumber,
   expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   limitedParseDouble as __limitedParseDouble,
+  parseEpochTimestamp as __parseEpochTimestamp,
   serializeFloat as __serializeFloat,
   strictParseInt32 as __strictParseInt32,
 } from "@aws-sdk/smithy-client";
@@ -1169,7 +1171,7 @@ export const deserializeAws_restJson1CreateComponentVersionCommand = async (
     contents.componentVersion = __expectString(data.componentVersion);
   }
   if (data.creationTimestamp !== undefined && data.creationTimestamp !== null) {
-    contents.creationTimestamp = new Date(Math.round(data.creationTimestamp * 1000));
+    contents.creationTimestamp = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.creationTimestamp)));
   }
   if (data.status !== undefined && data.status !== null) {
     contents.status = deserializeAws_restJson1CloudComponentStatus(data.status, context);
@@ -1577,7 +1579,7 @@ export const deserializeAws_restJson1DescribeComponentCommand = async (
     contents.componentVersion = __expectString(data.componentVersion);
   }
   if (data.creationTimestamp !== undefined && data.creationTimestamp !== null) {
-    contents.creationTimestamp = new Date(Math.round(data.creationTimestamp * 1000));
+    contents.creationTimestamp = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.creationTimestamp)));
   }
   if (data.description !== undefined && data.description !== null) {
     contents.description = __expectString(data.description);
@@ -1876,7 +1878,9 @@ export const deserializeAws_restJson1GetCoreDeviceCommand = async (
     contents.coreVersion = __expectString(data.coreVersion);
   }
   if (data.lastStatusUpdateTimestamp !== undefined && data.lastStatusUpdateTimestamp !== null) {
-    contents.lastStatusUpdateTimestamp = new Date(Math.round(data.lastStatusUpdateTimestamp * 1000));
+    contents.lastStatusUpdateTimestamp = __expectNonNull(
+      __parseEpochTimestamp(__expectNumber(data.lastStatusUpdateTimestamp))
+    );
   }
   if (data.platform !== undefined && data.platform !== null) {
     contents.platform = __expectString(data.platform);
@@ -1987,7 +1991,7 @@ export const deserializeAws_restJson1GetDeploymentCommand = async (
     contents.components = deserializeAws_restJson1ComponentDeploymentSpecifications(data.components, context);
   }
   if (data.creationTimestamp !== undefined && data.creationTimestamp !== null) {
-    contents.creationTimestamp = new Date(Math.round(data.creationTimestamp * 1000));
+    contents.creationTimestamp = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.creationTimestamp)));
   }
   if (data.deploymentId !== undefined && data.deploymentId !== null) {
     contents.deploymentId = __expectString(data.deploymentId);
@@ -3787,7 +3791,7 @@ const deserializeAws_restJson1AssociatedClientDevice = (
   return {
     associationTimestamp:
       output.associationTimestamp !== undefined && output.associationTimestamp !== null
-        ? new Date(Math.round(output.associationTimestamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.associationTimestamp)))
         : undefined,
     thingName: __expectString(output.thingName),
   } as any;
@@ -3897,7 +3901,7 @@ const deserializeAws_restJson1ComponentLatestVersion = (
     componentVersion: __expectString(output.componentVersion),
     creationTimestamp:
       output.creationTimestamp !== undefined && output.creationTimestamp !== null
-        ? new Date(Math.round(output.creationTimestamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.creationTimestamp)))
         : undefined,
     description: __expectString(output.description),
     platforms:
@@ -3980,7 +3984,7 @@ const deserializeAws_restJson1CoreDevice = (output: any, context: __SerdeContext
     coreDeviceThingName: __expectString(output.coreDeviceThingName),
     lastStatusUpdateTimestamp:
       output.lastStatusUpdateTimestamp !== undefined && output.lastStatusUpdateTimestamp !== null
-        ? new Date(Math.round(output.lastStatusUpdateTimestamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastStatusUpdateTimestamp)))
         : undefined,
     status: __expectString(output.status),
   } as any;
@@ -4001,7 +4005,7 @@ const deserializeAws_restJson1Deployment = (output: any, context: __SerdeContext
   return {
     creationTimestamp:
       output.creationTimestamp !== undefined && output.creationTimestamp !== null
-        ? new Date(Math.round(output.creationTimestamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.creationTimestamp)))
         : undefined,
     deploymentId: __expectString(output.deploymentId),
     deploymentName: __expectString(output.deploymentName),
@@ -4106,7 +4110,7 @@ const deserializeAws_restJson1EffectiveDeployment = (output: any, context: __Ser
     coreDeviceExecutionStatus: __expectString(output.coreDeviceExecutionStatus),
     creationTimestamp:
       output.creationTimestamp !== undefined && output.creationTimestamp !== null
-        ? new Date(Math.round(output.creationTimestamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.creationTimestamp)))
         : undefined,
     deploymentId: __expectString(output.deploymentId),
     deploymentName: __expectString(output.deploymentName),
@@ -4115,7 +4119,7 @@ const deserializeAws_restJson1EffectiveDeployment = (output: any, context: __Ser
     iotJobId: __expectString(output.iotJobId),
     modifiedTimestamp:
       output.modifiedTimestamp !== undefined && output.modifiedTimestamp !== null
-        ? new Date(Math.round(output.modifiedTimestamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.modifiedTimestamp)))
         : undefined,
     reason: __expectString(output.reason),
     targetArn: __expectString(output.targetArn),

--- a/clients/client-groundstation/protocols/Aws_restJson1.ts
+++ b/clients/client-groundstation/protocols/Aws_restJson1.ts
@@ -94,10 +94,12 @@ import {
   expectBoolean as __expectBoolean,
   expectInt32 as __expectInt32,
   expectNonNull as __expectNonNull,
+  expectNumber as __expectNumber,
   expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   limitedParseDouble as __limitedParseDouble,
+  parseEpochTimestamp as __parseEpochTimestamp,
   serializeFloat as __serializeFloat,
 } from "@aws-sdk/smithy-client";
 import {
@@ -1448,7 +1450,7 @@ export const deserializeAws_restJson1DescribeContactCommand = async (
     contents.dataflowList = deserializeAws_restJson1DataflowList(data.dataflowList, context);
   }
   if (data.endTime !== undefined && data.endTime !== null) {
-    contents.endTime = new Date(Math.round(data.endTime * 1000));
+    contents.endTime = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.endTime)));
   }
   if (data.errorMessage !== undefined && data.errorMessage !== null) {
     contents.errorMessage = __expectString(data.errorMessage);
@@ -1463,10 +1465,10 @@ export const deserializeAws_restJson1DescribeContactCommand = async (
     contents.missionProfileArn = __expectString(data.missionProfileArn);
   }
   if (data.postPassEndTime !== undefined && data.postPassEndTime !== null) {
-    contents.postPassEndTime = new Date(Math.round(data.postPassEndTime * 1000));
+    contents.postPassEndTime = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.postPassEndTime)));
   }
   if (data.prePassStartTime !== undefined && data.prePassStartTime !== null) {
-    contents.prePassStartTime = new Date(Math.round(data.prePassStartTime * 1000));
+    contents.prePassStartTime = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.prePassStartTime)));
   }
   if (data.region !== undefined && data.region !== null) {
     contents.region = __expectString(data.region);
@@ -1475,7 +1477,7 @@ export const deserializeAws_restJson1DescribeContactCommand = async (
     contents.satelliteArn = __expectString(data.satelliteArn);
   }
   if (data.startTime !== undefined && data.startTime !== null) {
-    contents.startTime = new Date(Math.round(data.startTime * 1000));
+    contents.startTime = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.startTime)));
   }
   if (data.tags !== undefined && data.tags !== null) {
     contents.tags = deserializeAws_restJson1TagsMap(data.tags, context);
@@ -3354,7 +3356,9 @@ const deserializeAws_restJson1ContactData = (output: any, context: __SerdeContex
     contactId: __expectString(output.contactId),
     contactStatus: __expectString(output.contactStatus),
     endTime:
-      output.endTime !== undefined && output.endTime !== null ? new Date(Math.round(output.endTime * 1000)) : undefined,
+      output.endTime !== undefined && output.endTime !== null
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.endTime)))
+        : undefined,
     errorMessage: __expectString(output.errorMessage),
     groundStation: __expectString(output.groundStation),
     maximumElevation:
@@ -3364,17 +3368,17 @@ const deserializeAws_restJson1ContactData = (output: any, context: __SerdeContex
     missionProfileArn: __expectString(output.missionProfileArn),
     postPassEndTime:
       output.postPassEndTime !== undefined && output.postPassEndTime !== null
-        ? new Date(Math.round(output.postPassEndTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.postPassEndTime)))
         : undefined,
     prePassStartTime:
       output.prePassStartTime !== undefined && output.prePassStartTime !== null
-        ? new Date(Math.round(output.prePassStartTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.prePassStartTime)))
         : undefined,
     region: __expectString(output.region),
     satelliteArn: __expectString(output.satelliteArn),
     startTime:
       output.startTime !== undefined && output.startTime !== null
-        ? new Date(Math.round(output.startTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.startTime)))
         : undefined,
     tags:
       output.tags !== undefined && output.tags !== null

--- a/clients/client-guardduty/protocols/Aws_restJson1.ts
+++ b/clients/client-guardduty/protocols/Aws_restJson1.ts
@@ -208,10 +208,12 @@ import {
   expectInt32 as __expectInt32,
   expectLong as __expectLong,
   expectNonNull as __expectNonNull,
+  expectNumber as __expectNumber,
   expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   limitedParseDouble as __limitedParseDouble,
+  parseEpochTimestamp as __parseEpochTimestamp,
 } from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
@@ -7111,7 +7113,7 @@ const deserializeAws_restJson1S3BucketDetail = (output: any, context: __SerdeCon
     Arn: __expectString(output.arn),
     CreatedAt:
       output.createdAt !== undefined && output.createdAt !== null
-        ? new Date(Math.round(output.createdAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.createdAt)))
         : undefined,
     DefaultServerSideEncryption:
       output.defaultServerSideEncryption !== undefined && output.defaultServerSideEncryption !== null

--- a/clients/client-health/protocols/Aws_json1_1.ts
+++ b/clients/client-health/protocols/Aws_json1_1.ts
@@ -92,7 +92,13 @@ import {
   UnsupportedLocale,
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
-import { expectInt32 as __expectInt32, expectString as __expectString } from "@aws-sdk/smithy-client";
+import {
+  expectInt32 as __expectInt32,
+  expectNonNull as __expectNonNull,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
+  parseEpochTimestamp as __parseEpochTimestamp,
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   HeaderBag as __HeaderBag,
@@ -1541,7 +1547,7 @@ const deserializeAws_json1_1AffectedEntity = (output: any, context: __SerdeConte
     eventArn: __expectString(output.eventArn),
     lastUpdatedTime:
       output.lastUpdatedTime !== undefined && output.lastUpdatedTime !== null
-        ? new Date(Math.round(output.lastUpdatedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastUpdatedTime)))
         : undefined,
     statusCode: __expectString(output.statusCode),
     tags:
@@ -1810,19 +1816,21 @@ const deserializeAws_json1_1Event = (output: any, context: __SerdeContext): Even
     arn: __expectString(output.arn),
     availabilityZone: __expectString(output.availabilityZone),
     endTime:
-      output.endTime !== undefined && output.endTime !== null ? new Date(Math.round(output.endTime * 1000)) : undefined,
+      output.endTime !== undefined && output.endTime !== null
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.endTime)))
+        : undefined,
     eventScopeCode: __expectString(output.eventScopeCode),
     eventTypeCategory: __expectString(output.eventTypeCategory),
     eventTypeCode: __expectString(output.eventTypeCode),
     lastUpdatedTime:
       output.lastUpdatedTime !== undefined && output.lastUpdatedTime !== null
-        ? new Date(Math.round(output.lastUpdatedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastUpdatedTime)))
         : undefined,
     region: __expectString(output.region),
     service: __expectString(output.service),
     startTime:
       output.startTime !== undefined && output.startTime !== null
-        ? new Date(Math.round(output.startTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.startTime)))
         : undefined,
     statusCode: __expectString(output.statusCode),
   } as any;
@@ -1941,19 +1949,21 @@ const deserializeAws_json1_1OrganizationEvent = (output: any, context: __SerdeCo
   return {
     arn: __expectString(output.arn),
     endTime:
-      output.endTime !== undefined && output.endTime !== null ? new Date(Math.round(output.endTime * 1000)) : undefined,
+      output.endTime !== undefined && output.endTime !== null
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.endTime)))
+        : undefined,
     eventScopeCode: __expectString(output.eventScopeCode),
     eventTypeCategory: __expectString(output.eventTypeCategory),
     eventTypeCode: __expectString(output.eventTypeCode),
     lastUpdatedTime:
       output.lastUpdatedTime !== undefined && output.lastUpdatedTime !== null
-        ? new Date(Math.round(output.lastUpdatedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastUpdatedTime)))
         : undefined,
     region: __expectString(output.region),
     service: __expectString(output.service),
     startTime:
       output.startTime !== undefined && output.startTime !== null
-        ? new Date(Math.round(output.startTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.startTime)))
         : undefined,
     statusCode: __expectString(output.statusCode),
   } as any;

--- a/clients/client-healthlake/protocols/Aws_json1_0.ts
+++ b/clients/client-healthlake/protocols/Aws_json1_0.ts
@@ -75,7 +75,12 @@ import {
   ValidationException,
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
-import { expectString as __expectString } from "@aws-sdk/smithy-client";
+import {
+  expectNonNull as __expectNonNull,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
+  parseEpochTimestamp as __parseEpochTimestamp,
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   HeaderBag as __HeaderBag,
@@ -1631,7 +1636,7 @@ const deserializeAws_json1_0DatastoreProperties = (output: any, context: __Serde
   return {
     CreatedAt:
       output.CreatedAt !== undefined && output.CreatedAt !== null
-        ? new Date(Math.round(output.CreatedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreatedAt)))
         : undefined,
     DatastoreArn: __expectString(output.DatastoreArn),
     DatastoreEndpoint: __expectString(output.DatastoreEndpoint),
@@ -1714,7 +1719,9 @@ const deserializeAws_json1_0ExportJobProperties = (output: any, context: __Serde
     DataAccessRoleArn: __expectString(output.DataAccessRoleArn),
     DatastoreId: __expectString(output.DatastoreId),
     EndTime:
-      output.EndTime !== undefined && output.EndTime !== null ? new Date(Math.round(output.EndTime * 1000)) : undefined,
+      output.EndTime !== undefined && output.EndTime !== null
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.EndTime)))
+        : undefined,
     JobId: __expectString(output.JobId),
     JobName: __expectString(output.JobName),
     JobStatus: __expectString(output.JobStatus),
@@ -1725,7 +1732,7 @@ const deserializeAws_json1_0ExportJobProperties = (output: any, context: __Serde
         : undefined,
     SubmitTime:
       output.SubmitTime !== undefined && output.SubmitTime !== null
-        ? new Date(Math.round(output.SubmitTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.SubmitTime)))
         : undefined,
   } as any;
 };
@@ -1746,7 +1753,9 @@ const deserializeAws_json1_0ImportJobProperties = (output: any, context: __Serde
     DataAccessRoleArn: __expectString(output.DataAccessRoleArn),
     DatastoreId: __expectString(output.DatastoreId),
     EndTime:
-      output.EndTime !== undefined && output.EndTime !== null ? new Date(Math.round(output.EndTime * 1000)) : undefined,
+      output.EndTime !== undefined && output.EndTime !== null
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.EndTime)))
+        : undefined,
     InputDataConfig:
       output.InputDataConfig !== undefined && output.InputDataConfig !== null
         ? deserializeAws_json1_0InputDataConfig(output.InputDataConfig, context)
@@ -1761,7 +1770,7 @@ const deserializeAws_json1_0ImportJobProperties = (output: any, context: __Serde
     Message: __expectString(output.Message),
     SubmitTime:
       output.SubmitTime !== undefined && output.SubmitTime !== null
-        ? new Date(Math.round(output.SubmitTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.SubmitTime)))
         : undefined,
   } as any;
 };

--- a/clients/client-honeycode/protocols/Aws_restJson1.ts
+++ b/clients/client-honeycode/protocols/Aws_restJson1.ts
@@ -73,9 +73,11 @@ import {
   expectInt32 as __expectInt32,
   expectLong as __expectLong,
   expectNonNull as __expectNonNull,
+  expectNumber as __expectNumber,
   expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
+  parseEpochTimestamp as __parseEpochTimestamp,
 } from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
@@ -2633,7 +2635,7 @@ const deserializeAws_restJson1TableDataImportJobMetadata = (
         : undefined,
     submitTime:
       output.submitTime !== undefined && output.submitTime !== null
-        ? new Date(Math.round(output.submitTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.submitTime)))
         : undefined,
     submitter:
       output.submitter !== undefined && output.submitter !== null

--- a/clients/client-iam/protocols/Aws_query.ts
+++ b/clients/client-iam/protocols/Aws_query.ts
@@ -703,11 +703,13 @@ import {
 } from "../models/models_1";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
+  expectNonNull as __expectNonNull,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   getArrayIfSingleItem as __getArrayIfSingleItem,
   getValueFromTextNode as __getValueFromTextNode,
   parseBoolean as __parseBoolean,
+  parseRfc3339DateTime as __parseRfc3339DateTime,
   strictParseInt32 as __strictParseInt32,
 } from "@aws-sdk/smithy-client";
 import {
@@ -17340,7 +17342,7 @@ const deserializeAws_queryAccessDetail = (output: any, context: __SerdeContext):
     contents.EntityPath = __expectString(output["EntityPath"]);
   }
   if (output["LastAuthenticatedTime"] !== undefined) {
-    contents.LastAuthenticatedTime = new Date(output["LastAuthenticatedTime"]);
+    contents.LastAuthenticatedTime = __expectNonNull(__parseRfc3339DateTime(output["LastAuthenticatedTime"]));
   }
   if (output["TotalAuthenticatedEntities"] !== undefined) {
     contents.TotalAuthenticatedEntities = __strictParseInt32(output["TotalAuthenticatedEntities"]) as number;
@@ -17380,7 +17382,7 @@ const deserializeAws_queryAccessKey = (output: any, context: __SerdeContext): Ac
     contents.SecretAccessKey = __expectString(output["SecretAccessKey"]);
   }
   if (output["CreateDate"] !== undefined) {
-    contents.CreateDate = new Date(output["CreateDate"]);
+    contents.CreateDate = __expectNonNull(__parseRfc3339DateTime(output["CreateDate"]));
   }
   return contents;
 };
@@ -17392,7 +17394,7 @@ const deserializeAws_queryAccessKeyLastUsed = (output: any, context: __SerdeCont
     Region: undefined,
   };
   if (output["LastUsedDate"] !== undefined) {
-    contents.LastUsedDate = new Date(output["LastUsedDate"]);
+    contents.LastUsedDate = __expectNonNull(__parseRfc3339DateTime(output["LastUsedDate"]));
   }
   if (output["ServiceName"] !== undefined) {
     contents.ServiceName = __expectString(output["ServiceName"]);
@@ -17420,7 +17422,7 @@ const deserializeAws_queryAccessKeyMetadata = (output: any, context: __SerdeCont
     contents.Status = __expectString(output["Status"]);
   }
   if (output["CreateDate"] !== undefined) {
-    contents.CreateDate = new Date(output["CreateDate"]);
+    contents.CreateDate = __expectNonNull(__parseRfc3339DateTime(output["CreateDate"]));
   }
   return contents;
 };
@@ -17850,7 +17852,7 @@ const deserializeAws_queryEntityDetails = (output: any, context: __SerdeContext)
     contents.EntityInfo = deserializeAws_queryEntityInfo(output["EntityInfo"], context);
   }
   if (output["LastAuthenticated"] !== undefined) {
-    contents.LastAuthenticated = new Date(output["LastAuthenticated"]);
+    contents.LastAuthenticated = __expectNonNull(__parseRfc3339DateTime(output["LastAuthenticated"]));
   }
   return contents;
 };
@@ -18201,7 +18203,7 @@ const deserializeAws_queryGetCredentialReportResponse = (
     contents.ReportFormat = __expectString(output["ReportFormat"]);
   }
   if (output["GeneratedTime"] !== undefined) {
-    contents.GeneratedTime = new Date(output["GeneratedTime"]);
+    contents.GeneratedTime = __expectNonNull(__parseRfc3339DateTime(output["GeneratedTime"]));
   }
   return contents;
 };
@@ -18305,7 +18307,7 @@ const deserializeAws_queryGetOpenIDConnectProviderResponse = (
     );
   }
   if (output["CreateDate"] !== undefined) {
-    contents.CreateDate = new Date(output["CreateDate"]);
+    contents.CreateDate = __expectNonNull(__parseRfc3339DateTime(output["CreateDate"]));
   }
   if (output.Tags === "") {
     contents.Tags = [];
@@ -18335,10 +18337,10 @@ const deserializeAws_queryGetOrganizationsAccessReportResponse = (
     contents.JobStatus = __expectString(output["JobStatus"]);
   }
   if (output["JobCreationDate"] !== undefined) {
-    contents.JobCreationDate = new Date(output["JobCreationDate"]);
+    contents.JobCreationDate = __expectNonNull(__parseRfc3339DateTime(output["JobCreationDate"]));
   }
   if (output["JobCompletionDate"] !== undefined) {
-    contents.JobCompletionDate = new Date(output["JobCompletionDate"]);
+    contents.JobCompletionDate = __expectNonNull(__parseRfc3339DateTime(output["JobCompletionDate"]));
   }
   if (output["NumberOfServicesAccessible"] !== undefined) {
     contents.NumberOfServicesAccessible = __strictParseInt32(output["NumberOfServicesAccessible"]) as number;
@@ -18429,10 +18431,10 @@ const deserializeAws_queryGetSAMLProviderResponse = (output: any, context: __Ser
     contents.SAMLMetadataDocument = __expectString(output["SAMLMetadataDocument"]);
   }
   if (output["CreateDate"] !== undefined) {
-    contents.CreateDate = new Date(output["CreateDate"]);
+    contents.CreateDate = __expectNonNull(__parseRfc3339DateTime(output["CreateDate"]));
   }
   if (output["ValidUntil"] !== undefined) {
-    contents.ValidUntil = new Date(output["ValidUntil"]);
+    contents.ValidUntil = __expectNonNull(__parseRfc3339DateTime(output["ValidUntil"]));
   }
   if (output.Tags === "") {
     contents.Tags = [];
@@ -18477,7 +18479,7 @@ const deserializeAws_queryGetServiceLastAccessedDetailsResponse = (
     contents.JobType = __expectString(output["JobType"]);
   }
   if (output["JobCreationDate"] !== undefined) {
-    contents.JobCreationDate = new Date(output["JobCreationDate"]);
+    contents.JobCreationDate = __expectNonNull(__parseRfc3339DateTime(output["JobCreationDate"]));
   }
   if (output.ServicesLastAccessed === "") {
     contents.ServicesLastAccessed = [];
@@ -18489,7 +18491,7 @@ const deserializeAws_queryGetServiceLastAccessedDetailsResponse = (
     );
   }
   if (output["JobCompletionDate"] !== undefined) {
-    contents.JobCompletionDate = new Date(output["JobCompletionDate"]);
+    contents.JobCompletionDate = __expectNonNull(__parseRfc3339DateTime(output["JobCompletionDate"]));
   }
   if (output["IsTruncated"] !== undefined) {
     contents.IsTruncated = __parseBoolean(output["IsTruncated"]);
@@ -18520,10 +18522,10 @@ const deserializeAws_queryGetServiceLastAccessedDetailsWithEntitiesResponse = (
     contents.JobStatus = __expectString(output["JobStatus"]);
   }
   if (output["JobCreationDate"] !== undefined) {
-    contents.JobCreationDate = new Date(output["JobCreationDate"]);
+    contents.JobCreationDate = __expectNonNull(__parseRfc3339DateTime(output["JobCreationDate"]));
   }
   if (output["JobCompletionDate"] !== undefined) {
-    contents.JobCompletionDate = new Date(output["JobCompletionDate"]);
+    contents.JobCompletionDate = __expectNonNull(__parseRfc3339DateTime(output["JobCompletionDate"]));
   }
   if (output.EntityDetailsList === "") {
     contents.EntityDetailsList = [];
@@ -18622,7 +18624,7 @@ const deserializeAws_queryGroup = (output: any, context: __SerdeContext): Group 
     contents.Arn = __expectString(output["Arn"]);
   }
   if (output["CreateDate"] !== undefined) {
-    contents.CreateDate = new Date(output["CreateDate"]);
+    contents.CreateDate = __expectNonNull(__parseRfc3339DateTime(output["CreateDate"]));
   }
   return contents;
 };
@@ -18650,7 +18652,7 @@ const deserializeAws_queryGroupDetail = (output: any, context: __SerdeContext): 
     contents.Arn = __expectString(output["Arn"]);
   }
   if (output["CreateDate"] !== undefined) {
-    contents.CreateDate = new Date(output["CreateDate"]);
+    contents.CreateDate = __expectNonNull(__parseRfc3339DateTime(output["CreateDate"]));
   }
   if (output.GroupPolicyList === "") {
     contents.GroupPolicyList = [];
@@ -18729,7 +18731,7 @@ const deserializeAws_queryInstanceProfile = (output: any, context: __SerdeContex
     contents.Arn = __expectString(output["Arn"]);
   }
   if (output["CreateDate"] !== undefined) {
-    contents.CreateDate = new Date(output["CreateDate"]);
+    contents.CreateDate = __expectNonNull(__parseRfc3339DateTime(output["CreateDate"]));
   }
   if (output.Roles === "") {
     contents.Roles = [];
@@ -19752,7 +19754,7 @@ const deserializeAws_queryLoginProfile = (output: any, context: __SerdeContext):
     contents.UserName = __expectString(output["UserName"]);
   }
   if (output["CreateDate"] !== undefined) {
-    contents.CreateDate = new Date(output["CreateDate"]);
+    contents.CreateDate = __expectNonNull(__parseRfc3339DateTime(output["CreateDate"]));
   }
   if (output["PasswordResetRequired"] !== undefined) {
     contents.PasswordResetRequired = __parseBoolean(output["PasswordResetRequired"]);
@@ -19829,10 +19831,10 @@ const deserializeAws_queryManagedPolicyDetail = (output: any, context: __SerdeCo
     contents.Description = __expectString(output["Description"]);
   }
   if (output["CreateDate"] !== undefined) {
-    contents.CreateDate = new Date(output["CreateDate"]);
+    contents.CreateDate = __expectNonNull(__parseRfc3339DateTime(output["CreateDate"]));
   }
   if (output["UpdateDate"] !== undefined) {
-    contents.UpdateDate = new Date(output["UpdateDate"]);
+    contents.UpdateDate = __expectNonNull(__parseRfc3339DateTime(output["UpdateDate"]));
   }
   if (output.PolicyVersionList === "") {
     contents.PolicyVersionList = [];
@@ -19873,7 +19875,7 @@ const deserializeAws_queryMFADevice = (output: any, context: __SerdeContext): MF
     contents.SerialNumber = __expectString(output["SerialNumber"]);
   }
   if (output["EnableDate"] !== undefined) {
-    contents.EnableDate = new Date(output["EnableDate"]);
+    contents.EnableDate = __expectNonNull(__parseRfc3339DateTime(output["EnableDate"]));
   }
   return contents;
 };
@@ -20054,10 +20056,10 @@ const deserializeAws_queryPolicy = (output: any, context: __SerdeContext): Polic
     contents.Description = __expectString(output["Description"]);
   }
   if (output["CreateDate"] !== undefined) {
-    contents.CreateDate = new Date(output["CreateDate"]);
+    contents.CreateDate = __expectNonNull(__parseRfc3339DateTime(output["CreateDate"]));
   }
   if (output["UpdateDate"] !== undefined) {
-    contents.UpdateDate = new Date(output["UpdateDate"]);
+    contents.UpdateDate = __expectNonNull(__parseRfc3339DateTime(output["UpdateDate"]));
   }
   if (output.Tags === "") {
     contents.Tags = [];
@@ -20287,7 +20289,7 @@ const deserializeAws_queryPolicyVersion = (output: any, context: __SerdeContext)
     contents.IsDefaultVersion = __parseBoolean(output["IsDefaultVersion"]);
   }
   if (output["CreateDate"] !== undefined) {
-    contents.CreateDate = new Date(output["CreateDate"]);
+    contents.CreateDate = __expectNonNull(__parseRfc3339DateTime(output["CreateDate"]));
   }
   return contents;
 };
@@ -20427,7 +20429,7 @@ const deserializeAws_queryRole = (output: any, context: __SerdeContext): Role =>
     contents.Arn = __expectString(output["Arn"]);
   }
   if (output["CreateDate"] !== undefined) {
-    contents.CreateDate = new Date(output["CreateDate"]);
+    contents.CreateDate = __expectNonNull(__parseRfc3339DateTime(output["CreateDate"]));
   }
   if (output["AssumeRolePolicyDocument"] !== undefined) {
     contents.AssumeRolePolicyDocument = __expectString(output["AssumeRolePolicyDocument"]);
@@ -20484,7 +20486,7 @@ const deserializeAws_queryRoleDetail = (output: any, context: __SerdeContext): R
     contents.Arn = __expectString(output["Arn"]);
   }
   if (output["CreateDate"] !== undefined) {
-    contents.CreateDate = new Date(output["CreateDate"]);
+    contents.CreateDate = __expectNonNull(__parseRfc3339DateTime(output["CreateDate"]));
   }
   if (output["AssumeRolePolicyDocument"] !== undefined) {
     contents.AssumeRolePolicyDocument = __expectString(output["AssumeRolePolicyDocument"]);
@@ -20551,7 +20553,7 @@ const deserializeAws_queryRoleLastUsed = (output: any, context: __SerdeContext):
     Region: undefined,
   };
   if (output["LastUsedDate"] !== undefined) {
-    contents.LastUsedDate = new Date(output["LastUsedDate"]);
+    contents.LastUsedDate = __expectNonNull(__parseRfc3339DateTime(output["LastUsedDate"]));
   }
   if (output["Region"] !== undefined) {
     contents.Region = __expectString(output["Region"]);
@@ -20611,10 +20613,10 @@ const deserializeAws_querySAMLProviderListEntry = (output: any, context: __Serde
     contents.Arn = __expectString(output["Arn"]);
   }
   if (output["ValidUntil"] !== undefined) {
-    contents.ValidUntil = new Date(output["ValidUntil"]);
+    contents.ValidUntil = __expectNonNull(__parseRfc3339DateTime(output["ValidUntil"]));
   }
   if (output["CreateDate"] !== undefined) {
-    contents.CreateDate = new Date(output["CreateDate"]);
+    contents.CreateDate = __expectNonNull(__parseRfc3339DateTime(output["CreateDate"]));
   }
   return contents;
 };
@@ -20683,10 +20685,10 @@ const deserializeAws_queryServerCertificateMetadata = (
     contents.Arn = __expectString(output["Arn"]);
   }
   if (output["UploadDate"] !== undefined) {
-    contents.UploadDate = new Date(output["UploadDate"]);
+    contents.UploadDate = __expectNonNull(__parseRfc3339DateTime(output["UploadDate"]));
   }
   if (output["Expiration"] !== undefined) {
-    contents.Expiration = new Date(output["Expiration"]);
+    contents.Expiration = __expectNonNull(__parseRfc3339DateTime(output["Expiration"]));
   }
   return contents;
 };
@@ -20729,7 +20731,7 @@ const deserializeAws_queryServiceLastAccessed = (output: any, context: __SerdeCo
     contents.ServiceName = __expectString(output["ServiceName"]);
   }
   if (output["LastAuthenticated"] !== undefined) {
-    contents.LastAuthenticated = new Date(output["LastAuthenticated"]);
+    contents.LastAuthenticated = __expectNonNull(__parseRfc3339DateTime(output["LastAuthenticated"]));
   }
   if (output["ServiceNamespace"] !== undefined) {
     contents.ServiceNamespace = __expectString(output["ServiceNamespace"]);
@@ -20796,7 +20798,7 @@ const deserializeAws_queryServiceSpecificCredential = (
     Status: undefined,
   };
   if (output["CreateDate"] !== undefined) {
-    contents.CreateDate = new Date(output["CreateDate"]);
+    contents.CreateDate = __expectNonNull(__parseRfc3339DateTime(output["CreateDate"]));
   }
   if (output["ServiceName"] !== undefined) {
     contents.ServiceName = __expectString(output["ServiceName"]);
@@ -20841,7 +20843,7 @@ const deserializeAws_queryServiceSpecificCredentialMetadata = (
     contents.ServiceUserName = __expectString(output["ServiceUserName"]);
   }
   if (output["CreateDate"] !== undefined) {
-    contents.CreateDate = new Date(output["CreateDate"]);
+    contents.CreateDate = __expectNonNull(__parseRfc3339DateTime(output["CreateDate"]));
   }
   if (output["ServiceSpecificCredentialId"] !== undefined) {
     contents.ServiceSpecificCredentialId = __expectString(output["ServiceSpecificCredentialId"]);
@@ -20887,7 +20889,7 @@ const deserializeAws_querySigningCertificate = (output: any, context: __SerdeCon
     contents.Status = __expectString(output["Status"]);
   }
   if (output["UploadDate"] !== undefined) {
-    contents.UploadDate = new Date(output["UploadDate"]);
+    contents.UploadDate = __expectNonNull(__parseRfc3339DateTime(output["UploadDate"]));
   }
   return contents;
 };
@@ -20941,7 +20943,7 @@ const deserializeAws_querySSHPublicKey = (output: any, context: __SerdeContext):
     contents.Status = __expectString(output["Status"]);
   }
   if (output["UploadDate"] !== undefined) {
-    contents.UploadDate = new Date(output["UploadDate"]);
+    contents.UploadDate = __expectNonNull(__parseRfc3339DateTime(output["UploadDate"]));
   }
   return contents;
 };
@@ -20974,7 +20976,7 @@ const deserializeAws_querySSHPublicKeyMetadata = (output: any, context: __SerdeC
     contents.Status = __expectString(output["Status"]);
   }
   if (output["UploadDate"] !== undefined) {
-    contents.UploadDate = new Date(output["UploadDate"]);
+    contents.UploadDate = __expectNonNull(__parseRfc3339DateTime(output["UploadDate"]));
   }
   return contents;
 };
@@ -21077,7 +21079,7 @@ const deserializeAws_queryTrackedActionLastAccessed = (
     contents.LastAccessedEntity = __expectString(output["LastAccessedEntity"]);
   }
   if (output["LastAccessedTime"] !== undefined) {
-    contents.LastAccessedTime = new Date(output["LastAccessedTime"]);
+    contents.LastAccessedTime = __expectNonNull(__parseRfc3339DateTime(output["LastAccessedTime"]));
   }
   if (output["LastAccessedRegion"] !== undefined) {
     contents.LastAccessedRegion = __expectString(output["LastAccessedRegion"]);
@@ -21229,10 +21231,10 @@ const deserializeAws_queryUser = (output: any, context: __SerdeContext): User =>
     contents.Arn = __expectString(output["Arn"]);
   }
   if (output["CreateDate"] !== undefined) {
-    contents.CreateDate = new Date(output["CreateDate"]);
+    contents.CreateDate = __expectNonNull(__parseRfc3339DateTime(output["CreateDate"]));
   }
   if (output["PasswordLastUsed"] !== undefined) {
-    contents.PasswordLastUsed = new Date(output["PasswordLastUsed"]);
+    contents.PasswordLastUsed = __expectNonNull(__parseRfc3339DateTime(output["PasswordLastUsed"]));
   }
   if (output["PermissionsBoundary"] !== undefined) {
     contents.PermissionsBoundary = deserializeAws_queryAttachedPermissionsBoundary(
@@ -21275,7 +21277,7 @@ const deserializeAws_queryUserDetail = (output: any, context: __SerdeContext): U
     contents.Arn = __expectString(output["Arn"]);
   }
   if (output["CreateDate"] !== undefined) {
-    contents.CreateDate = new Date(output["CreateDate"]);
+    contents.CreateDate = __expectNonNull(__parseRfc3339DateTime(output["CreateDate"]));
   }
   if (output.UserPolicyList === "") {
     contents.UserPolicyList = [];
@@ -21363,7 +21365,7 @@ const deserializeAws_queryVirtualMFADevice = (output: any, context: __SerdeConte
     contents.User = deserializeAws_queryUser(output["User"], context);
   }
   if (output["EnableDate"] !== undefined) {
-    contents.EnableDate = new Date(output["EnableDate"]);
+    contents.EnableDate = __expectNonNull(__parseRfc3339DateTime(output["EnableDate"]));
   }
   if (output.Tags === "") {
     contents.Tags = [];

--- a/clients/client-inspector/protocols/Aws_json1_1.ts
+++ b/clients/client-inspector/protocols/Aws_json1_1.ts
@@ -232,8 +232,11 @@ import {
   expectBoolean as __expectBoolean,
   expectInt32 as __expectInt32,
   expectLong as __expectLong,
+  expectNonNull as __expectNonNull,
+  expectNumber as __expectNumber,
   expectString as __expectString,
   limitedParseDouble as __limitedParseDouble,
+  parseEpochTimestamp as __parseEpochTimestamp,
 } from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
@@ -4707,11 +4710,11 @@ const deserializeAws_json1_1AssessmentRun = (output: any, context: __SerdeContex
     assessmentTemplateArn: __expectString(output.assessmentTemplateArn),
     completedAt:
       output.completedAt !== undefined && output.completedAt !== null
-        ? new Date(Math.round(output.completedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.completedAt)))
         : undefined,
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
-        ? new Date(Math.round(output.createdAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.createdAt)))
         : undefined,
     dataCollected: __expectBoolean(output.dataCollected),
     durationInSeconds: __expectInt32(output.durationInSeconds),
@@ -4730,12 +4733,12 @@ const deserializeAws_json1_1AssessmentRun = (output: any, context: __SerdeContex
         : undefined,
     startedAt:
       output.startedAt !== undefined && output.startedAt !== null
-        ? new Date(Math.round(output.startedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.startedAt)))
         : undefined,
     state: __expectString(output.state),
     stateChangedAt:
       output.stateChangedAt !== undefined && output.stateChangedAt !== null
-        ? new Date(Math.round(output.stateChangedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.stateChangedAt)))
         : undefined,
     stateChanges:
       output.stateChanges !== undefined && output.stateChanges !== null
@@ -4831,7 +4834,10 @@ const deserializeAws_json1_1AssessmentRunNotification = (
   context: __SerdeContext
 ): AssessmentRunNotification => {
   return {
-    date: output.date !== undefined && output.date !== null ? new Date(Math.round(output.date * 1000)) : undefined,
+    date:
+      output.date !== undefined && output.date !== null
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.date)))
+        : undefined,
     error: __expectBoolean(output.error),
     event: __expectString(output.event),
     message: __expectString(output.message),
@@ -4862,7 +4868,7 @@ const deserializeAws_json1_1AssessmentRunStateChange = (
     state: __expectString(output.state),
     stateChangedAt:
       output.stateChangedAt !== undefined && output.stateChangedAt !== null
-        ? new Date(Math.round(output.stateChangedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.stateChangedAt)))
         : undefined,
   } as any;
 };
@@ -4886,13 +4892,13 @@ const deserializeAws_json1_1AssessmentTarget = (output: any, context: __SerdeCon
     arn: __expectString(output.arn),
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
-        ? new Date(Math.round(output.createdAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.createdAt)))
         : undefined,
     name: __expectString(output.name),
     resourceGroupArn: __expectString(output.resourceGroupArn),
     updatedAt:
       output.updatedAt !== undefined && output.updatedAt !== null
-        ? new Date(Math.round(output.updatedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.updatedAt)))
         : undefined,
   } as any;
 };
@@ -4915,7 +4921,7 @@ const deserializeAws_json1_1AssessmentTemplate = (output: any, context: __SerdeC
     assessmentTargetArn: __expectString(output.assessmentTargetArn),
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
-        ? new Date(Math.round(output.createdAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.createdAt)))
         : undefined,
     durationInSeconds: __expectInt32(output.durationInSeconds),
     lastAssessmentRunArn: __expectString(output.lastAssessmentRunArn),
@@ -5085,7 +5091,7 @@ const deserializeAws_json1_1DescribeCrossAccountAccessRoleResponse = (
   return {
     registeredAt:
       output.registeredAt !== undefined && output.registeredAt !== null
-        ? new Date(Math.round(output.registeredAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.registeredAt)))
         : undefined,
     roleArn: __expectString(output.roleArn),
     valid: __expectBoolean(output.valid),
@@ -5161,7 +5167,7 @@ const deserializeAws_json1_1EventSubscription = (output: any, context: __SerdeCo
     event: __expectString(output.event),
     subscribedAt:
       output.subscribedAt !== undefined && output.subscribedAt !== null
-        ? new Date(Math.round(output.subscribedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.subscribedAt)))
         : undefined,
   } as any;
 };
@@ -5270,7 +5276,7 @@ const deserializeAws_json1_1Finding = (output: any, context: __SerdeContext): Fi
     confidence: __expectInt32(output.confidence),
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
-        ? new Date(Math.round(output.createdAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.createdAt)))
         : undefined,
     description: __expectString(output.description),
     id: __expectString(output.id),
@@ -5287,7 +5293,7 @@ const deserializeAws_json1_1Finding = (output: any, context: __SerdeContext): Fi
     title: __expectString(output.title),
     updatedAt:
       output.updatedAt !== undefined && output.updatedAt !== null
-        ? new Date(Math.round(output.updatedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.updatedAt)))
         : undefined,
     userAttributes:
       output.userAttributes !== undefined && output.userAttributes !== null
@@ -5628,7 +5634,7 @@ const deserializeAws_json1_1ResourceGroup = (output: any, context: __SerdeContex
     arn: __expectString(output.arn),
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
-        ? new Date(Math.round(output.createdAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.createdAt)))
         : undefined,
     tags:
       output.tags !== undefined && output.tags !== null

--- a/clients/client-iot-1click-projects/protocols/Aws_restJson1.ts
+++ b/clients/client-iot-1click-projects/protocols/Aws_restJson1.ts
@@ -42,9 +42,11 @@ import {
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
   expectNonNull as __expectNonNull,
+  expectNumber as __expectNumber,
   expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
+  parseEpochTimestamp as __parseEpochTimestamp,
 } from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
@@ -2073,13 +2075,13 @@ const deserializeAws_restJson1PlacementDescription = (output: any, context: __Se
         : undefined,
     createdDate:
       output.createdDate !== undefined && output.createdDate !== null
-        ? new Date(Math.round(output.createdDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.createdDate)))
         : undefined,
     placementName: __expectString(output.placementName),
     projectName: __expectString(output.projectName),
     updatedDate:
       output.updatedDate !== undefined && output.updatedDate !== null
-        ? new Date(Math.round(output.updatedDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.updatedDate)))
         : undefined,
   } as any;
 };
@@ -2088,13 +2090,13 @@ const deserializeAws_restJson1PlacementSummary = (output: any, context: __SerdeC
   return {
     createdDate:
       output.createdDate !== undefined && output.createdDate !== null
-        ? new Date(Math.round(output.createdDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.createdDate)))
         : undefined,
     placementName: __expectString(output.placementName),
     projectName: __expectString(output.projectName),
     updatedDate:
       output.updatedDate !== undefined && output.updatedDate !== null
-        ? new Date(Math.round(output.updatedDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.updatedDate)))
         : undefined,
   } as any;
 };
@@ -2128,7 +2130,7 @@ const deserializeAws_restJson1ProjectDescription = (output: any, context: __Serd
     arn: __expectString(output.arn),
     createdDate:
       output.createdDate !== undefined && output.createdDate !== null
-        ? new Date(Math.round(output.createdDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.createdDate)))
         : undefined,
     description: __expectString(output.description),
     placementTemplate:
@@ -2142,7 +2144,7 @@ const deserializeAws_restJson1ProjectDescription = (output: any, context: __Serd
         : undefined,
     updatedDate:
       output.updatedDate !== undefined && output.updatedDate !== null
-        ? new Date(Math.round(output.updatedDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.updatedDate)))
         : undefined,
   } as any;
 };
@@ -2152,7 +2154,7 @@ const deserializeAws_restJson1ProjectSummary = (output: any, context: __SerdeCon
     arn: __expectString(output.arn),
     createdDate:
       output.createdDate !== undefined && output.createdDate !== null
-        ? new Date(Math.round(output.createdDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.createdDate)))
         : undefined,
     projectName: __expectString(output.projectName),
     tags:
@@ -2161,7 +2163,7 @@ const deserializeAws_restJson1ProjectSummary = (output: any, context: __SerdeCon
         : undefined,
     updatedDate:
       output.updatedDate !== undefined && output.updatedDate !== null
-        ? new Date(Math.round(output.updatedDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.updatedDate)))
         : undefined,
   } as any;
 };

--- a/clients/client-iot-events-data/protocols/Aws_restJson1.ts
+++ b/clients/client-iot-events-data/protocols/Aws_restJson1.ts
@@ -59,9 +59,11 @@ import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@a
 import {
   expectInt32 as __expectInt32,
   expectNonNull as __expectNonNull,
+  expectNumber as __expectNumber,
   expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
+  parseEpochTimestamp as __parseEpochTimestamp,
 } from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
@@ -1649,12 +1651,12 @@ const deserializeAws_restJson1Alarm = (output: any, context: __SerdeContext): Al
         : undefined,
     creationTime:
       output.creationTime !== undefined && output.creationTime !== null
-        ? new Date(Math.round(output.creationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.creationTime)))
         : undefined,
     keyValue: __expectString(output.keyValue),
     lastUpdateTime:
       output.lastUpdateTime !== undefined && output.lastUpdateTime !== null
-        ? new Date(Math.round(output.lastUpdateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastUpdateTime)))
         : undefined,
     severity: __expectInt32(output.severity),
   } as any;
@@ -1695,12 +1697,12 @@ const deserializeAws_restJson1AlarmSummary = (output: any, context: __SerdeConte
     alarmModelVersion: __expectString(output.alarmModelVersion),
     creationTime:
       output.creationTime !== undefined && output.creationTime !== null
-        ? new Date(Math.round(output.creationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.creationTime)))
         : undefined,
     keyValue: __expectString(output.keyValue),
     lastUpdateTime:
       output.lastUpdateTime !== undefined && output.lastUpdateTime !== null
-        ? new Date(Math.round(output.lastUpdateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastUpdateTime)))
         : undefined,
     stateName: __expectString(output.stateName),
   } as any;
@@ -1811,14 +1813,14 @@ const deserializeAws_restJson1Detector = (output: any, context: __SerdeContext):
   return {
     creationTime:
       output.creationTime !== undefined && output.creationTime !== null
-        ? new Date(Math.round(output.creationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.creationTime)))
         : undefined,
     detectorModelName: __expectString(output.detectorModelName),
     detectorModelVersion: __expectString(output.detectorModelVersion),
     keyValue: __expectString(output.keyValue),
     lastUpdateTime:
       output.lastUpdateTime !== undefined && output.lastUpdateTime !== null
-        ? new Date(Math.round(output.lastUpdateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastUpdateTime)))
         : undefined,
     state:
       output.state !== undefined && output.state !== null
@@ -1862,14 +1864,14 @@ const deserializeAws_restJson1DetectorSummary = (output: any, context: __SerdeCo
   return {
     creationTime:
       output.creationTime !== undefined && output.creationTime !== null
-        ? new Date(Math.round(output.creationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.creationTime)))
         : undefined,
     detectorModelName: __expectString(output.detectorModelName),
     detectorModelVersion: __expectString(output.detectorModelVersion),
     keyValue: __expectString(output.keyValue),
     lastUpdateTime:
       output.lastUpdateTime !== undefined && output.lastUpdateTime !== null
-        ? new Date(Math.round(output.lastUpdateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastUpdateTime)))
         : undefined,
     state:
       output.state !== undefined && output.state !== null
@@ -1956,7 +1958,7 @@ const deserializeAws_restJson1Timer = (output: any, context: __SerdeContext): Ti
     name: __expectString(output.name),
     timestamp:
       output.timestamp !== undefined && output.timestamp !== null
-        ? new Date(Math.round(output.timestamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.timestamp)))
         : undefined,
   } as any;
 };

--- a/clients/client-iot-events/protocols/Aws_restJson1.ts
+++ b/clients/client-iot-events/protocols/Aws_restJson1.ts
@@ -135,9 +135,11 @@ import {
   expectBoolean as __expectBoolean,
   expectInt32 as __expectInt32,
   expectNonNull as __expectNonNull,
+  expectNumber as __expectNumber,
   expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
+  parseEpochTimestamp as __parseEpochTimestamp,
 } from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
@@ -979,10 +981,10 @@ export const deserializeAws_restJson1CreateAlarmModelCommand = async (
     contents.alarmModelVersion = __expectString(data.alarmModelVersion);
   }
   if (data.creationTime !== undefined && data.creationTime !== null) {
-    contents.creationTime = new Date(Math.round(data.creationTime * 1000));
+    contents.creationTime = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.creationTime)));
   }
   if (data.lastUpdateTime !== undefined && data.lastUpdateTime !== null) {
-    contents.lastUpdateTime = new Date(Math.round(data.lastUpdateTime * 1000));
+    contents.lastUpdateTime = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.lastUpdateTime)));
   }
   if (data.status !== undefined && data.status !== null) {
     contents.status = __expectString(data.status);
@@ -1592,13 +1594,13 @@ export const deserializeAws_restJson1DescribeAlarmModelCommand = async (
     contents.alarmRule = deserializeAws_restJson1AlarmRule(data.alarmRule, context);
   }
   if (data.creationTime !== undefined && data.creationTime !== null) {
-    contents.creationTime = new Date(Math.round(data.creationTime * 1000));
+    contents.creationTime = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.creationTime)));
   }
   if (data.key !== undefined && data.key !== null) {
     contents.key = __expectString(data.key);
   }
   if (data.lastUpdateTime !== undefined && data.lastUpdateTime !== null) {
-    contents.lastUpdateTime = new Date(Math.round(data.lastUpdateTime * 1000));
+    contents.lastUpdateTime = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.lastUpdateTime)));
   }
   if (data.roleArn !== undefined && data.roleArn !== null) {
     contents.roleArn = __expectString(data.roleArn);
@@ -3124,10 +3126,10 @@ export const deserializeAws_restJson1UpdateAlarmModelCommand = async (
     contents.alarmModelVersion = __expectString(data.alarmModelVersion);
   }
   if (data.creationTime !== undefined && data.creationTime !== null) {
-    contents.creationTime = new Date(Math.round(data.creationTime * 1000));
+    contents.creationTime = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.creationTime)));
   }
   if (data.lastUpdateTime !== undefined && data.lastUpdateTime !== null) {
-    contents.lastUpdateTime = new Date(Math.round(data.lastUpdateTime * 1000));
+    contents.lastUpdateTime = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.lastUpdateTime)));
   }
   if (data.status !== undefined && data.status !== null) {
     contents.status = __expectString(data.status);
@@ -4377,7 +4379,7 @@ const deserializeAws_restJson1AlarmModelSummary = (output: any, context: __Serde
     alarmModelName: __expectString(output.alarmModelName),
     creationTime:
       output.creationTime !== undefined && output.creationTime !== null
-        ? new Date(Math.round(output.creationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.creationTime)))
         : undefined,
   } as any;
 };
@@ -4406,11 +4408,11 @@ const deserializeAws_restJson1AlarmModelVersionSummary = (
     alarmModelVersion: __expectString(output.alarmModelVersion),
     creationTime:
       output.creationTime !== undefined && output.creationTime !== null
-        ? new Date(Math.round(output.creationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.creationTime)))
         : undefined,
     lastUpdateTime:
       output.lastUpdateTime !== undefined && output.lastUpdateTime !== null
-        ? new Date(Math.round(output.lastUpdateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastUpdateTime)))
         : undefined,
     roleArn: __expectString(output.roleArn),
     status: __expectString(output.status),
@@ -4576,7 +4578,7 @@ const deserializeAws_restJson1DetectorModelConfiguration = (
   return {
     creationTime:
       output.creationTime !== undefined && output.creationTime !== null
-        ? new Date(Math.round(output.creationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.creationTime)))
         : undefined,
     detectorModelArn: __expectString(output.detectorModelArn),
     detectorModelDescription: __expectString(output.detectorModelDescription),
@@ -4586,7 +4588,7 @@ const deserializeAws_restJson1DetectorModelConfiguration = (
     key: __expectString(output.key),
     lastUpdateTime:
       output.lastUpdateTime !== undefined && output.lastUpdateTime !== null
-        ? new Date(Math.round(output.lastUpdateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastUpdateTime)))
         : undefined,
     roleArn: __expectString(output.roleArn),
     status: __expectString(output.status),
@@ -4624,7 +4626,7 @@ const deserializeAws_restJson1DetectorModelSummary = (output: any, context: __Se
   return {
     creationTime:
       output.creationTime !== undefined && output.creationTime !== null
-        ? new Date(Math.round(output.creationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.creationTime)))
         : undefined,
     detectorModelDescription: __expectString(output.detectorModelDescription),
     detectorModelName: __expectString(output.detectorModelName),
@@ -4652,7 +4654,7 @@ const deserializeAws_restJson1DetectorModelVersionSummary = (
   return {
     creationTime:
       output.creationTime !== undefined && output.creationTime !== null
-        ? new Date(Math.round(output.creationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.creationTime)))
         : undefined,
     detectorModelArn: __expectString(output.detectorModelArn),
     detectorModelName: __expectString(output.detectorModelName),
@@ -4660,7 +4662,7 @@ const deserializeAws_restJson1DetectorModelVersionSummary = (
     evaluationMethod: __expectString(output.evaluationMethod),
     lastUpdateTime:
       output.lastUpdateTime !== undefined && output.lastUpdateTime !== null
-        ? new Date(Math.round(output.lastUpdateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastUpdateTime)))
         : undefined,
     roleArn: __expectString(output.roleArn),
     status: __expectString(output.status),
@@ -4795,14 +4797,14 @@ const deserializeAws_restJson1InputConfiguration = (output: any, context: __Serd
   return {
     creationTime:
       output.creationTime !== undefined && output.creationTime !== null
-        ? new Date(Math.round(output.creationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.creationTime)))
         : undefined,
     inputArn: __expectString(output.inputArn),
     inputDescription: __expectString(output.inputDescription),
     inputName: __expectString(output.inputName),
     lastUpdateTime:
       output.lastUpdateTime !== undefined && output.lastUpdateTime !== null
-        ? new Date(Math.round(output.lastUpdateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastUpdateTime)))
         : undefined,
     status: __expectString(output.status),
   } as any;
@@ -4832,14 +4834,14 @@ const deserializeAws_restJson1InputSummary = (output: any, context: __SerdeConte
   return {
     creationTime:
       output.creationTime !== undefined && output.creationTime !== null
-        ? new Date(Math.round(output.creationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.creationTime)))
         : undefined,
     inputArn: __expectString(output.inputArn),
     inputDescription: __expectString(output.inputDescription),
     inputName: __expectString(output.inputName),
     lastUpdateTime:
       output.lastUpdateTime !== undefined && output.lastUpdateTime !== null
-        ? new Date(Math.round(output.lastUpdateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastUpdateTime)))
         : undefined,
     status: __expectString(output.status),
   } as any;

--- a/clients/client-iot/protocols/Aws_restJson1.ts
+++ b/clients/client-iot/protocols/Aws_restJson1.ts
@@ -865,10 +865,12 @@ import {
   expectInt32 as __expectInt32,
   expectLong as __expectLong,
   expectNonNull as __expectNonNull,
+  expectNumber as __expectNumber,
   expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   limitedParseDouble as __limitedParseDouble,
+  parseEpochTimestamp as __parseEpochTimestamp,
   serializeFloat as __serializeFloat,
 } from "@aws-sdk/smithy-client";
 import {
@@ -11520,7 +11522,7 @@ export const deserializeAws_restJson1CreateProvisioningClaimCommand = async (
     contents.certificatePem = __expectString(data.certificatePem);
   }
   if (data.expiration !== undefined && data.expiration !== null) {
-    contents.expiration = new Date(Math.round(data.expiration * 1000));
+    contents.expiration = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.expiration)));
   }
   if (data.keyPair !== undefined && data.keyPair !== null) {
     contents.keyPair = deserializeAws_restJson1KeyPair(data.keyPair, context);
@@ -15630,10 +15632,10 @@ export const deserializeAws_restJson1DescribeAuditMitigationActionsTaskCommand =
     );
   }
   if (data.endTime !== undefined && data.endTime !== null) {
-    contents.endTime = new Date(Math.round(data.endTime * 1000));
+    contents.endTime = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.endTime)));
   }
   if (data.startTime !== undefined && data.startTime !== null) {
-    contents.startTime = new Date(Math.round(data.startTime * 1000));
+    contents.startTime = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.startTime)));
   }
   if (data.target !== undefined && data.target !== null) {
     contents.target = deserializeAws_restJson1AuditMitigationActionsTaskTarget(data.target, context);
@@ -15734,7 +15736,7 @@ export const deserializeAws_restJson1DescribeAuditSuppressionCommand = async (
     contents.description = __expectString(data.description);
   }
   if (data.expirationDate !== undefined && data.expirationDate !== null) {
-    contents.expirationDate = new Date(Math.round(data.expirationDate * 1000));
+    contents.expirationDate = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.expirationDate)));
   }
   if (data.resourceIdentifier !== undefined && data.resourceIdentifier !== null) {
     contents.resourceIdentifier = deserializeAws_restJson1ResourceIdentifier(data.resourceIdentifier, context);
@@ -15830,7 +15832,7 @@ export const deserializeAws_restJson1DescribeAuditTaskCommand = async (
     contents.scheduledAuditName = __expectString(data.scheduledAuditName);
   }
   if (data.taskStartTime !== undefined && data.taskStartTime !== null) {
-    contents.taskStartTime = new Date(Math.round(data.taskStartTime * 1000));
+    contents.taskStartTime = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.taskStartTime)));
   }
   if (data.taskStatistics !== undefined && data.taskStatistics !== null) {
     contents.taskStatistics = deserializeAws_restJson1TaskStatistics(data.taskStatistics, context);
@@ -16320,13 +16322,13 @@ export const deserializeAws_restJson1DescribeCustomMetricCommand = async (
   };
   const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.creationDate !== undefined && data.creationDate !== null) {
-    contents.creationDate = new Date(Math.round(data.creationDate * 1000));
+    contents.creationDate = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.creationDate)));
   }
   if (data.displayName !== undefined && data.displayName !== null) {
     contents.displayName = __expectString(data.displayName);
   }
   if (data.lastModifiedDate !== undefined && data.lastModifiedDate !== null) {
-    contents.lastModifiedDate = new Date(Math.round(data.lastModifiedDate * 1000));
+    contents.lastModifiedDate = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.lastModifiedDate)));
   }
   if (data.metricArn !== undefined && data.metricArn !== null) {
     contents.metricArn = __expectString(data.metricArn);
@@ -16596,10 +16598,10 @@ export const deserializeAws_restJson1DescribeDimensionCommand = async (
     contents.arn = __expectString(data.arn);
   }
   if (data.creationDate !== undefined && data.creationDate !== null) {
-    contents.creationDate = new Date(Math.round(data.creationDate * 1000));
+    contents.creationDate = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.creationDate)));
   }
   if (data.lastModifiedDate !== undefined && data.lastModifiedDate !== null) {
-    contents.lastModifiedDate = new Date(Math.round(data.lastModifiedDate * 1000));
+    contents.lastModifiedDate = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.lastModifiedDate)));
   }
   if (data.name !== undefined && data.name !== null) {
     contents.name = __expectString(data.name);
@@ -16713,7 +16715,7 @@ export const deserializeAws_restJson1DescribeDomainConfigurationCommand = async 
     contents.domainType = __expectString(data.domainType);
   }
   if (data.lastStatusChangeDate !== undefined && data.lastStatusChangeDate !== null) {
-    contents.lastStatusChangeDate = new Date(Math.round(data.lastStatusChangeDate * 1000));
+    contents.lastStatusChangeDate = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.lastStatusChangeDate)));
   }
   if (data.serverCertificates !== undefined && data.serverCertificates !== null) {
     contents.serverCertificates = deserializeAws_restJson1ServerCertificates(data.serverCertificates, context);
@@ -16895,13 +16897,13 @@ export const deserializeAws_restJson1DescribeEventConfigurationsCommand = async 
   };
   const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.creationDate !== undefined && data.creationDate !== null) {
-    contents.creationDate = new Date(Math.round(data.creationDate * 1000));
+    contents.creationDate = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.creationDate)));
   }
   if (data.eventConfigurations !== undefined && data.eventConfigurations !== null) {
     contents.eventConfigurations = deserializeAws_restJson1EventConfigurations(data.eventConfigurations, context);
   }
   if (data.lastModifiedDate !== undefined && data.lastModifiedDate !== null) {
-    contents.lastModifiedDate = new Date(Math.round(data.lastModifiedDate * 1000));
+    contents.lastModifiedDate = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.lastModifiedDate)));
   }
   return Promise.resolve(contents);
 };
@@ -16982,7 +16984,7 @@ export const deserializeAws_restJson1DescribeFleetMetricCommand = async (
     contents.aggregationType = deserializeAws_restJson1AggregationType(data.aggregationType, context);
   }
   if (data.creationDate !== undefined && data.creationDate !== null) {
-    contents.creationDate = new Date(Math.round(data.creationDate * 1000));
+    contents.creationDate = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.creationDate)));
   }
   if (data.description !== undefined && data.description !== null) {
     contents.description = __expectString(data.description);
@@ -16991,7 +16993,7 @@ export const deserializeAws_restJson1DescribeFleetMetricCommand = async (
     contents.indexName = __expectString(data.indexName);
   }
   if (data.lastModifiedDate !== undefined && data.lastModifiedDate !== null) {
-    contents.lastModifiedDate = new Date(Math.round(data.lastModifiedDate * 1000));
+    contents.lastModifiedDate = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.lastModifiedDate)));
   }
   if (data.metricArn !== undefined && data.metricArn !== null) {
     contents.metricArn = __expectString(data.metricArn);
@@ -17384,7 +17386,7 @@ export const deserializeAws_restJson1DescribeJobTemplateCommand = async (
     contents.abortConfig = deserializeAws_restJson1AbortConfig(data.abortConfig, context);
   }
   if (data.createdAt !== undefined && data.createdAt !== null) {
-    contents.createdAt = new Date(Math.round(data.createdAt * 1000));
+    contents.createdAt = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.createdAt)));
   }
   if (data.description !== undefined && data.description !== null) {
     contents.description = __expectString(data.description);
@@ -17512,10 +17514,10 @@ export const deserializeAws_restJson1DescribeMitigationActionCommand = async (
     contents.actionType = __expectString(data.actionType);
   }
   if (data.creationDate !== undefined && data.creationDate !== null) {
-    contents.creationDate = new Date(Math.round(data.creationDate * 1000));
+    contents.creationDate = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.creationDate)));
   }
   if (data.lastModifiedDate !== undefined && data.lastModifiedDate !== null) {
-    contents.lastModifiedDate = new Date(Math.round(data.lastModifiedDate * 1000));
+    contents.lastModifiedDate = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.lastModifiedDate)));
   }
   if (data.roleArn !== undefined && data.roleArn !== null) {
     contents.roleArn = __expectString(data.roleArn);
@@ -17606,7 +17608,7 @@ export const deserializeAws_restJson1DescribeProvisioningTemplateCommand = async
   };
   const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.creationDate !== undefined && data.creationDate !== null) {
-    contents.creationDate = new Date(Math.round(data.creationDate * 1000));
+    contents.creationDate = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.creationDate)));
   }
   if (data.defaultVersionId !== undefined && data.defaultVersionId !== null) {
     contents.defaultVersionId = __expectInt32(data.defaultVersionId);
@@ -17618,7 +17620,7 @@ export const deserializeAws_restJson1DescribeProvisioningTemplateCommand = async
     contents.enabled = __expectBoolean(data.enabled);
   }
   if (data.lastModifiedDate !== undefined && data.lastModifiedDate !== null) {
-    contents.lastModifiedDate = new Date(Math.round(data.lastModifiedDate * 1000));
+    contents.lastModifiedDate = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.lastModifiedDate)));
   }
   if (data.preProvisioningHook !== undefined && data.preProvisioningHook !== null) {
     contents.preProvisioningHook = deserializeAws_restJson1ProvisioningHook(data.preProvisioningHook, context);
@@ -17723,7 +17725,7 @@ export const deserializeAws_restJson1DescribeProvisioningTemplateVersionCommand 
   };
   const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.creationDate !== undefined && data.creationDate !== null) {
-    contents.creationDate = new Date(Math.round(data.creationDate * 1000));
+    contents.creationDate = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.creationDate)));
   }
   if (data.isDefaultVersion !== undefined && data.isDefaultVersion !== null) {
     contents.isDefaultVersion = __expectBoolean(data.isDefaultVersion);
@@ -18040,10 +18042,10 @@ export const deserializeAws_restJson1DescribeSecurityProfileCommand = async (
     contents.behaviors = deserializeAws_restJson1Behaviors(data.behaviors, context);
   }
   if (data.creationDate !== undefined && data.creationDate !== null) {
-    contents.creationDate = new Date(Math.round(data.creationDate * 1000));
+    contents.creationDate = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.creationDate)));
   }
   if (data.lastModifiedDate !== undefined && data.lastModifiedDate !== null) {
-    contents.lastModifiedDate = new Date(Math.round(data.lastModifiedDate * 1000));
+    contents.lastModifiedDate = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.lastModifiedDate)));
   }
   if (data.securityProfileArn !== undefined && data.securityProfileArn !== null) {
     contents.securityProfileArn = __expectString(data.securityProfileArn);
@@ -18478,7 +18480,7 @@ export const deserializeAws_restJson1DescribeThingRegistrationTaskCommand = asyn
   };
   const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.creationDate !== undefined && data.creationDate !== null) {
-    contents.creationDate = new Date(Math.round(data.creationDate * 1000));
+    contents.creationDate = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.creationDate)));
   }
   if (data.failureCount !== undefined && data.failureCount !== null) {
     contents.failureCount = __expectInt32(data.failureCount);
@@ -18490,7 +18492,7 @@ export const deserializeAws_restJson1DescribeThingRegistrationTaskCommand = asyn
     contents.inputFileKey = __expectString(data.inputFileKey);
   }
   if (data.lastModifiedDate !== undefined && data.lastModifiedDate !== null) {
-    contents.lastModifiedDate = new Date(Math.round(data.lastModifiedDate * 1000));
+    contents.lastModifiedDate = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.lastModifiedDate)));
   }
   if (data.message !== undefined && data.message !== null) {
     contents.message = __expectString(data.message);
@@ -20122,7 +20124,7 @@ export const deserializeAws_restJson1GetPolicyCommand = async (
   };
   const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.creationDate !== undefined && data.creationDate !== null) {
-    contents.creationDate = new Date(Math.round(data.creationDate * 1000));
+    contents.creationDate = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.creationDate)));
   }
   if (data.defaultVersionId !== undefined && data.defaultVersionId !== null) {
     contents.defaultVersionId = __expectString(data.defaultVersionId);
@@ -20131,7 +20133,7 @@ export const deserializeAws_restJson1GetPolicyCommand = async (
     contents.generationId = __expectString(data.generationId);
   }
   if (data.lastModifiedDate !== undefined && data.lastModifiedDate !== null) {
-    contents.lastModifiedDate = new Date(Math.round(data.lastModifiedDate * 1000));
+    contents.lastModifiedDate = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.lastModifiedDate)));
   }
   if (data.policyArn !== undefined && data.policyArn !== null) {
     contents.policyArn = __expectString(data.policyArn);
@@ -20242,7 +20244,7 @@ export const deserializeAws_restJson1GetPolicyVersionCommand = async (
   };
   const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.creationDate !== undefined && data.creationDate !== null) {
-    contents.creationDate = new Date(Math.round(data.creationDate * 1000));
+    contents.creationDate = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.creationDate)));
   }
   if (data.generationId !== undefined && data.generationId !== null) {
     contents.generationId = __expectString(data.generationId);
@@ -20251,7 +20253,7 @@ export const deserializeAws_restJson1GetPolicyVersionCommand = async (
     contents.isDefaultVersion = __expectBoolean(data.isDefaultVersion);
   }
   if (data.lastModifiedDate !== undefined && data.lastModifiedDate !== null) {
-    contents.lastModifiedDate = new Date(Math.round(data.lastModifiedDate * 1000));
+    contents.lastModifiedDate = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.lastModifiedDate)));
   }
   if (data.policyArn !== undefined && data.policyArn !== null) {
     contents.policyArn = __expectString(data.policyArn);
@@ -28232,13 +28234,13 @@ export const deserializeAws_restJson1UpdateCustomMetricCommand = async (
   };
   const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.creationDate !== undefined && data.creationDate !== null) {
-    contents.creationDate = new Date(Math.round(data.creationDate * 1000));
+    contents.creationDate = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.creationDate)));
   }
   if (data.displayName !== undefined && data.displayName !== null) {
     contents.displayName = __expectString(data.displayName);
   }
   if (data.lastModifiedDate !== undefined && data.lastModifiedDate !== null) {
-    contents.lastModifiedDate = new Date(Math.round(data.lastModifiedDate * 1000));
+    contents.lastModifiedDate = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.lastModifiedDate)));
   }
   if (data.metricArn !== undefined && data.metricArn !== null) {
     contents.metricArn = __expectString(data.metricArn);
@@ -28334,10 +28336,10 @@ export const deserializeAws_restJson1UpdateDimensionCommand = async (
     contents.arn = __expectString(data.arn);
   }
   if (data.creationDate !== undefined && data.creationDate !== null) {
-    contents.creationDate = new Date(Math.round(data.creationDate * 1000));
+    contents.creationDate = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.creationDate)));
   }
   if (data.lastModifiedDate !== undefined && data.lastModifiedDate !== null) {
-    contents.lastModifiedDate = new Date(Math.round(data.lastModifiedDate * 1000));
+    contents.lastModifiedDate = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.lastModifiedDate)));
   }
   if (data.name !== undefined && data.name !== null) {
     contents.name = __expectString(data.name);
@@ -29346,10 +29348,10 @@ export const deserializeAws_restJson1UpdateSecurityProfileCommand = async (
     contents.behaviors = deserializeAws_restJson1Behaviors(data.behaviors, context);
   }
   if (data.creationDate !== undefined && data.creationDate !== null) {
-    contents.creationDate = new Date(Math.round(data.creationDate * 1000));
+    contents.creationDate = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.creationDate)));
   }
   if (data.lastModifiedDate !== undefined && data.lastModifiedDate !== null) {
-    contents.lastModifiedDate = new Date(Math.round(data.lastModifiedDate * 1000));
+    contents.lastModifiedDate = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.lastModifiedDate)));
   }
   if (data.securityProfileArn !== undefined && data.securityProfileArn !== null) {
     contents.securityProfileArn = __expectString(data.securityProfileArn);
@@ -32428,7 +32430,7 @@ const deserializeAws_restJson1ActiveViolation = (output: any, context: __SerdeCo
         : undefined,
     lastViolationTime:
       output.lastViolationTime !== undefined && output.lastViolationTime !== null
-        ? new Date(Math.round(output.lastViolationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastViolationTime)))
         : undefined,
     lastViolationValue:
       output.lastViolationValue !== undefined && output.lastViolationValue !== null
@@ -32443,7 +32445,7 @@ const deserializeAws_restJson1ActiveViolation = (output: any, context: __SerdeCo
     violationId: __expectString(output.violationId),
     violationStartTime:
       output.violationStartTime !== undefined && output.violationStartTime !== null
-        ? new Date(Math.round(output.violationStartTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.violationStartTime)))
         : undefined,
   } as any;
 };
@@ -32739,7 +32741,7 @@ const deserializeAws_restJson1AuditFinding = (output: any, context: __SerdeConte
     findingId: __expectString(output.findingId),
     findingTime:
       output.findingTime !== undefined && output.findingTime !== null
-        ? new Date(Math.round(output.findingTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.findingTime)))
         : undefined,
     isSuppressed: __expectBoolean(output.isSuppressed),
     nonCompliantResource:
@@ -32756,7 +32758,7 @@ const deserializeAws_restJson1AuditFinding = (output: any, context: __SerdeConte
     taskId: __expectString(output.taskId),
     taskStartTime:
       output.taskStartTime !== undefined && output.taskStartTime !== null
-        ? new Date(Math.round(output.taskStartTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.taskStartTime)))
         : undefined,
   } as any;
 };
@@ -32780,13 +32782,15 @@ const deserializeAws_restJson1AuditMitigationActionExecutionMetadata = (
     actionId: __expectString(output.actionId),
     actionName: __expectString(output.actionName),
     endTime:
-      output.endTime !== undefined && output.endTime !== null ? new Date(Math.round(output.endTime * 1000)) : undefined,
+      output.endTime !== undefined && output.endTime !== null
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.endTime)))
+        : undefined,
     errorCode: __expectString(output.errorCode),
     findingId: __expectString(output.findingId),
     message: __expectString(output.message),
     startTime:
       output.startTime !== undefined && output.startTime !== null
-        ? new Date(Math.round(output.startTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.startTime)))
         : undefined,
     status: __expectString(output.status),
     taskId: __expectString(output.taskId),
@@ -32814,7 +32818,7 @@ const deserializeAws_restJson1AuditMitigationActionsTaskMetadata = (
   return {
     startTime:
       output.startTime !== undefined && output.startTime !== null
-        ? new Date(Math.round(output.startTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.startTime)))
         : undefined,
     taskId: __expectString(output.taskId),
     taskStatus: __expectString(output.taskStatus),
@@ -32905,7 +32909,7 @@ const deserializeAws_restJson1AuditSuppression = (output: any, context: __SerdeC
     description: __expectString(output.description),
     expirationDate:
       output.expirationDate !== undefined && output.expirationDate !== null
-        ? new Date(Math.round(output.expirationDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.expirationDate)))
         : undefined,
     resourceIdentifier:
       output.resourceIdentifier !== undefined && output.resourceIdentifier !== null
@@ -32969,11 +32973,11 @@ const deserializeAws_restJson1AuthorizerDescription = (output: any, context: __S
     authorizerName: __expectString(output.authorizerName),
     creationDate:
       output.creationDate !== undefined && output.creationDate !== null
-        ? new Date(Math.round(output.creationDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.creationDate)))
         : undefined,
     lastModifiedDate:
       output.lastModifiedDate !== undefined && output.lastModifiedDate !== null
-        ? new Date(Math.round(output.lastModifiedDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastModifiedDate)))
         : undefined,
     signingDisabled: __expectBoolean(output.signingDisabled),
     status: __expectString(output.status),
@@ -33142,13 +33146,13 @@ const deserializeAws_restJson1BehaviorModelTrainingSummary = (
     datapointsCollectionPercentage: __limitedParseDouble(output.datapointsCollectionPercentage),
     lastModelRefreshDate:
       output.lastModelRefreshDate !== undefined && output.lastModelRefreshDate !== null
-        ? new Date(Math.round(output.lastModelRefreshDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastModelRefreshDate)))
         : undefined,
     modelStatus: __expectString(output.modelStatus),
     securityProfileName: __expectString(output.securityProfileName),
     trainingDataCollectionStartDate:
       output.trainingDataCollectionStartDate !== undefined && output.trainingDataCollectionStartDate !== null
-        ? new Date(Math.round(output.trainingDataCollectionStartDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.trainingDataCollectionStartDate)))
         : undefined,
   } as any;
 };
@@ -33168,7 +33172,7 @@ const deserializeAws_restJson1BillingGroupMetadata = (output: any, context: __Se
   return {
     creationDate:
       output.creationDate !== undefined && output.creationDate !== null
-        ? new Date(Math.round(output.creationDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.creationDate)))
         : undefined,
   } as any;
 };
@@ -33220,7 +33224,7 @@ const deserializeAws_restJson1CACertificate = (output: any, context: __SerdeCont
     certificateId: __expectString(output.certificateId),
     creationDate:
       output.creationDate !== undefined && output.creationDate !== null
-        ? new Date(Math.round(output.creationDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.creationDate)))
         : undefined,
     status: __expectString(output.status),
   } as any;
@@ -33237,13 +33241,13 @@ const deserializeAws_restJson1CACertificateDescription = (
     certificatePem: __expectString(output.certificatePem),
     creationDate:
       output.creationDate !== undefined && output.creationDate !== null
-        ? new Date(Math.round(output.creationDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.creationDate)))
         : undefined,
     customerVersion: __expectInt32(output.customerVersion),
     generationId: __expectString(output.generationId),
     lastModifiedDate:
       output.lastModifiedDate !== undefined && output.lastModifiedDate !== null
-        ? new Date(Math.round(output.lastModifiedDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastModifiedDate)))
         : undefined,
     ownedBy: __expectString(output.ownedBy),
     status: __expectString(output.status),
@@ -33272,7 +33276,7 @@ const deserializeAws_restJson1Certificate = (output: any, context: __SerdeContex
     certificateMode: __expectString(output.certificateMode),
     creationDate:
       output.creationDate !== undefined && output.creationDate !== null
-        ? new Date(Math.round(output.creationDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.creationDate)))
         : undefined,
     status: __expectString(output.status),
   } as any;
@@ -33290,13 +33294,13 @@ const deserializeAws_restJson1CertificateDescription = (
     certificatePem: __expectString(output.certificatePem),
     creationDate:
       output.creationDate !== undefined && output.creationDate !== null
-        ? new Date(Math.round(output.creationDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.creationDate)))
         : undefined,
     customerVersion: __expectInt32(output.customerVersion),
     generationId: __expectString(output.generationId),
     lastModifiedDate:
       output.lastModifiedDate !== undefined && output.lastModifiedDate !== null
-        ? new Date(Math.round(output.lastModifiedDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastModifiedDate)))
         : undefined,
     ownedBy: __expectString(output.ownedBy),
     previousOwnedBy: __expectString(output.previousOwnedBy),
@@ -33327,11 +33331,11 @@ const deserializeAws_restJson1CertificateValidity = (output: any, context: __Ser
   return {
     notAfter:
       output.notAfter !== undefined && output.notAfter !== null
-        ? new Date(Math.round(output.notAfter * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.notAfter)))
         : undefined,
     notBefore:
       output.notBefore !== undefined && output.notBefore !== null
-        ? new Date(Math.round(output.notBefore * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.notBefore)))
         : undefined,
   } as any;
 };
@@ -33486,11 +33490,11 @@ const deserializeAws_restJson1DetectMitigationActionExecution = (
     errorCode: __expectString(output.errorCode),
     executionEndDate:
       output.executionEndDate !== undefined && output.executionEndDate !== null
-        ? new Date(Math.round(output.executionEndDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.executionEndDate)))
         : undefined,
     executionStartDate:
       output.executionStartDate !== undefined && output.executionStartDate !== null
-        ? new Date(Math.round(output.executionStartDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.executionStartDate)))
         : undefined,
     message: __expectString(output.message),
     status: __expectString(output.status),
@@ -33542,12 +33546,12 @@ const deserializeAws_restJson1DetectMitigationActionsTaskSummary = (
         : undefined,
     taskEndTime:
       output.taskEndTime !== undefined && output.taskEndTime !== null
-        ? new Date(Math.round(output.taskEndTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.taskEndTime)))
         : undefined,
     taskId: __expectString(output.taskId),
     taskStartTime:
       output.taskStartTime !== undefined && output.taskStartTime !== null
-        ? new Date(Math.round(output.taskStartTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.taskStartTime)))
         : undefined,
     taskStatistics:
       output.taskStatistics !== undefined && output.taskStatistics !== null
@@ -33944,11 +33948,11 @@ const deserializeAws_restJson1Job = (output: any, context: __SerdeContext): Job 
     comment: __expectString(output.comment),
     completedAt:
       output.completedAt !== undefined && output.completedAt !== null
-        ? new Date(Math.round(output.completedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.completedAt)))
         : undefined,
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
-        ? new Date(Math.round(output.createdAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.createdAt)))
         : undefined,
     description: __expectString(output.description),
     forceCanceled: __expectBoolean(output.forceCanceled),
@@ -33965,7 +33969,7 @@ const deserializeAws_restJson1Job = (output: any, context: __SerdeContext): Job 
     jobTemplateArn: __expectString(output.jobTemplateArn),
     lastUpdatedAt:
       output.lastUpdatedAt !== undefined && output.lastUpdatedAt !== null
-        ? new Date(Math.round(output.lastUpdatedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastUpdatedAt)))
         : undefined,
     namespaceId: __expectString(output.namespaceId),
     presignedUrlConfig:
@@ -33994,15 +33998,15 @@ const deserializeAws_restJson1JobExecution = (output: any, context: __SerdeConte
     jobId: __expectString(output.jobId),
     lastUpdatedAt:
       output.lastUpdatedAt !== undefined && output.lastUpdatedAt !== null
-        ? new Date(Math.round(output.lastUpdatedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastUpdatedAt)))
         : undefined,
     queuedAt:
       output.queuedAt !== undefined && output.queuedAt !== null
-        ? new Date(Math.round(output.queuedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.queuedAt)))
         : undefined,
     startedAt:
       output.startedAt !== undefined && output.startedAt !== null
-        ? new Date(Math.round(output.startedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.startedAt)))
         : undefined,
     status: __expectString(output.status),
     statusDetails:
@@ -34044,15 +34048,15 @@ const deserializeAws_restJson1JobExecutionSummary = (output: any, context: __Ser
     executionNumber: __expectLong(output.executionNumber),
     lastUpdatedAt:
       output.lastUpdatedAt !== undefined && output.lastUpdatedAt !== null
-        ? new Date(Math.round(output.lastUpdatedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastUpdatedAt)))
         : undefined,
     queuedAt:
       output.queuedAt !== undefined && output.queuedAt !== null
-        ? new Date(Math.round(output.queuedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.queuedAt)))
         : undefined,
     startedAt:
       output.startedAt !== undefined && output.startedAt !== null
-        ? new Date(Math.round(output.startedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.startedAt)))
         : undefined,
     status: __expectString(output.status),
   } as any;
@@ -34133,17 +34137,17 @@ const deserializeAws_restJson1JobSummary = (output: any, context: __SerdeContext
   return {
     completedAt:
       output.completedAt !== undefined && output.completedAt !== null
-        ? new Date(Math.round(output.completedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.completedAt)))
         : undefined,
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
-        ? new Date(Math.round(output.createdAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.createdAt)))
         : undefined,
     jobArn: __expectString(output.jobArn),
     jobId: __expectString(output.jobId),
     lastUpdatedAt:
       output.lastUpdatedAt !== undefined && output.lastUpdatedAt !== null
-        ? new Date(Math.round(output.lastUpdatedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastUpdatedAt)))
         : undefined,
     status: __expectString(output.status),
     targetSelection: __expectString(output.targetSelection),
@@ -34177,7 +34181,7 @@ const deserializeAws_restJson1JobTemplateSummary = (output: any, context: __Serd
   return {
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
-        ? new Date(Math.round(output.createdAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.createdAt)))
         : undefined,
     description: __expectString(output.description),
     jobTemplateArn: __expectString(output.jobTemplateArn),
@@ -34356,7 +34360,7 @@ const deserializeAws_restJson1MitigationActionIdentifier = (
     actionName: __expectString(output.actionName),
     creationDate:
       output.creationDate !== undefined && output.creationDate !== null
-        ? new Date(Math.round(output.creationDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.creationDate)))
         : undefined,
   } as any;
 };
@@ -34503,7 +34507,7 @@ const deserializeAws_restJson1OTAUpdateInfo = (output: any, context: __SerdeCont
         : undefined,
     creationDate:
       output.creationDate !== undefined && output.creationDate !== null
-        ? new Date(Math.round(output.creationDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.creationDate)))
         : undefined,
     description: __expectString(output.description),
     errorInfo:
@@ -34512,7 +34516,7 @@ const deserializeAws_restJson1OTAUpdateInfo = (output: any, context: __SerdeCont
         : undefined,
     lastModifiedDate:
       output.lastModifiedDate !== undefined && output.lastModifiedDate !== null
-        ? new Date(Math.round(output.lastModifiedDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastModifiedDate)))
         : undefined,
     otaUpdateArn: __expectString(output.otaUpdateArn),
     otaUpdateFiles:
@@ -34548,7 +34552,7 @@ const deserializeAws_restJson1OTAUpdateSummary = (output: any, context: __SerdeC
   return {
     creationDate:
       output.creationDate !== undefined && output.creationDate !== null
-        ? new Date(Math.round(output.creationDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.creationDate)))
         : undefined,
     otaUpdateArn: __expectString(output.otaUpdateArn),
     otaUpdateId: __expectString(output.otaUpdateId),
@@ -34561,11 +34565,11 @@ const deserializeAws_restJson1OutgoingCertificate = (output: any, context: __Ser
     certificateId: __expectString(output.certificateId),
     creationDate:
       output.creationDate !== undefined && output.creationDate !== null
-        ? new Date(Math.round(output.creationDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.creationDate)))
         : undefined,
     transferDate:
       output.transferDate !== undefined && output.transferDate !== null
-        ? new Date(Math.round(output.transferDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.transferDate)))
         : undefined,
     transferMessage: __expectString(output.transferMessage),
     transferredTo: __expectString(output.transferredTo),
@@ -34645,7 +34649,7 @@ const deserializeAws_restJson1PolicyVersion = (output: any, context: __SerdeCont
   return {
     createDate:
       output.createDate !== undefined && output.createDate !== null
-        ? new Date(Math.round(output.createDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.createDate)))
         : undefined,
     isDefaultVersion: __expectBoolean(output.isDefaultVersion),
     versionId: __expectString(output.versionId),
@@ -34752,13 +34756,13 @@ const deserializeAws_restJson1ProvisioningTemplateSummary = (
   return {
     creationDate:
       output.creationDate !== undefined && output.creationDate !== null
-        ? new Date(Math.round(output.creationDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.creationDate)))
         : undefined,
     description: __expectString(output.description),
     enabled: __expectBoolean(output.enabled),
     lastModifiedDate:
       output.lastModifiedDate !== undefined && output.lastModifiedDate !== null
-        ? new Date(Math.round(output.lastModifiedDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastModifiedDate)))
         : undefined,
     templateArn: __expectString(output.templateArn),
     templateName: __expectString(output.templateName),
@@ -34786,7 +34790,7 @@ const deserializeAws_restJson1ProvisioningTemplateVersionSummary = (
   return {
     creationDate:
       output.creationDate !== undefined && output.creationDate !== null
-        ? new Date(Math.round(output.creationDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.creationDate)))
         : undefined,
     isDefaultVersion: __expectBoolean(output.isDefaultVersion),
     versionId: __expectInt32(output.versionId),
@@ -34960,12 +34964,12 @@ const deserializeAws_restJson1RoleAliasDescription = (output: any, context: __Se
   return {
     creationDate:
       output.creationDate !== undefined && output.creationDate !== null
-        ? new Date(Math.round(output.creationDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.creationDate)))
         : undefined,
     credentialDurationSeconds: __expectInt32(output.credentialDurationSeconds),
     lastModifiedDate:
       output.lastModifiedDate !== undefined && output.lastModifiedDate !== null
-        ? new Date(Math.round(output.lastModifiedDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastModifiedDate)))
         : undefined,
     owner: __expectString(output.owner),
     roleAlias: __expectString(output.roleAlias),
@@ -35286,7 +35290,7 @@ const deserializeAws_restJson1StreamInfo = (output: any, context: __SerdeContext
   return {
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
-        ? new Date(Math.round(output.createdAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.createdAt)))
         : undefined,
     description: __expectString(output.description),
     files:
@@ -35295,7 +35299,7 @@ const deserializeAws_restJson1StreamInfo = (output: any, context: __SerdeContext
         : undefined,
     lastUpdatedAt:
       output.lastUpdatedAt !== undefined && output.lastUpdatedAt !== null
-        ? new Date(Math.round(output.lastUpdatedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastUpdatedAt)))
         : undefined,
     roleArn: __expectString(output.roleArn),
     streamArn: __expectString(output.streamArn),
@@ -35560,7 +35564,7 @@ const deserializeAws_restJson1ThingGroupMetadata = (output: any, context: __Serd
   return {
     creationDate:
       output.creationDate !== undefined && output.creationDate !== null
-        ? new Date(Math.round(output.creationDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.creationDate)))
         : undefined,
     parentGroupName: __expectString(output.parentGroupName),
     rootToParentThingGroups:
@@ -35672,12 +35676,12 @@ const deserializeAws_restJson1ThingTypeMetadata = (output: any, context: __Serde
   return {
     creationDate:
       output.creationDate !== undefined && output.creationDate !== null
-        ? new Date(Math.round(output.creationDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.creationDate)))
         : undefined,
     deprecated: __expectBoolean(output.deprecated),
     deprecationDate:
       output.deprecationDate !== undefined && output.deprecationDate !== null
-        ? new Date(Math.round(output.deprecationDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.deprecationDate)))
         : undefined,
   } as any;
 };
@@ -35751,7 +35755,7 @@ const deserializeAws_restJson1TopicRule = (output: any, context: __SerdeContext)
     awsIotSqlVersion: __expectString(output.awsIotSqlVersion),
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
-        ? new Date(Math.round(output.createdAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.createdAt)))
         : undefined,
     description: __expectString(output.description),
     errorAction:
@@ -35769,7 +35773,7 @@ const deserializeAws_restJson1TopicRuleDestination = (output: any, context: __Se
     arn: __expectString(output.arn),
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
-        ? new Date(Math.round(output.createdAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.createdAt)))
         : undefined,
     httpUrlProperties:
       output.httpUrlProperties !== undefined && output.httpUrlProperties !== null
@@ -35777,7 +35781,7 @@ const deserializeAws_restJson1TopicRuleDestination = (output: any, context: __Se
         : undefined,
     lastUpdatedAt:
       output.lastUpdatedAt !== undefined && output.lastUpdatedAt !== null
-        ? new Date(Math.round(output.lastUpdatedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastUpdatedAt)))
         : undefined,
     status: __expectString(output.status),
     statusReason: __expectString(output.statusReason),
@@ -35810,7 +35814,7 @@ const deserializeAws_restJson1TopicRuleDestinationSummary = (
     arn: __expectString(output.arn),
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
-        ? new Date(Math.round(output.createdAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.createdAt)))
         : undefined,
     httpUrlSummary:
       output.httpUrlSummary !== undefined && output.httpUrlSummary !== null
@@ -35818,7 +35822,7 @@ const deserializeAws_restJson1TopicRuleDestinationSummary = (
         : undefined,
     lastUpdatedAt:
       output.lastUpdatedAt !== undefined && output.lastUpdatedAt !== null
-        ? new Date(Math.round(output.lastUpdatedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastUpdatedAt)))
         : undefined,
     status: __expectString(output.status),
     statusReason: __expectString(output.statusReason),
@@ -35844,7 +35848,7 @@ const deserializeAws_restJson1TopicRuleListItem = (output: any, context: __Serde
   return {
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
-        ? new Date(Math.round(output.createdAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.createdAt)))
         : undefined,
     ruleArn: __expectString(output.ruleArn),
     ruleDisabled: __expectBoolean(output.ruleDisabled),
@@ -35857,16 +35861,16 @@ const deserializeAws_restJson1TransferData = (output: any, context: __SerdeConte
   return {
     acceptDate:
       output.acceptDate !== undefined && output.acceptDate !== null
-        ? new Date(Math.round(output.acceptDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.acceptDate)))
         : undefined,
     rejectDate:
       output.rejectDate !== undefined && output.rejectDate !== null
-        ? new Date(Math.round(output.rejectDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.rejectDate)))
         : undefined,
     rejectReason: __expectString(output.rejectReason),
     transferDate:
       output.transferDate !== undefined && output.transferDate !== null
-        ? new Date(Math.round(output.transferDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.transferDate)))
         : undefined,
     transferMessage: __expectString(output.transferMessage),
   } as any;
@@ -35925,7 +35929,7 @@ const deserializeAws_restJson1ViolationEvent = (output: any, context: __SerdeCon
         : undefined,
     violationEventTime:
       output.violationEventTime !== undefined && output.violationEventTime !== null
-        ? new Date(Math.round(output.violationEventTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.violationEventTime)))
         : undefined,
     violationEventType: __expectString(output.violationEventType),
     violationId: __expectString(output.violationId),
@@ -35947,10 +35951,12 @@ const deserializeAws_restJson1ViolationEventOccurrenceRange = (
 ): ViolationEventOccurrenceRange => {
   return {
     endTime:
-      output.endTime !== undefined && output.endTime !== null ? new Date(Math.round(output.endTime * 1000)) : undefined,
+      output.endTime !== undefined && output.endTime !== null
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.endTime)))
+        : undefined,
     startTime:
       output.startTime !== undefined && output.startTime !== null
-        ? new Date(Math.round(output.startTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.startTime)))
         : undefined,
   } as any;
 };

--- a/clients/client-iotanalytics/protocols/Aws_restJson1.ts
+++ b/clients/client-iotanalytics/protocols/Aws_restJson1.ts
@@ -149,10 +149,12 @@ import {
   expectBoolean as __expectBoolean,
   expectInt32 as __expectInt32,
   expectNonNull as __expectNonNull,
+  expectNumber as __expectNumber,
   expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   limitedParseDouble as __limitedParseDouble,
+  parseEpochTimestamp as __parseEpochTimestamp,
   serializeFloat as __serializeFloat,
 } from "@aws-sdk/smithy-client";
 import {
@@ -2803,7 +2805,7 @@ export const deserializeAws_restJson1GetDatasetContentCommand = async (
     contents.status = deserializeAws_restJson1DatasetContentStatus(data.status, context);
   }
   if (data.timestamp !== undefined && data.timestamp !== null) {
-    contents.timestamp = new Date(Math.round(data.timestamp * 1000));
+    contents.timestamp = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.timestamp)));
   }
   return Promise.resolve(contents);
 };
@@ -5189,15 +5191,15 @@ const deserializeAws_restJson1Channel = (output: any, context: __SerdeContext): 
     arn: __expectString(output.arn),
     creationTime:
       output.creationTime !== undefined && output.creationTime !== null
-        ? new Date(Math.round(output.creationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.creationTime)))
         : undefined,
     lastMessageArrivalTime:
       output.lastMessageArrivalTime !== undefined && output.lastMessageArrivalTime !== null
-        ? new Date(Math.round(output.lastMessageArrivalTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastMessageArrivalTime)))
         : undefined,
     lastUpdateTime:
       output.lastUpdateTime !== undefined && output.lastUpdateTime !== null
-        ? new Date(Math.round(output.lastUpdateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastUpdateTime)))
         : undefined,
     name: __expectString(output.name),
     retentionPeriod:
@@ -5275,15 +5277,15 @@ const deserializeAws_restJson1ChannelSummary = (output: any, context: __SerdeCon
         : undefined,
     creationTime:
       output.creationTime !== undefined && output.creationTime !== null
-        ? new Date(Math.round(output.creationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.creationTime)))
         : undefined,
     lastMessageArrivalTime:
       output.lastMessageArrivalTime !== undefined && output.lastMessageArrivalTime !== null
-        ? new Date(Math.round(output.lastMessageArrivalTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastMessageArrivalTime)))
         : undefined,
     lastUpdateTime:
       output.lastUpdateTime !== undefined && output.lastUpdateTime !== null
-        ? new Date(Math.round(output.lastUpdateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastUpdateTime)))
         : undefined,
     status: __expectString(output.status),
   } as any;
@@ -5382,11 +5384,11 @@ const deserializeAws_restJson1Dataset = (output: any, context: __SerdeContext): 
         : undefined,
     creationTime:
       output.creationTime !== undefined && output.creationTime !== null
-        ? new Date(Math.round(output.creationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.creationTime)))
         : undefined,
     lastUpdateTime:
       output.lastUpdateTime !== undefined && output.lastUpdateTime !== null
-        ? new Date(Math.round(output.lastUpdateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastUpdateTime)))
         : undefined,
     lateDataRules:
       output.lateDataRules !== undefined && output.lateDataRules !== null
@@ -5523,15 +5525,15 @@ const deserializeAws_restJson1DatasetContentSummary = (output: any, context: __S
   return {
     completionTime:
       output.completionTime !== undefined && output.completionTime !== null
-        ? new Date(Math.round(output.completionTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.completionTime)))
         : undefined,
     creationTime:
       output.creationTime !== undefined && output.creationTime !== null
-        ? new Date(Math.round(output.creationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.creationTime)))
         : undefined,
     scheduleTime:
       output.scheduleTime !== undefined && output.scheduleTime !== null
-        ? new Date(Math.round(output.scheduleTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.scheduleTime)))
         : undefined,
     status:
       output.status !== undefined && output.status !== null
@@ -5587,12 +5589,12 @@ const deserializeAws_restJson1DatasetSummary = (output: any, context: __SerdeCon
         : undefined,
     creationTime:
       output.creationTime !== undefined && output.creationTime !== null
-        ? new Date(Math.round(output.creationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.creationTime)))
         : undefined,
     datasetName: __expectString(output.datasetName),
     lastUpdateTime:
       output.lastUpdateTime !== undefined && output.lastUpdateTime !== null
-        ? new Date(Math.round(output.lastUpdateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastUpdateTime)))
         : undefined,
     status: __expectString(output.status),
     triggers:
@@ -5631,7 +5633,7 @@ const deserializeAws_restJson1Datastore = (output: any, context: __SerdeContext)
     arn: __expectString(output.arn),
     creationTime:
       output.creationTime !== undefined && output.creationTime !== null
-        ? new Date(Math.round(output.creationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.creationTime)))
         : undefined,
     datastorePartitions:
       output.datastorePartitions !== undefined && output.datastorePartitions !== null
@@ -5643,11 +5645,11 @@ const deserializeAws_restJson1Datastore = (output: any, context: __SerdeContext)
         : undefined,
     lastMessageArrivalTime:
       output.lastMessageArrivalTime !== undefined && output.lastMessageArrivalTime !== null
-        ? new Date(Math.round(output.lastMessageArrivalTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastMessageArrivalTime)))
         : undefined,
     lastUpdateTime:
       output.lastUpdateTime !== undefined && output.lastUpdateTime !== null
-        ? new Date(Math.round(output.lastUpdateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastUpdateTime)))
         : undefined,
     name: __expectString(output.name),
     retentionPeriod:
@@ -5787,7 +5789,7 @@ const deserializeAws_restJson1DatastoreSummary = (output: any, context: __SerdeC
   return {
     creationTime:
       output.creationTime !== undefined && output.creationTime !== null
-        ? new Date(Math.round(output.creationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.creationTime)))
         : undefined,
     datastoreName: __expectString(output.datastoreName),
     datastorePartitions:
@@ -5801,11 +5803,11 @@ const deserializeAws_restJson1DatastoreSummary = (output: any, context: __SerdeC
     fileFormatType: __expectString(output.fileFormatType),
     lastMessageArrivalTime:
       output.lastMessageArrivalTime !== undefined && output.lastMessageArrivalTime !== null
-        ? new Date(Math.round(output.lastMessageArrivalTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastMessageArrivalTime)))
         : undefined,
     lastUpdateTime:
       output.lastUpdateTime !== undefined && output.lastUpdateTime !== null
-        ? new Date(Math.round(output.lastUpdateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastUpdateTime)))
         : undefined,
     status: __expectString(output.status),
   } as any;
@@ -5857,7 +5859,7 @@ const deserializeAws_restJson1EstimatedResourceSize = (output: any, context: __S
   return {
     estimatedOn:
       output.estimatedOn !== undefined && output.estimatedOn !== null
-        ? new Date(Math.round(output.estimatedOn * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.estimatedOn)))
         : undefined,
     estimatedSizeInBytes: __limitedParseDouble(output.estimatedSizeInBytes),
   } as any;
@@ -6042,11 +6044,11 @@ const deserializeAws_restJson1Pipeline = (output: any, context: __SerdeContext):
     arn: __expectString(output.arn),
     creationTime:
       output.creationTime !== undefined && output.creationTime !== null
-        ? new Date(Math.round(output.creationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.creationTime)))
         : undefined,
     lastUpdateTime:
       output.lastUpdateTime !== undefined && output.lastUpdateTime !== null
-        ? new Date(Math.round(output.lastUpdateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastUpdateTime)))
         : undefined,
     name: __expectString(output.name),
     reprocessingSummaries:
@@ -6127,11 +6129,11 @@ const deserializeAws_restJson1PipelineSummary = (output: any, context: __SerdeCo
   return {
     creationTime:
       output.creationTime !== undefined && output.creationTime !== null
-        ? new Date(Math.round(output.creationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.creationTime)))
         : undefined,
     lastUpdateTime:
       output.lastUpdateTime !== undefined && output.lastUpdateTime !== null
-        ? new Date(Math.round(output.lastUpdateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastUpdateTime)))
         : undefined,
     pipelineName: __expectString(output.pipelineName),
     reprocessingSummaries:
@@ -6190,7 +6192,7 @@ const deserializeAws_restJson1ReprocessingSummary = (output: any, context: __Ser
   return {
     creationTime:
       output.creationTime !== undefined && output.creationTime !== null
-        ? new Date(Math.round(output.creationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.creationTime)))
         : undefined,
     id: __expectString(output.id),
     status: __expectString(output.status),

--- a/clients/client-iotdeviceadvisor/protocols/Aws_restJson1.ts
+++ b/clients/client-iotdeviceadvisor/protocols/Aws_restJson1.ts
@@ -45,9 +45,11 @@ import {
   expectBoolean as __expectBoolean,
   expectInt32 as __expectInt32,
   expectNonNull as __expectNonNull,
+  expectNumber as __expectNumber,
   expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
+  parseEpochTimestamp as __parseEpochTimestamp,
 } from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
@@ -507,7 +509,7 @@ export const deserializeAws_restJson1CreateSuiteDefinitionCommand = async (
   };
   const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.createdAt !== undefined && data.createdAt !== null) {
-    contents.createdAt = new Date(Math.round(data.createdAt * 1000));
+    contents.createdAt = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.createdAt)));
   }
   if (data.suiteDefinitionArn !== undefined && data.suiteDefinitionArn !== null) {
     contents.suiteDefinitionArn = __expectString(data.suiteDefinitionArn);
@@ -645,10 +647,10 @@ export const deserializeAws_restJson1GetSuiteDefinitionCommand = async (
   };
   const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.createdAt !== undefined && data.createdAt !== null) {
-    contents.createdAt = new Date(Math.round(data.createdAt * 1000));
+    contents.createdAt = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.createdAt)));
   }
   if (data.lastModifiedAt !== undefined && data.lastModifiedAt !== null) {
-    contents.lastModifiedAt = new Date(Math.round(data.lastModifiedAt * 1000));
+    contents.lastModifiedAt = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.lastModifiedAt)));
   }
   if (data.latestVersion !== undefined && data.latestVersion !== null) {
     contents.latestVersion = __expectString(data.latestVersion);
@@ -750,13 +752,13 @@ export const deserializeAws_restJson1GetSuiteRunCommand = async (
   };
   const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.endTime !== undefined && data.endTime !== null) {
-    contents.endTime = new Date(Math.round(data.endTime * 1000));
+    contents.endTime = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.endTime)));
   }
   if (data.errorReason !== undefined && data.errorReason !== null) {
     contents.errorReason = __expectString(data.errorReason);
   }
   if (data.startTime !== undefined && data.startTime !== null) {
-    contents.startTime = new Date(Math.round(data.startTime * 1000));
+    contents.startTime = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.startTime)));
   }
   if (data.status !== undefined && data.status !== null) {
     contents.status = __expectString(data.status);
@@ -1132,7 +1134,7 @@ export const deserializeAws_restJson1StartSuiteRunCommand = async (
   };
   const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.createdAt !== undefined && data.createdAt !== null) {
-    contents.createdAt = new Date(Math.round(data.createdAt * 1000));
+    contents.createdAt = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.createdAt)));
   }
   if (data.suiteRunArn !== undefined && data.suiteRunArn !== null) {
     contents.suiteRunArn = __expectString(data.suiteRunArn);
@@ -1415,10 +1417,10 @@ export const deserializeAws_restJson1UpdateSuiteDefinitionCommand = async (
   };
   const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.createdAt !== undefined && data.createdAt !== null) {
-    contents.createdAt = new Date(Math.round(data.createdAt * 1000));
+    contents.createdAt = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.createdAt)));
   }
   if (data.lastUpdatedAt !== undefined && data.lastUpdatedAt !== null) {
-    contents.lastUpdatedAt = new Date(Math.round(data.lastUpdatedAt * 1000));
+    contents.lastUpdatedAt = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.lastUpdatedAt)));
   }
   if (data.suiteDefinitionArn !== undefined && data.suiteDefinitionArn !== null) {
     contents.suiteDefinitionArn = __expectString(data.suiteDefinitionArn);
@@ -1694,7 +1696,7 @@ const deserializeAws_restJson1SuiteDefinitionInformation = (
   return {
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
-        ? new Date(Math.round(output.createdAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.createdAt)))
         : undefined,
     defaultDevices:
       output.defaultDevices !== undefined && output.defaultDevices !== null
@@ -1737,14 +1739,17 @@ const deserializeAws_restJson1SuiteRunInformation = (output: any, context: __Ser
   return {
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
-        ? new Date(Math.round(output.createdAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.createdAt)))
         : undefined,
-    endAt: output.endAt !== undefined && output.endAt !== null ? new Date(Math.round(output.endAt * 1000)) : undefined,
+    endAt:
+      output.endAt !== undefined && output.endAt !== null
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.endAt)))
+        : undefined,
     failed: __expectInt32(output.failed),
     passed: __expectInt32(output.passed),
     startedAt:
       output.startedAt !== undefined && output.startedAt !== null
-        ? new Date(Math.round(output.startedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.startedAt)))
         : undefined,
     status: __expectString(output.status),
     suiteDefinitionId: __expectString(output.suiteDefinitionId),
@@ -1780,12 +1785,14 @@ const deserializeAws_restJson1TagMap = (output: any, context: __SerdeContext): {
 const deserializeAws_restJson1TestCaseRun = (output: any, context: __SerdeContext): TestCaseRun => {
   return {
     endTime:
-      output.endTime !== undefined && output.endTime !== null ? new Date(Math.round(output.endTime * 1000)) : undefined,
+      output.endTime !== undefined && output.endTime !== null
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.endTime)))
+        : undefined,
     failure: __expectString(output.failure),
     logUrl: __expectString(output.logUrl),
     startTime:
       output.startTime !== undefined && output.startTime !== null
-        ? new Date(Math.round(output.startTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.startTime)))
         : undefined,
     status: __expectString(output.status),
     testCaseDefinitionId: __expectString(output.testCaseDefinitionId),

--- a/clients/client-iotsecuretunneling/protocols/Aws_json1_1.ts
+++ b/clients/client-iotsecuretunneling/protocols/Aws_json1_1.ts
@@ -33,7 +33,13 @@ import {
   UntagResourceResponse,
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
-import { expectInt32 as __expectInt32, expectString as __expectString } from "@aws-sdk/smithy-client";
+import {
+  expectInt32 as __expectInt32,
+  expectNonNull as __expectNonNull,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
+  parseEpochTimestamp as __parseEpochTimestamp,
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   HeaderBag as __HeaderBag,
@@ -657,7 +663,7 @@ const deserializeAws_json1_1ConnectionState = (output: any, context: __SerdeCont
   return {
     lastUpdatedAt:
       output.lastUpdatedAt !== undefined && output.lastUpdatedAt !== null
-        ? new Date(Math.round(output.lastUpdatedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastUpdatedAt)))
         : undefined,
     status: __expectString(output.status),
   } as any;
@@ -771,7 +777,7 @@ const deserializeAws_json1_1Tunnel = (output: any, context: __SerdeContext): Tun
   return {
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
-        ? new Date(Math.round(output.createdAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.createdAt)))
         : undefined,
     description: __expectString(output.description),
     destinationConfig:
@@ -784,7 +790,7 @@ const deserializeAws_json1_1Tunnel = (output: any, context: __SerdeContext): Tun
         : undefined,
     lastUpdatedAt:
       output.lastUpdatedAt !== undefined && output.lastUpdatedAt !== null
-        ? new Date(Math.round(output.lastUpdatedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastUpdatedAt)))
         : undefined,
     sourceConnectionState:
       output.sourceConnectionState !== undefined && output.sourceConnectionState !== null
@@ -808,12 +814,12 @@ const deserializeAws_json1_1TunnelSummary = (output: any, context: __SerdeContex
   return {
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
-        ? new Date(Math.round(output.createdAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.createdAt)))
         : undefined,
     description: __expectString(output.description),
     lastUpdatedAt:
       output.lastUpdatedAt !== undefined && output.lastUpdatedAt !== null
-        ? new Date(Math.round(output.lastUpdatedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastUpdatedAt)))
         : undefined,
     status: __expectString(output.status),
     tunnelArn: __expectString(output.tunnelArn),

--- a/clients/client-iotsitewise/protocols/Aws_restJson1.ts
+++ b/clients/client-iotsitewise/protocols/Aws_restJson1.ts
@@ -212,10 +212,12 @@ import {
   expectInt32 as __expectInt32,
   expectLong as __expectLong,
   expectNonNull as __expectNonNull,
+  expectNumber as __expectNumber,
   expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   limitedParseDouble as __limitedParseDouble,
+  parseEpochTimestamp as __parseEpochTimestamp,
   serializeFloat as __serializeFloat,
 } from "@aws-sdk/smithy-client";
 import {
@@ -4198,7 +4200,9 @@ export const deserializeAws_restJson1DescribeAccessPolicyCommand = async (
     contents.accessPolicyArn = __expectString(data.accessPolicyArn);
   }
   if (data.accessPolicyCreationDate !== undefined && data.accessPolicyCreationDate !== null) {
-    contents.accessPolicyCreationDate = new Date(Math.round(data.accessPolicyCreationDate * 1000));
+    contents.accessPolicyCreationDate = __expectNonNull(
+      __parseEpochTimestamp(__expectNumber(data.accessPolicyCreationDate))
+    );
   }
   if (data.accessPolicyId !== undefined && data.accessPolicyId !== null) {
     contents.accessPolicyId = __expectString(data.accessPolicyId);
@@ -4207,7 +4211,9 @@ export const deserializeAws_restJson1DescribeAccessPolicyCommand = async (
     contents.accessPolicyIdentity = deserializeAws_restJson1Identity(data.accessPolicyIdentity, context);
   }
   if (data.accessPolicyLastUpdateDate !== undefined && data.accessPolicyLastUpdateDate !== null) {
-    contents.accessPolicyLastUpdateDate = new Date(Math.round(data.accessPolicyLastUpdateDate * 1000));
+    contents.accessPolicyLastUpdateDate = __expectNonNull(
+      __parseEpochTimestamp(__expectNumber(data.accessPolicyLastUpdateDate))
+    );
   }
   if (data.accessPolicyPermission !== undefined && data.accessPolicyPermission !== null) {
     contents.accessPolicyPermission = __expectString(data.accessPolicyPermission);
@@ -4307,7 +4313,7 @@ export const deserializeAws_restJson1DescribeAssetCommand = async (
     contents.assetCompositeModels = deserializeAws_restJson1AssetCompositeModels(data.assetCompositeModels, context);
   }
   if (data.assetCreationDate !== undefined && data.assetCreationDate !== null) {
-    contents.assetCreationDate = new Date(Math.round(data.assetCreationDate * 1000));
+    contents.assetCreationDate = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.assetCreationDate)));
   }
   if (data.assetHierarchies !== undefined && data.assetHierarchies !== null) {
     contents.assetHierarchies = deserializeAws_restJson1AssetHierarchies(data.assetHierarchies, context);
@@ -4316,7 +4322,7 @@ export const deserializeAws_restJson1DescribeAssetCommand = async (
     contents.assetId = __expectString(data.assetId);
   }
   if (data.assetLastUpdateDate !== undefined && data.assetLastUpdateDate !== null) {
-    contents.assetLastUpdateDate = new Date(Math.round(data.assetLastUpdateDate * 1000));
+    contents.assetLastUpdateDate = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.assetLastUpdateDate)));
   }
   if (data.assetModelId !== undefined && data.assetModelId !== null) {
     contents.assetModelId = __expectString(data.assetModelId);
@@ -4425,7 +4431,9 @@ export const deserializeAws_restJson1DescribeAssetModelCommand = async (
     );
   }
   if (data.assetModelCreationDate !== undefined && data.assetModelCreationDate !== null) {
-    contents.assetModelCreationDate = new Date(Math.round(data.assetModelCreationDate * 1000));
+    contents.assetModelCreationDate = __expectNonNull(
+      __parseEpochTimestamp(__expectNumber(data.assetModelCreationDate))
+    );
   }
   if (data.assetModelDescription !== undefined && data.assetModelDescription !== null) {
     contents.assetModelDescription = __expectString(data.assetModelDescription);
@@ -4437,7 +4445,9 @@ export const deserializeAws_restJson1DescribeAssetModelCommand = async (
     contents.assetModelId = __expectString(data.assetModelId);
   }
   if (data.assetModelLastUpdateDate !== undefined && data.assetModelLastUpdateDate !== null) {
-    contents.assetModelLastUpdateDate = new Date(Math.round(data.assetModelLastUpdateDate * 1000));
+    contents.assetModelLastUpdateDate = __expectNonNull(
+      __parseEpochTimestamp(__expectNumber(data.assetModelLastUpdateDate))
+    );
   }
   if (data.assetModelName !== undefined && data.assetModelName !== null) {
     contents.assetModelName = __expectString(data.assetModelName);
@@ -4630,7 +4640,7 @@ export const deserializeAws_restJson1DescribeDashboardCommand = async (
     contents.dashboardArn = __expectString(data.dashboardArn);
   }
   if (data.dashboardCreationDate !== undefined && data.dashboardCreationDate !== null) {
-    contents.dashboardCreationDate = new Date(Math.round(data.dashboardCreationDate * 1000));
+    contents.dashboardCreationDate = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.dashboardCreationDate)));
   }
   if (data.dashboardDefinition !== undefined && data.dashboardDefinition !== null) {
     contents.dashboardDefinition = __expectString(data.dashboardDefinition);
@@ -4642,7 +4652,9 @@ export const deserializeAws_restJson1DescribeDashboardCommand = async (
     contents.dashboardId = __expectString(data.dashboardId);
   }
   if (data.dashboardLastUpdateDate !== undefined && data.dashboardLastUpdateDate !== null) {
-    contents.dashboardLastUpdateDate = new Date(Math.round(data.dashboardLastUpdateDate * 1000));
+    contents.dashboardLastUpdateDate = __expectNonNull(
+      __parseEpochTimestamp(__expectNumber(data.dashboardLastUpdateDate))
+    );
   }
   if (data.dashboardName !== undefined && data.dashboardName !== null) {
     contents.dashboardName = __expectString(data.dashboardName);
@@ -4812,7 +4824,7 @@ export const deserializeAws_restJson1DescribeGatewayCommand = async (
   };
   const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.creationDate !== undefined && data.creationDate !== null) {
-    contents.creationDate = new Date(Math.round(data.creationDate * 1000));
+    contents.creationDate = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.creationDate)));
   }
   if (data.gatewayArn !== undefined && data.gatewayArn !== null) {
     contents.gatewayArn = __expectString(data.gatewayArn);
@@ -4833,7 +4845,7 @@ export const deserializeAws_restJson1DescribeGatewayCommand = async (
     contents.gatewayPlatform = deserializeAws_restJson1GatewayPlatform(data.gatewayPlatform, context);
   }
   if (data.lastUpdateDate !== undefined && data.lastUpdateDate !== null) {
-    contents.lastUpdateDate = new Date(Math.round(data.lastUpdateDate * 1000));
+    contents.lastUpdateDate = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.lastUpdateDate)));
   }
   return Promise.resolve(contents);
 };
@@ -5114,7 +5126,7 @@ export const deserializeAws_restJson1DescribePortalCommand = async (
     contents.portalContactEmail = __expectString(data.portalContactEmail);
   }
   if (data.portalCreationDate !== undefined && data.portalCreationDate !== null) {
-    contents.portalCreationDate = new Date(Math.round(data.portalCreationDate * 1000));
+    contents.portalCreationDate = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.portalCreationDate)));
   }
   if (data.portalDescription !== undefined && data.portalDescription !== null) {
     contents.portalDescription = __expectString(data.portalDescription);
@@ -5123,7 +5135,7 @@ export const deserializeAws_restJson1DescribePortalCommand = async (
     contents.portalId = __expectString(data.portalId);
   }
   if (data.portalLastUpdateDate !== undefined && data.portalLastUpdateDate !== null) {
-    contents.portalLastUpdateDate = new Date(Math.round(data.portalLastUpdateDate * 1000));
+    contents.portalLastUpdateDate = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.portalLastUpdateDate)));
   }
   if (data.portalLogoImageLocation !== undefined && data.portalLogoImageLocation !== null) {
     contents.portalLogoImageLocation = deserializeAws_restJson1ImageLocation(data.portalLogoImageLocation, context);
@@ -5229,7 +5241,7 @@ export const deserializeAws_restJson1DescribeProjectCommand = async (
     contents.projectArn = __expectString(data.projectArn);
   }
   if (data.projectCreationDate !== undefined && data.projectCreationDate !== null) {
-    contents.projectCreationDate = new Date(Math.round(data.projectCreationDate * 1000));
+    contents.projectCreationDate = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.projectCreationDate)));
   }
   if (data.projectDescription !== undefined && data.projectDescription !== null) {
     contents.projectDescription = __expectString(data.projectDescription);
@@ -5238,7 +5250,7 @@ export const deserializeAws_restJson1DescribeProjectCommand = async (
     contents.projectId = __expectString(data.projectId);
   }
   if (data.projectLastUpdateDate !== undefined && data.projectLastUpdateDate !== null) {
-    contents.projectLastUpdateDate = new Date(Math.round(data.projectLastUpdateDate * 1000));
+    contents.projectLastUpdateDate = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.projectLastUpdateDate)));
   }
   if (data.projectName !== undefined && data.projectName !== null) {
     contents.projectName = __expectString(data.projectName);
@@ -5326,7 +5338,7 @@ export const deserializeAws_restJson1DescribeStorageConfigurationCommand = async
     contents.configurationStatus = deserializeAws_restJson1ConfigurationStatus(data.configurationStatus, context);
   }
   if (data.lastUpdateDate !== undefined && data.lastUpdateDate !== null) {
-    contents.lastUpdateDate = new Date(Math.round(data.lastUpdateDate * 1000));
+    contents.lastUpdateDate = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.lastUpdateDate)));
   }
   if (data.multiLayerStorage !== undefined && data.multiLayerStorage !== null) {
     contents.multiLayerStorage = deserializeAws_restJson1MultiLayerStorage(data.multiLayerStorage, context);
@@ -8727,7 +8739,7 @@ const deserializeAws_restJson1AccessPolicySummary = (output: any, context: __Ser
   return {
     creationDate:
       output.creationDate !== undefined && output.creationDate !== null
-        ? new Date(Math.round(output.creationDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.creationDate)))
         : undefined,
     id: __expectString(output.id),
     identity:
@@ -8736,7 +8748,7 @@ const deserializeAws_restJson1AccessPolicySummary = (output: any, context: __Ser
         : undefined,
     lastUpdateDate:
       output.lastUpdateDate !== undefined && output.lastUpdateDate !== null
-        ? new Date(Math.round(output.lastUpdateDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastUpdateDate)))
         : undefined,
     permission: __expectString(output.permission),
     resource:
@@ -8751,7 +8763,7 @@ const deserializeAws_restJson1AggregatedValue = (output: any, context: __SerdeCo
     quality: __expectString(output.quality),
     timestamp:
       output.timestamp !== undefined && output.timestamp !== null
-        ? new Date(Math.round(output.timestamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.timestamp)))
         : undefined,
     value:
       output.value !== undefined && output.value !== null
@@ -8955,13 +8967,13 @@ const deserializeAws_restJson1AssetModelSummary = (output: any, context: __Serde
     arn: __expectString(output.arn),
     creationDate:
       output.creationDate !== undefined && output.creationDate !== null
-        ? new Date(Math.round(output.creationDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.creationDate)))
         : undefined,
     description: __expectString(output.description),
     id: __expectString(output.id),
     lastUpdateDate:
       output.lastUpdateDate !== undefined && output.lastUpdateDate !== null
-        ? new Date(Math.round(output.lastUpdateDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastUpdateDate)))
         : undefined,
     name: __expectString(output.name),
     status:
@@ -9079,7 +9091,7 @@ const deserializeAws_restJson1AssetSummary = (output: any, context: __SerdeConte
     assetModelId: __expectString(output.assetModelId),
     creationDate:
       output.creationDate !== undefined && output.creationDate !== null
-        ? new Date(Math.round(output.creationDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.creationDate)))
         : undefined,
     hierarchies:
       output.hierarchies !== undefined && output.hierarchies !== null
@@ -9088,7 +9100,7 @@ const deserializeAws_restJson1AssetSummary = (output: any, context: __SerdeConte
     id: __expectString(output.id),
     lastUpdateDate:
       output.lastUpdateDate !== undefined && output.lastUpdateDate !== null
-        ? new Date(Math.round(output.lastUpdateDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastUpdateDate)))
         : undefined,
     name: __expectString(output.name),
     status:
@@ -9121,7 +9133,7 @@ const deserializeAws_restJson1AssociatedAssetsSummary = (
     assetModelId: __expectString(output.assetModelId),
     creationDate:
       output.creationDate !== undefined && output.creationDate !== null
-        ? new Date(Math.round(output.creationDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.creationDate)))
         : undefined,
     hierarchies:
       output.hierarchies !== undefined && output.hierarchies !== null
@@ -9130,7 +9142,7 @@ const deserializeAws_restJson1AssociatedAssetsSummary = (
     id: __expectString(output.id),
     lastUpdateDate:
       output.lastUpdateDate !== undefined && output.lastUpdateDate !== null
-        ? new Date(Math.round(output.lastUpdateDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastUpdateDate)))
         : undefined,
     name: __expectString(output.name),
     status:
@@ -9288,13 +9300,13 @@ const deserializeAws_restJson1DashboardSummary = (output: any, context: __SerdeC
   return {
     creationDate:
       output.creationDate !== undefined && output.creationDate !== null
-        ? new Date(Math.round(output.creationDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.creationDate)))
         : undefined,
     description: __expectString(output.description),
     id: __expectString(output.id),
     lastUpdateDate:
       output.lastUpdateDate !== undefined && output.lastUpdateDate !== null
-        ? new Date(Math.round(output.lastUpdateDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastUpdateDate)))
         : undefined,
     name: __expectString(output.name),
   } as any;
@@ -9408,7 +9420,7 @@ const deserializeAws_restJson1GatewaySummary = (output: any, context: __SerdeCon
   return {
     creationDate:
       output.creationDate !== undefined && output.creationDate !== null
-        ? new Date(Math.round(output.creationDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.creationDate)))
         : undefined,
     gatewayCapabilitySummaries:
       output.gatewayCapabilitySummaries !== undefined && output.gatewayCapabilitySummaries !== null
@@ -9422,7 +9434,7 @@ const deserializeAws_restJson1GatewaySummary = (output: any, context: __SerdeCon
         : undefined,
     lastUpdateDate:
       output.lastUpdateDate !== undefined && output.lastUpdateDate !== null
-        ? new Date(Math.round(output.lastUpdateDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastUpdateDate)))
         : undefined,
   } as any;
 };
@@ -9625,13 +9637,13 @@ const deserializeAws_restJson1PortalSummary = (output: any, context: __SerdeCont
   return {
     creationDate:
       output.creationDate !== undefined && output.creationDate !== null
-        ? new Date(Math.round(output.creationDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.creationDate)))
         : undefined,
     description: __expectString(output.description),
     id: __expectString(output.id),
     lastUpdateDate:
       output.lastUpdateDate !== undefined && output.lastUpdateDate !== null
-        ? new Date(Math.round(output.lastUpdateDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastUpdateDate)))
         : undefined,
     name: __expectString(output.name),
     roleArn: __expectString(output.roleArn),
@@ -9664,13 +9676,13 @@ const deserializeAws_restJson1ProjectSummary = (output: any, context: __SerdeCon
   return {
     creationDate:
       output.creationDate !== undefined && output.creationDate !== null
-        ? new Date(Math.round(output.creationDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.creationDate)))
         : undefined,
     description: __expectString(output.description),
     id: __expectString(output.id),
     lastUpdateDate:
       output.lastUpdateDate !== undefined && output.lastUpdateDate !== null
-        ? new Date(Math.round(output.lastUpdateDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastUpdateDate)))
         : undefined,
     name: __expectString(output.name),
   } as any;

--- a/clients/client-iotthingsgraph/protocols/Aws_json1_1.ts
+++ b/clients/client-iotthingsgraph/protocols/Aws_json1_1.ts
@@ -198,7 +198,10 @@ import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@a
 import {
   expectBoolean as __expectBoolean,
   expectLong as __expectLong,
+  expectNonNull as __expectNonNull,
+  expectNumber as __expectNumber,
   expectString as __expectString,
+  parseEpochTimestamp as __parseEpochTimestamp,
 } from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
@@ -4174,7 +4177,7 @@ const deserializeAws_json1_1EntityDescription = (output: any, context: __SerdeCo
     arn: __expectString(output.arn),
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
-        ? new Date(Math.round(output.createdAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.createdAt)))
         : undefined,
     definition:
       output.definition !== undefined && output.definition !== null
@@ -4203,7 +4206,7 @@ const deserializeAws_json1_1FlowExecutionMessage = (output: any, context: __Serd
     payload: __expectString(output.payload),
     timestamp:
       output.timestamp !== undefined && output.timestamp !== null
-        ? new Date(Math.round(output.timestamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.timestamp)))
         : undefined,
   } as any;
 };
@@ -4234,7 +4237,7 @@ const deserializeAws_json1_1FlowExecutionSummary = (output: any, context: __Serd
   return {
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
-        ? new Date(Math.round(output.createdAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.createdAt)))
         : undefined,
     flowExecutionId: __expectString(output.flowExecutionId),
     flowTemplateId: __expectString(output.flowTemplateId),
@@ -4242,7 +4245,7 @@ const deserializeAws_json1_1FlowExecutionSummary = (output: any, context: __Serd
     systemInstanceId: __expectString(output.systemInstanceId),
     updatedAt:
       output.updatedAt !== undefined && output.updatedAt !== null
-        ? new Date(Math.round(output.updatedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.updatedAt)))
         : undefined,
   } as any;
 };
@@ -4280,7 +4283,7 @@ const deserializeAws_json1_1FlowTemplateSummary = (output: any, context: __Serde
     arn: __expectString(output.arn),
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
-        ? new Date(Math.round(output.createdAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.createdAt)))
         : undefined,
     id: __expectString(output.id),
     revisionNumber: __expectLong(output.revisionNumber),
@@ -4378,7 +4381,7 @@ const deserializeAws_json1_1GetUploadStatusResponse = (
   return {
     createdDate:
       output.createdDate !== undefined && output.createdDate !== null
-        ? new Date(Math.round(output.createdDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.createdDate)))
         : undefined,
     failureReason:
       output.failureReason !== undefined && output.failureReason !== null
@@ -4602,7 +4605,7 @@ const deserializeAws_json1_1SystemInstanceSummary = (output: any, context: __Ser
     arn: __expectString(output.arn),
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
-        ? new Date(Math.round(output.createdAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.createdAt)))
         : undefined,
     greengrassGroupId: __expectString(output.greengrassGroupId),
     greengrassGroupName: __expectString(output.greengrassGroupName),
@@ -4612,7 +4615,7 @@ const deserializeAws_json1_1SystemInstanceSummary = (output: any, context: __Ser
     target: __expectString(output.target),
     updatedAt:
       output.updatedAt !== undefined && output.updatedAt !== null
-        ? new Date(Math.round(output.updatedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.updatedAt)))
         : undefined,
   } as any;
 };
@@ -4653,7 +4656,7 @@ const deserializeAws_json1_1SystemTemplateSummary = (output: any, context: __Ser
     arn: __expectString(output.arn),
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
-        ? new Date(Math.round(output.createdAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.createdAt)))
         : undefined,
     id: __expectString(output.id),
     revisionNumber: __expectLong(output.revisionNumber),

--- a/clients/client-ivs/protocols/Aws_restJson1.ts
+++ b/clients/client-ivs/protocols/Aws_restJson1.ts
@@ -81,6 +81,7 @@ import {
   expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
+  parseRfc3339DateTime as __parseRfc3339DateTime,
 } from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
@@ -3167,7 +3168,10 @@ const deserializeAws_restJson1_Stream = (output: any, context: __SerdeContext): 
     channelArn: __expectString(output.channelArn),
     health: __expectString(output.health),
     playbackUrl: __expectString(output.playbackUrl),
-    startTime: output.startTime !== undefined && output.startTime !== null ? new Date(output.startTime) : undefined,
+    startTime:
+      output.startTime !== undefined && output.startTime !== null
+        ? __expectNonNull(__parseRfc3339DateTime(output.startTime))
+        : undefined,
     state: __expectString(output.state),
     viewerCount: __expectLong(output.viewerCount),
   } as any;
@@ -3233,7 +3237,10 @@ const deserializeAws_restJson1StreamSummary = (output: any, context: __SerdeCont
   return {
     channelArn: __expectString(output.channelArn),
     health: __expectString(output.health),
-    startTime: output.startTime !== undefined && output.startTime !== null ? new Date(output.startTime) : undefined,
+    startTime:
+      output.startTime !== undefined && output.startTime !== null
+        ? __expectNonNull(__parseRfc3339DateTime(output.startTime))
+        : undefined,
     state: __expectString(output.state),
     viewerCount: __expectLong(output.viewerCount),
   } as any;

--- a/clients/client-kafka/protocols/Aws_restJson1.ts
+++ b/clients/client-kafka/protocols/Aws_restJson1.ts
@@ -138,6 +138,7 @@ import {
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   limitedParseDouble as __limitedParseDouble,
+  parseRfc3339DateTime as __parseRfc3339DateTime,
 } from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
@@ -1508,7 +1509,7 @@ export const deserializeAws_restJson1CreateConfigurationCommand = async (
     contents.Arn = __expectString(data.arn);
   }
   if (data.creationTime !== undefined && data.creationTime !== null) {
-    contents.CreationTime = new Date(data.creationTime);
+    contents.CreationTime = __expectNonNull(__parseRfc3339DateTime(data.creationTime));
   }
   if (data.latestRevision !== undefined && data.latestRevision !== null) {
     contents.LatestRevision = deserializeAws_restJson1ConfigurationRevision(data.latestRevision, context);
@@ -1969,7 +1970,7 @@ export const deserializeAws_restJson1DescribeConfigurationCommand = async (
     contents.Arn = __expectString(data.arn);
   }
   if (data.creationTime !== undefined && data.creationTime !== null) {
-    contents.CreationTime = new Date(data.creationTime);
+    contents.CreationTime = __expectNonNull(__parseRfc3339DateTime(data.creationTime));
   }
   if (data.description !== undefined && data.description !== null) {
     contents.Description = __expectString(data.description);
@@ -2086,7 +2087,7 @@ export const deserializeAws_restJson1DescribeConfigurationRevisionCommand = asyn
     contents.Arn = __expectString(data.arn);
   }
   if (data.creationTime !== undefined && data.creationTime !== null) {
-    contents.CreationTime = new Date(data.creationTime);
+    contents.CreationTime = __expectNonNull(__parseRfc3339DateTime(data.creationTime));
   }
   if (data.description !== undefined && data.description !== null) {
     contents.Description = __expectString(data.description);
@@ -4648,7 +4649,9 @@ const deserializeAws_restJson1ClusterInfo = (output: any, context: __SerdeContex
     ClusterArn: __expectString(output.clusterArn),
     ClusterName: __expectString(output.clusterName),
     CreationTime:
-      output.creationTime !== undefined && output.creationTime !== null ? new Date(output.creationTime) : undefined,
+      output.creationTime !== undefined && output.creationTime !== null
+        ? __expectNonNull(__parseRfc3339DateTime(output.creationTime))
+        : undefined,
     CurrentBrokerSoftwareInfo:
       output.currentBrokerSoftwareInfo !== undefined && output.currentBrokerSoftwareInfo !== null
         ? deserializeAws_restJson1BrokerSoftwareInfo(output.currentBrokerSoftwareInfo, context)
@@ -4687,8 +4690,13 @@ const deserializeAws_restJson1ClusterOperationInfo = (output: any, context: __Se
     ClientRequestId: __expectString(output.clientRequestId),
     ClusterArn: __expectString(output.clusterArn),
     CreationTime:
-      output.creationTime !== undefined && output.creationTime !== null ? new Date(output.creationTime) : undefined,
-    EndTime: output.endTime !== undefined && output.endTime !== null ? new Date(output.endTime) : undefined,
+      output.creationTime !== undefined && output.creationTime !== null
+        ? __expectNonNull(__parseRfc3339DateTime(output.creationTime))
+        : undefined,
+    EndTime:
+      output.endTime !== undefined && output.endTime !== null
+        ? __expectNonNull(__parseRfc3339DateTime(output.endTime))
+        : undefined,
     ErrorInfo:
       output.errorInfo !== undefined && output.errorInfo !== null
         ? deserializeAws_restJson1ErrorInfo(output.errorInfo, context)
@@ -4747,7 +4755,9 @@ const deserializeAws_restJson1Configuration = (output: any, context: __SerdeCont
   return {
     Arn: __expectString(output.arn),
     CreationTime:
-      output.creationTime !== undefined && output.creationTime !== null ? new Date(output.creationTime) : undefined,
+      output.creationTime !== undefined && output.creationTime !== null
+        ? __expectNonNull(__parseRfc3339DateTime(output.creationTime))
+        : undefined,
     Description: __expectString(output.description),
     KafkaVersions:
       output.kafkaVersions !== undefined && output.kafkaVersions !== null
@@ -4772,7 +4782,9 @@ const deserializeAws_restJson1ConfigurationInfo = (output: any, context: __Serde
 const deserializeAws_restJson1ConfigurationRevision = (output: any, context: __SerdeContext): ConfigurationRevision => {
   return {
     CreationTime:
-      output.creationTime !== undefined && output.creationTime !== null ? new Date(output.creationTime) : undefined,
+      output.creationTime !== undefined && output.creationTime !== null
+        ? __expectNonNull(__parseRfc3339DateTime(output.creationTime))
+        : undefined,
     Description: __expectString(output.description),
     Revision: __expectLong(output.revision),
   } as any;

--- a/clients/client-kendra/protocols/Aws_json1_1.ts
+++ b/clients/client-kendra/protocols/Aws_json1_1.ts
@@ -287,8 +287,11 @@ import {
   expectBoolean as __expectBoolean,
   expectInt32 as __expectInt32,
   expectLong as __expectLong,
+  expectNonNull as __expectNonNull,
+  expectNumber as __expectNumber,
   expectString as __expectString,
   limitedParseFloat32 as __limitedParseFloat32,
+  parseEpochTimestamp as __parseEpochTimestamp,
   serializeFloat as __serializeFloat,
 } from "@aws-sdk/smithy-client";
 import {
@@ -7819,7 +7822,7 @@ const deserializeAws_json1_1DataSourceSummary = (output: any, context: __SerdeCo
   return {
     CreatedAt:
       output.CreatedAt !== undefined && output.CreatedAt !== null
-        ? new Date(Math.round(output.CreatedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreatedAt)))
         : undefined,
     Id: __expectString(output.Id),
     Name: __expectString(output.Name),
@@ -7827,7 +7830,7 @@ const deserializeAws_json1_1DataSourceSummary = (output: any, context: __SerdeCo
     Type: __expectString(output.Type),
     UpdatedAt:
       output.UpdatedAt !== undefined && output.UpdatedAt !== null
-        ? new Date(Math.round(output.UpdatedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.UpdatedAt)))
         : undefined,
   } as any;
 };
@@ -7847,7 +7850,9 @@ const deserializeAws_json1_1DataSourceSyncJob = (output: any, context: __SerdeCo
   return {
     DataSourceErrorCode: __expectString(output.DataSourceErrorCode),
     EndTime:
-      output.EndTime !== undefined && output.EndTime !== null ? new Date(Math.round(output.EndTime * 1000)) : undefined,
+      output.EndTime !== undefined && output.EndTime !== null
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.EndTime)))
+        : undefined,
     ErrorCode: __expectString(output.ErrorCode),
     ErrorMessage: __expectString(output.ErrorMessage),
     ExecutionId: __expectString(output.ExecutionId),
@@ -7857,7 +7862,7 @@ const deserializeAws_json1_1DataSourceSyncJob = (output: any, context: __SerdeCo
         : undefined,
     StartTime:
       output.StartTime !== undefined && output.StartTime !== null
-        ? new Date(Math.round(output.StartTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.StartTime)))
         : undefined,
     Status: __expectString(output.Status),
   } as any;
@@ -7942,7 +7947,7 @@ const deserializeAws_json1_1DescribeDataSourceResponse = (
         : undefined,
     CreatedAt:
       output.CreatedAt !== undefined && output.CreatedAt !== null
-        ? new Date(Math.round(output.CreatedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreatedAt)))
         : undefined,
     Description: __expectString(output.Description),
     ErrorMessage: __expectString(output.ErrorMessage),
@@ -7955,7 +7960,7 @@ const deserializeAws_json1_1DescribeDataSourceResponse = (
     Type: __expectString(output.Type),
     UpdatedAt:
       output.UpdatedAt !== undefined && output.UpdatedAt !== null
-        ? new Date(Math.round(output.UpdatedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.UpdatedAt)))
         : undefined,
   } as any;
 };
@@ -7964,7 +7969,7 @@ const deserializeAws_json1_1DescribeFaqResponse = (output: any, context: __Serde
   return {
     CreatedAt:
       output.CreatedAt !== undefined && output.CreatedAt !== null
-        ? new Date(Math.round(output.CreatedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreatedAt)))
         : undefined,
     Description: __expectString(output.Description),
     ErrorMessage: __expectString(output.ErrorMessage),
@@ -7980,7 +7985,7 @@ const deserializeAws_json1_1DescribeFaqResponse = (output: any, context: __Serde
     Status: __expectString(output.Status),
     UpdatedAt:
       output.UpdatedAt !== undefined && output.UpdatedAt !== null
-        ? new Date(Math.round(output.UpdatedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.UpdatedAt)))
         : undefined,
   } as any;
 };
@@ -7993,7 +7998,7 @@ const deserializeAws_json1_1DescribeIndexResponse = (output: any, context: __Ser
         : undefined,
     CreatedAt:
       output.CreatedAt !== undefined && output.CreatedAt !== null
-        ? new Date(Math.round(output.CreatedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreatedAt)))
         : undefined,
     Description: __expectString(output.Description),
     DocumentMetadataConfigurations:
@@ -8016,7 +8021,7 @@ const deserializeAws_json1_1DescribeIndexResponse = (output: any, context: __Ser
     Status: __expectString(output.Status),
     UpdatedAt:
       output.UpdatedAt !== undefined && output.UpdatedAt !== null
-        ? new Date(Math.round(output.UpdatedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.UpdatedAt)))
         : undefined,
     UserContextPolicy: __expectString(output.UserContextPolicy),
     UserTokenConfigurations:
@@ -8048,7 +8053,7 @@ const deserializeAws_json1_1DescribeQuerySuggestionsBlockListResponse = (
   return {
     CreatedAt:
       output.CreatedAt !== undefined && output.CreatedAt !== null
-        ? new Date(Math.round(output.CreatedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreatedAt)))
         : undefined,
     Description: __expectString(output.Description),
     ErrorMessage: __expectString(output.ErrorMessage),
@@ -8065,7 +8070,7 @@ const deserializeAws_json1_1DescribeQuerySuggestionsBlockListResponse = (
     Status: __expectString(output.Status),
     UpdatedAt:
       output.UpdatedAt !== undefined && output.UpdatedAt !== null
-        ? new Date(Math.round(output.UpdatedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.UpdatedAt)))
         : undefined,
   } as any;
 };
@@ -8078,11 +8083,11 @@ const deserializeAws_json1_1DescribeQuerySuggestionsConfigResponse = (
     IncludeQueriesWithoutUserInformation: __expectBoolean(output.IncludeQueriesWithoutUserInformation),
     LastClearTime:
       output.LastClearTime !== undefined && output.LastClearTime !== null
-        ? new Date(Math.round(output.LastClearTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastClearTime)))
         : undefined,
     LastSuggestionsBuildTime:
       output.LastSuggestionsBuildTime !== undefined && output.LastSuggestionsBuildTime !== null
-        ? new Date(Math.round(output.LastSuggestionsBuildTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastSuggestionsBuildTime)))
         : undefined,
     MinimumNumberOfQueryingUsers: __expectInt32(output.MinimumNumberOfQueryingUsers),
     MinimumQueryCount: __expectInt32(output.MinimumQueryCount),
@@ -8100,7 +8105,7 @@ const deserializeAws_json1_1DescribeThesaurusResponse = (
   return {
     CreatedAt:
       output.CreatedAt !== undefined && output.CreatedAt !== null
-        ? new Date(Math.round(output.CreatedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreatedAt)))
         : undefined,
     Description: __expectString(output.Description),
     ErrorMessage: __expectString(output.ErrorMessage),
@@ -8118,7 +8123,7 @@ const deserializeAws_json1_1DescribeThesaurusResponse = (
     TermCount: __expectLong(output.TermCount),
     UpdatedAt:
       output.UpdatedAt !== undefined && output.UpdatedAt !== null
-        ? new Date(Math.round(output.UpdatedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.UpdatedAt)))
         : undefined,
   } as any;
 };
@@ -8158,7 +8163,7 @@ const deserializeAws_json1_1DocumentAttributeStringListValue = (output: any, con
 const deserializeAws_json1_1DocumentAttributeValue = (output: any, context: __SerdeContext): DocumentAttributeValue => {
   if (output.DateValue !== undefined && output.DateValue !== null) {
     return {
-      DateValue: new Date(Math.round(output.DateValue * 1000)),
+      DateValue: __expectNonNull(__parseEpochTimestamp(__expectNumber(output.DateValue))),
     };
   }
   if (__expectLong(output.LongValue) !== undefined) {
@@ -8319,7 +8324,7 @@ const deserializeAws_json1_1FaqSummary = (output: any, context: __SerdeContext):
   return {
     CreatedAt:
       output.CreatedAt !== undefined && output.CreatedAt !== null
-        ? new Date(Math.round(output.CreatedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreatedAt)))
         : undefined,
     FileFormat: __expectString(output.FileFormat),
     Id: __expectString(output.Id),
@@ -8327,7 +8332,7 @@ const deserializeAws_json1_1FaqSummary = (output: any, context: __SerdeContext):
     Status: __expectString(output.Status),
     UpdatedAt:
       output.UpdatedAt !== undefined && output.UpdatedAt !== null
-        ? new Date(Math.round(output.UpdatedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.UpdatedAt)))
         : undefined,
   } as any;
 };
@@ -8408,12 +8413,12 @@ const deserializeAws_json1_1GroupOrderingIdSummary = (output: any, context: __Se
     FailureReason: __expectString(output.FailureReason),
     LastUpdatedAt:
       output.LastUpdatedAt !== undefined && output.LastUpdatedAt !== null
-        ? new Date(Math.round(output.LastUpdatedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastUpdatedAt)))
         : undefined,
     OrderingId: __expectLong(output.OrderingId),
     ReceivedAt:
       output.ReceivedAt !== undefined && output.ReceivedAt !== null
-        ? new Date(Math.round(output.ReceivedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.ReceivedAt)))
         : undefined,
     Status: __expectString(output.Status),
   } as any;
@@ -8453,7 +8458,7 @@ const deserializeAws_json1_1IndexConfigurationSummary = (
   return {
     CreatedAt:
       output.CreatedAt !== undefined && output.CreatedAt !== null
-        ? new Date(Math.round(output.CreatedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreatedAt)))
         : undefined,
     Edition: __expectString(output.Edition),
     Id: __expectString(output.Id),
@@ -8461,7 +8466,7 @@ const deserializeAws_json1_1IndexConfigurationSummary = (
     Status: __expectString(output.Status),
     UpdatedAt:
       output.UpdatedAt !== undefined && output.UpdatedAt !== null
-        ? new Date(Math.round(output.UpdatedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.UpdatedAt)))
         : undefined,
   } as any;
 };
@@ -8751,7 +8756,7 @@ const deserializeAws_json1_1QuerySuggestionsBlockListSummary = (
   return {
     CreatedAt:
       output.CreatedAt !== undefined && output.CreatedAt !== null
-        ? new Date(Math.round(output.CreatedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreatedAt)))
         : undefined,
     Id: __expectString(output.Id),
     ItemCount: __expectInt32(output.ItemCount),
@@ -8759,7 +8764,7 @@ const deserializeAws_json1_1QuerySuggestionsBlockListSummary = (
     Status: __expectString(output.Status),
     UpdatedAt:
       output.UpdatedAt !== undefined && output.UpdatedAt !== null
-        ? new Date(Math.round(output.UpdatedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.UpdatedAt)))
         : undefined,
   } as any;
 };
@@ -9398,14 +9403,14 @@ const deserializeAws_json1_1ThesaurusSummary = (output: any, context: __SerdeCon
   return {
     CreatedAt:
       output.CreatedAt !== undefined && output.CreatedAt !== null
-        ? new Date(Math.round(output.CreatedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreatedAt)))
         : undefined,
     Id: __expectString(output.Id),
     Name: __expectString(output.Name),
     Status: __expectString(output.Status),
     UpdatedAt:
       output.UpdatedAt !== undefined && output.UpdatedAt !== null
-        ? new Date(Math.round(output.UpdatedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.UpdatedAt)))
         : undefined,
   } as any;
 };

--- a/clients/client-kinesis-analytics-v2/protocols/Aws_json1_1.ts
+++ b/clients/client-kinesis-analytics-v2/protocols/Aws_json1_1.ts
@@ -299,7 +299,10 @@ import {
   expectBoolean as __expectBoolean,
   expectInt32 as __expectInt32,
   expectLong as __expectLong,
+  expectNonNull as __expectNonNull,
+  expectNumber as __expectNumber,
   expectString as __expectString,
+  parseEpochTimestamp as __parseEpochTimestamp,
 } from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
@@ -5522,11 +5525,11 @@ const deserializeAws_json1_1ApplicationDetail = (output: any, context: __SerdeCo
     ConditionalToken: __expectString(output.ConditionalToken),
     CreateTimestamp:
       output.CreateTimestamp !== undefined && output.CreateTimestamp !== null
-        ? new Date(Math.round(output.CreateTimestamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreateTimestamp)))
         : undefined,
     LastUpdateTimestamp:
       output.LastUpdateTimestamp !== undefined && output.LastUpdateTimestamp !== null
-        ? new Date(Math.round(output.LastUpdateTimestamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastUpdateTimestamp)))
         : undefined,
     RuntimeEnvironment: __expectString(output.RuntimeEnvironment),
     ServiceExecutionRole: __expectString(output.ServiceExecutionRole),
@@ -6528,7 +6531,7 @@ const deserializeAws_json1_1SnapshotDetails = (output: any, context: __SerdeCont
     ApplicationVersionId: __expectLong(output.ApplicationVersionId),
     SnapshotCreationTimestamp:
       output.SnapshotCreationTimestamp !== undefined && output.SnapshotCreationTimestamp !== null
-        ? new Date(Math.round(output.SnapshotCreationTimestamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.SnapshotCreationTimestamp)))
         : undefined,
     SnapshotName: __expectString(output.SnapshotName),
     SnapshotStatus: __expectString(output.SnapshotStatus),

--- a/clients/client-kinesis-analytics/protocols/Aws_json1_1.ts
+++ b/clients/client-kinesis-analytics/protocols/Aws_json1_1.ts
@@ -166,7 +166,10 @@ import {
   expectBoolean as __expectBoolean,
   expectInt32 as __expectInt32,
   expectLong as __expectLong,
+  expectNonNull as __expectNonNull,
+  expectNumber as __expectNumber,
   expectString as __expectString,
+  parseEpochTimestamp as __parseEpochTimestamp,
 } from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
@@ -3184,7 +3187,7 @@ const deserializeAws_json1_1ApplicationDetail = (output: any, context: __SerdeCo
         : undefined,
     CreateTimestamp:
       output.CreateTimestamp !== undefined && output.CreateTimestamp !== null
-        ? new Date(Math.round(output.CreateTimestamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreateTimestamp)))
         : undefined,
     InputDescriptions:
       output.InputDescriptions !== undefined && output.InputDescriptions !== null
@@ -3192,7 +3195,7 @@ const deserializeAws_json1_1ApplicationDetail = (output: any, context: __SerdeCo
         : undefined,
     LastUpdateTimestamp:
       output.LastUpdateTimestamp !== undefined && output.LastUpdateTimestamp !== null
-        ? new Date(Math.round(output.LastUpdateTimestamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastUpdateTimestamp)))
         : undefined,
     OutputDescriptions:
       output.OutputDescriptions !== undefined && output.OutputDescriptions !== null

--- a/clients/client-kinesis-video-archived-media/protocols/Aws_restJson1.ts
+++ b/clients/client-kinesis-video-archived-media/protocols/Aws_restJson1.ts
@@ -36,8 +36,10 @@ import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@a
 import {
   expectLong as __expectLong,
   expectNonNull as __expectNonNull,
+  expectNumber as __expectNumber,
   expectObject as __expectObject,
   expectString as __expectString,
+  parseEpochTimestamp as __parseEpochTimestamp,
 } from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
@@ -972,11 +974,11 @@ const deserializeAws_restJson1Fragment = (output: any, context: __SerdeContext):
     FragmentSizeInBytes: __expectLong(output.FragmentSizeInBytes),
     ProducerTimestamp:
       output.ProducerTimestamp !== undefined && output.ProducerTimestamp !== null
-        ? new Date(Math.round(output.ProducerTimestamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.ProducerTimestamp)))
         : undefined,
     ServerTimestamp:
       output.ServerTimestamp !== undefined && output.ServerTimestamp !== null
-        ? new Date(Math.round(output.ServerTimestamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.ServerTimestamp)))
         : undefined,
   } as any;
 };

--- a/clients/client-kinesis-video/protocols/Aws_restJson1.ts
+++ b/clients/client-kinesis-video/protocols/Aws_restJson1.ts
@@ -69,8 +69,10 @@ import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@a
 import {
   expectInt32 as __expectInt32,
   expectNonNull as __expectNonNull,
+  expectNumber as __expectNumber,
   expectObject as __expectObject,
   expectString as __expectString,
+  parseEpochTimestamp as __parseEpochTimestamp,
 } from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
@@ -2569,7 +2571,7 @@ const deserializeAws_restJson1ChannelInfo = (output: any, context: __SerdeContex
     ChannelType: __expectString(output.ChannelType),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     SingleMasterConfiguration:
       output.SingleMasterConfiguration !== undefined && output.SingleMasterConfiguration !== null
@@ -2639,7 +2641,7 @@ const deserializeAws_restJson1StreamInfo = (output: any, context: __SerdeContext
   return {
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     DataRetentionInHours: __expectInt32(output.DataRetentionInHours),
     DeviceName: __expectString(output.DeviceName),

--- a/clients/client-kinesis/protocols/Aws_json1_1.ts
+++ b/clients/client-kinesis/protocols/Aws_json1_1.ts
@@ -145,7 +145,10 @@ import {
   expectBoolean as __expectBoolean,
   expectInt32 as __expectInt32,
   expectLong as __expectLong,
+  expectNonNull as __expectNonNull,
+  expectNumber as __expectNumber,
   expectString as __expectString,
+  parseEpochTimestamp as __parseEpochTimestamp,
 } from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
@@ -3321,7 +3324,7 @@ const deserializeAws_json1_1Consumer = (output: any, context: __SerdeContext): C
     ConsumerARN: __expectString(output.ConsumerARN),
     ConsumerCreationTimestamp:
       output.ConsumerCreationTimestamp !== undefined && output.ConsumerCreationTimestamp !== null
-        ? new Date(Math.round(output.ConsumerCreationTimestamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.ConsumerCreationTimestamp)))
         : undefined,
     ConsumerName: __expectString(output.ConsumerName),
     ConsumerStatus: __expectString(output.ConsumerStatus),
@@ -3333,7 +3336,7 @@ const deserializeAws_json1_1ConsumerDescription = (output: any, context: __Serde
     ConsumerARN: __expectString(output.ConsumerARN),
     ConsumerCreationTimestamp:
       output.ConsumerCreationTimestamp !== undefined && output.ConsumerCreationTimestamp !== null
-        ? new Date(Math.round(output.ConsumerCreationTimestamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.ConsumerCreationTimestamp)))
         : undefined,
     ConsumerName: __expectString(output.ConsumerName),
     ConsumerStatus: __expectString(output.ConsumerStatus),
@@ -3653,7 +3656,7 @@ const deserializeAws_json1_1_Record = (output: any, context: __SerdeContext): _R
   return {
     ApproximateArrivalTimestamp:
       output.ApproximateArrivalTimestamp !== undefined && output.ApproximateArrivalTimestamp !== null
-        ? new Date(Math.round(output.ApproximateArrivalTimestamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.ApproximateArrivalTimestamp)))
         : undefined,
     Data: output.Data !== undefined && output.Data !== null ? context.base64Decoder(output.Data) : undefined,
     EncryptionType: __expectString(output.EncryptionType),
@@ -3762,7 +3765,7 @@ const deserializeAws_json1_1StreamDescription = (output: any, context: __SerdeCo
     StreamARN: __expectString(output.StreamARN),
     StreamCreationTimestamp:
       output.StreamCreationTimestamp !== undefined && output.StreamCreationTimestamp !== null
-        ? new Date(Math.round(output.StreamCreationTimestamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.StreamCreationTimestamp)))
         : undefined,
     StreamName: __expectString(output.StreamName),
     StreamStatus: __expectString(output.StreamStatus),
@@ -3786,7 +3789,7 @@ const deserializeAws_json1_1StreamDescriptionSummary = (
     StreamARN: __expectString(output.StreamARN),
     StreamCreationTimestamp:
       output.StreamCreationTimestamp !== undefined && output.StreamCreationTimestamp !== null
-        ? new Date(Math.round(output.StreamCreationTimestamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.StreamCreationTimestamp)))
         : undefined,
     StreamName: __expectString(output.StreamName),
     StreamStatus: __expectString(output.StreamStatus),

--- a/clients/client-kms/protocols/Aws_json1_1.ts
+++ b/clients/client-kms/protocols/Aws_json1_1.ts
@@ -225,7 +225,10 @@ import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@a
 import {
   expectBoolean as __expectBoolean,
   expectInt32 as __expectInt32,
+  expectNonNull as __expectNonNull,
+  expectNumber as __expectNumber,
   expectString as __expectString,
+  parseEpochTimestamp as __parseEpochTimestamp,
 } from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
@@ -6643,11 +6646,11 @@ const deserializeAws_json1_1AliasListEntry = (output: any, context: __SerdeConte
     AliasName: __expectString(output.AliasName),
     CreationDate:
       output.CreationDate !== undefined && output.CreationDate !== null
-        ? new Date(Math.round(output.CreationDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationDate)))
         : undefined,
     LastUpdatedDate:
       output.LastUpdatedDate !== undefined && output.LastUpdatedDate !== null
-        ? new Date(Math.round(output.LastUpdatedDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastUpdatedDate)))
         : undefined,
     TargetKeyId: __expectString(output.TargetKeyId),
   } as any;
@@ -6805,7 +6808,7 @@ const deserializeAws_json1_1CustomKeyStoresListEntry = (
     ConnectionState: __expectString(output.ConnectionState),
     CreationDate:
       output.CreationDate !== undefined && output.CreationDate !== null
-        ? new Date(Math.round(output.CreationDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationDate)))
         : undefined,
     CustomKeyStoreId: __expectString(output.CustomKeyStoreId),
     CustomKeyStoreName: __expectString(output.CustomKeyStoreName),
@@ -7021,7 +7024,7 @@ const deserializeAws_json1_1GetParametersForImportResponse = (
     KeyId: __expectString(output.KeyId),
     ParametersValidTo:
       output.ParametersValidTo !== undefined && output.ParametersValidTo !== null
-        ? new Date(Math.round(output.ParametersValidTo * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.ParametersValidTo)))
         : undefined,
     PublicKey:
       output.PublicKey !== undefined && output.PublicKey !== null ? context.base64Decoder(output.PublicKey) : undefined,
@@ -7079,7 +7082,7 @@ const deserializeAws_json1_1GrantListEntry = (output: any, context: __SerdeConte
         : undefined,
     CreationDate:
       output.CreationDate !== undefined && output.CreationDate !== null
-        ? new Date(Math.round(output.CreationDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationDate)))
         : undefined,
     GrantId: __expectString(output.GrantId),
     GranteePrincipal: __expectString(output.GranteePrincipal),
@@ -7230,13 +7233,13 @@ const deserializeAws_json1_1KeyMetadata = (output: any, context: __SerdeContext)
     CloudHsmClusterId: __expectString(output.CloudHsmClusterId),
     CreationDate:
       output.CreationDate !== undefined && output.CreationDate !== null
-        ? new Date(Math.round(output.CreationDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationDate)))
         : undefined,
     CustomKeyStoreId: __expectString(output.CustomKeyStoreId),
     CustomerMasterKeySpec: __expectString(output.CustomerMasterKeySpec),
     DeletionDate:
       output.DeletionDate !== undefined && output.DeletionDate !== null
-        ? new Date(Math.round(output.DeletionDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.DeletionDate)))
         : undefined,
     Description: __expectString(output.Description),
     Enabled: __expectBoolean(output.Enabled),
@@ -7262,7 +7265,9 @@ const deserializeAws_json1_1KeyMetadata = (output: any, context: __SerdeContext)
         ? deserializeAws_json1_1SigningAlgorithmSpecList(output.SigningAlgorithms, context)
         : undefined,
     ValidTo:
-      output.ValidTo !== undefined && output.ValidTo !== null ? new Date(Math.round(output.ValidTo * 1000)) : undefined,
+      output.ValidTo !== undefined && output.ValidTo !== null
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.ValidTo)))
+        : undefined,
   } as any;
 };
 
@@ -7461,7 +7466,7 @@ const deserializeAws_json1_1ScheduleKeyDeletionResponse = (
   return {
     DeletionDate:
       output.DeletionDate !== undefined && output.DeletionDate !== null
-        ? new Date(Math.round(output.DeletionDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.DeletionDate)))
         : undefined,
     KeyId: __expectString(output.KeyId),
     KeyState: __expectString(output.KeyState),

--- a/clients/client-lakeformation/protocols/Aws_json1_1.ts
+++ b/clients/client-lakeformation/protocols/Aws_json1_1.ts
@@ -133,7 +133,12 @@ import {
   UpdateResourceResponse,
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
-import { expectString as __expectString } from "@aws-sdk/smithy-client";
+import {
+  expectNonNull as __expectNonNull,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
+  parseEpochTimestamp as __parseEpochTimestamp,
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   HeaderBag as __HeaderBag,
@@ -3633,7 +3638,7 @@ const deserializeAws_json1_1ResourceInfo = (output: any, context: __SerdeContext
   return {
     LastModified:
       output.LastModified !== undefined && output.LastModified !== null
-        ? new Date(Math.round(output.LastModified * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastModified)))
         : undefined,
     ResourceArn: __expectString(output.ResourceArn),
     RoleArn: __expectString(output.RoleArn),

--- a/clients/client-lambda/protocols/Aws_restJson1.ts
+++ b/clients/client-lambda/protocols/Aws_restJson1.ts
@@ -239,10 +239,12 @@ import {
   expectInt32 as __expectInt32,
   expectLong as __expectLong,
   expectNonNull as __expectNonNull,
+  expectNumber as __expectNumber,
   expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   limitedParseDouble as __limitedParseDouble,
+  parseEpochTimestamp as __parseEpochTimestamp,
   serializeFloat as __serializeFloat,
 } from "@aws-sdk/smithy-client";
 import {
@@ -2874,7 +2876,7 @@ export const deserializeAws_restJson1CreateEventSourceMappingCommand = async (
     );
   }
   if (data.LastModified !== undefined && data.LastModified !== null) {
-    contents.LastModified = new Date(Math.round(data.LastModified * 1000));
+    contents.LastModified = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.LastModified)));
   }
   if (data.LastProcessingResult !== undefined && data.LastProcessingResult !== null) {
     contents.LastProcessingResult = __expectString(data.LastProcessingResult);
@@ -2910,7 +2912,9 @@ export const deserializeAws_restJson1CreateEventSourceMappingCommand = async (
     contents.StartingPosition = __expectString(data.StartingPosition);
   }
   if (data.StartingPositionTimestamp !== undefined && data.StartingPositionTimestamp !== null) {
-    contents.StartingPositionTimestamp = new Date(Math.round(data.StartingPositionTimestamp * 1000));
+    contents.StartingPositionTimestamp = __expectNonNull(
+      __parseEpochTimestamp(__expectNumber(data.StartingPositionTimestamp))
+    );
   }
   if (data.State !== undefined && data.State !== null) {
     contents.State = __expectString(data.State);
@@ -3443,7 +3447,7 @@ export const deserializeAws_restJson1DeleteEventSourceMappingCommand = async (
     );
   }
   if (data.LastModified !== undefined && data.LastModified !== null) {
-    contents.LastModified = new Date(Math.round(data.LastModified * 1000));
+    contents.LastModified = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.LastModified)));
   }
   if (data.LastProcessingResult !== undefined && data.LastProcessingResult !== null) {
     contents.LastProcessingResult = __expectString(data.LastProcessingResult);
@@ -3479,7 +3483,9 @@ export const deserializeAws_restJson1DeleteEventSourceMappingCommand = async (
     contents.StartingPosition = __expectString(data.StartingPosition);
   }
   if (data.StartingPositionTimestamp !== undefined && data.StartingPositionTimestamp !== null) {
-    contents.StartingPositionTimestamp = new Date(Math.round(data.StartingPositionTimestamp * 1000));
+    contents.StartingPositionTimestamp = __expectNonNull(
+      __parseEpochTimestamp(__expectNumber(data.StartingPositionTimestamp))
+    );
   }
   if (data.State !== undefined && data.State !== null) {
     contents.State = __expectString(data.State);
@@ -4342,7 +4348,7 @@ export const deserializeAws_restJson1GetEventSourceMappingCommand = async (
     );
   }
   if (data.LastModified !== undefined && data.LastModified !== null) {
-    contents.LastModified = new Date(Math.round(data.LastModified * 1000));
+    contents.LastModified = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.LastModified)));
   }
   if (data.LastProcessingResult !== undefined && data.LastProcessingResult !== null) {
     contents.LastProcessingResult = __expectString(data.LastProcessingResult);
@@ -4378,7 +4384,9 @@ export const deserializeAws_restJson1GetEventSourceMappingCommand = async (
     contents.StartingPosition = __expectString(data.StartingPosition);
   }
   if (data.StartingPositionTimestamp !== undefined && data.StartingPositionTimestamp !== null) {
-    contents.StartingPositionTimestamp = new Date(Math.round(data.StartingPositionTimestamp * 1000));
+    contents.StartingPositionTimestamp = __expectNonNull(
+      __parseEpochTimestamp(__expectNumber(data.StartingPositionTimestamp))
+    );
   }
   if (data.State !== undefined && data.State !== null) {
     contents.State = __expectString(data.State);
@@ -4934,7 +4942,7 @@ export const deserializeAws_restJson1GetFunctionEventInvokeConfigCommand = async
     contents.FunctionArn = __expectString(data.FunctionArn);
   }
   if (data.LastModified !== undefined && data.LastModified !== null) {
-    contents.LastModified = new Date(Math.round(data.LastModified * 1000));
+    contents.LastModified = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.LastModified)));
   }
   if (data.MaximumEventAgeInSeconds !== undefined && data.MaximumEventAgeInSeconds !== null) {
     contents.MaximumEventAgeInSeconds = __expectInt32(data.MaximumEventAgeInSeconds);
@@ -7280,7 +7288,7 @@ export const deserializeAws_restJson1PutFunctionEventInvokeConfigCommand = async
     contents.FunctionArn = __expectString(data.FunctionArn);
   }
   if (data.LastModified !== undefined && data.LastModified !== null) {
-    contents.LastModified = new Date(Math.round(data.LastModified * 1000));
+    contents.LastModified = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.LastModified)));
   }
   if (data.MaximumEventAgeInSeconds !== undefined && data.MaximumEventAgeInSeconds !== null) {
     contents.MaximumEventAgeInSeconds = __expectInt32(data.MaximumEventAgeInSeconds);
@@ -8049,7 +8057,7 @@ export const deserializeAws_restJson1UpdateEventSourceMappingCommand = async (
     );
   }
   if (data.LastModified !== undefined && data.LastModified !== null) {
-    contents.LastModified = new Date(Math.round(data.LastModified * 1000));
+    contents.LastModified = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.LastModified)));
   }
   if (data.LastProcessingResult !== undefined && data.LastProcessingResult !== null) {
     contents.LastProcessingResult = __expectString(data.LastProcessingResult);
@@ -8085,7 +8093,9 @@ export const deserializeAws_restJson1UpdateEventSourceMappingCommand = async (
     contents.StartingPosition = __expectString(data.StartingPosition);
   }
   if (data.StartingPositionTimestamp !== undefined && data.StartingPositionTimestamp !== null) {
-    contents.StartingPositionTimestamp = new Date(Math.round(data.StartingPositionTimestamp * 1000));
+    contents.StartingPositionTimestamp = __expectNonNull(
+      __parseEpochTimestamp(__expectNumber(data.StartingPositionTimestamp))
+    );
   }
   if (data.State !== undefined && data.State !== null) {
     contents.State = __expectString(data.State);
@@ -8691,7 +8701,7 @@ export const deserializeAws_restJson1UpdateFunctionEventInvokeConfigCommand = as
     contents.FunctionArn = __expectString(data.FunctionArn);
   }
   if (data.LastModified !== undefined && data.LastModified !== null) {
-    contents.LastModified = new Date(Math.round(data.LastModified * 1000));
+    contents.LastModified = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.LastModified)));
   }
   if (data.MaximumEventAgeInSeconds !== undefined && data.MaximumEventAgeInSeconds !== null) {
     contents.MaximumEventAgeInSeconds = __expectInt32(data.MaximumEventAgeInSeconds);
@@ -10061,7 +10071,7 @@ const deserializeAws_restJson1EventSourceMappingConfiguration = (
         : undefined,
     LastModified:
       output.LastModified !== undefined && output.LastModified !== null
-        ? new Date(Math.round(output.LastModified * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastModified)))
         : undefined,
     LastProcessingResult: __expectString(output.LastProcessingResult),
     MaximumBatchingWindowInSeconds: __expectInt32(output.MaximumBatchingWindowInSeconds),
@@ -10083,7 +10093,7 @@ const deserializeAws_restJson1EventSourceMappingConfiguration = (
     StartingPosition: __expectString(output.StartingPosition),
     StartingPositionTimestamp:
       output.StartingPositionTimestamp !== undefined && output.StartingPositionTimestamp !== null
-        ? new Date(Math.round(output.StartingPositionTimestamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.StartingPositionTimestamp)))
         : undefined,
     State: __expectString(output.State),
     StateTransitionReason: __expectString(output.StateTransitionReason),
@@ -10217,7 +10227,7 @@ const deserializeAws_restJson1FunctionEventInvokeConfig = (
     FunctionArn: __expectString(output.FunctionArn),
     LastModified:
       output.LastModified !== undefined && output.LastModified !== null
-        ? new Date(Math.round(output.LastModified * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastModified)))
         : undefined,
     MaximumEventAgeInSeconds: __expectInt32(output.MaximumEventAgeInSeconds),
     MaximumRetryAttempts: __expectInt32(output.MaximumRetryAttempts),

--- a/clients/client-lex-model-building-service/protocols/Aws_restJson1.ts
+++ b/clients/client-lex-model-building-service/protocols/Aws_restJson1.ts
@@ -120,10 +120,12 @@ import {
   expectBoolean as __expectBoolean,
   expectInt32 as __expectInt32,
   expectNonNull as __expectNonNull,
+  expectNumber as __expectNumber,
   expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   limitedParseDouble as __limitedParseDouble,
+  parseEpochTimestamp as __parseEpochTimestamp,
   serializeFloat as __serializeFloat,
 } from "@aws-sdk/smithy-client";
 import {
@@ -1671,7 +1673,7 @@ export const deserializeAws_restJson1CreateBotVersionCommand = async (
     contents.clarificationPrompt = deserializeAws_restJson1Prompt(data.clarificationPrompt, context);
   }
   if (data.createdDate !== undefined && data.createdDate !== null) {
-    contents.createdDate = new Date(Math.round(data.createdDate * 1000));
+    contents.createdDate = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.createdDate)));
   }
   if (data.description !== undefined && data.description !== null) {
     contents.description = __expectString(data.description);
@@ -1692,7 +1694,7 @@ export const deserializeAws_restJson1CreateBotVersionCommand = async (
     contents.intents = deserializeAws_restJson1IntentList(data.intents, context);
   }
   if (data.lastUpdatedDate !== undefined && data.lastUpdatedDate !== null) {
-    contents.lastUpdatedDate = new Date(Math.round(data.lastUpdatedDate * 1000));
+    contents.lastUpdatedDate = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.lastUpdatedDate)));
   }
   if (data.locale !== undefined && data.locale !== null) {
     contents.locale = __expectString(data.locale);
@@ -1828,7 +1830,7 @@ export const deserializeAws_restJson1CreateIntentVersionCommand = async (
     contents.confirmationPrompt = deserializeAws_restJson1Prompt(data.confirmationPrompt, context);
   }
   if (data.createdDate !== undefined && data.createdDate !== null) {
-    contents.createdDate = new Date(Math.round(data.createdDate * 1000));
+    contents.createdDate = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.createdDate)));
   }
   if (data.description !== undefined && data.description !== null) {
     contents.description = __expectString(data.description);
@@ -1849,7 +1851,7 @@ export const deserializeAws_restJson1CreateIntentVersionCommand = async (
     contents.kendraConfiguration = deserializeAws_restJson1KendraConfiguration(data.kendraConfiguration, context);
   }
   if (data.lastUpdatedDate !== undefined && data.lastUpdatedDate !== null) {
-    contents.lastUpdatedDate = new Date(Math.round(data.lastUpdatedDate * 1000));
+    contents.lastUpdatedDate = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.lastUpdatedDate)));
   }
   if (data.name !== undefined && data.name !== null) {
     contents.name = __expectString(data.name);
@@ -1977,7 +1979,7 @@ export const deserializeAws_restJson1CreateSlotTypeVersionCommand = async (
     contents.checksum = __expectString(data.checksum);
   }
   if (data.createdDate !== undefined && data.createdDate !== null) {
-    contents.createdDate = new Date(Math.round(data.createdDate * 1000));
+    contents.createdDate = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.createdDate)));
   }
   if (data.description !== undefined && data.description !== null) {
     contents.description = __expectString(data.description);
@@ -1986,7 +1988,7 @@ export const deserializeAws_restJson1CreateSlotTypeVersionCommand = async (
     contents.enumerationValues = deserializeAws_restJson1EnumerationValues(data.enumerationValues, context);
   }
   if (data.lastUpdatedDate !== undefined && data.lastUpdatedDate !== null) {
-    contents.lastUpdatedDate = new Date(Math.round(data.lastUpdatedDate * 1000));
+    contents.lastUpdatedDate = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.lastUpdatedDate)));
   }
   if (data.name !== undefined && data.name !== null) {
     contents.name = __expectString(data.name);
@@ -2923,7 +2925,7 @@ export const deserializeAws_restJson1GetBotCommand = async (
     contents.clarificationPrompt = deserializeAws_restJson1Prompt(data.clarificationPrompt, context);
   }
   if (data.createdDate !== undefined && data.createdDate !== null) {
-    contents.createdDate = new Date(Math.round(data.createdDate * 1000));
+    contents.createdDate = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.createdDate)));
   }
   if (data.description !== undefined && data.description !== null) {
     contents.description = __expectString(data.description);
@@ -2944,7 +2946,7 @@ export const deserializeAws_restJson1GetBotCommand = async (
     contents.intents = deserializeAws_restJson1IntentList(data.intents, context);
   }
   if (data.lastUpdatedDate !== undefined && data.lastUpdatedDate !== null) {
-    contents.lastUpdatedDate = new Date(Math.round(data.lastUpdatedDate * 1000));
+    contents.lastUpdatedDate = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.lastUpdatedDate)));
   }
   if (data.locale !== undefined && data.locale !== null) {
     contents.locale = __expectString(data.locale);
@@ -3060,13 +3062,13 @@ export const deserializeAws_restJson1GetBotAliasCommand = async (
     contents.conversationLogs = deserializeAws_restJson1ConversationLogsResponse(data.conversationLogs, context);
   }
   if (data.createdDate !== undefined && data.createdDate !== null) {
-    contents.createdDate = new Date(Math.round(data.createdDate * 1000));
+    contents.createdDate = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.createdDate)));
   }
   if (data.description !== undefined && data.description !== null) {
     contents.description = __expectString(data.description);
   }
   if (data.lastUpdatedDate !== undefined && data.lastUpdatedDate !== null) {
-    contents.lastUpdatedDate = new Date(Math.round(data.lastUpdatedDate * 1000));
+    contents.lastUpdatedDate = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.lastUpdatedDate)));
   }
   if (data.name !== undefined && data.name !== null) {
     contents.name = __expectString(data.name);
@@ -3240,7 +3242,7 @@ export const deserializeAws_restJson1GetBotChannelAssociationCommand = async (
     contents.botName = __expectString(data.botName);
   }
   if (data.createdDate !== undefined && data.createdDate !== null) {
-    contents.createdDate = new Date(Math.round(data.createdDate * 1000));
+    contents.createdDate = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.createdDate)));
   }
   if (data.description !== undefined && data.description !== null) {
     contents.description = __expectString(data.description);
@@ -3924,7 +3926,7 @@ export const deserializeAws_restJson1GetImportCommand = async (
   };
   const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.createdDate !== undefined && data.createdDate !== null) {
-    contents.createdDate = new Date(Math.round(data.createdDate * 1000));
+    contents.createdDate = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.createdDate)));
   }
   if (data.failureReason !== undefined && data.failureReason !== null) {
     contents.failureReason = deserializeAws_restJson1StringList(data.failureReason, context);
@@ -4047,7 +4049,7 @@ export const deserializeAws_restJson1GetIntentCommand = async (
     contents.confirmationPrompt = deserializeAws_restJson1Prompt(data.confirmationPrompt, context);
   }
   if (data.createdDate !== undefined && data.createdDate !== null) {
-    contents.createdDate = new Date(Math.round(data.createdDate * 1000));
+    contents.createdDate = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.createdDate)));
   }
   if (data.description !== undefined && data.description !== null) {
     contents.description = __expectString(data.description);
@@ -4068,7 +4070,7 @@ export const deserializeAws_restJson1GetIntentCommand = async (
     contents.kendraConfiguration = deserializeAws_restJson1KendraConfiguration(data.kendraConfiguration, context);
   }
   if (data.lastUpdatedDate !== undefined && data.lastUpdatedDate !== null) {
-    contents.lastUpdatedDate = new Date(Math.round(data.lastUpdatedDate * 1000));
+    contents.lastUpdatedDate = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.lastUpdatedDate)));
   }
   if (data.name !== undefined && data.name !== null) {
     contents.name = __expectString(data.name);
@@ -4355,7 +4357,7 @@ export const deserializeAws_restJson1GetMigrationCommand = async (
     contents.migrationStrategy = __expectString(data.migrationStrategy);
   }
   if (data.migrationTimestamp !== undefined && data.migrationTimestamp !== null) {
-    contents.migrationTimestamp = new Date(Math.round(data.migrationTimestamp * 1000));
+    contents.migrationTimestamp = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.migrationTimestamp)));
   }
   if (data.v1BotLocale !== undefined && data.v1BotLocale !== null) {
     contents.v1BotLocale = __expectString(data.v1BotLocale);
@@ -4536,7 +4538,7 @@ export const deserializeAws_restJson1GetSlotTypeCommand = async (
     contents.checksum = __expectString(data.checksum);
   }
   if (data.createdDate !== undefined && data.createdDate !== null) {
-    contents.createdDate = new Date(Math.round(data.createdDate * 1000));
+    contents.createdDate = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.createdDate)));
   }
   if (data.description !== undefined && data.description !== null) {
     contents.description = __expectString(data.description);
@@ -4545,7 +4547,7 @@ export const deserializeAws_restJson1GetSlotTypeCommand = async (
     contents.enumerationValues = deserializeAws_restJson1EnumerationValues(data.enumerationValues, context);
   }
   if (data.lastUpdatedDate !== undefined && data.lastUpdatedDate !== null) {
-    contents.lastUpdatedDate = new Date(Math.round(data.lastUpdatedDate * 1000));
+    contents.lastUpdatedDate = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.lastUpdatedDate)));
   }
   if (data.name !== undefined && data.name !== null) {
     contents.name = __expectString(data.name);
@@ -4996,7 +4998,7 @@ export const deserializeAws_restJson1PutBotCommand = async (
     contents.createVersion = __expectBoolean(data.createVersion);
   }
   if (data.createdDate !== undefined && data.createdDate !== null) {
-    contents.createdDate = new Date(Math.round(data.createdDate * 1000));
+    contents.createdDate = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.createdDate)));
   }
   if (data.description !== undefined && data.description !== null) {
     contents.description = __expectString(data.description);
@@ -5017,7 +5019,7 @@ export const deserializeAws_restJson1PutBotCommand = async (
     contents.intents = deserializeAws_restJson1IntentList(data.intents, context);
   }
   if (data.lastUpdatedDate !== undefined && data.lastUpdatedDate !== null) {
-    contents.lastUpdatedDate = new Date(Math.round(data.lastUpdatedDate * 1000));
+    contents.lastUpdatedDate = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.lastUpdatedDate)));
   }
   if (data.locale !== undefined && data.locale !== null) {
     contents.locale = __expectString(data.locale);
@@ -5145,13 +5147,13 @@ export const deserializeAws_restJson1PutBotAliasCommand = async (
     contents.conversationLogs = deserializeAws_restJson1ConversationLogsResponse(data.conversationLogs, context);
   }
   if (data.createdDate !== undefined && data.createdDate !== null) {
-    contents.createdDate = new Date(Math.round(data.createdDate * 1000));
+    contents.createdDate = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.createdDate)));
   }
   if (data.description !== undefined && data.description !== null) {
     contents.description = __expectString(data.description);
   }
   if (data.lastUpdatedDate !== undefined && data.lastUpdatedDate !== null) {
-    contents.lastUpdatedDate = new Date(Math.round(data.lastUpdatedDate * 1000));
+    contents.lastUpdatedDate = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.lastUpdatedDate)));
   }
   if (data.name !== undefined && data.name !== null) {
     contents.name = __expectString(data.name);
@@ -5274,7 +5276,7 @@ export const deserializeAws_restJson1PutIntentCommand = async (
     contents.createVersion = __expectBoolean(data.createVersion);
   }
   if (data.createdDate !== undefined && data.createdDate !== null) {
-    contents.createdDate = new Date(Math.round(data.createdDate * 1000));
+    contents.createdDate = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.createdDate)));
   }
   if (data.description !== undefined && data.description !== null) {
     contents.description = __expectString(data.description);
@@ -5295,7 +5297,7 @@ export const deserializeAws_restJson1PutIntentCommand = async (
     contents.kendraConfiguration = deserializeAws_restJson1KendraConfiguration(data.kendraConfiguration, context);
   }
   if (data.lastUpdatedDate !== undefined && data.lastUpdatedDate !== null) {
-    contents.lastUpdatedDate = new Date(Math.round(data.lastUpdatedDate * 1000));
+    contents.lastUpdatedDate = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.lastUpdatedDate)));
   }
   if (data.name !== undefined && data.name !== null) {
     contents.name = __expectString(data.name);
@@ -5419,7 +5421,7 @@ export const deserializeAws_restJson1PutSlotTypeCommand = async (
     contents.createVersion = __expectBoolean(data.createVersion);
   }
   if (data.createdDate !== undefined && data.createdDate !== null) {
-    contents.createdDate = new Date(Math.round(data.createdDate * 1000));
+    contents.createdDate = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.createdDate)));
   }
   if (data.description !== undefined && data.description !== null) {
     contents.description = __expectString(data.description);
@@ -5428,7 +5430,7 @@ export const deserializeAws_restJson1PutSlotTypeCommand = async (
     contents.enumerationValues = deserializeAws_restJson1EnumerationValues(data.enumerationValues, context);
   }
   if (data.lastUpdatedDate !== undefined && data.lastUpdatedDate !== null) {
-    contents.lastUpdatedDate = new Date(Math.round(data.lastUpdatedDate * 1000));
+    contents.lastUpdatedDate = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.lastUpdatedDate)));
   }
   if (data.name !== undefined && data.name !== null) {
     contents.name = __expectString(data.name);
@@ -5539,7 +5541,7 @@ export const deserializeAws_restJson1StartImportCommand = async (
   };
   const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.createdDate !== undefined && data.createdDate !== null) {
-    contents.createdDate = new Date(Math.round(data.createdDate * 1000));
+    contents.createdDate = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.createdDate)));
   }
   if (data.importId !== undefined && data.importId !== null) {
     contents.importId = __expectString(data.importId);
@@ -5641,7 +5643,7 @@ export const deserializeAws_restJson1StartMigrationCommand = async (
     contents.migrationStrategy = __expectString(data.migrationStrategy);
   }
   if (data.migrationTimestamp !== undefined && data.migrationTimestamp !== null) {
-    contents.migrationTimestamp = new Date(Math.round(data.migrationTimestamp * 1000));
+    contents.migrationTimestamp = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.migrationTimestamp)));
   }
   if (data.v1BotLocale !== undefined && data.v1BotLocale !== null) {
     contents.v1BotLocale = __expectString(data.v1BotLocale);
@@ -6375,12 +6377,12 @@ const deserializeAws_restJson1BotAliasMetadata = (output: any, context: __SerdeC
         : undefined,
     createdDate:
       output.createdDate !== undefined && output.createdDate !== null
-        ? new Date(Math.round(output.createdDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.createdDate)))
         : undefined,
     description: __expectString(output.description),
     lastUpdatedDate:
       output.lastUpdatedDate !== undefined && output.lastUpdatedDate !== null
-        ? new Date(Math.round(output.lastUpdatedDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastUpdatedDate)))
         : undefined,
     name: __expectString(output.name),
   } as any;
@@ -6407,7 +6409,7 @@ const deserializeAws_restJson1BotChannelAssociation = (output: any, context: __S
     botName: __expectString(output.botName),
     createdDate:
       output.createdDate !== undefined && output.createdDate !== null
-        ? new Date(Math.round(output.createdDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.createdDate)))
         : undefined,
     description: __expectString(output.description),
     failureReason: __expectString(output.failureReason),
@@ -6435,12 +6437,12 @@ const deserializeAws_restJson1BotMetadata = (output: any, context: __SerdeContex
   return {
     createdDate:
       output.createdDate !== undefined && output.createdDate !== null
-        ? new Date(Math.round(output.createdDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.createdDate)))
         : undefined,
     description: __expectString(output.description),
     lastUpdatedDate:
       output.lastUpdatedDate !== undefined && output.lastUpdatedDate !== null
-        ? new Date(Math.round(output.lastUpdatedDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastUpdatedDate)))
         : undefined,
     name: __expectString(output.name),
     status: __expectString(output.status),
@@ -6645,12 +6647,12 @@ const deserializeAws_restJson1IntentMetadata = (output: any, context: __SerdeCon
   return {
     createdDate:
       output.createdDate !== undefined && output.createdDate !== null
-        ? new Date(Math.round(output.createdDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.createdDate)))
         : undefined,
     description: __expectString(output.description),
     lastUpdatedDate:
       output.lastUpdatedDate !== undefined && output.lastUpdatedDate !== null
-        ? new Date(Math.round(output.lastUpdatedDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastUpdatedDate)))
         : undefined,
     name: __expectString(output.name),
     version: __expectString(output.version),
@@ -6818,7 +6820,7 @@ const deserializeAws_restJson1MigrationSummary = (output: any, context: __SerdeC
     migrationStrategy: __expectString(output.migrationStrategy),
     migrationTimestamp:
       output.migrationTimestamp !== undefined && output.migrationTimestamp !== null
-        ? new Date(Math.round(output.migrationTimestamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.migrationTimestamp)))
         : undefined,
     v1BotLocale: __expectString(output.v1BotLocale),
     v1BotName: __expectString(output.v1BotName),
@@ -6965,12 +6967,12 @@ const deserializeAws_restJson1SlotTypeMetadata = (output: any, context: __SerdeC
   return {
     createdDate:
       output.createdDate !== undefined && output.createdDate !== null
-        ? new Date(Math.round(output.createdDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.createdDate)))
         : undefined,
     description: __expectString(output.description),
     lastUpdatedDate:
       output.lastUpdatedDate !== undefined && output.lastUpdatedDate !== null
-        ? new Date(Math.round(output.lastUpdatedDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastUpdatedDate)))
         : undefined,
     name: __expectString(output.name),
     version: __expectString(output.version),
@@ -7064,11 +7066,11 @@ const deserializeAws_restJson1UtteranceData = (output: any, context: __SerdeCont
     distinctUsers: __expectInt32(output.distinctUsers),
     firstUtteredDate:
       output.firstUtteredDate !== undefined && output.firstUtteredDate !== null
-        ? new Date(Math.round(output.firstUtteredDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.firstUtteredDate)))
         : undefined,
     lastUtteredDate:
       output.lastUtteredDate !== undefined && output.lastUtteredDate !== null
-        ? new Date(Math.round(output.lastUtteredDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastUtteredDate)))
         : undefined,
     utteranceString: __expectString(output.utteranceString),
   } as any;

--- a/clients/client-lex-models-v2/protocols/Aws_restJson1.ts
+++ b/clients/client-lex-models-v2/protocols/Aws_restJson1.ts
@@ -172,10 +172,12 @@ import {
   expectBoolean as __expectBoolean,
   expectInt32 as __expectInt32,
   expectNonNull as __expectNonNull,
+  expectNumber as __expectNumber,
   expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   limitedParseDouble as __limitedParseDouble,
+  parseEpochTimestamp as __parseEpochTimestamp,
   serializeFloat as __serializeFloat,
   strictParseInt32 as __strictParseInt32,
 } from "@aws-sdk/smithy-client";
@@ -2794,7 +2796,9 @@ export const deserializeAws_restJson1BuildBotLocaleCommand = async (
     contents.botVersion = __expectString(data.botVersion);
   }
   if (data.lastBuildSubmittedDateTime !== undefined && data.lastBuildSubmittedDateTime !== null) {
-    contents.lastBuildSubmittedDateTime = new Date(Math.round(data.lastBuildSubmittedDateTime * 1000));
+    contents.lastBuildSubmittedDateTime = __expectNonNull(
+      __parseEpochTimestamp(__expectNumber(data.lastBuildSubmittedDateTime))
+    );
   }
   if (data.localeId !== undefined && data.localeId !== null) {
     contents.localeId = __expectString(data.localeId);
@@ -2913,7 +2917,7 @@ export const deserializeAws_restJson1CreateBotCommand = async (
     contents.botTags = deserializeAws_restJson1TagMap(data.botTags, context);
   }
   if (data.creationDateTime !== undefined && data.creationDateTime !== null) {
-    contents.creationDateTime = new Date(Math.round(data.creationDateTime * 1000));
+    contents.creationDateTime = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.creationDateTime)));
   }
   if (data.dataPrivacy !== undefined && data.dataPrivacy !== null) {
     contents.dataPrivacy = deserializeAws_restJson1DataPrivacy(data.dataPrivacy, context);
@@ -3060,7 +3064,7 @@ export const deserializeAws_restJson1CreateBotAliasCommand = async (
     );
   }
   if (data.creationDateTime !== undefined && data.creationDateTime !== null) {
-    contents.creationDateTime = new Date(Math.round(data.creationDateTime * 1000));
+    contents.creationDateTime = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.creationDateTime)));
   }
   if (data.description !== undefined && data.description !== null) {
     contents.description = __expectString(data.description);
@@ -3184,7 +3188,7 @@ export const deserializeAws_restJson1CreateBotLocaleCommand = async (
     contents.botVersion = __expectString(data.botVersion);
   }
   if (data.creationDateTime !== undefined && data.creationDateTime !== null) {
-    contents.creationDateTime = new Date(Math.round(data.creationDateTime * 1000));
+    contents.creationDateTime = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.creationDateTime)));
   }
   if (data.description !== undefined && data.description !== null) {
     contents.description = __expectString(data.description);
@@ -3314,7 +3318,7 @@ export const deserializeAws_restJson1CreateBotVersionCommand = async (
     );
   }
   if (data.creationDateTime !== undefined && data.creationDateTime !== null) {
-    contents.creationDateTime = new Date(Math.round(data.creationDateTime * 1000));
+    contents.creationDateTime = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.creationDateTime)));
   }
   if (data.description !== undefined && data.description !== null) {
     contents.description = __expectString(data.description);
@@ -3416,7 +3420,7 @@ export const deserializeAws_restJson1CreateExportCommand = async (
   };
   const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.creationDateTime !== undefined && data.creationDateTime !== null) {
-    contents.creationDateTime = new Date(Math.round(data.creationDateTime * 1000));
+    contents.creationDateTime = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.creationDateTime)));
   }
   if (data.exportId !== undefined && data.exportId !== null) {
     contents.exportId = __expectString(data.exportId);
@@ -3547,7 +3551,7 @@ export const deserializeAws_restJson1CreateIntentCommand = async (
     contents.botVersion = __expectString(data.botVersion);
   }
   if (data.creationDateTime !== undefined && data.creationDateTime !== null) {
-    contents.creationDateTime = new Date(Math.round(data.creationDateTime * 1000));
+    contents.creationDateTime = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.creationDateTime)));
   }
   if (data.description !== undefined && data.description !== null) {
     contents.description = __expectString(data.description);
@@ -3910,7 +3914,7 @@ export const deserializeAws_restJson1CreateSlotCommand = async (
     contents.botVersion = __expectString(data.botVersion);
   }
   if (data.creationDateTime !== undefined && data.creationDateTime !== null) {
-    contents.creationDateTime = new Date(Math.round(data.creationDateTime * 1000));
+    contents.creationDateTime = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.creationDateTime)));
   }
   if (data.description !== undefined && data.description !== null) {
     contents.description = __expectString(data.description);
@@ -4050,7 +4054,7 @@ export const deserializeAws_restJson1CreateSlotTypeCommand = async (
     contents.botVersion = __expectString(data.botVersion);
   }
   if (data.creationDateTime !== undefined && data.creationDateTime !== null) {
-    contents.creationDateTime = new Date(Math.round(data.creationDateTime * 1000));
+    contents.creationDateTime = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.creationDateTime)));
   }
   if (data.description !== undefined && data.description !== null) {
     contents.description = __expectString(data.description);
@@ -5310,7 +5314,7 @@ export const deserializeAws_restJson1DescribeBotCommand = async (
     contents.botStatus = __expectString(data.botStatus);
   }
   if (data.creationDateTime !== undefined && data.creationDateTime !== null) {
-    contents.creationDateTime = new Date(Math.round(data.creationDateTime * 1000));
+    contents.creationDateTime = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.creationDateTime)));
   }
   if (data.dataPrivacy !== undefined && data.dataPrivacy !== null) {
     contents.dataPrivacy = deserializeAws_restJson1DataPrivacy(data.dataPrivacy, context);
@@ -5322,7 +5326,7 @@ export const deserializeAws_restJson1DescribeBotCommand = async (
     contents.idleSessionTTLInSeconds = __expectInt32(data.idleSessionTTLInSeconds);
   }
   if (data.lastUpdatedDateTime !== undefined && data.lastUpdatedDateTime !== null) {
-    contents.lastUpdatedDateTime = new Date(Math.round(data.lastUpdatedDateTime * 1000));
+    contents.lastUpdatedDateTime = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.lastUpdatedDateTime)));
   }
   if (data.roleArn !== undefined && data.roleArn !== null) {
     contents.roleArn = __expectString(data.roleArn);
@@ -5456,13 +5460,13 @@ export const deserializeAws_restJson1DescribeBotAliasCommand = async (
     );
   }
   if (data.creationDateTime !== undefined && data.creationDateTime !== null) {
-    contents.creationDateTime = new Date(Math.round(data.creationDateTime * 1000));
+    contents.creationDateTime = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.creationDateTime)));
   }
   if (data.description !== undefined && data.description !== null) {
     contents.description = __expectString(data.description);
   }
   if (data.lastUpdatedDateTime !== undefined && data.lastUpdatedDateTime !== null) {
-    contents.lastUpdatedDateTime = new Date(Math.round(data.lastUpdatedDateTime * 1000));
+    contents.lastUpdatedDateTime = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.lastUpdatedDateTime)));
   }
   if (data.sentimentAnalysisSettings !== undefined && data.sentimentAnalysisSettings !== null) {
     contents.sentimentAnalysisSettings = deserializeAws_restJson1SentimentAnalysisSettings(
@@ -5584,7 +5588,7 @@ export const deserializeAws_restJson1DescribeBotLocaleCommand = async (
     contents.botVersion = __expectString(data.botVersion);
   }
   if (data.creationDateTime !== undefined && data.creationDateTime !== null) {
-    contents.creationDateTime = new Date(Math.round(data.creationDateTime * 1000));
+    contents.creationDateTime = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.creationDateTime)));
   }
   if (data.description !== undefined && data.description !== null) {
     contents.description = __expectString(data.description);
@@ -5596,10 +5600,12 @@ export const deserializeAws_restJson1DescribeBotLocaleCommand = async (
     contents.intentsCount = __expectInt32(data.intentsCount);
   }
   if (data.lastBuildSubmittedDateTime !== undefined && data.lastBuildSubmittedDateTime !== null) {
-    contents.lastBuildSubmittedDateTime = new Date(Math.round(data.lastBuildSubmittedDateTime * 1000));
+    contents.lastBuildSubmittedDateTime = __expectNonNull(
+      __parseEpochTimestamp(__expectNumber(data.lastBuildSubmittedDateTime))
+    );
   }
   if (data.lastUpdatedDateTime !== undefined && data.lastUpdatedDateTime !== null) {
-    contents.lastUpdatedDateTime = new Date(Math.round(data.lastUpdatedDateTime * 1000));
+    contents.lastUpdatedDateTime = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.lastUpdatedDateTime)));
   }
   if (data.localeId !== undefined && data.localeId !== null) {
     contents.localeId = __expectString(data.localeId);
@@ -5722,7 +5728,7 @@ export const deserializeAws_restJson1DescribeBotVersionCommand = async (
     contents.botVersion = __expectString(data.botVersion);
   }
   if (data.creationDateTime !== undefined && data.creationDateTime !== null) {
-    contents.creationDateTime = new Date(Math.round(data.creationDateTime * 1000));
+    contents.creationDateTime = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.creationDateTime)));
   }
   if (data.dataPrivacy !== undefined && data.dataPrivacy !== null) {
     contents.dataPrivacy = deserializeAws_restJson1DataPrivacy(data.dataPrivacy, context);
@@ -5831,7 +5837,7 @@ export const deserializeAws_restJson1DescribeExportCommand = async (
   };
   const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.creationDateTime !== undefined && data.creationDateTime !== null) {
-    contents.creationDateTime = new Date(Math.round(data.creationDateTime * 1000));
+    contents.creationDateTime = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.creationDateTime)));
   }
   if (data.downloadUrl !== undefined && data.downloadUrl !== null) {
     contents.downloadUrl = __expectString(data.downloadUrl);
@@ -5849,7 +5855,7 @@ export const deserializeAws_restJson1DescribeExportCommand = async (
     contents.fileFormat = __expectString(data.fileFormat);
   }
   if (data.lastUpdatedDateTime !== undefined && data.lastUpdatedDateTime !== null) {
-    contents.lastUpdatedDateTime = new Date(Math.round(data.lastUpdatedDateTime * 1000));
+    contents.lastUpdatedDateTime = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.lastUpdatedDateTime)));
   }
   if (data.resourceSpecification !== undefined && data.resourceSpecification !== null) {
     contents.resourceSpecification = deserializeAws_restJson1ExportResourceSpecification(
@@ -5942,7 +5948,7 @@ export const deserializeAws_restJson1DescribeImportCommand = async (
   };
   const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.creationDateTime !== undefined && data.creationDateTime !== null) {
-    contents.creationDateTime = new Date(Math.round(data.creationDateTime * 1000));
+    contents.creationDateTime = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.creationDateTime)));
   }
   if (data.failureReasons !== undefined && data.failureReasons !== null) {
     contents.failureReasons = deserializeAws_restJson1FailureReasons(data.failureReasons, context);
@@ -5960,7 +5966,7 @@ export const deserializeAws_restJson1DescribeImportCommand = async (
     contents.importedResourceName = __expectString(data.importedResourceName);
   }
   if (data.lastUpdatedDateTime !== undefined && data.lastUpdatedDateTime !== null) {
-    contents.lastUpdatedDateTime = new Date(Math.round(data.lastUpdatedDateTime * 1000));
+    contents.lastUpdatedDateTime = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.lastUpdatedDateTime)));
   }
   if (data.mergeStrategy !== undefined && data.mergeStrategy !== null) {
     contents.mergeStrategy = __expectString(data.mergeStrategy);
@@ -6071,7 +6077,7 @@ export const deserializeAws_restJson1DescribeIntentCommand = async (
     contents.botVersion = __expectString(data.botVersion);
   }
   if (data.creationDateTime !== undefined && data.creationDateTime !== null) {
-    contents.creationDateTime = new Date(Math.round(data.creationDateTime * 1000));
+    contents.creationDateTime = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.creationDateTime)));
   }
   if (data.description !== undefined && data.description !== null) {
     contents.description = __expectString(data.description);
@@ -6107,7 +6113,7 @@ export const deserializeAws_restJson1DescribeIntentCommand = async (
     contents.kendraConfiguration = deserializeAws_restJson1KendraConfiguration(data.kendraConfiguration, context);
   }
   if (data.lastUpdatedDateTime !== undefined && data.lastUpdatedDateTime !== null) {
-    contents.lastUpdatedDateTime = new Date(Math.round(data.lastUpdatedDateTime * 1000));
+    contents.lastUpdatedDateTime = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.lastUpdatedDateTime)));
   }
   if (data.localeId !== undefined && data.localeId !== null) {
     contents.localeId = __expectString(data.localeId);
@@ -6306,7 +6312,7 @@ export const deserializeAws_restJson1DescribeSlotCommand = async (
     contents.botVersion = __expectString(data.botVersion);
   }
   if (data.creationDateTime !== undefined && data.creationDateTime !== null) {
-    contents.creationDateTime = new Date(Math.round(data.creationDateTime * 1000));
+    contents.creationDateTime = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.creationDateTime)));
   }
   if (data.description !== undefined && data.description !== null) {
     contents.description = __expectString(data.description);
@@ -6315,7 +6321,7 @@ export const deserializeAws_restJson1DescribeSlotCommand = async (
     contents.intentId = __expectString(data.intentId);
   }
   if (data.lastUpdatedDateTime !== undefined && data.lastUpdatedDateTime !== null) {
-    contents.lastUpdatedDateTime = new Date(Math.round(data.lastUpdatedDateTime * 1000));
+    contents.lastUpdatedDateTime = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.lastUpdatedDateTime)));
   }
   if (data.localeId !== undefined && data.localeId !== null) {
     contents.localeId = __expectString(data.localeId);
@@ -6442,13 +6448,13 @@ export const deserializeAws_restJson1DescribeSlotTypeCommand = async (
     contents.botVersion = __expectString(data.botVersion);
   }
   if (data.creationDateTime !== undefined && data.creationDateTime !== null) {
-    contents.creationDateTime = new Date(Math.round(data.creationDateTime * 1000));
+    contents.creationDateTime = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.creationDateTime)));
   }
   if (data.description !== undefined && data.description !== null) {
     contents.description = __expectString(data.description);
   }
   if (data.lastUpdatedDateTime !== undefined && data.lastUpdatedDateTime !== null) {
-    contents.lastUpdatedDateTime = new Date(Math.round(data.lastUpdatedDateTime * 1000));
+    contents.lastUpdatedDateTime = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.lastUpdatedDateTime)));
   }
   if (data.localeId !== undefined && data.localeId !== null) {
     contents.localeId = __expectString(data.localeId);
@@ -7622,7 +7628,7 @@ export const deserializeAws_restJson1StartImportCommand = async (
   };
   const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.creationDateTime !== undefined && data.creationDateTime !== null) {
-    contents.creationDateTime = new Date(Math.round(data.creationDateTime * 1000));
+    contents.creationDateTime = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.creationDateTime)));
   }
   if (data.importId !== undefined && data.importId !== null) {
     contents.importId = __expectString(data.importId);
@@ -7899,7 +7905,7 @@ export const deserializeAws_restJson1UpdateBotCommand = async (
     contents.botStatus = __expectString(data.botStatus);
   }
   if (data.creationDateTime !== undefined && data.creationDateTime !== null) {
-    contents.creationDateTime = new Date(Math.round(data.creationDateTime * 1000));
+    contents.creationDateTime = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.creationDateTime)));
   }
   if (data.dataPrivacy !== undefined && data.dataPrivacy !== null) {
     contents.dataPrivacy = deserializeAws_restJson1DataPrivacy(data.dataPrivacy, context);
@@ -7911,7 +7917,7 @@ export const deserializeAws_restJson1UpdateBotCommand = async (
     contents.idleSessionTTLInSeconds = __expectInt32(data.idleSessionTTLInSeconds);
   }
   if (data.lastUpdatedDateTime !== undefined && data.lastUpdatedDateTime !== null) {
-    contents.lastUpdatedDateTime = new Date(Math.round(data.lastUpdatedDateTime * 1000));
+    contents.lastUpdatedDateTime = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.lastUpdatedDateTime)));
   }
   if (data.roleArn !== undefined && data.roleArn !== null) {
     contents.roleArn = __expectString(data.roleArn);
@@ -8046,13 +8052,13 @@ export const deserializeAws_restJson1UpdateBotAliasCommand = async (
     );
   }
   if (data.creationDateTime !== undefined && data.creationDateTime !== null) {
-    contents.creationDateTime = new Date(Math.round(data.creationDateTime * 1000));
+    contents.creationDateTime = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.creationDateTime)));
   }
   if (data.description !== undefined && data.description !== null) {
     contents.description = __expectString(data.description);
   }
   if (data.lastUpdatedDateTime !== undefined && data.lastUpdatedDateTime !== null) {
-    contents.lastUpdatedDateTime = new Date(Math.round(data.lastUpdatedDateTime * 1000));
+    contents.lastUpdatedDateTime = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.lastUpdatedDateTime)));
   }
   if (data.sentimentAnalysisSettings !== undefined && data.sentimentAnalysisSettings !== null) {
     contents.sentimentAnalysisSettings = deserializeAws_restJson1SentimentAnalysisSettings(
@@ -8172,7 +8178,7 @@ export const deserializeAws_restJson1UpdateBotLocaleCommand = async (
     contents.botVersion = __expectString(data.botVersion);
   }
   if (data.creationDateTime !== undefined && data.creationDateTime !== null) {
-    contents.creationDateTime = new Date(Math.round(data.creationDateTime * 1000));
+    contents.creationDateTime = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.creationDateTime)));
   }
   if (data.description !== undefined && data.description !== null) {
     contents.description = __expectString(data.description);
@@ -8181,7 +8187,7 @@ export const deserializeAws_restJson1UpdateBotLocaleCommand = async (
     contents.failureReasons = deserializeAws_restJson1FailureReasons(data.failureReasons, context);
   }
   if (data.lastUpdatedDateTime !== undefined && data.lastUpdatedDateTime !== null) {
-    contents.lastUpdatedDateTime = new Date(Math.round(data.lastUpdatedDateTime * 1000));
+    contents.lastUpdatedDateTime = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.lastUpdatedDateTime)));
   }
   if (data.localeId !== undefined && data.localeId !== null) {
     contents.localeId = __expectString(data.localeId);
@@ -8293,7 +8299,7 @@ export const deserializeAws_restJson1UpdateExportCommand = async (
   };
   const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.creationDateTime !== undefined && data.creationDateTime !== null) {
-    contents.creationDateTime = new Date(Math.round(data.creationDateTime * 1000));
+    contents.creationDateTime = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.creationDateTime)));
   }
   if (data.exportId !== undefined && data.exportId !== null) {
     contents.exportId = __expectString(data.exportId);
@@ -8305,7 +8311,7 @@ export const deserializeAws_restJson1UpdateExportCommand = async (
     contents.fileFormat = __expectString(data.fileFormat);
   }
   if (data.lastUpdatedDateTime !== undefined && data.lastUpdatedDateTime !== null) {
-    contents.lastUpdatedDateTime = new Date(Math.round(data.lastUpdatedDateTime * 1000));
+    contents.lastUpdatedDateTime = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.lastUpdatedDateTime)));
   }
   if (data.resourceSpecification !== undefined && data.resourceSpecification !== null) {
     contents.resourceSpecification = deserializeAws_restJson1ExportResourceSpecification(
@@ -8429,7 +8435,7 @@ export const deserializeAws_restJson1UpdateIntentCommand = async (
     contents.botVersion = __expectString(data.botVersion);
   }
   if (data.creationDateTime !== undefined && data.creationDateTime !== null) {
-    contents.creationDateTime = new Date(Math.round(data.creationDateTime * 1000));
+    contents.creationDateTime = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.creationDateTime)));
   }
   if (data.description !== undefined && data.description !== null) {
     contents.description = __expectString(data.description);
@@ -8465,7 +8471,7 @@ export const deserializeAws_restJson1UpdateIntentCommand = async (
     contents.kendraConfiguration = deserializeAws_restJson1KendraConfiguration(data.kendraConfiguration, context);
   }
   if (data.lastUpdatedDateTime !== undefined && data.lastUpdatedDateTime !== null) {
-    contents.lastUpdatedDateTime = new Date(Math.round(data.lastUpdatedDateTime * 1000));
+    contents.lastUpdatedDateTime = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.lastUpdatedDateTime)));
   }
   if (data.localeId !== undefined && data.localeId !== null) {
     contents.localeId = __expectString(data.localeId);
@@ -8692,7 +8698,7 @@ export const deserializeAws_restJson1UpdateSlotCommand = async (
     contents.botVersion = __expectString(data.botVersion);
   }
   if (data.creationDateTime !== undefined && data.creationDateTime !== null) {
-    contents.creationDateTime = new Date(Math.round(data.creationDateTime * 1000));
+    contents.creationDateTime = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.creationDateTime)));
   }
   if (data.description !== undefined && data.description !== null) {
     contents.description = __expectString(data.description);
@@ -8701,7 +8707,7 @@ export const deserializeAws_restJson1UpdateSlotCommand = async (
     contents.intentId = __expectString(data.intentId);
   }
   if (data.lastUpdatedDateTime !== undefined && data.lastUpdatedDateTime !== null) {
-    contents.lastUpdatedDateTime = new Date(Math.round(data.lastUpdatedDateTime * 1000));
+    contents.lastUpdatedDateTime = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.lastUpdatedDateTime)));
   }
   if (data.localeId !== undefined && data.localeId !== null) {
     contents.localeId = __expectString(data.localeId);
@@ -8836,13 +8842,13 @@ export const deserializeAws_restJson1UpdateSlotTypeCommand = async (
     contents.botVersion = __expectString(data.botVersion);
   }
   if (data.creationDateTime !== undefined && data.creationDateTime !== null) {
-    contents.creationDateTime = new Date(Math.round(data.creationDateTime * 1000));
+    contents.creationDateTime = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.creationDateTime)));
   }
   if (data.description !== undefined && data.description !== null) {
     contents.description = __expectString(data.description);
   }
   if (data.lastUpdatedDateTime !== undefined && data.lastUpdatedDateTime !== null) {
-    contents.lastUpdatedDateTime = new Date(Math.round(data.lastUpdatedDateTime * 1000));
+    contents.lastUpdatedDateTime = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.lastUpdatedDateTime)));
   }
   if (data.localeId !== undefined && data.localeId !== null) {
     contents.localeId = __expectString(data.localeId);
@@ -10084,10 +10090,12 @@ const deserializeAws_restJson1BotAliasHistoryEvent = (output: any, context: __Se
   return {
     botVersion: __expectString(output.botVersion),
     endDate:
-      output.endDate !== undefined && output.endDate !== null ? new Date(Math.round(output.endDate * 1000)) : undefined,
+      output.endDate !== undefined && output.endDate !== null
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.endDate)))
+        : undefined,
     startDate:
       output.startDate !== undefined && output.startDate !== null
-        ? new Date(Math.round(output.startDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.startDate)))
         : undefined,
   } as any;
 };
@@ -10145,12 +10153,12 @@ const deserializeAws_restJson1BotAliasSummary = (output: any, context: __SerdeCo
     botVersion: __expectString(output.botVersion),
     creationDateTime:
       output.creationDateTime !== undefined && output.creationDateTime !== null
-        ? new Date(Math.round(output.creationDateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.creationDateTime)))
         : undefined,
     description: __expectString(output.description),
     lastUpdatedDateTime:
       output.lastUpdatedDateTime !== undefined && output.lastUpdatedDateTime !== null
-        ? new Date(Math.round(output.lastUpdatedDateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastUpdatedDateTime)))
         : undefined,
   } as any;
 };
@@ -10215,7 +10223,7 @@ const deserializeAws_restJson1BotLocaleHistoryEvent = (output: any, context: __S
     event: __expectString(output.event),
     eventDate:
       output.eventDate !== undefined && output.eventDate !== null
-        ? new Date(Math.round(output.eventDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.eventDate)))
         : undefined,
   } as any;
 };
@@ -10256,11 +10264,11 @@ const deserializeAws_restJson1BotLocaleSummary = (output: any, context: __SerdeC
     description: __expectString(output.description),
     lastBuildSubmittedDateTime:
       output.lastBuildSubmittedDateTime !== undefined && output.lastBuildSubmittedDateTime !== null
-        ? new Date(Math.round(output.lastBuildSubmittedDateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastBuildSubmittedDateTime)))
         : undefined,
     lastUpdatedDateTime:
       output.lastUpdatedDateTime !== undefined && output.lastUpdatedDateTime !== null
-        ? new Date(Math.round(output.lastUpdatedDateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastUpdatedDateTime)))
         : undefined,
     localeId: __expectString(output.localeId),
     localeName: __expectString(output.localeName),
@@ -10286,7 +10294,7 @@ const deserializeAws_restJson1BotSummary = (output: any, context: __SerdeContext
     description: __expectString(output.description),
     lastUpdatedDateTime:
       output.lastUpdatedDateTime !== undefined && output.lastUpdatedDateTime !== null
-        ? new Date(Math.round(output.lastUpdatedDateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastUpdatedDateTime)))
         : undefined,
     latestBotVersion: __expectString(output.latestBotVersion),
   } as any;
@@ -10337,7 +10345,7 @@ const deserializeAws_restJson1BotVersionSummary = (output: any, context: __Serde
     botVersion: __expectString(output.botVersion),
     creationDateTime:
       output.creationDateTime !== undefined && output.creationDateTime !== null
-        ? new Date(Math.round(output.creationDateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.creationDateTime)))
         : undefined,
     description: __expectString(output.description),
   } as any;
@@ -10493,14 +10501,14 @@ const deserializeAws_restJson1ExportSummary = (output: any, context: __SerdeCont
   return {
     creationDateTime:
       output.creationDateTime !== undefined && output.creationDateTime !== null
-        ? new Date(Math.round(output.creationDateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.creationDateTime)))
         : undefined,
     exportId: __expectString(output.exportId),
     exportStatus: __expectString(output.exportStatus),
     fileFormat: __expectString(output.fileFormat),
     lastUpdatedDateTime:
       output.lastUpdatedDateTime !== undefined && output.lastUpdatedDateTime !== null
-        ? new Date(Math.round(output.lastUpdatedDateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastUpdatedDateTime)))
         : undefined,
     resourceSpecification:
       output.resourceSpecification !== undefined && output.resourceSpecification !== null
@@ -10572,7 +10580,7 @@ const deserializeAws_restJson1ImportSummary = (output: any, context: __SerdeCont
   return {
     creationDateTime:
       output.creationDateTime !== undefined && output.creationDateTime !== null
-        ? new Date(Math.round(output.creationDateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.creationDateTime)))
         : undefined,
     importId: __expectString(output.importId),
     importStatus: __expectString(output.importStatus),
@@ -10580,7 +10588,7 @@ const deserializeAws_restJson1ImportSummary = (output: any, context: __SerdeCont
     importedResourceName: __expectString(output.importedResourceName),
     lastUpdatedDateTime:
       output.lastUpdatedDateTime !== undefined && output.lastUpdatedDateTime !== null
-        ? new Date(Math.round(output.lastUpdatedDateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastUpdatedDateTime)))
         : undefined,
     mergeStrategy: __expectString(output.mergeStrategy),
   } as any;
@@ -10652,7 +10660,7 @@ const deserializeAws_restJson1IntentSummary = (output: any, context: __SerdeCont
     intentName: __expectString(output.intentName),
     lastUpdatedDateTime:
       output.lastUpdatedDateTime !== undefined && output.lastUpdatedDateTime !== null
-        ? new Date(Math.round(output.lastUpdatedDateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastUpdatedDateTime)))
         : undefined,
     outputContexts:
       output.outputContexts !== undefined && output.outputContexts !== null
@@ -10897,7 +10905,7 @@ const deserializeAws_restJson1SlotSummary = (output: any, context: __SerdeContex
     description: __expectString(output.description),
     lastUpdatedDateTime:
       output.lastUpdatedDateTime !== undefined && output.lastUpdatedDateTime !== null
-        ? new Date(Math.round(output.lastUpdatedDateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastUpdatedDateTime)))
         : undefined,
     slotConstraint: __expectString(output.slotConstraint),
     slotId: __expectString(output.slotId),
@@ -10926,7 +10934,7 @@ const deserializeAws_restJson1SlotTypeSummary = (output: any, context: __SerdeCo
     description: __expectString(output.description),
     lastUpdatedDateTime:
       output.lastUpdatedDateTime !== undefined && output.lastUpdatedDateTime !== null
-        ? new Date(Math.round(output.lastUpdatedDateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastUpdatedDateTime)))
         : undefined,
     parentSlotTypeSignature: __expectString(output.parentSlotTypeSignature),
     slotTypeId: __expectString(output.slotTypeId),

--- a/clients/client-license-manager/protocols/Aws_json1_1.ts
+++ b/clients/client-license-manager/protocols/Aws_json1_1.ts
@@ -266,7 +266,10 @@ import {
   expectBoolean as __expectBoolean,
   expectInt32 as __expectInt32,
   expectLong as __expectLong,
+  expectNonNull as __expectNonNull,
+  expectNumber as __expectNumber,
   expectString as __expectString,
+  parseEpochTimestamp as __parseEpochTimestamp,
 } from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
@@ -6597,7 +6600,7 @@ const deserializeAws_json1_1AutomatedDiscoveryInformation = (
   return {
     LastRunTime:
       output.LastRunTime !== undefined && output.LastRunTime !== null
-        ? new Date(Math.round(output.LastRunTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastRunTime)))
         : undefined,
   } as any;
 };
@@ -7189,7 +7192,7 @@ const deserializeAws_json1_1LicenseConfigurationAssociation = (
     AmiAssociationScope: __expectString(output.AmiAssociationScope),
     AssociationTime:
       output.AssociationTime !== undefined && output.AssociationTime !== null
-        ? new Date(Math.round(output.AssociationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.AssociationTime)))
         : undefined,
     ResourceArn: __expectString(output.ResourceArn),
     ResourceOwnerId: __expectString(output.ResourceOwnerId),
@@ -7229,7 +7232,7 @@ const deserializeAws_json1_1LicenseConfigurationUsage = (
   return {
     AssociationTime:
       output.AssociationTime !== undefined && output.AssociationTime !== null
-        ? new Date(Math.round(output.AssociationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.AssociationTime)))
         : undefined,
     ConsumedLicenses: __expectLong(output.ConsumedLicenses),
     ResourceArn: __expectString(output.ResourceArn),
@@ -7272,7 +7275,7 @@ const deserializeAws_json1_1LicenseOperationFailure = (
     ErrorMessage: __expectString(output.ErrorMessage),
     FailureTime:
       output.FailureTime !== undefined && output.FailureTime !== null
-        ? new Date(Math.round(output.FailureTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.FailureTime)))
         : undefined,
     MetadataList:
       output.MetadataList !== undefined && output.MetadataList !== null

--- a/clients/client-lightsail/protocols/Aws_json1_1.ts
+++ b/clients/client-lightsail/protocols/Aws_json1_1.ts
@@ -802,9 +802,12 @@ import {
   expectBoolean as __expectBoolean,
   expectInt32 as __expectInt32,
   expectLong as __expectLong,
+  expectNonNull as __expectNonNull,
+  expectNumber as __expectNumber,
   expectString as __expectString,
   limitedParseDouble as __limitedParseDouble,
   limitedParseFloat32 as __limitedParseFloat32,
+  parseEpochTimestamp as __parseEpochTimestamp,
   serializeFloat as __serializeFloat,
 } from "@aws-sdk/smithy-client";
 import {
@@ -20053,7 +20056,7 @@ const deserializeAws_json1_1AccessKey = (output: any, context: __SerdeContext): 
     accessKeyId: __expectString(output.accessKeyId),
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
-        ? new Date(Math.round(output.createdAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.createdAt)))
         : undefined,
     lastUsed:
       output.lastUsed !== undefined && output.lastUsed !== null
@@ -20068,7 +20071,7 @@ const deserializeAws_json1_1AccessKeyLastUsed = (output: any, context: __SerdeCo
   return {
     lastUsedDate:
       output.lastUsedDate !== undefined && output.lastUsedDate !== null
-        ? new Date(Math.round(output.lastUsedDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastUsedDate)))
         : undefined,
     region: __expectString(output.region),
     serviceName: __expectString(output.serviceName),
@@ -20146,7 +20149,7 @@ const deserializeAws_json1_1Alarm = (output: any, context: __SerdeContext): Alar
         : undefined,
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
-        ? new Date(Math.round(output.createdAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.createdAt)))
         : undefined,
     datapointsToAlarm: __expectInt32(output.datapointsToAlarm),
     evaluationPeriods: __expectInt32(output.evaluationPeriods),
@@ -20272,7 +20275,7 @@ const deserializeAws_json1_1AutoSnapshotDetails = (output: any, context: __Serde
   return {
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
-        ? new Date(Math.round(output.createdAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.createdAt)))
         : undefined,
     date: __expectString(output.date),
     fromAttachedDisks:
@@ -20351,7 +20354,7 @@ const deserializeAws_json1_1Bucket = (output: any, context: __SerdeContext): Buc
     bundleId: __expectString(output.bundleId),
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
-        ? new Date(Math.round(output.createdAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.createdAt)))
         : undefined,
     location:
       output.location !== undefined && output.location !== null
@@ -20502,7 +20505,7 @@ const deserializeAws_json1_1Certificate = (output: any, context: __SerdeContext)
     arn: __expectString(output.arn),
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
-        ? new Date(Math.round(output.createdAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.createdAt)))
         : undefined,
     domainName: __expectString(output.domainName),
     domainValidationRecords:
@@ -20513,18 +20516,18 @@ const deserializeAws_json1_1Certificate = (output: any, context: __SerdeContext)
     inUseResourceCount: __expectInt32(output.inUseResourceCount),
     issuedAt:
       output.issuedAt !== undefined && output.issuedAt !== null
-        ? new Date(Math.round(output.issuedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.issuedAt)))
         : undefined,
     issuerCA: __expectString(output.issuerCA),
     keyAlgorithm: __expectString(output.keyAlgorithm),
     name: __expectString(output.name),
     notAfter:
       output.notAfter !== undefined && output.notAfter !== null
-        ? new Date(Math.round(output.notAfter * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.notAfter)))
         : undefined,
     notBefore:
       output.notBefore !== undefined && output.notBefore !== null
-        ? new Date(Math.round(output.notBefore * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.notBefore)))
         : undefined,
     renewalSummary:
       output.renewalSummary !== undefined && output.renewalSummary !== null
@@ -20534,7 +20537,7 @@ const deserializeAws_json1_1Certificate = (output: any, context: __SerdeContext)
     revocationReason: __expectString(output.revocationReason),
     revokedAt:
       output.revokedAt !== undefined && output.revokedAt !== null
-        ? new Date(Math.round(output.revokedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.revokedAt)))
         : undefined,
     serialNumber: __expectString(output.serialNumber),
     status: __expectString(output.status),
@@ -20597,7 +20600,7 @@ const deserializeAws_json1_1CloudFormationStackRecord = (
     arn: __expectString(output.arn),
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
-        ? new Date(Math.round(output.createdAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.createdAt)))
         : undefined,
     destinationInfo:
       output.destinationInfo !== undefined && output.destinationInfo !== null
@@ -20662,7 +20665,7 @@ const deserializeAws_json1_1ContactMethod = (output: any, context: __SerdeContex
     contactEndpoint: __expectString(output.contactEndpoint),
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
-        ? new Date(Math.round(output.createdAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.createdAt)))
         : undefined,
     location:
       output.location !== undefined && output.location !== null
@@ -20723,7 +20726,7 @@ const deserializeAws_json1_1ContainerImage = (output: any, context: __SerdeConte
   return {
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
-        ? new Date(Math.round(output.createdAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.createdAt)))
         : undefined,
     digest: __expectString(output.digest),
     image: __expectString(output.image),
@@ -20759,7 +20762,7 @@ const deserializeAws_json1_1ContainerService = (output: any, context: __SerdeCon
     containerServiceName: __expectString(output.containerServiceName),
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
-        ? new Date(Math.round(output.createdAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.createdAt)))
         : undefined,
     currentDeployment:
       output.currentDeployment !== undefined && output.currentDeployment !== null
@@ -20808,7 +20811,7 @@ const deserializeAws_json1_1ContainerServiceDeployment = (
         : undefined,
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
-        ? new Date(Math.round(output.createdAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.createdAt)))
         : undefined,
     publicEndpoint:
       output.publicEndpoint !== undefined && output.publicEndpoint !== null
@@ -20879,7 +20882,7 @@ const deserializeAws_json1_1ContainerServiceLogEvent = (
   return {
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
-        ? new Date(Math.round(output.createdAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.createdAt)))
         : undefined,
     message: __expectString(output.message),
   } as any;
@@ -20986,7 +20989,7 @@ const deserializeAws_json1_1ContainerServiceRegistryLogin = (
   return {
     expiresAt:
       output.expiresAt !== undefined && output.expiresAt !== null
-        ? new Date(Math.round(output.expiresAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.expiresAt)))
         : undefined,
     password: __expectString(output.password),
     registry: __expectString(output.registry),
@@ -21611,7 +21614,7 @@ const deserializeAws_json1_1Disk = (output: any, context: __SerdeContext): Disk 
     attachmentState: __expectString(output.attachmentState),
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
-        ? new Date(Math.round(output.createdAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.createdAt)))
         : undefined,
     gbInUse: __expectInt32(output.gbInUse),
     iops: __expectInt32(output.iops),
@@ -21670,7 +21673,7 @@ const deserializeAws_json1_1DiskSnapshot = (output: any, context: __SerdeContext
     arn: __expectString(output.arn),
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
-        ? new Date(Math.round(output.createdAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.createdAt)))
         : undefined,
     fromDiskArn: __expectString(output.fromDiskArn),
     fromDiskName: __expectString(output.fromDiskName),
@@ -21748,7 +21751,7 @@ const deserializeAws_json1_1Domain = (output: any, context: __SerdeContext): Dom
     arn: __expectString(output.arn),
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
-        ? new Date(Math.round(output.createdAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.createdAt)))
         : undefined,
     domainEntries:
       output.domainEntries !== undefined && output.domainEntries !== null
@@ -21876,7 +21879,7 @@ const deserializeAws_json1_1ExportSnapshotRecord = (output: any, context: __Serd
     arn: __expectString(output.arn),
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
-        ? new Date(Math.round(output.createdAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.createdAt)))
         : undefined,
     destinationInfo:
       output.destinationInfo !== undefined && output.destinationInfo !== null
@@ -21918,7 +21921,7 @@ const deserializeAws_json1_1ExportSnapshotRecordSourceInfo = (
     arn: __expectString(output.arn),
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
-        ? new Date(Math.round(output.createdAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.createdAt)))
         : undefined,
     diskSnapshotInfo:
       output.diskSnapshotInfo !== undefined && output.diskSnapshotInfo !== null
@@ -22199,7 +22202,7 @@ const deserializeAws_json1_1GetDistributionLatestCacheResetResult = (
   return {
     createTime:
       output.createTime !== undefined && output.createTime !== null
-        ? new Date(Math.round(output.createTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.createTime)))
         : undefined,
     status: __expectString(output.status),
   } as any;
@@ -22527,7 +22530,7 @@ const deserializeAws_json1_1GetRelationalDatabaseMasterUserPasswordResult = (
   return {
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
-        ? new Date(Math.round(output.createdAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.createdAt)))
         : undefined,
     masterUserPassword: __expectString(output.masterUserPassword),
   } as any;
@@ -22656,16 +22659,16 @@ const deserializeAws_json1_1HostKeyAttributes = (output: any, context: __SerdeCo
     fingerprintSHA256: __expectString(output.fingerprintSHA256),
     notValidAfter:
       output.notValidAfter !== undefined && output.notValidAfter !== null
-        ? new Date(Math.round(output.notValidAfter * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.notValidAfter)))
         : undefined,
     notValidBefore:
       output.notValidBefore !== undefined && output.notValidBefore !== null
-        ? new Date(Math.round(output.notValidBefore * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.notValidBefore)))
         : undefined,
     publicKey: __expectString(output.publicKey),
     witnessedAt:
       output.witnessedAt !== undefined && output.witnessedAt !== null
-        ? new Date(Math.round(output.witnessedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.witnessedAt)))
         : undefined,
   } as any;
 };
@@ -22702,7 +22705,7 @@ const deserializeAws_json1_1Instance = (output: any, context: __SerdeContext): I
     bundleId: __expectString(output.bundleId),
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
-        ? new Date(Math.round(output.createdAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.createdAt)))
         : undefined,
     hardware:
       output.hardware !== undefined && output.hardware !== null
@@ -22745,7 +22748,7 @@ const deserializeAws_json1_1InstanceAccessDetails = (output: any, context: __Ser
     certKey: __expectString(output.certKey),
     expiresAt:
       output.expiresAt !== undefined && output.expiresAt !== null
-        ? new Date(Math.round(output.expiresAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.expiresAt)))
         : undefined,
     hostKeys:
       output.hostKeys !== undefined && output.hostKeys !== null
@@ -22907,7 +22910,7 @@ const deserializeAws_json1_1InstanceSnapshot = (output: any, context: __SerdeCon
     arn: __expectString(output.arn),
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
-        ? new Date(Math.round(output.createdAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.createdAt)))
         : undefined,
     fromAttachedDisks:
       output.fromAttachedDisks !== undefined && output.fromAttachedDisks !== null
@@ -22995,7 +22998,7 @@ const deserializeAws_json1_1KeyPair = (output: any, context: __SerdeContext): Ke
     arn: __expectString(output.arn),
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
-        ? new Date(Math.round(output.createdAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.createdAt)))
         : undefined,
     fingerprint: __expectString(output.fingerprint),
     location:
@@ -23043,7 +23046,7 @@ const deserializeAws_json1_1LightsailDistribution = (output: any, context: __Ser
     certificateName: __expectString(output.certificateName),
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
-        ? new Date(Math.round(output.createdAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.createdAt)))
         : undefined,
     defaultCacheBehavior:
       output.defaultCacheBehavior !== undefined && output.defaultCacheBehavior !== null
@@ -23081,7 +23084,7 @@ const deserializeAws_json1_1LoadBalancer = (output: any, context: __SerdeContext
         : undefined,
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
-        ? new Date(Math.round(output.createdAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.createdAt)))
         : undefined,
     dnsName: __expectString(output.dnsName),
     healthCheckPath: __expectString(output.healthCheckPath),
@@ -23152,7 +23155,7 @@ const deserializeAws_json1_1LoadBalancerTlsCertificate = (
     arn: __expectString(output.arn),
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
-        ? new Date(Math.round(output.createdAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.createdAt)))
         : undefined,
     domainName: __expectString(output.domainName),
     domainValidationRecords:
@@ -23166,7 +23169,7 @@ const deserializeAws_json1_1LoadBalancerTlsCertificate = (
     isAttached: __expectBoolean(output.isAttached),
     issuedAt:
       output.issuedAt !== undefined && output.issuedAt !== null
-        ? new Date(Math.round(output.issuedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.issuedAt)))
         : undefined,
     issuer: __expectString(output.issuer),
     keyAlgorithm: __expectString(output.keyAlgorithm),
@@ -23178,11 +23181,11 @@ const deserializeAws_json1_1LoadBalancerTlsCertificate = (
     name: __expectString(output.name),
     notAfter:
       output.notAfter !== undefined && output.notAfter !== null
-        ? new Date(Math.round(output.notAfter * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.notAfter)))
         : undefined,
     notBefore:
       output.notBefore !== undefined && output.notBefore !== null
-        ? new Date(Math.round(output.notBefore * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.notBefore)))
         : undefined,
     renewalSummary:
       output.renewalSummary !== undefined && output.renewalSummary !== null
@@ -23192,7 +23195,7 @@ const deserializeAws_json1_1LoadBalancerTlsCertificate = (
     revocationReason: __expectString(output.revocationReason),
     revokedAt:
       output.revokedAt !== undefined && output.revokedAt !== null
-        ? new Date(Math.round(output.revokedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.revokedAt)))
         : undefined,
     serial: __expectString(output.serial),
     signatureAlgorithm: __expectString(output.signatureAlgorithm),
@@ -23319,7 +23322,7 @@ const deserializeAws_json1_1LogEvent = (output: any, context: __SerdeContext): L
   return {
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
-        ? new Date(Math.round(output.createdAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.createdAt)))
         : undefined,
     message: __expectString(output.message),
   } as any;
@@ -23345,7 +23348,7 @@ const deserializeAws_json1_1MetricDatapoint = (output: any, context: __SerdeCont
     sum: __limitedParseDouble(output.sum),
     timestamp:
       output.timestamp !== undefined && output.timestamp !== null
-        ? new Date(Math.round(output.timestamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.timestamp)))
         : undefined,
     unit: __expectString(output.unit),
   } as any;
@@ -23415,7 +23418,7 @@ const deserializeAws_json1_1Operation = (output: any, context: __SerdeContext): 
   return {
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
-        ? new Date(Math.round(output.createdAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.createdAt)))
         : undefined,
     errorCode: __expectString(output.errorCode),
     errorDetails: __expectString(output.errorDetails),
@@ -23432,7 +23435,7 @@ const deserializeAws_json1_1Operation = (output: any, context: __SerdeContext): 
     status: __expectString(output.status),
     statusChangedAt:
       output.statusChangedAt !== undefined && output.statusChangedAt !== null
-        ? new Date(Math.round(output.statusChangedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.statusChangedAt)))
         : undefined,
   } as any;
 };
@@ -23504,7 +23507,7 @@ const deserializeAws_json1_1PendingMaintenanceAction = (
     action: __expectString(output.action),
     currentApplyDate:
       output.currentApplyDate !== undefined && output.currentApplyDate !== null
-        ? new Date(Math.round(output.currentApplyDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.currentApplyDate)))
         : undefined,
     description: __expectString(output.description),
   } as any;
@@ -23663,7 +23666,7 @@ const deserializeAws_json1_1RelationalDatabase = (output: any, context: __SerdeC
     caCertificateIdentifier: __expectString(output.caCertificateIdentifier),
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
-        ? new Date(Math.round(output.createdAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.createdAt)))
         : undefined,
     engine: __expectString(output.engine),
     engineVersion: __expectString(output.engineVersion),
@@ -23673,7 +23676,7 @@ const deserializeAws_json1_1RelationalDatabase = (output: any, context: __SerdeC
         : undefined,
     latestRestorableTime:
       output.latestRestorableTime !== undefined && output.latestRestorableTime !== null
-        ? new Date(Math.round(output.latestRestorableTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.latestRestorableTime)))
         : undefined,
     location:
       output.location !== undefined && output.location !== null
@@ -23787,7 +23790,7 @@ const deserializeAws_json1_1RelationalDatabaseEvent = (
   return {
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
-        ? new Date(Math.round(output.createdAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.createdAt)))
         : undefined,
     eventCategories:
       output.eventCategories !== undefined && output.eventCategories !== null
@@ -23872,7 +23875,7 @@ const deserializeAws_json1_1RelationalDatabaseSnapshot = (
     arn: __expectString(output.arn),
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
-        ? new Date(Math.round(output.createdAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.createdAt)))
         : undefined,
     engine: __expectString(output.engine),
     engineVersion: __expectString(output.engineVersion),
@@ -23929,7 +23932,7 @@ const deserializeAws_json1_1RenewalSummary = (output: any, context: __SerdeConte
     renewalStatusReason: __expectString(output.renewalStatusReason),
     updatedAt:
       output.updatedAt !== undefined && output.updatedAt !== null
-        ? new Date(Math.round(output.updatedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.updatedAt)))
         : undefined,
   } as any;
 };
@@ -23941,7 +23944,7 @@ const deserializeAws_json1_1ResetDistributionCacheResult = (
   return {
     createTime:
       output.createTime !== undefined && output.createTime !== null
-        ? new Date(Math.round(output.createTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.createTime)))
         : undefined,
     operation:
       output.operation !== undefined && output.operation !== null
@@ -24045,7 +24048,7 @@ const deserializeAws_json1_1StaticIp = (output: any, context: __SerdeContext): S
     attachedTo: __expectString(output.attachedTo),
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
-        ? new Date(Math.round(output.createdAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.createdAt)))
         : undefined,
     ipAddress: __expectString(output.ipAddress),
     isAttached: __expectBoolean(output.isAttached),

--- a/clients/client-location/protocols/Aws_restJson1.ts
+++ b/clients/client-location/protocols/Aws_restJson1.ts
@@ -177,6 +177,7 @@ import {
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   limitedParseDouble as __limitedParseDouble,
+  parseRfc3339DateTime as __parseRfc3339DateTime,
   serializeFloat as __serializeFloat,
 } from "@aws-sdk/smithy-client";
 import {
@@ -3016,7 +3017,7 @@ export const deserializeAws_restJson1CreateGeofenceCollectionCommand = async (
     contents.CollectionName = __expectString(data.CollectionName);
   }
   if (data.CreateTime !== undefined && data.CreateTime !== null) {
-    contents.CreateTime = new Date(data.CreateTime);
+    contents.CreateTime = __expectNonNull(__parseRfc3339DateTime(data.CreateTime));
   }
   return Promise.resolve(contents);
 };
@@ -3105,7 +3106,7 @@ export const deserializeAws_restJson1CreateMapCommand = async (
   };
   const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CreateTime !== undefined && data.CreateTime !== null) {
-    contents.CreateTime = new Date(data.CreateTime);
+    contents.CreateTime = __expectNonNull(__parseRfc3339DateTime(data.CreateTime));
   }
   if (data.MapArn !== undefined && data.MapArn !== null) {
     contents.MapArn = __expectString(data.MapArn);
@@ -3200,7 +3201,7 @@ export const deserializeAws_restJson1CreatePlaceIndexCommand = async (
   };
   const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CreateTime !== undefined && data.CreateTime !== null) {
-    contents.CreateTime = new Date(data.CreateTime);
+    contents.CreateTime = __expectNonNull(__parseRfc3339DateTime(data.CreateTime));
   }
   if (data.IndexArn !== undefined && data.IndexArn !== null) {
     contents.IndexArn = __expectString(data.IndexArn);
@@ -3301,7 +3302,7 @@ export const deserializeAws_restJson1CreateRouteCalculatorCommand = async (
     contents.CalculatorName = __expectString(data.CalculatorName);
   }
   if (data.CreateTime !== undefined && data.CreateTime !== null) {
-    contents.CreateTime = new Date(data.CreateTime);
+    contents.CreateTime = __expectNonNull(__parseRfc3339DateTime(data.CreateTime));
   }
   return Promise.resolve(contents);
 };
@@ -3390,7 +3391,7 @@ export const deserializeAws_restJson1CreateTrackerCommand = async (
   };
   const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CreateTime !== undefined && data.CreateTime !== null) {
-    contents.CreateTime = new Date(data.CreateTime);
+    contents.CreateTime = __expectNonNull(__parseRfc3339DateTime(data.CreateTime));
   }
   if (data.TrackerArn !== undefined && data.TrackerArn !== null) {
     contents.TrackerArn = __expectString(data.TrackerArn);
@@ -3912,7 +3913,7 @@ export const deserializeAws_restJson1DescribeGeofenceCollectionCommand = async (
     contents.CollectionName = __expectString(data.CollectionName);
   }
   if (data.CreateTime !== undefined && data.CreateTime !== null) {
-    contents.CreateTime = new Date(data.CreateTime);
+    contents.CreateTime = __expectNonNull(__parseRfc3339DateTime(data.CreateTime));
   }
   if (data.Description !== undefined && data.Description !== null) {
     contents.Description = __expectString(data.Description);
@@ -3930,7 +3931,7 @@ export const deserializeAws_restJson1DescribeGeofenceCollectionCommand = async (
     contents.Tags = deserializeAws_restJson1TagMap(data.Tags, context);
   }
   if (data.UpdateTime !== undefined && data.UpdateTime !== null) {
-    contents.UpdateTime = new Date(data.UpdateTime);
+    contents.UpdateTime = __expectNonNull(__parseRfc3339DateTime(data.UpdateTime));
   }
   return Promise.resolve(contents);
 };
@@ -4028,7 +4029,7 @@ export const deserializeAws_restJson1DescribeMapCommand = async (
     contents.Configuration = deserializeAws_restJson1MapConfiguration(data.Configuration, context);
   }
   if (data.CreateTime !== undefined && data.CreateTime !== null) {
-    contents.CreateTime = new Date(data.CreateTime);
+    contents.CreateTime = __expectNonNull(__parseRfc3339DateTime(data.CreateTime));
   }
   if (data.DataSource !== undefined && data.DataSource !== null) {
     contents.DataSource = __expectString(data.DataSource);
@@ -4049,7 +4050,7 @@ export const deserializeAws_restJson1DescribeMapCommand = async (
     contents.Tags = deserializeAws_restJson1TagMap(data.Tags, context);
   }
   if (data.UpdateTime !== undefined && data.UpdateTime !== null) {
-    contents.UpdateTime = new Date(data.UpdateTime);
+    contents.UpdateTime = __expectNonNull(__parseRfc3339DateTime(data.UpdateTime));
   }
   return Promise.resolve(contents);
 };
@@ -4144,7 +4145,7 @@ export const deserializeAws_restJson1DescribePlaceIndexCommand = async (
   };
   const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CreateTime !== undefined && data.CreateTime !== null) {
-    contents.CreateTime = new Date(data.CreateTime);
+    contents.CreateTime = __expectNonNull(__parseRfc3339DateTime(data.CreateTime));
   }
   if (data.DataSource !== undefined && data.DataSource !== null) {
     contents.DataSource = __expectString(data.DataSource);
@@ -4171,7 +4172,7 @@ export const deserializeAws_restJson1DescribePlaceIndexCommand = async (
     contents.Tags = deserializeAws_restJson1TagMap(data.Tags, context);
   }
   if (data.UpdateTime !== undefined && data.UpdateTime !== null) {
-    contents.UpdateTime = new Date(data.UpdateTime);
+    contents.UpdateTime = __expectNonNull(__parseRfc3339DateTime(data.UpdateTime));
   }
   return Promise.resolve(contents);
 };
@@ -4271,7 +4272,7 @@ export const deserializeAws_restJson1DescribeRouteCalculatorCommand = async (
     contents.CalculatorName = __expectString(data.CalculatorName);
   }
   if (data.CreateTime !== undefined && data.CreateTime !== null) {
-    contents.CreateTime = new Date(data.CreateTime);
+    contents.CreateTime = __expectNonNull(__parseRfc3339DateTime(data.CreateTime));
   }
   if (data.DataSource !== undefined && data.DataSource !== null) {
     contents.DataSource = __expectString(data.DataSource);
@@ -4286,7 +4287,7 @@ export const deserializeAws_restJson1DescribeRouteCalculatorCommand = async (
     contents.Tags = deserializeAws_restJson1TagMap(data.Tags, context);
   }
   if (data.UpdateTime !== undefined && data.UpdateTime !== null) {
-    contents.UpdateTime = new Date(data.UpdateTime);
+    contents.UpdateTime = __expectNonNull(__parseRfc3339DateTime(data.UpdateTime));
   }
   return Promise.resolve(contents);
 };
@@ -4381,7 +4382,7 @@ export const deserializeAws_restJson1DescribeTrackerCommand = async (
   };
   const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CreateTime !== undefined && data.CreateTime !== null) {
-    contents.CreateTime = new Date(data.CreateTime);
+    contents.CreateTime = __expectNonNull(__parseRfc3339DateTime(data.CreateTime));
   }
   if (data.Description !== undefined && data.Description !== null) {
     contents.Description = __expectString(data.Description);
@@ -4405,7 +4406,7 @@ export const deserializeAws_restJson1DescribeTrackerCommand = async (
     contents.TrackerName = __expectString(data.TrackerName);
   }
   if (data.UpdateTime !== undefined && data.UpdateTime !== null) {
-    contents.UpdateTime = new Date(data.UpdateTime);
+    contents.UpdateTime = __expectNonNull(__parseRfc3339DateTime(data.UpdateTime));
   }
   return Promise.resolve(contents);
 };
@@ -4584,10 +4585,10 @@ export const deserializeAws_restJson1GetDevicePositionCommand = async (
     contents.Position = deserializeAws_restJson1Position(data.Position, context);
   }
   if (data.ReceivedTime !== undefined && data.ReceivedTime !== null) {
-    contents.ReceivedTime = new Date(data.ReceivedTime);
+    contents.ReceivedTime = __expectNonNull(__parseRfc3339DateTime(data.ReceivedTime));
   }
   if (data.SampleTime !== undefined && data.SampleTime !== null) {
-    contents.SampleTime = new Date(data.SampleTime);
+    contents.SampleTime = __expectNonNull(__parseRfc3339DateTime(data.SampleTime));
   }
   return Promise.resolve(contents);
 };
@@ -4769,7 +4770,7 @@ export const deserializeAws_restJson1GetGeofenceCommand = async (
   };
   const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CreateTime !== undefined && data.CreateTime !== null) {
-    contents.CreateTime = new Date(data.CreateTime);
+    contents.CreateTime = __expectNonNull(__parseRfc3339DateTime(data.CreateTime));
   }
   if (data.GeofenceId !== undefined && data.GeofenceId !== null) {
     contents.GeofenceId = __expectString(data.GeofenceId);
@@ -4781,7 +4782,7 @@ export const deserializeAws_restJson1GetGeofenceCommand = async (
     contents.Status = __expectString(data.Status);
   }
   if (data.UpdateTime !== undefined && data.UpdateTime !== null) {
-    contents.UpdateTime = new Date(data.UpdateTime);
+    contents.UpdateTime = __expectNonNull(__parseRfc3339DateTime(data.UpdateTime));
   }
   return Promise.resolve(contents);
 };
@@ -5993,13 +5994,13 @@ export const deserializeAws_restJson1PutGeofenceCommand = async (
   };
   const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CreateTime !== undefined && data.CreateTime !== null) {
-    contents.CreateTime = new Date(data.CreateTime);
+    contents.CreateTime = __expectNonNull(__parseRfc3339DateTime(data.CreateTime));
   }
   if (data.GeofenceId !== undefined && data.GeofenceId !== null) {
     contents.GeofenceId = __expectString(data.GeofenceId);
   }
   if (data.UpdateTime !== undefined && data.UpdateTime !== null) {
-    contents.UpdateTime = new Date(data.UpdateTime);
+    contents.UpdateTime = __expectNonNull(__parseRfc3339DateTime(data.UpdateTime));
   }
   return Promise.resolve(contents);
 };
@@ -6450,7 +6451,7 @@ export const deserializeAws_restJson1UpdateGeofenceCollectionCommand = async (
     contents.CollectionName = __expectString(data.CollectionName);
   }
   if (data.UpdateTime !== undefined && data.UpdateTime !== null) {
-    contents.UpdateTime = new Date(data.UpdateTime);
+    contents.UpdateTime = __expectNonNull(__parseRfc3339DateTime(data.UpdateTime));
   }
   return Promise.resolve(contents);
 };
@@ -6545,7 +6546,7 @@ export const deserializeAws_restJson1UpdateMapCommand = async (
     contents.MapName = __expectString(data.MapName);
   }
   if (data.UpdateTime !== undefined && data.UpdateTime !== null) {
-    contents.UpdateTime = new Date(data.UpdateTime);
+    contents.UpdateTime = __expectNonNull(__parseRfc3339DateTime(data.UpdateTime));
   }
   return Promise.resolve(contents);
 };
@@ -6640,7 +6641,7 @@ export const deserializeAws_restJson1UpdatePlaceIndexCommand = async (
     contents.IndexName = __expectString(data.IndexName);
   }
   if (data.UpdateTime !== undefined && data.UpdateTime !== null) {
-    contents.UpdateTime = new Date(data.UpdateTime);
+    contents.UpdateTime = __expectNonNull(__parseRfc3339DateTime(data.UpdateTime));
   }
   return Promise.resolve(contents);
 };
@@ -6735,7 +6736,7 @@ export const deserializeAws_restJson1UpdateRouteCalculatorCommand = async (
     contents.CalculatorName = __expectString(data.CalculatorName);
   }
   if (data.UpdateTime !== undefined && data.UpdateTime !== null) {
-    contents.UpdateTime = new Date(data.UpdateTime);
+    contents.UpdateTime = __expectNonNull(__parseRfc3339DateTime(data.UpdateTime));
   }
   return Promise.resolve(contents);
 };
@@ -6830,7 +6831,7 @@ export const deserializeAws_restJson1UpdateTrackerCommand = async (
     contents.TrackerName = __expectString(data.TrackerName);
   }
   if (data.UpdateTime !== undefined && data.UpdateTime !== null) {
-    contents.UpdateTime = new Date(data.UpdateTime);
+    contents.UpdateTime = __expectNonNull(__parseRfc3339DateTime(data.UpdateTime));
   }
   return Promise.resolve(contents);
 };
@@ -7319,7 +7320,10 @@ const deserializeAws_restJson1BatchEvaluateGeofencesError = (
       output.Error !== undefined && output.Error !== null
         ? deserializeAws_restJson1BatchItemError(output.Error, context)
         : undefined,
-    SampleTime: output.SampleTime !== undefined && output.SampleTime !== null ? new Date(output.SampleTime) : undefined,
+    SampleTime:
+      output.SampleTime !== undefined && output.SampleTime !== null
+        ? __expectNonNull(__parseRfc3339DateTime(output.SampleTime))
+        : undefined,
   } as any;
 };
 
@@ -7400,9 +7404,15 @@ const deserializeAws_restJson1BatchPutGeofenceSuccess = (
   context: __SerdeContext
 ): BatchPutGeofenceSuccess => {
   return {
-    CreateTime: output.CreateTime !== undefined && output.CreateTime !== null ? new Date(output.CreateTime) : undefined,
+    CreateTime:
+      output.CreateTime !== undefined && output.CreateTime !== null
+        ? __expectNonNull(__parseRfc3339DateTime(output.CreateTime))
+        : undefined,
     GeofenceId: __expectString(output.GeofenceId),
-    UpdateTime: output.UpdateTime !== undefined && output.UpdateTime !== null ? new Date(output.UpdateTime) : undefined,
+    UpdateTime:
+      output.UpdateTime !== undefined && output.UpdateTime !== null
+        ? __expectNonNull(__parseRfc3339DateTime(output.UpdateTime))
+        : undefined,
   } as any;
 };
 
@@ -7430,7 +7440,10 @@ const deserializeAws_restJson1BatchUpdateDevicePositionError = (
       output.Error !== undefined && output.Error !== null
         ? deserializeAws_restJson1BatchItemError(output.Error, context)
         : undefined,
-    SampleTime: output.SampleTime !== undefined && output.SampleTime !== null ? new Date(output.SampleTime) : undefined,
+    SampleTime:
+      output.SampleTime !== undefined && output.SampleTime !== null
+        ? __expectNonNull(__parseRfc3339DateTime(output.SampleTime))
+        : undefined,
   } as any;
 };
 
@@ -7500,8 +7513,13 @@ const deserializeAws_restJson1DevicePosition = (output: any, context: __SerdeCon
         ? deserializeAws_restJson1Position(output.Position, context)
         : undefined,
     ReceivedTime:
-      output.ReceivedTime !== undefined && output.ReceivedTime !== null ? new Date(output.ReceivedTime) : undefined,
-    SampleTime: output.SampleTime !== undefined && output.SampleTime !== null ? new Date(output.SampleTime) : undefined,
+      output.ReceivedTime !== undefined && output.ReceivedTime !== null
+        ? __expectNonNull(__parseRfc3339DateTime(output.ReceivedTime))
+        : undefined,
+    SampleTime:
+      output.SampleTime !== undefined && output.SampleTime !== null
+        ? __expectNonNull(__parseRfc3339DateTime(output.SampleTime))
+        : undefined,
   } as any;
 };
 
@@ -7611,7 +7629,10 @@ const deserializeAws_restJson1ListDevicePositionsResponseEntry = (
       output.Position !== undefined && output.Position !== null
         ? deserializeAws_restJson1Position(output.Position, context)
         : undefined,
-    SampleTime: output.SampleTime !== undefined && output.SampleTime !== null ? new Date(output.SampleTime) : undefined,
+    SampleTime:
+      output.SampleTime !== undefined && output.SampleTime !== null
+        ? __expectNonNull(__parseRfc3339DateTime(output.SampleTime))
+        : undefined,
   } as any;
 };
 
@@ -7635,11 +7656,17 @@ const deserializeAws_restJson1ListGeofenceCollectionsResponseEntry = (
 ): ListGeofenceCollectionsResponseEntry => {
   return {
     CollectionName: __expectString(output.CollectionName),
-    CreateTime: output.CreateTime !== undefined && output.CreateTime !== null ? new Date(output.CreateTime) : undefined,
+    CreateTime:
+      output.CreateTime !== undefined && output.CreateTime !== null
+        ? __expectNonNull(__parseRfc3339DateTime(output.CreateTime))
+        : undefined,
     Description: __expectString(output.Description),
     PricingPlan: __expectString(output.PricingPlan),
     PricingPlanDataSource: __expectString(output.PricingPlanDataSource),
-    UpdateTime: output.UpdateTime !== undefined && output.UpdateTime !== null ? new Date(output.UpdateTime) : undefined,
+    UpdateTime:
+      output.UpdateTime !== undefined && output.UpdateTime !== null
+        ? __expectNonNull(__parseRfc3339DateTime(output.UpdateTime))
+        : undefined,
   } as any;
 };
 
@@ -7662,14 +7689,20 @@ const deserializeAws_restJson1ListGeofenceResponseEntry = (
   context: __SerdeContext
 ): ListGeofenceResponseEntry => {
   return {
-    CreateTime: output.CreateTime !== undefined && output.CreateTime !== null ? new Date(output.CreateTime) : undefined,
+    CreateTime:
+      output.CreateTime !== undefined && output.CreateTime !== null
+        ? __expectNonNull(__parseRfc3339DateTime(output.CreateTime))
+        : undefined,
     GeofenceId: __expectString(output.GeofenceId),
     Geometry:
       output.Geometry !== undefined && output.Geometry !== null
         ? deserializeAws_restJson1GeofenceGeometry(output.Geometry, context)
         : undefined,
     Status: __expectString(output.Status),
-    UpdateTime: output.UpdateTime !== undefined && output.UpdateTime !== null ? new Date(output.UpdateTime) : undefined,
+    UpdateTime:
+      output.UpdateTime !== undefined && output.UpdateTime !== null
+        ? __expectNonNull(__parseRfc3339DateTime(output.UpdateTime))
+        : undefined,
   } as any;
 };
 
@@ -7689,12 +7722,18 @@ const deserializeAws_restJson1ListGeofenceResponseEntryList = (
 
 const deserializeAws_restJson1ListMapsResponseEntry = (output: any, context: __SerdeContext): ListMapsResponseEntry => {
   return {
-    CreateTime: output.CreateTime !== undefined && output.CreateTime !== null ? new Date(output.CreateTime) : undefined,
+    CreateTime:
+      output.CreateTime !== undefined && output.CreateTime !== null
+        ? __expectNonNull(__parseRfc3339DateTime(output.CreateTime))
+        : undefined,
     DataSource: __expectString(output.DataSource),
     Description: __expectString(output.Description),
     MapName: __expectString(output.MapName),
     PricingPlan: __expectString(output.PricingPlan),
-    UpdateTime: output.UpdateTime !== undefined && output.UpdateTime !== null ? new Date(output.UpdateTime) : undefined,
+    UpdateTime:
+      output.UpdateTime !== undefined && output.UpdateTime !== null
+        ? __expectNonNull(__parseRfc3339DateTime(output.UpdateTime))
+        : undefined,
   } as any;
 };
 
@@ -7717,12 +7756,18 @@ const deserializeAws_restJson1ListPlaceIndexesResponseEntry = (
   context: __SerdeContext
 ): ListPlaceIndexesResponseEntry => {
   return {
-    CreateTime: output.CreateTime !== undefined && output.CreateTime !== null ? new Date(output.CreateTime) : undefined,
+    CreateTime:
+      output.CreateTime !== undefined && output.CreateTime !== null
+        ? __expectNonNull(__parseRfc3339DateTime(output.CreateTime))
+        : undefined,
     DataSource: __expectString(output.DataSource),
     Description: __expectString(output.Description),
     IndexName: __expectString(output.IndexName),
     PricingPlan: __expectString(output.PricingPlan),
-    UpdateTime: output.UpdateTime !== undefined && output.UpdateTime !== null ? new Date(output.UpdateTime) : undefined,
+    UpdateTime:
+      output.UpdateTime !== undefined && output.UpdateTime !== null
+        ? __expectNonNull(__parseRfc3339DateTime(output.UpdateTime))
+        : undefined,
   } as any;
 };
 
@@ -7746,11 +7791,17 @@ const deserializeAws_restJson1ListRouteCalculatorsResponseEntry = (
 ): ListRouteCalculatorsResponseEntry => {
   return {
     CalculatorName: __expectString(output.CalculatorName),
-    CreateTime: output.CreateTime !== undefined && output.CreateTime !== null ? new Date(output.CreateTime) : undefined,
+    CreateTime:
+      output.CreateTime !== undefined && output.CreateTime !== null
+        ? __expectNonNull(__parseRfc3339DateTime(output.CreateTime))
+        : undefined,
     DataSource: __expectString(output.DataSource),
     Description: __expectString(output.Description),
     PricingPlan: __expectString(output.PricingPlan),
-    UpdateTime: output.UpdateTime !== undefined && output.UpdateTime !== null ? new Date(output.UpdateTime) : undefined,
+    UpdateTime:
+      output.UpdateTime !== undefined && output.UpdateTime !== null
+        ? __expectNonNull(__parseRfc3339DateTime(output.UpdateTime))
+        : undefined,
   } as any;
 };
 
@@ -7773,12 +7824,18 @@ const deserializeAws_restJson1ListTrackersResponseEntry = (
   context: __SerdeContext
 ): ListTrackersResponseEntry => {
   return {
-    CreateTime: output.CreateTime !== undefined && output.CreateTime !== null ? new Date(output.CreateTime) : undefined,
+    CreateTime:
+      output.CreateTime !== undefined && output.CreateTime !== null
+        ? __expectNonNull(__parseRfc3339DateTime(output.CreateTime))
+        : undefined,
     Description: __expectString(output.Description),
     PricingPlan: __expectString(output.PricingPlan),
     PricingPlanDataSource: __expectString(output.PricingPlanDataSource),
     TrackerName: __expectString(output.TrackerName),
-    UpdateTime: output.UpdateTime !== undefined && output.UpdateTime !== null ? new Date(output.UpdateTime) : undefined,
+    UpdateTime:
+      output.UpdateTime !== undefined && output.UpdateTime !== null
+        ? __expectNonNull(__parseRfc3339DateTime(output.UpdateTime))
+        : undefined,
   } as any;
 };
 

--- a/clients/client-lookoutequipment/protocols/Aws_json1_0.ts
+++ b/clients/client-lookoutequipment/protocols/Aws_json1_0.ts
@@ -127,7 +127,10 @@ import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@a
 import {
   LazyJsonString as __LazyJsonString,
   expectLong as __expectLong,
+  expectNonNull as __expectNonNull,
+  expectNumber as __expectNumber,
   expectString as __expectString,
+  parseEpochTimestamp as __parseEpochTimestamp,
 } from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
@@ -3018,7 +3021,7 @@ const deserializeAws_json1_0DatasetSummary = (output: any, context: __SerdeConte
   return {
     CreatedAt:
       output.CreatedAt !== undefined && output.CreatedAt !== null
-        ? new Date(Math.round(output.CreatedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreatedAt)))
         : undefined,
     DatasetArn: __expectString(output.DatasetArn),
     DatasetName: __expectString(output.DatasetName),
@@ -3033,7 +3036,7 @@ const deserializeAws_json1_0DescribeDataIngestionJobResponse = (
   return {
     CreatedAt:
       output.CreatedAt !== undefined && output.CreatedAt !== null
-        ? new Date(Math.round(output.CreatedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreatedAt)))
         : undefined,
     DatasetArn: __expectString(output.DatasetArn),
     FailedReason: __expectString(output.FailedReason),
@@ -3054,7 +3057,7 @@ const deserializeAws_json1_0DescribeDatasetResponse = (
   return {
     CreatedAt:
       output.CreatedAt !== undefined && output.CreatedAt !== null
-        ? new Date(Math.round(output.CreatedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreatedAt)))
         : undefined,
     DatasetArn: __expectString(output.DatasetArn),
     DatasetName: __expectString(output.DatasetName),
@@ -3064,7 +3067,7 @@ const deserializeAws_json1_0DescribeDatasetResponse = (
         : undefined,
     LastUpdatedAt:
       output.LastUpdatedAt !== undefined && output.LastUpdatedAt !== null
-        ? new Date(Math.round(output.LastUpdatedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastUpdatedAt)))
         : undefined,
     Schema: output.Schema !== undefined && output.Schema !== null ? new __LazyJsonString(output.Schema) : undefined,
     ServerSideKmsKeyId: __expectString(output.ServerSideKmsKeyId),
@@ -3079,7 +3082,7 @@ const deserializeAws_json1_0DescribeInferenceSchedulerResponse = (
   return {
     CreatedAt:
       output.CreatedAt !== undefined && output.CreatedAt !== null
-        ? new Date(Math.round(output.CreatedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreatedAt)))
         : undefined,
     DataDelayOffsetInMinutes: __expectLong(output.DataDelayOffsetInMinutes),
     DataInputConfiguration:
@@ -3100,7 +3103,7 @@ const deserializeAws_json1_0DescribeInferenceSchedulerResponse = (
     Status: __expectString(output.Status),
     UpdatedAt:
       output.UpdatedAt !== undefined && output.UpdatedAt !== null
-        ? new Date(Math.round(output.UpdatedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.UpdatedAt)))
         : undefined,
   } as any;
 };
@@ -3109,7 +3112,7 @@ const deserializeAws_json1_0DescribeModelResponse = (output: any, context: __Ser
   return {
     CreatedAt:
       output.CreatedAt !== undefined && output.CreatedAt !== null
-        ? new Date(Math.round(output.CreatedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreatedAt)))
         : undefined,
     DataPreProcessingConfiguration:
       output.DataPreProcessingConfiguration !== undefined && output.DataPreProcessingConfiguration !== null
@@ -3119,11 +3122,11 @@ const deserializeAws_json1_0DescribeModelResponse = (output: any, context: __Ser
     DatasetName: __expectString(output.DatasetName),
     EvaluationDataEndTime:
       output.EvaluationDataEndTime !== undefined && output.EvaluationDataEndTime !== null
-        ? new Date(Math.round(output.EvaluationDataEndTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.EvaluationDataEndTime)))
         : undefined,
     EvaluationDataStartTime:
       output.EvaluationDataStartTime !== undefined && output.EvaluationDataStartTime !== null
-        ? new Date(Math.round(output.EvaluationDataStartTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.EvaluationDataStartTime)))
         : undefined,
     FailedReason: __expectString(output.FailedReason),
     LabelsInputConfiguration:
@@ -3132,7 +3135,7 @@ const deserializeAws_json1_0DescribeModelResponse = (output: any, context: __Ser
         : undefined,
     LastUpdatedTime:
       output.LastUpdatedTime !== undefined && output.LastUpdatedTime !== null
-        ? new Date(Math.round(output.LastUpdatedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastUpdatedTime)))
         : undefined,
     ModelArn: __expectString(output.ModelArn),
     ModelMetrics:
@@ -3146,19 +3149,19 @@ const deserializeAws_json1_0DescribeModelResponse = (output: any, context: __Ser
     Status: __expectString(output.Status),
     TrainingDataEndTime:
       output.TrainingDataEndTime !== undefined && output.TrainingDataEndTime !== null
-        ? new Date(Math.round(output.TrainingDataEndTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.TrainingDataEndTime)))
         : undefined,
     TrainingDataStartTime:
       output.TrainingDataStartTime !== undefined && output.TrainingDataStartTime !== null
-        ? new Date(Math.round(output.TrainingDataStartTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.TrainingDataStartTime)))
         : undefined,
     TrainingExecutionEndTime:
       output.TrainingExecutionEndTime !== undefined && output.TrainingExecutionEndTime !== null
-        ? new Date(Math.round(output.TrainingExecutionEndTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.TrainingExecutionEndTime)))
         : undefined,
     TrainingExecutionStartTime:
       output.TrainingExecutionStartTime !== undefined && output.TrainingExecutionStartTime !== null
-        ? new Date(Math.round(output.TrainingExecutionStartTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.TrainingExecutionStartTime)))
         : undefined,
   } as any;
 };
@@ -3188,7 +3191,7 @@ const deserializeAws_json1_0InferenceExecutionSummary = (
         : undefined,
     DataEndTime:
       output.DataEndTime !== undefined && output.DataEndTime !== null
-        ? new Date(Math.round(output.DataEndTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.DataEndTime)))
         : undefined,
     DataInputConfiguration:
       output.DataInputConfiguration !== undefined && output.DataInputConfiguration !== null
@@ -3200,7 +3203,7 @@ const deserializeAws_json1_0InferenceExecutionSummary = (
         : undefined,
     DataStartTime:
       output.DataStartTime !== undefined && output.DataStartTime !== null
-        ? new Date(Math.round(output.DataStartTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.DataStartTime)))
         : undefined,
     FailedReason: __expectString(output.FailedReason),
     InferenceSchedulerArn: __expectString(output.InferenceSchedulerArn),
@@ -3209,7 +3212,7 @@ const deserializeAws_json1_0InferenceExecutionSummary = (
     ModelName: __expectString(output.ModelName),
     ScheduledStartTime:
       output.ScheduledStartTime !== undefined && output.ScheduledStartTime !== null
-        ? new Date(Math.round(output.ScheduledStartTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.ScheduledStartTime)))
         : undefined,
     Status: __expectString(output.Status),
   } as any;
@@ -3443,7 +3446,7 @@ const deserializeAws_json1_0ModelSummary = (output: any, context: __SerdeContext
   return {
     CreatedAt:
       output.CreatedAt !== undefined && output.CreatedAt !== null
-        ? new Date(Math.round(output.CreatedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreatedAt)))
         : undefined,
     DatasetArn: __expectString(output.DatasetArn),
     DatasetName: __expectString(output.DatasetName),

--- a/clients/client-lookoutmetrics/protocols/Aws_restJson1.ts
+++ b/clients/client-lookoutmetrics/protocols/Aws_restJson1.ts
@@ -107,10 +107,12 @@ import {
   expectBoolean as __expectBoolean,
   expectInt32 as __expectInt32,
   expectNonNull as __expectNonNull,
+  expectNumber as __expectNumber,
   expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   limitedParseDouble as __limitedParseDouble,
+  parseEpochTimestamp as __parseEpochTimestamp,
 } from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
@@ -1721,7 +1723,7 @@ export const deserializeAws_restJson1DescribeAnomalyDetectorCommand = async (
     contents.AnomalyDetectorName = __expectString(data.AnomalyDetectorName);
   }
   if (data.CreationTime !== undefined && data.CreationTime !== null) {
-    contents.CreationTime = new Date(Math.round(data.CreationTime * 1000));
+    contents.CreationTime = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.CreationTime)));
   }
   if (data.FailureReason !== undefined && data.FailureReason !== null) {
     contents.FailureReason = __expectString(data.FailureReason);
@@ -1730,7 +1732,7 @@ export const deserializeAws_restJson1DescribeAnomalyDetectorCommand = async (
     contents.KmsKeyArn = __expectString(data.KmsKeyArn);
   }
   if (data.LastModificationTime !== undefined && data.LastModificationTime !== null) {
-    contents.LastModificationTime = new Date(Math.round(data.LastModificationTime * 1000));
+    contents.LastModificationTime = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.LastModificationTime)));
   }
   if (data.Status !== undefined && data.Status !== null) {
     contents.Status = __expectString(data.Status);
@@ -1835,13 +1837,13 @@ export const deserializeAws_restJson1DescribeMetricSetCommand = async (
     contents.AnomalyDetectorArn = __expectString(data.AnomalyDetectorArn);
   }
   if (data.CreationTime !== undefined && data.CreationTime !== null) {
-    contents.CreationTime = new Date(Math.round(data.CreationTime * 1000));
+    contents.CreationTime = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.CreationTime)));
   }
   if (data.DimensionList !== undefined && data.DimensionList !== null) {
     contents.DimensionList = deserializeAws_restJson1DimensionList(data.DimensionList, context);
   }
   if (data.LastModificationTime !== undefined && data.LastModificationTime !== null) {
-    contents.LastModificationTime = new Date(Math.round(data.LastModificationTime * 1000));
+    contents.LastModificationTime = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.LastModificationTime)));
   }
   if (data.MetricList !== undefined && data.MetricList !== null) {
     contents.MetricList = deserializeAws_restJson1MetricList(data.MetricList, context);
@@ -3661,11 +3663,11 @@ const deserializeAws_restJson1Alert = (output: any, context: __SerdeContext): Al
     AnomalyDetectorArn: __expectString(output.AnomalyDetectorArn),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     LastModificationTime:
       output.LastModificationTime !== undefined && output.LastModificationTime !== null
-        ? new Date(Math.round(output.LastModificationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastModificationTime)))
         : undefined,
   } as any;
 };
@@ -3680,11 +3682,11 @@ const deserializeAws_restJson1AlertSummary = (output: any, context: __SerdeConte
     AnomalyDetectorArn: __expectString(output.AnomalyDetectorArn),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     LastModificationTime:
       output.LastModificationTime !== undefined && output.LastModificationTime !== null
-        ? new Date(Math.round(output.LastModificationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastModificationTime)))
         : undefined,
     Tags:
       output.Tags !== undefined && output.Tags !== null
@@ -3723,11 +3725,11 @@ const deserializeAws_restJson1AnomalyDetectorSummary = (
     AnomalyDetectorName: __expectString(output.AnomalyDetectorName),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     LastModificationTime:
       output.LastModificationTime !== undefined && output.LastModificationTime !== null
-        ? new Date(Math.round(output.LastModificationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastModificationTime)))
         : undefined,
     Status: __expectString(output.Status),
     Tags:
@@ -4062,11 +4064,11 @@ const deserializeAws_restJson1MetricSetSummary = (output: any, context: __SerdeC
     AnomalyDetectorArn: __expectString(output.AnomalyDetectorArn),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     LastModificationTime:
       output.LastModificationTime !== undefined && output.LastModificationTime !== null
-        ? new Date(Math.round(output.LastModificationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastModificationTime)))
         : undefined,
     MetricSetArn: __expectString(output.MetricSetArn),
     MetricSetDescription: __expectString(output.MetricSetDescription),

--- a/clients/client-lookoutvision/protocols/Aws_restJson1.ts
+++ b/clients/client-lookoutvision/protocols/Aws_restJson1.ts
@@ -54,10 +54,12 @@ import {
   expectBoolean as __expectBoolean,
   expectInt32 as __expectInt32,
   expectNonNull as __expectNonNull,
+  expectNumber as __expectNumber,
   expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   limitedParseFloat32 as __limitedParseFloat32,
+  parseEpochTimestamp as __parseEpochTimestamp,
   strictParseInt32 as __strictParseInt32,
 } from "@aws-sdk/smithy-client";
 import {
@@ -2854,7 +2856,7 @@ const deserializeAws_restJson1DatasetDescription = (output: any, context: __Serd
   return {
     CreationTimestamp:
       output.CreationTimestamp !== undefined && output.CreationTimestamp !== null
-        ? new Date(Math.round(output.CreationTimestamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTimestamp)))
         : undefined,
     DatasetType: __expectString(output.DatasetType),
     ImageStats:
@@ -2863,7 +2865,7 @@ const deserializeAws_restJson1DatasetDescription = (output: any, context: __Serd
         : undefined,
     LastUpdatedTimestamp:
       output.LastUpdatedTimestamp !== undefined && output.LastUpdatedTimestamp !== null
-        ? new Date(Math.round(output.LastUpdatedTimestamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastUpdatedTimestamp)))
         : undefined,
     ProjectName: __expectString(output.ProjectName),
     Status: __expectString(output.Status),
@@ -2895,7 +2897,7 @@ const deserializeAws_restJson1DatasetMetadata = (output: any, context: __SerdeCo
   return {
     CreationTimestamp:
       output.CreationTimestamp !== undefined && output.CreationTimestamp !== null
-        ? new Date(Math.round(output.CreationTimestamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTimestamp)))
         : undefined,
     DatasetType: __expectString(output.DatasetType),
     Status: __expectString(output.Status),
@@ -2935,12 +2937,12 @@ const deserializeAws_restJson1ModelDescription = (output: any, context: __SerdeC
   return {
     CreationTimestamp:
       output.CreationTimestamp !== undefined && output.CreationTimestamp !== null
-        ? new Date(Math.round(output.CreationTimestamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTimestamp)))
         : undefined,
     Description: __expectString(output.Description),
     EvaluationEndTimestamp:
       output.EvaluationEndTimestamp !== undefined && output.EvaluationEndTimestamp !== null
-        ? new Date(Math.round(output.EvaluationEndTimestamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.EvaluationEndTimestamp)))
         : undefined,
     EvaluationManifest:
       output.EvaluationManifest !== undefined && output.EvaluationManifest !== null
@@ -2970,7 +2972,7 @@ const deserializeAws_restJson1ModelMetadata = (output: any, context: __SerdeCont
   return {
     CreationTimestamp:
       output.CreationTimestamp !== undefined && output.CreationTimestamp !== null
-        ? new Date(Math.round(output.CreationTimestamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTimestamp)))
         : undefined,
     Description: __expectString(output.Description),
     ModelArn: __expectString(output.ModelArn),
@@ -3023,7 +3025,7 @@ const deserializeAws_restJson1ProjectDescription = (output: any, context: __Serd
   return {
     CreationTimestamp:
       output.CreationTimestamp !== undefined && output.CreationTimestamp !== null
-        ? new Date(Math.round(output.CreationTimestamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTimestamp)))
         : undefined,
     Datasets:
       output.Datasets !== undefined && output.Datasets !== null
@@ -3038,7 +3040,7 @@ const deserializeAws_restJson1ProjectMetadata = (output: any, context: __SerdeCo
   return {
     CreationTimestamp:
       output.CreationTimestamp !== undefined && output.CreationTimestamp !== null
-        ? new Date(Math.round(output.CreationTimestamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTimestamp)))
         : undefined,
     ProjectArn: __expectString(output.ProjectArn),
     ProjectName: __expectString(output.ProjectName),

--- a/clients/client-machine-learning/protocols/Aws_json1_1.ts
+++ b/clients/client-machine-learning/protocols/Aws_json1_1.ts
@@ -148,8 +148,11 @@ import {
   expectBoolean as __expectBoolean,
   expectInt32 as __expectInt32,
   expectLong as __expectLong,
+  expectNonNull as __expectNonNull,
+  expectNumber as __expectNumber,
   expectString as __expectString,
   limitedParseFloat32 as __limitedParseFloat32,
+  parseEpochTimestamp as __parseEpochTimestamp,
   serializeFloat as __serializeFloat,
 } from "@aws-sdk/smithy-client";
 import {
@@ -3094,18 +3097,18 @@ const deserializeAws_json1_1BatchPrediction = (output: any, context: __SerdeCont
     ComputeTime: __expectLong(output.ComputeTime),
     CreatedAt:
       output.CreatedAt !== undefined && output.CreatedAt !== null
-        ? new Date(Math.round(output.CreatedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreatedAt)))
         : undefined,
     CreatedByIamUser: __expectString(output.CreatedByIamUser),
     FinishedAt:
       output.FinishedAt !== undefined && output.FinishedAt !== null
-        ? new Date(Math.round(output.FinishedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.FinishedAt)))
         : undefined,
     InputDataLocationS3: __expectString(output.InputDataLocationS3),
     InvalidRecordCount: __expectLong(output.InvalidRecordCount),
     LastUpdatedAt:
       output.LastUpdatedAt !== undefined && output.LastUpdatedAt !== null
-        ? new Date(Math.round(output.LastUpdatedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastUpdatedAt)))
         : undefined,
     MLModelId: __expectString(output.MLModelId),
     Message: __expectString(output.Message),
@@ -3113,7 +3116,7 @@ const deserializeAws_json1_1BatchPrediction = (output: any, context: __SerdeCont
     OutputUri: __expectString(output.OutputUri),
     StartedAt:
       output.StartedAt !== undefined && output.StartedAt !== null
-        ? new Date(Math.round(output.StartedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.StartedAt)))
         : undefined,
     Status: __expectString(output.Status),
     TotalRecordCount: __expectLong(output.TotalRecordCount),
@@ -3198,7 +3201,7 @@ const deserializeAws_json1_1DataSource = (output: any, context: __SerdeContext):
     ComputeTime: __expectLong(output.ComputeTime),
     CreatedAt:
       output.CreatedAt !== undefined && output.CreatedAt !== null
-        ? new Date(Math.round(output.CreatedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreatedAt)))
         : undefined,
     CreatedByIamUser: __expectString(output.CreatedByIamUser),
     DataLocationS3: __expectString(output.DataLocationS3),
@@ -3207,11 +3210,11 @@ const deserializeAws_json1_1DataSource = (output: any, context: __SerdeContext):
     DataSourceId: __expectString(output.DataSourceId),
     FinishedAt:
       output.FinishedAt !== undefined && output.FinishedAt !== null
-        ? new Date(Math.round(output.FinishedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.FinishedAt)))
         : undefined,
     LastUpdatedAt:
       output.LastUpdatedAt !== undefined && output.LastUpdatedAt !== null
-        ? new Date(Math.round(output.LastUpdatedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastUpdatedAt)))
         : undefined,
     Message: __expectString(output.Message),
     Name: __expectString(output.Name),
@@ -3227,7 +3230,7 @@ const deserializeAws_json1_1DataSource = (output: any, context: __SerdeContext):
     RoleARN: __expectString(output.RoleARN),
     StartedAt:
       output.StartedAt !== undefined && output.StartedAt !== null
-        ? new Date(Math.round(output.StartedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.StartedAt)))
         : undefined,
     Status: __expectString(output.Status),
   } as any;
@@ -3371,19 +3374,19 @@ const deserializeAws_json1_1Evaluation = (output: any, context: __SerdeContext):
     ComputeTime: __expectLong(output.ComputeTime),
     CreatedAt:
       output.CreatedAt !== undefined && output.CreatedAt !== null
-        ? new Date(Math.round(output.CreatedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreatedAt)))
         : undefined,
     CreatedByIamUser: __expectString(output.CreatedByIamUser),
     EvaluationDataSourceId: __expectString(output.EvaluationDataSourceId),
     EvaluationId: __expectString(output.EvaluationId),
     FinishedAt:
       output.FinishedAt !== undefined && output.FinishedAt !== null
-        ? new Date(Math.round(output.FinishedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.FinishedAt)))
         : undefined,
     InputDataLocationS3: __expectString(output.InputDataLocationS3),
     LastUpdatedAt:
       output.LastUpdatedAt !== undefined && output.LastUpdatedAt !== null
-        ? new Date(Math.round(output.LastUpdatedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastUpdatedAt)))
         : undefined,
     MLModelId: __expectString(output.MLModelId),
     Message: __expectString(output.Message),
@@ -3394,7 +3397,7 @@ const deserializeAws_json1_1Evaluation = (output: any, context: __SerdeContext):
         : undefined,
     StartedAt:
       output.StartedAt !== undefined && output.StartedAt !== null
-        ? new Date(Math.round(output.StartedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.StartedAt)))
         : undefined,
     Status: __expectString(output.Status),
   } as any;
@@ -3421,18 +3424,18 @@ const deserializeAws_json1_1GetBatchPredictionOutput = (
     ComputeTime: __expectLong(output.ComputeTime),
     CreatedAt:
       output.CreatedAt !== undefined && output.CreatedAt !== null
-        ? new Date(Math.round(output.CreatedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreatedAt)))
         : undefined,
     CreatedByIamUser: __expectString(output.CreatedByIamUser),
     FinishedAt:
       output.FinishedAt !== undefined && output.FinishedAt !== null
-        ? new Date(Math.round(output.FinishedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.FinishedAt)))
         : undefined,
     InputDataLocationS3: __expectString(output.InputDataLocationS3),
     InvalidRecordCount: __expectLong(output.InvalidRecordCount),
     LastUpdatedAt:
       output.LastUpdatedAt !== undefined && output.LastUpdatedAt !== null
-        ? new Date(Math.round(output.LastUpdatedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastUpdatedAt)))
         : undefined,
     LogUri: __expectString(output.LogUri),
     MLModelId: __expectString(output.MLModelId),
@@ -3441,7 +3444,7 @@ const deserializeAws_json1_1GetBatchPredictionOutput = (
     OutputUri: __expectString(output.OutputUri),
     StartedAt:
       output.StartedAt !== undefined && output.StartedAt !== null
-        ? new Date(Math.round(output.StartedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.StartedAt)))
         : undefined,
     Status: __expectString(output.Status),
     TotalRecordCount: __expectLong(output.TotalRecordCount),
@@ -3454,7 +3457,7 @@ const deserializeAws_json1_1GetDataSourceOutput = (output: any, context: __Serde
     ComputeTime: __expectLong(output.ComputeTime),
     CreatedAt:
       output.CreatedAt !== undefined && output.CreatedAt !== null
-        ? new Date(Math.round(output.CreatedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreatedAt)))
         : undefined,
     CreatedByIamUser: __expectString(output.CreatedByIamUser),
     DataLocationS3: __expectString(output.DataLocationS3),
@@ -3464,11 +3467,11 @@ const deserializeAws_json1_1GetDataSourceOutput = (output: any, context: __Serde
     DataSourceSchema: __expectString(output.DataSourceSchema),
     FinishedAt:
       output.FinishedAt !== undefined && output.FinishedAt !== null
-        ? new Date(Math.round(output.FinishedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.FinishedAt)))
         : undefined,
     LastUpdatedAt:
       output.LastUpdatedAt !== undefined && output.LastUpdatedAt !== null
-        ? new Date(Math.round(output.LastUpdatedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastUpdatedAt)))
         : undefined,
     LogUri: __expectString(output.LogUri),
     Message: __expectString(output.Message),
@@ -3485,7 +3488,7 @@ const deserializeAws_json1_1GetDataSourceOutput = (output: any, context: __Serde
     RoleARN: __expectString(output.RoleARN),
     StartedAt:
       output.StartedAt !== undefined && output.StartedAt !== null
-        ? new Date(Math.round(output.StartedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.StartedAt)))
         : undefined,
     Status: __expectString(output.Status),
   } as any;
@@ -3496,19 +3499,19 @@ const deserializeAws_json1_1GetEvaluationOutput = (output: any, context: __Serde
     ComputeTime: __expectLong(output.ComputeTime),
     CreatedAt:
       output.CreatedAt !== undefined && output.CreatedAt !== null
-        ? new Date(Math.round(output.CreatedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreatedAt)))
         : undefined,
     CreatedByIamUser: __expectString(output.CreatedByIamUser),
     EvaluationDataSourceId: __expectString(output.EvaluationDataSourceId),
     EvaluationId: __expectString(output.EvaluationId),
     FinishedAt:
       output.FinishedAt !== undefined && output.FinishedAt !== null
-        ? new Date(Math.round(output.FinishedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.FinishedAt)))
         : undefined,
     InputDataLocationS3: __expectString(output.InputDataLocationS3),
     LastUpdatedAt:
       output.LastUpdatedAt !== undefined && output.LastUpdatedAt !== null
-        ? new Date(Math.round(output.LastUpdatedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastUpdatedAt)))
         : undefined,
     LogUri: __expectString(output.LogUri),
     MLModelId: __expectString(output.MLModelId),
@@ -3520,7 +3523,7 @@ const deserializeAws_json1_1GetEvaluationOutput = (output: any, context: __Serde
         : undefined,
     StartedAt:
       output.StartedAt !== undefined && output.StartedAt !== null
-        ? new Date(Math.round(output.StartedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.StartedAt)))
         : undefined,
     Status: __expectString(output.Status),
   } as any;
@@ -3531,7 +3534,7 @@ const deserializeAws_json1_1GetMLModelOutput = (output: any, context: __SerdeCon
     ComputeTime: __expectLong(output.ComputeTime),
     CreatedAt:
       output.CreatedAt !== undefined && output.CreatedAt !== null
-        ? new Date(Math.round(output.CreatedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreatedAt)))
         : undefined,
     CreatedByIamUser: __expectString(output.CreatedByIamUser),
     EndpointInfo:
@@ -3540,12 +3543,12 @@ const deserializeAws_json1_1GetMLModelOutput = (output: any, context: __SerdeCon
         : undefined,
     FinishedAt:
       output.FinishedAt !== undefined && output.FinishedAt !== null
-        ? new Date(Math.round(output.FinishedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.FinishedAt)))
         : undefined,
     InputDataLocationS3: __expectString(output.InputDataLocationS3),
     LastUpdatedAt:
       output.LastUpdatedAt !== undefined && output.LastUpdatedAt !== null
-        ? new Date(Math.round(output.LastUpdatedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastUpdatedAt)))
         : undefined,
     LogUri: __expectString(output.LogUri),
     MLModelId: __expectString(output.MLModelId),
@@ -3557,12 +3560,12 @@ const deserializeAws_json1_1GetMLModelOutput = (output: any, context: __SerdeCon
     ScoreThreshold: __limitedParseFloat32(output.ScoreThreshold),
     ScoreThresholdLastUpdatedAt:
       output.ScoreThresholdLastUpdatedAt !== undefined && output.ScoreThresholdLastUpdatedAt !== null
-        ? new Date(Math.round(output.ScoreThresholdLastUpdatedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.ScoreThresholdLastUpdatedAt)))
         : undefined,
     SizeInBytes: __expectLong(output.SizeInBytes),
     StartedAt:
       output.StartedAt !== undefined && output.StartedAt !== null
-        ? new Date(Math.round(output.StartedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.StartedAt)))
         : undefined,
     Status: __expectString(output.Status),
     TrainingDataSourceId: __expectString(output.TrainingDataSourceId),
@@ -3619,7 +3622,7 @@ const deserializeAws_json1_1MLModel = (output: any, context: __SerdeContext): ML
     ComputeTime: __expectLong(output.ComputeTime),
     CreatedAt:
       output.CreatedAt !== undefined && output.CreatedAt !== null
-        ? new Date(Math.round(output.CreatedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreatedAt)))
         : undefined,
     CreatedByIamUser: __expectString(output.CreatedByIamUser),
     EndpointInfo:
@@ -3628,12 +3631,12 @@ const deserializeAws_json1_1MLModel = (output: any, context: __SerdeContext): ML
         : undefined,
     FinishedAt:
       output.FinishedAt !== undefined && output.FinishedAt !== null
-        ? new Date(Math.round(output.FinishedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.FinishedAt)))
         : undefined,
     InputDataLocationS3: __expectString(output.InputDataLocationS3),
     LastUpdatedAt:
       output.LastUpdatedAt !== undefined && output.LastUpdatedAt !== null
-        ? new Date(Math.round(output.LastUpdatedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastUpdatedAt)))
         : undefined,
     MLModelId: __expectString(output.MLModelId),
     MLModelType: __expectString(output.MLModelType),
@@ -3642,12 +3645,12 @@ const deserializeAws_json1_1MLModel = (output: any, context: __SerdeContext): ML
     ScoreThreshold: __limitedParseFloat32(output.ScoreThreshold),
     ScoreThresholdLastUpdatedAt:
       output.ScoreThresholdLastUpdatedAt !== undefined && output.ScoreThresholdLastUpdatedAt !== null
-        ? new Date(Math.round(output.ScoreThresholdLastUpdatedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.ScoreThresholdLastUpdatedAt)))
         : undefined,
     SizeInBytes: __expectLong(output.SizeInBytes),
     StartedAt:
       output.StartedAt !== undefined && output.StartedAt !== null
-        ? new Date(Math.round(output.StartedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.StartedAt)))
         : undefined,
     Status: __expectString(output.Status),
     TrainingDataSourceId: __expectString(output.TrainingDataSourceId),
@@ -3751,7 +3754,7 @@ const deserializeAws_json1_1RealtimeEndpointInfo = (output: any, context: __Serd
   return {
     CreatedAt:
       output.CreatedAt !== undefined && output.CreatedAt !== null
-        ? new Date(Math.round(output.CreatedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreatedAt)))
         : undefined,
     EndpointStatus: __expectString(output.EndpointStatus),
     EndpointUrl: __expectString(output.EndpointUrl),

--- a/clients/client-macie2/protocols/Aws_restJson1.ts
+++ b/clients/client-macie2/protocols/Aws_restJson1.ts
@@ -285,6 +285,7 @@ import {
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   limitedParseDouble as __limitedParseDouble,
+  parseRfc3339DateTime as __parseRfc3339DateTime,
 } from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
@@ -3336,7 +3337,7 @@ export const deserializeAws_restJson1DescribeClassificationJobCommand = async (
     contents.clientToken = __expectString(data.clientToken);
   }
   if (data.createdAt !== undefined && data.createdAt !== null) {
-    contents.createdAt = new Date(data.createdAt);
+    contents.createdAt = __expectNonNull(__parseRfc3339DateTime(data.createdAt));
   }
   if (data.customDataIdentifierIds !== undefined && data.customDataIdentifierIds !== null) {
     contents.customDataIdentifierIds = deserializeAws_restJson1__listOf__string(data.customDataIdentifierIds, context);
@@ -3363,7 +3364,7 @@ export const deserializeAws_restJson1DescribeClassificationJobCommand = async (
     contents.lastRunErrorStatus = deserializeAws_restJson1LastRunErrorStatus(data.lastRunErrorStatus, context);
   }
   if (data.lastRunTime !== undefined && data.lastRunTime !== null) {
-    contents.lastRunTime = new Date(data.lastRunTime);
+    contents.lastRunTime = __expectNonNull(__parseRfc3339DateTime(data.lastRunTime));
   }
   if (data.name !== undefined && data.name !== null) {
     contents.name = __expectString(data.name);
@@ -4439,7 +4440,7 @@ export const deserializeAws_restJson1GetBucketStatisticsCommand = async (
     contents.classifiableSizeInBytes = __expectLong(data.classifiableSizeInBytes);
   }
   if (data.lastUpdated !== undefined && data.lastUpdated !== null) {
-    contents.lastUpdated = new Date(data.lastUpdated);
+    contents.lastUpdated = __expectNonNull(__parseRfc3339DateTime(data.lastUpdated));
   }
   if (data.objectCount !== undefined && data.objectCount !== null) {
     contents.objectCount = __expectLong(data.objectCount);
@@ -4679,7 +4680,7 @@ export const deserializeAws_restJson1GetCustomDataIdentifierCommand = async (
     contents.arn = __expectString(data.arn);
   }
   if (data.createdAt !== undefined && data.createdAt !== null) {
-    contents.createdAt = new Date(data.createdAt);
+    contents.createdAt = __expectNonNull(__parseRfc3339DateTime(data.createdAt));
   }
   if (data.deleted !== undefined && data.deleted !== null) {
     contents.deleted = __expectBoolean(data.deleted);
@@ -5359,7 +5360,7 @@ export const deserializeAws_restJson1GetMacieSessionCommand = async (
   };
   const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.createdAt !== undefined && data.createdAt !== null) {
-    contents.createdAt = new Date(data.createdAt);
+    contents.createdAt = __expectNonNull(__parseRfc3339DateTime(data.createdAt));
   }
   if (data.findingPublishingFrequency !== undefined && data.findingPublishingFrequency !== null) {
     contents.findingPublishingFrequency = __expectString(data.findingPublishingFrequency);
@@ -5371,7 +5372,7 @@ export const deserializeAws_restJson1GetMacieSessionCommand = async (
     contents.status = __expectString(data.status);
   }
   if (data.updatedAt !== undefined && data.updatedAt !== null) {
-    contents.updatedAt = new Date(data.updatedAt);
+    contents.updatedAt = __expectNonNull(__parseRfc3339DateTime(data.updatedAt));
   }
   return Promise.resolve(contents);
 };
@@ -5597,7 +5598,7 @@ export const deserializeAws_restJson1GetMemberCommand = async (
     contents.email = __expectString(data.email);
   }
   if (data.invitedAt !== undefined && data.invitedAt !== null) {
-    contents.invitedAt = new Date(data.invitedAt);
+    contents.invitedAt = __expectNonNull(__parseRfc3339DateTime(data.invitedAt));
   }
   if (data.masterAccountId !== undefined && data.masterAccountId !== null) {
     contents.masterAccountId = __expectString(data.masterAccountId);
@@ -5609,7 +5610,7 @@ export const deserializeAws_restJson1GetMemberCommand = async (
     contents.tags = deserializeAws_restJson1TagMap(data.tags, context);
   }
   if (data.updatedAt !== undefined && data.updatedAt !== null) {
-    contents.updatedAt = new Date(data.updatedAt);
+    contents.updatedAt = __expectNonNull(__parseRfc3339DateTime(data.updatedAt));
   }
   return Promise.resolve(contents);
 };
@@ -8715,8 +8716,14 @@ const deserializeAws_restJson1ApiCallDetails = (output: any, context: __SerdeCon
   return {
     api: __expectString(output.api),
     apiServiceName: __expectString(output.apiServiceName),
-    firstSeen: output.firstSeen !== undefined && output.firstSeen !== null ? new Date(output.firstSeen) : undefined,
-    lastSeen: output.lastSeen !== undefined && output.lastSeen !== null ? new Date(output.lastSeen) : undefined,
+    firstSeen:
+      output.firstSeen !== undefined && output.firstSeen !== null
+        ? __expectNonNull(__parseRfc3339DateTime(output.firstSeen))
+        : undefined,
+    lastSeen:
+      output.lastSeen !== undefined && output.lastSeen !== null
+        ? __expectNonNull(__parseRfc3339DateTime(output.lastSeen))
+        : undefined,
   } as any;
 };
 
@@ -8752,7 +8759,10 @@ const deserializeAws_restJson1BatchGetCustomDataIdentifierSummary = (
 ): BatchGetCustomDataIdentifierSummary => {
   return {
     arn: __expectString(output.arn),
-    createdAt: output.createdAt !== undefined && output.createdAt !== null ? new Date(output.createdAt) : undefined,
+    createdAt:
+      output.createdAt !== undefined && output.createdAt !== null
+        ? __expectNonNull(__parseRfc3339DateTime(output.createdAt))
+        : undefined,
     deleted: __expectBoolean(output.deleted),
     description: __expectString(output.description),
     id: __expectString(output.id),
@@ -8843,7 +8853,7 @@ const deserializeAws_restJson1BucketMetadata = (output: any, context: __SerdeCon
     bucketArn: __expectString(output.bucketArn),
     bucketCreatedAt:
       output.bucketCreatedAt !== undefined && output.bucketCreatedAt !== null
-        ? new Date(output.bucketCreatedAt)
+        ? __expectNonNull(__parseRfc3339DateTime(output.bucketCreatedAt))
         : undefined,
     bucketName: __expectString(output.bucketName),
     classifiableObjectCount: __expectLong(output.classifiableObjectCount),
@@ -8853,7 +8863,9 @@ const deserializeAws_restJson1BucketMetadata = (output: any, context: __SerdeCon
         ? deserializeAws_restJson1JobDetails(output.jobDetails, context)
         : undefined,
     lastUpdated:
-      output.lastUpdated !== undefined && output.lastUpdated !== null ? new Date(output.lastUpdated) : undefined,
+      output.lastUpdated !== undefined && output.lastUpdated !== null
+        ? __expectNonNull(__parseRfc3339DateTime(output.lastUpdated))
+        : undefined,
     objectCount: __expectLong(output.objectCount),
     objectCountByEncryptionType:
       output.objectCountByEncryptionType !== undefined && output.objectCountByEncryptionType !== null
@@ -9088,7 +9100,10 @@ const deserializeAws_restJson1CustomDataIdentifierSummary = (
 ): CustomDataIdentifierSummary => {
   return {
     arn: __expectString(output.arn),
-    createdAt: output.createdAt !== undefined && output.createdAt !== null ? new Date(output.createdAt) : undefined,
+    createdAt:
+      output.createdAt !== undefined && output.createdAt !== null
+        ? __expectNonNull(__parseRfc3339DateTime(output.createdAt))
+        : undefined,
     description: __expectString(output.description),
     id: __expectString(output.id),
     name: __expectString(output.name),
@@ -9173,7 +9188,10 @@ const deserializeAws_restJson1Finding = (output: any, context: __SerdeContext): 
         ? deserializeAws_restJson1ClassificationDetails(output.classificationDetails, context)
         : undefined,
     count: __expectLong(output.count),
-    createdAt: output.createdAt !== undefined && output.createdAt !== null ? new Date(output.createdAt) : undefined,
+    createdAt:
+      output.createdAt !== undefined && output.createdAt !== null
+        ? __expectNonNull(__parseRfc3339DateTime(output.createdAt))
+        : undefined,
     description: __expectString(output.description),
     id: __expectString(output.id),
     partition: __expectString(output.partition),
@@ -9194,7 +9212,10 @@ const deserializeAws_restJson1Finding = (output: any, context: __SerdeContext): 
         : undefined,
     title: __expectString(output.title),
     type: __expectString(output.type),
-    updatedAt: output.updatedAt !== undefined && output.updatedAt !== null ? new Date(output.updatedAt) : undefined,
+    updatedAt:
+      output.updatedAt !== undefined && output.updatedAt !== null
+        ? __expectNonNull(__parseRfc3339DateTime(output.updatedAt))
+        : undefined,
   } as any;
 };
 
@@ -9270,7 +9291,10 @@ const deserializeAws_restJson1Invitation = (output: any, context: __SerdeContext
   return {
     accountId: __expectString(output.accountId),
     invitationId: __expectString(output.invitationId),
-    invitedAt: output.invitedAt !== undefined && output.invitedAt !== null ? new Date(output.invitedAt) : undefined,
+    invitedAt:
+      output.invitedAt !== undefined && output.invitedAt !== null
+        ? __expectNonNull(__parseRfc3339DateTime(output.invitedAt))
+        : undefined,
     relationshipStatus: __expectString(output.relationshipStatus),
   } as any;
 };
@@ -9333,7 +9357,7 @@ const deserializeAws_restJson1JobDetails = (output: any, context: __SerdeContext
     lastJobId: __expectString(output.lastJobId),
     lastJobRunTime:
       output.lastJobRunTime !== undefined && output.lastJobRunTime !== null
-        ? new Date(output.lastJobRunTime)
+        ? __expectNonNull(__parseRfc3339DateTime(output.lastJobRunTime))
         : undefined,
   } as any;
 };
@@ -9387,7 +9411,10 @@ const deserializeAws_restJson1JobSummary = (output: any, context: __SerdeContext
       output.bucketDefinitions !== undefined && output.bucketDefinitions !== null
         ? deserializeAws_restJson1__listOfS3BucketDefinitionForJob(output.bucketDefinitions, context)
         : undefined,
-    createdAt: output.createdAt !== undefined && output.createdAt !== null ? new Date(output.createdAt) : undefined,
+    createdAt:
+      output.createdAt !== undefined && output.createdAt !== null
+        ? __expectNonNull(__parseRfc3339DateTime(output.createdAt))
+        : undefined,
     jobId: __expectString(output.jobId),
     jobStatus: __expectString(output.jobStatus),
     jobType: __expectString(output.jobType),
@@ -9470,14 +9497,20 @@ const deserializeAws_restJson1Member = (output: any, context: __SerdeContext): M
     administratorAccountId: __expectString(output.administratorAccountId),
     arn: __expectString(output.arn),
     email: __expectString(output.email),
-    invitedAt: output.invitedAt !== undefined && output.invitedAt !== null ? new Date(output.invitedAt) : undefined,
+    invitedAt:
+      output.invitedAt !== undefined && output.invitedAt !== null
+        ? __expectNonNull(__parseRfc3339DateTime(output.invitedAt))
+        : undefined,
     masterAccountId: __expectString(output.masterAccountId),
     relationshipStatus: __expectString(output.relationshipStatus),
     tags:
       output.tags !== undefined && output.tags !== null
         ? deserializeAws_restJson1TagMap(output.tags, context)
         : undefined,
-    updatedAt: output.updatedAt !== undefined && output.updatedAt !== null ? new Date(output.updatedAt) : undefined,
+    updatedAt:
+      output.updatedAt !== undefined && output.updatedAt !== null
+        ? __expectNonNull(__parseRfc3339DateTime(output.updatedAt))
+        : undefined,
   } as any;
 };
 
@@ -9636,7 +9669,10 @@ const deserializeAws_restJson1S3Bucket = (output: any, context: __SerdeContext):
   return {
     allowsUnencryptedObjectUploads: __expectString(output.allowsUnencryptedObjectUploads),
     arn: __expectString(output.arn),
-    createdAt: output.createdAt !== undefined && output.createdAt !== null ? new Date(output.createdAt) : undefined,
+    createdAt:
+      output.createdAt !== undefined && output.createdAt !== null
+        ? __expectNonNull(__parseRfc3339DateTime(output.createdAt))
+        : undefined,
     defaultServerSideEncryption:
       output.defaultServerSideEncryption !== undefined && output.defaultServerSideEncryption !== null
         ? deserializeAws_restJson1ServerSideEncryption(output.defaultServerSideEncryption, context)
@@ -9725,7 +9761,9 @@ const deserializeAws_restJson1S3Object = (output: any, context: __SerdeContext):
     extension: __expectString(output.extension),
     key: __expectString(output.key),
     lastModified:
-      output.lastModified !== undefined && output.lastModified !== null ? new Date(output.lastModified) : undefined,
+      output.lastModified !== undefined && output.lastModified !== null
+        ? __expectNonNull(__parseRfc3339DateTime(output.lastModified))
+        : undefined,
     path: __expectString(output.path),
     publicAccess: __expectBoolean(output.publicAccess),
     serverSideEncryption:
@@ -9821,7 +9859,9 @@ const deserializeAws_restJson1SessionContextAttributes = (
 ): SessionContextAttributes => {
   return {
     creationDate:
-      output.creationDate !== undefined && output.creationDate !== null ? new Date(output.creationDate) : undefined,
+      output.creationDate !== undefined && output.creationDate !== null
+        ? __expectNonNull(__parseRfc3339DateTime(output.creationDate))
+        : undefined,
     mfaAuthenticated: __expectBoolean(output.mfaAuthenticated),
   } as any;
 };
@@ -9948,7 +9988,7 @@ const deserializeAws_restJson1UsageRecord = (output: any, context: __SerdeContex
     accountId: __expectString(output.accountId),
     freeTrialStartDate:
       output.freeTrialStartDate !== undefined && output.freeTrialStartDate !== null
-        ? new Date(output.freeTrialStartDate)
+        ? __expectNonNull(__parseRfc3339DateTime(output.freeTrialStartDate))
         : undefined,
     usage:
       output.usage !== undefined && output.usage !== null
@@ -10006,10 +10046,14 @@ const deserializeAws_restJson1UserIdentityRoot = (output: any, context: __SerdeC
 const deserializeAws_restJson1UserPausedDetails = (output: any, context: __SerdeContext): UserPausedDetails => {
   return {
     jobExpiresAt:
-      output.jobExpiresAt !== undefined && output.jobExpiresAt !== null ? new Date(output.jobExpiresAt) : undefined,
+      output.jobExpiresAt !== undefined && output.jobExpiresAt !== null
+        ? __expectNonNull(__parseRfc3339DateTime(output.jobExpiresAt))
+        : undefined,
     jobImminentExpirationHealthEventArn: __expectString(output.jobImminentExpirationHealthEventArn),
     jobPausedAt:
-      output.jobPausedAt !== undefined && output.jobPausedAt !== null ? new Date(output.jobPausedAt) : undefined,
+      output.jobPausedAt !== undefined && output.jobPausedAt !== null
+        ? __expectNonNull(__parseRfc3339DateTime(output.jobPausedAt))
+        : undefined,
   } as any;
 };
 

--- a/clients/client-managedblockchain/protocols/Aws_restJson1.ts
+++ b/clients/client-managedblockchain/protocols/Aws_restJson1.ts
@@ -79,6 +79,7 @@ import {
   expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
+  parseRfc3339DateTime as __parseRfc3339DateTime,
 } from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
@@ -3439,10 +3440,12 @@ const deserializeAws_restJson1Invitation = (output: any, context: __SerdeContext
   return {
     Arn: __expectString(output.Arn),
     CreationDate:
-      output.CreationDate !== undefined && output.CreationDate !== null ? new Date(output.CreationDate) : undefined,
+      output.CreationDate !== undefined && output.CreationDate !== null
+        ? __expectNonNull(__parseRfc3339DateTime(output.CreationDate))
+        : undefined,
     ExpirationDate:
       output.ExpirationDate !== undefined && output.ExpirationDate !== null
-        ? new Date(output.ExpirationDate)
+        ? __expectNonNull(__parseRfc3339DateTime(output.ExpirationDate))
         : undefined,
     InvitationId: __expectString(output.InvitationId),
     NetworkSummary:
@@ -3500,7 +3503,9 @@ const deserializeAws_restJson1Member = (output: any, context: __SerdeContext): M
   return {
     Arn: __expectString(output.Arn),
     CreationDate:
-      output.CreationDate !== undefined && output.CreationDate !== null ? new Date(output.CreationDate) : undefined,
+      output.CreationDate !== undefined && output.CreationDate !== null
+        ? __expectNonNull(__parseRfc3339DateTime(output.CreationDate))
+        : undefined,
     Description: __expectString(output.Description),
     FrameworkAttributes:
       output.FrameworkAttributes !== undefined && output.FrameworkAttributes !== null
@@ -3572,7 +3577,9 @@ const deserializeAws_restJson1MemberSummary = (output: any, context: __SerdeCont
   return {
     Arn: __expectString(output.Arn),
     CreationDate:
-      output.CreationDate !== undefined && output.CreationDate !== null ? new Date(output.CreationDate) : undefined,
+      output.CreationDate !== undefined && output.CreationDate !== null
+        ? __expectNonNull(__parseRfc3339DateTime(output.CreationDate))
+        : undefined,
     Description: __expectString(output.Description),
     Id: __expectString(output.Id),
     IsOwned: __expectBoolean(output.IsOwned),
@@ -3596,7 +3603,9 @@ const deserializeAws_restJson1Network = (output: any, context: __SerdeContext): 
   return {
     Arn: __expectString(output.Arn),
     CreationDate:
-      output.CreationDate !== undefined && output.CreationDate !== null ? new Date(output.CreationDate) : undefined,
+      output.CreationDate !== undefined && output.CreationDate !== null
+        ? __expectNonNull(__parseRfc3339DateTime(output.CreationDate))
+        : undefined,
     Description: __expectString(output.Description),
     Framework: __expectString(output.Framework),
     FrameworkAttributes:
@@ -3658,7 +3667,9 @@ const deserializeAws_restJson1NetworkSummary = (output: any, context: __SerdeCon
   return {
     Arn: __expectString(output.Arn),
     CreationDate:
-      output.CreationDate !== undefined && output.CreationDate !== null ? new Date(output.CreationDate) : undefined,
+      output.CreationDate !== undefined && output.CreationDate !== null
+        ? __expectNonNull(__parseRfc3339DateTime(output.CreationDate))
+        : undefined,
     Description: __expectString(output.Description),
     Framework: __expectString(output.Framework),
     FrameworkVersion: __expectString(output.FrameworkVersion),
@@ -3684,7 +3695,9 @@ const deserializeAws_restJson1Node = (output: any, context: __SerdeContext): Nod
     Arn: __expectString(output.Arn),
     AvailabilityZone: __expectString(output.AvailabilityZone),
     CreationDate:
-      output.CreationDate !== undefined && output.CreationDate !== null ? new Date(output.CreationDate) : undefined,
+      output.CreationDate !== undefined && output.CreationDate !== null
+        ? __expectNonNull(__parseRfc3339DateTime(output.CreationDate))
+        : undefined,
     FrameworkAttributes:
       output.FrameworkAttributes !== undefined && output.FrameworkAttributes !== null
         ? deserializeAws_restJson1NodeFrameworkAttributes(output.FrameworkAttributes, context)
@@ -3773,7 +3786,9 @@ const deserializeAws_restJson1NodeSummary = (output: any, context: __SerdeContex
     Arn: __expectString(output.Arn),
     AvailabilityZone: __expectString(output.AvailabilityZone),
     CreationDate:
-      output.CreationDate !== undefined && output.CreationDate !== null ? new Date(output.CreationDate) : undefined,
+      output.CreationDate !== undefined && output.CreationDate !== null
+        ? __expectNonNull(__parseRfc3339DateTime(output.CreationDate))
+        : undefined,
     Id: __expectString(output.Id),
     InstanceType: __expectString(output.InstanceType),
     Status: __expectString(output.Status),
@@ -3811,11 +3826,13 @@ const deserializeAws_restJson1Proposal = (output: any, context: __SerdeContext):
         : undefined,
     Arn: __expectString(output.Arn),
     CreationDate:
-      output.CreationDate !== undefined && output.CreationDate !== null ? new Date(output.CreationDate) : undefined,
+      output.CreationDate !== undefined && output.CreationDate !== null
+        ? __expectNonNull(__parseRfc3339DateTime(output.CreationDate))
+        : undefined,
     Description: __expectString(output.Description),
     ExpirationDate:
       output.ExpirationDate !== undefined && output.ExpirationDate !== null
-        ? new Date(output.ExpirationDate)
+        ? __expectNonNull(__parseRfc3339DateTime(output.ExpirationDate))
         : undefined,
     NetworkId: __expectString(output.NetworkId),
     NoVoteCount: __expectInt32(output.NoVoteCount),
@@ -3849,11 +3866,13 @@ const deserializeAws_restJson1ProposalSummary = (output: any, context: __SerdeCo
   return {
     Arn: __expectString(output.Arn),
     CreationDate:
-      output.CreationDate !== undefined && output.CreationDate !== null ? new Date(output.CreationDate) : undefined,
+      output.CreationDate !== undefined && output.CreationDate !== null
+        ? __expectNonNull(__parseRfc3339DateTime(output.CreationDate))
+        : undefined,
     Description: __expectString(output.Description),
     ExpirationDate:
       output.ExpirationDate !== undefined && output.ExpirationDate !== null
-        ? new Date(output.ExpirationDate)
+        ? __expectNonNull(__parseRfc3339DateTime(output.ExpirationDate))
         : undefined,
     ProposalId: __expectString(output.ProposalId),
     ProposedByMemberId: __expectString(output.ProposedByMemberId),

--- a/clients/client-marketplace-entitlement-service/protocols/Aws_json1_1.ts
+++ b/clients/client-marketplace-entitlement-service/protocols/Aws_json1_1.ts
@@ -13,8 +13,11 @@ import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@a
 import {
   expectBoolean as __expectBoolean,
   expectInt32 as __expectInt32,
+  expectNonNull as __expectNonNull,
+  expectNumber as __expectNumber,
   expectString as __expectString,
   limitedParseDouble as __limitedParseDouble,
+  parseEpochTimestamp as __parseEpochTimestamp,
 } from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
@@ -198,7 +201,7 @@ const deserializeAws_json1_1Entitlement = (output: any, context: __SerdeContext)
     Dimension: __expectString(output.Dimension),
     ExpirationDate:
       output.ExpirationDate !== undefined && output.ExpirationDate !== null
-        ? new Date(Math.round(output.ExpirationDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.ExpirationDate)))
         : undefined,
     ProductCode: __expectString(output.ProductCode),
     Value:

--- a/clients/client-marketplace-metering/protocols/Aws_json1_1.ts
+++ b/clients/client-marketplace-metering/protocols/Aws_json1_1.ts
@@ -34,7 +34,13 @@ import {
   UsageRecordResult,
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
-import { expectInt32 as __expectInt32, expectString as __expectString } from "@aws-sdk/smithy-client";
+import {
+  expectInt32 as __expectInt32,
+  expectNonNull as __expectNonNull,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
+  parseEpochTimestamp as __parseEpochTimestamp,
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   HeaderBag as __HeaderBag,
@@ -1039,7 +1045,7 @@ const deserializeAws_json1_1RegisterUsageResult = (output: any, context: __Serde
   return {
     PublicKeyRotationTimestamp:
       output.PublicKeyRotationTimestamp !== undefined && output.PublicKeyRotationTimestamp !== null
-        ? new Date(Math.round(output.PublicKeyRotationTimestamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.PublicKeyRotationTimestamp)))
         : undefined,
     Signature: __expectString(output.Signature),
   } as any;
@@ -1113,7 +1119,7 @@ const deserializeAws_json1_1UsageRecord = (output: any, context: __SerdeContext)
     Quantity: __expectInt32(output.Quantity),
     Timestamp:
       output.Timestamp !== undefined && output.Timestamp !== null
-        ? new Date(Math.round(output.Timestamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.Timestamp)))
         : undefined,
     UsageAllocations:
       output.UsageAllocations !== undefined && output.UsageAllocations !== null

--- a/clients/client-mediaconvert/protocols/Aws_restJson1.ts
+++ b/clients/client-mediaconvert/protocols/Aws_restJson1.ts
@@ -209,10 +209,12 @@ import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@a
 import {
   expectInt32 as __expectInt32,
   expectNonNull as __expectNonNull,
+  expectNumber as __expectNumber,
   expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   limitedParseDouble as __limitedParseDouble,
+  parseEpochTimestamp as __parseEpochTimestamp,
   serializeFloat as __serializeFloat,
 } from "@aws-sdk/smithy-client";
 import {
@@ -8466,7 +8468,7 @@ const deserializeAws_restJson1Job = (output: any, context: __SerdeContext): Job 
     BillingTagsSource: __expectString(output.billingTagsSource),
     CreatedAt:
       output.createdAt !== undefined && output.createdAt !== null
-        ? new Date(Math.round(output.createdAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.createdAt)))
         : undefined,
     CurrentPhase: __expectString(output.currentPhase),
     ErrorCode: __expectInt32(output.errorCode),
@@ -8585,7 +8587,7 @@ const deserializeAws_restJson1JobTemplate = (output: any, context: __SerdeContex
     Category: __expectString(output.category),
     CreatedAt:
       output.createdAt !== undefined && output.createdAt !== null
-        ? new Date(Math.round(output.createdAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.createdAt)))
         : undefined,
     Description: __expectString(output.description),
     HopDestinations:
@@ -8594,7 +8596,7 @@ const deserializeAws_restJson1JobTemplate = (output: any, context: __SerdeContex
         : undefined,
     LastUpdated:
       output.lastUpdated !== undefined && output.lastUpdated !== null
-        ? new Date(Math.round(output.lastUpdated * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastUpdated)))
         : undefined,
     Name: __expectString(output.name),
     Priority: __expectInt32(output.priority),
@@ -9189,12 +9191,12 @@ const deserializeAws_restJson1Preset = (output: any, context: __SerdeContext): P
     Category: __expectString(output.category),
     CreatedAt:
       output.createdAt !== undefined && output.createdAt !== null
-        ? new Date(Math.round(output.createdAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.createdAt)))
         : undefined,
     Description: __expectString(output.description),
     LastUpdated:
       output.lastUpdated !== undefined && output.lastUpdated !== null
-        ? new Date(Math.round(output.lastUpdated * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastUpdated)))
         : undefined,
     Name: __expectString(output.name),
     Settings:
@@ -9249,12 +9251,12 @@ const deserializeAws_restJson1Queue = (output: any, context: __SerdeContext): Qu
     Arn: __expectString(output.arn),
     CreatedAt:
       output.createdAt !== undefined && output.createdAt !== null
-        ? new Date(Math.round(output.createdAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.createdAt)))
         : undefined,
     Description: __expectString(output.description),
     LastUpdated:
       output.lastUpdated !== undefined && output.lastUpdated !== null
-        ? new Date(Math.round(output.lastUpdated * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastUpdated)))
         : undefined,
     Name: __expectString(output.name),
     PricingPlan: __expectString(output.pricingPlan),
@@ -9275,7 +9277,7 @@ const deserializeAws_restJson1QueueTransition = (output: any, context: __SerdeCo
     SourceQueue: __expectString(output.sourceQueue),
     Timestamp:
       output.timestamp !== undefined && output.timestamp !== null
-        ? new Date(Math.round(output.timestamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.timestamp)))
         : undefined,
   } as any;
 };
@@ -9305,11 +9307,11 @@ const deserializeAws_restJson1ReservationPlan = (output: any, context: __SerdeCo
     Commitment: __expectString(output.commitment),
     ExpiresAt:
       output.expiresAt !== undefined && output.expiresAt !== null
-        ? new Date(Math.round(output.expiresAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.expiresAt)))
         : undefined,
     PurchasedAt:
       output.purchasedAt !== undefined && output.purchasedAt !== null
-        ? new Date(Math.round(output.purchasedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.purchasedAt)))
         : undefined,
     RenewalType: __expectString(output.renewalType),
     ReservedSlots: __expectInt32(output.reservedSlots),
@@ -9473,15 +9475,15 @@ const deserializeAws_restJson1Timing = (output: any, context: __SerdeContext): T
   return {
     FinishTime:
       output.finishTime !== undefined && output.finishTime !== null
-        ? new Date(Math.round(output.finishTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.finishTime)))
         : undefined,
     StartTime:
       output.startTime !== undefined && output.startTime !== null
-        ? new Date(Math.round(output.startTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.startTime)))
         : undefined,
     SubmitTime:
       output.submitTime !== undefined && output.submitTime !== null
-        ? new Date(Math.round(output.submitTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.submitTime)))
         : undefined,
   } as any;
 };

--- a/clients/client-medialive/protocols/Aws_restJson1.ts
+++ b/clients/client-medialive/protocols/Aws_restJson1.ts
@@ -359,6 +359,7 @@ import {
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   limitedParseDouble as __limitedParseDouble,
+  parseRfc7231DateTime as __parseRfc7231DateTime,
   serializeFloat as __serializeFloat,
   strictParseLong as __strictParseLong,
 } from "@aws-sdk/smithy-client";
@@ -5140,7 +5141,7 @@ export const deserializeAws_restJson1DescribeInputDeviceThumbnailCommand = async
     contents.ETag = output.headers["etag"];
   }
   if (output.headers["last-modified"] !== undefined) {
-    contents.LastModified = new Date(output.headers["last-modified"]);
+    contents.LastModified = __expectNonNull(__parseRfc7231DateTime(output.headers["last-modified"]));
   }
   const data: any = output.body;
   contents.Body = data;

--- a/clients/client-mediastore-data/protocols/Aws_restJson1.ts
+++ b/clients/client-mediastore-data/protocols/Aws_restJson1.ts
@@ -14,9 +14,12 @@ import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@a
 import {
   expectLong as __expectLong,
   expectNonNull as __expectNonNull,
+  expectNumber as __expectNumber,
   expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
+  parseEpochTimestamp as __parseEpochTimestamp,
+  parseRfc7231DateTime as __parseRfc7231DateTime,
   strictParseLong as __strictParseLong,
 } from "@aws-sdk/smithy-client";
 import {
@@ -297,7 +300,7 @@ export const deserializeAws_restJson1DescribeObjectCommand = async (
     contents.CacheControl = output.headers["cache-control"];
   }
   if (output.headers["last-modified"] !== undefined) {
-    contents.LastModified = new Date(output.headers["last-modified"]);
+    contents.LastModified = __expectNonNull(__parseRfc7231DateTime(output.headers["last-modified"]));
   }
   await collectBody(output.body, context);
   return Promise.resolve(contents);
@@ -390,7 +393,7 @@ export const deserializeAws_restJson1GetObjectCommand = async (
     contents.ETag = output.headers["etag"];
   }
   if (output.headers["last-modified"] !== undefined) {
-    contents.LastModified = new Date(output.headers["last-modified"]);
+    contents.LastModified = __expectNonNull(__parseRfc7231DateTime(output.headers["last-modified"]));
   }
   const data: any = output.body;
   contents.Body = data;
@@ -674,7 +677,7 @@ const deserializeAws_restJson1Item = (output: any, context: __SerdeContext): Ite
     ETag: __expectString(output.ETag),
     LastModified:
       output.LastModified !== undefined && output.LastModified !== null
-        ? new Date(Math.round(output.LastModified * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastModified)))
         : undefined,
     Name: __expectString(output.Name),
     Type: __expectString(output.Type),

--- a/clients/client-mediastore/protocols/Aws_json1_1.ts
+++ b/clients/client-mediastore/protocols/Aws_json1_1.ts
@@ -88,7 +88,10 @@ import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@a
 import {
   expectBoolean as __expectBoolean,
   expectInt32 as __expectInt32,
+  expectNonNull as __expectNonNull,
+  expectNumber as __expectNumber,
   expectString as __expectString,
+  parseEpochTimestamp as __parseEpochTimestamp,
 } from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
@@ -2294,7 +2297,7 @@ const deserializeAws_json1_1Container = (output: any, context: __SerdeContext): 
     AccessLoggingEnabled: __expectBoolean(output.AccessLoggingEnabled),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     Endpoint: __expectString(output.Endpoint),
     Name: __expectString(output.Name),

--- a/clients/client-mediatailor/protocols/Aws_restJson1.ts
+++ b/clients/client-mediatailor/protocols/Aws_restJson1.ts
@@ -102,9 +102,11 @@ import {
   expectInt32 as __expectInt32,
   expectLong as __expectLong,
   expectNonNull as __expectNonNull,
+  expectNumber as __expectNumber,
   expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
+  parseEpochTimestamp as __parseEpochTimestamp,
 } from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
@@ -1274,13 +1276,13 @@ export const deserializeAws_restJson1CreateChannelCommand = async (
     contents.ChannelState = __expectString(data.ChannelState);
   }
   if (data.CreationTime !== undefined && data.CreationTime !== null) {
-    contents.CreationTime = new Date(Math.round(data.CreationTime * 1000));
+    contents.CreationTime = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.CreationTime)));
   }
   if (data.FillerSlate !== undefined && data.FillerSlate !== null) {
     contents.FillerSlate = deserializeAws_restJson1SlateSource(data.FillerSlate, context);
   }
   if (data.LastModifiedTime !== undefined && data.LastModifiedTime !== null) {
-    contents.LastModifiedTime = new Date(Math.round(data.LastModifiedTime * 1000));
+    contents.LastModifiedTime = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.LastModifiedTime)));
   }
   if (data.Outputs !== undefined && data.Outputs !== null) {
     contents.Outputs = deserializeAws_restJson1ResponseOutputs(data.Outputs, context);
@@ -1352,13 +1354,13 @@ export const deserializeAws_restJson1CreateProgramCommand = async (
     contents.ChannelName = __expectString(data.ChannelName);
   }
   if (data.CreationTime !== undefined && data.CreationTime !== null) {
-    contents.CreationTime = new Date(Math.round(data.CreationTime * 1000));
+    contents.CreationTime = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.CreationTime)));
   }
   if (data.ProgramName !== undefined && data.ProgramName !== null) {
     contents.ProgramName = __expectString(data.ProgramName);
   }
   if (data.ScheduledStartTime !== undefined && data.ScheduledStartTime !== null) {
-    contents.ScheduledStartTime = new Date(Math.round(data.ScheduledStartTime * 1000));
+    contents.ScheduledStartTime = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.ScheduledStartTime)));
   }
   if (data.SourceLocationName !== undefined && data.SourceLocationName !== null) {
     contents.SourceLocationName = __expectString(data.SourceLocationName);
@@ -1424,7 +1426,7 @@ export const deserializeAws_restJson1CreateSourceLocationCommand = async (
     contents.Arn = __expectString(data.Arn);
   }
   if (data.CreationTime !== undefined && data.CreationTime !== null) {
-    contents.CreationTime = new Date(Math.round(data.CreationTime * 1000));
+    contents.CreationTime = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.CreationTime)));
   }
   if (data.DefaultSegmentDeliveryConfiguration !== undefined && data.DefaultSegmentDeliveryConfiguration !== null) {
     contents.DefaultSegmentDeliveryConfiguration = deserializeAws_restJson1DefaultSegmentDeliveryConfiguration(
@@ -1436,7 +1438,7 @@ export const deserializeAws_restJson1CreateSourceLocationCommand = async (
     contents.HttpConfiguration = deserializeAws_restJson1HttpConfiguration(data.HttpConfiguration, context);
   }
   if (data.LastModifiedTime !== undefined && data.LastModifiedTime !== null) {
-    contents.LastModifiedTime = new Date(Math.round(data.LastModifiedTime * 1000));
+    contents.LastModifiedTime = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.LastModifiedTime)));
   }
   if (data.SourceLocationName !== undefined && data.SourceLocationName !== null) {
     contents.SourceLocationName = __expectString(data.SourceLocationName);
@@ -1498,7 +1500,7 @@ export const deserializeAws_restJson1CreateVodSourceCommand = async (
     contents.Arn = __expectString(data.Arn);
   }
   if (data.CreationTime !== undefined && data.CreationTime !== null) {
-    contents.CreationTime = new Date(Math.round(data.CreationTime * 1000));
+    contents.CreationTime = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.CreationTime)));
   }
   if (data.HttpPackageConfigurations !== undefined && data.HttpPackageConfigurations !== null) {
     contents.HttpPackageConfigurations = deserializeAws_restJson1HttpPackageConfigurations(
@@ -1507,7 +1509,7 @@ export const deserializeAws_restJson1CreateVodSourceCommand = async (
     );
   }
   if (data.LastModifiedTime !== undefined && data.LastModifiedTime !== null) {
-    contents.LastModifiedTime = new Date(Math.round(data.LastModifiedTime * 1000));
+    contents.LastModifiedTime = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.LastModifiedTime)));
   }
   if (data.SourceLocationName !== undefined && data.SourceLocationName !== null) {
     contents.SourceLocationName = __expectString(data.SourceLocationName);
@@ -1838,13 +1840,13 @@ export const deserializeAws_restJson1DescribeChannelCommand = async (
     contents.ChannelState = __expectString(data.ChannelState);
   }
   if (data.CreationTime !== undefined && data.CreationTime !== null) {
-    contents.CreationTime = new Date(Math.round(data.CreationTime * 1000));
+    contents.CreationTime = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.CreationTime)));
   }
   if (data.FillerSlate !== undefined && data.FillerSlate !== null) {
     contents.FillerSlate = deserializeAws_restJson1SlateSource(data.FillerSlate, context);
   }
   if (data.LastModifiedTime !== undefined && data.LastModifiedTime !== null) {
-    contents.LastModifiedTime = new Date(Math.round(data.LastModifiedTime * 1000));
+    contents.LastModifiedTime = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.LastModifiedTime)));
   }
   if (data.Outputs !== undefined && data.Outputs !== null) {
     contents.Outputs = deserializeAws_restJson1ResponseOutputs(data.Outputs, context);
@@ -1916,13 +1918,13 @@ export const deserializeAws_restJson1DescribeProgramCommand = async (
     contents.ChannelName = __expectString(data.ChannelName);
   }
   if (data.CreationTime !== undefined && data.CreationTime !== null) {
-    contents.CreationTime = new Date(Math.round(data.CreationTime * 1000));
+    contents.CreationTime = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.CreationTime)));
   }
   if (data.ProgramName !== undefined && data.ProgramName !== null) {
     contents.ProgramName = __expectString(data.ProgramName);
   }
   if (data.ScheduledStartTime !== undefined && data.ScheduledStartTime !== null) {
-    contents.ScheduledStartTime = new Date(Math.round(data.ScheduledStartTime * 1000));
+    contents.ScheduledStartTime = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.ScheduledStartTime)));
   }
   if (data.SourceLocationName !== undefined && data.SourceLocationName !== null) {
     contents.SourceLocationName = __expectString(data.SourceLocationName);
@@ -1988,7 +1990,7 @@ export const deserializeAws_restJson1DescribeSourceLocationCommand = async (
     contents.Arn = __expectString(data.Arn);
   }
   if (data.CreationTime !== undefined && data.CreationTime !== null) {
-    contents.CreationTime = new Date(Math.round(data.CreationTime * 1000));
+    contents.CreationTime = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.CreationTime)));
   }
   if (data.DefaultSegmentDeliveryConfiguration !== undefined && data.DefaultSegmentDeliveryConfiguration !== null) {
     contents.DefaultSegmentDeliveryConfiguration = deserializeAws_restJson1DefaultSegmentDeliveryConfiguration(
@@ -2000,7 +2002,7 @@ export const deserializeAws_restJson1DescribeSourceLocationCommand = async (
     contents.HttpConfiguration = deserializeAws_restJson1HttpConfiguration(data.HttpConfiguration, context);
   }
   if (data.LastModifiedTime !== undefined && data.LastModifiedTime !== null) {
-    contents.LastModifiedTime = new Date(Math.round(data.LastModifiedTime * 1000));
+    contents.LastModifiedTime = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.LastModifiedTime)));
   }
   if (data.SourceLocationName !== undefined && data.SourceLocationName !== null) {
     contents.SourceLocationName = __expectString(data.SourceLocationName);
@@ -2062,7 +2064,7 @@ export const deserializeAws_restJson1DescribeVodSourceCommand = async (
     contents.Arn = __expectString(data.Arn);
   }
   if (data.CreationTime !== undefined && data.CreationTime !== null) {
-    contents.CreationTime = new Date(Math.round(data.CreationTime * 1000));
+    contents.CreationTime = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.CreationTime)));
   }
   if (data.HttpPackageConfigurations !== undefined && data.HttpPackageConfigurations !== null) {
     contents.HttpPackageConfigurations = deserializeAws_restJson1HttpPackageConfigurations(
@@ -2071,7 +2073,7 @@ export const deserializeAws_restJson1DescribeVodSourceCommand = async (
     );
   }
   if (data.LastModifiedTime !== undefined && data.LastModifiedTime !== null) {
-    contents.LastModifiedTime = new Date(Math.round(data.LastModifiedTime * 1000));
+    contents.LastModifiedTime = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.LastModifiedTime)));
   }
   if (data.SourceLocationName !== undefined && data.SourceLocationName !== null) {
     contents.SourceLocationName = __expectString(data.SourceLocationName);
@@ -3031,13 +3033,13 @@ export const deserializeAws_restJson1UpdateChannelCommand = async (
     contents.ChannelState = __expectString(data.ChannelState);
   }
   if (data.CreationTime !== undefined && data.CreationTime !== null) {
-    contents.CreationTime = new Date(Math.round(data.CreationTime * 1000));
+    contents.CreationTime = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.CreationTime)));
   }
   if (data.FillerSlate !== undefined && data.FillerSlate !== null) {
     contents.FillerSlate = deserializeAws_restJson1SlateSource(data.FillerSlate, context);
   }
   if (data.LastModifiedTime !== undefined && data.LastModifiedTime !== null) {
-    contents.LastModifiedTime = new Date(Math.round(data.LastModifiedTime * 1000));
+    contents.LastModifiedTime = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.LastModifiedTime)));
   }
   if (data.Outputs !== undefined && data.Outputs !== null) {
     contents.Outputs = deserializeAws_restJson1ResponseOutputs(data.Outputs, context);
@@ -3106,7 +3108,7 @@ export const deserializeAws_restJson1UpdateSourceLocationCommand = async (
     contents.Arn = __expectString(data.Arn);
   }
   if (data.CreationTime !== undefined && data.CreationTime !== null) {
-    contents.CreationTime = new Date(Math.round(data.CreationTime * 1000));
+    contents.CreationTime = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.CreationTime)));
   }
   if (data.DefaultSegmentDeliveryConfiguration !== undefined && data.DefaultSegmentDeliveryConfiguration !== null) {
     contents.DefaultSegmentDeliveryConfiguration = deserializeAws_restJson1DefaultSegmentDeliveryConfiguration(
@@ -3118,7 +3120,7 @@ export const deserializeAws_restJson1UpdateSourceLocationCommand = async (
     contents.HttpConfiguration = deserializeAws_restJson1HttpConfiguration(data.HttpConfiguration, context);
   }
   if (data.LastModifiedTime !== undefined && data.LastModifiedTime !== null) {
-    contents.LastModifiedTime = new Date(Math.round(data.LastModifiedTime * 1000));
+    contents.LastModifiedTime = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.LastModifiedTime)));
   }
   if (data.SourceLocationName !== undefined && data.SourceLocationName !== null) {
     contents.SourceLocationName = __expectString(data.SourceLocationName);
@@ -3180,7 +3182,7 @@ export const deserializeAws_restJson1UpdateVodSourceCommand = async (
     contents.Arn = __expectString(data.Arn);
   }
   if (data.CreationTime !== undefined && data.CreationTime !== null) {
-    contents.CreationTime = new Date(Math.round(data.CreationTime * 1000));
+    contents.CreationTime = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.CreationTime)));
   }
   if (data.HttpPackageConfigurations !== undefined && data.HttpPackageConfigurations !== null) {
     contents.HttpPackageConfigurations = deserializeAws_restJson1HttpPackageConfigurations(
@@ -3189,7 +3191,7 @@ export const deserializeAws_restJson1UpdateVodSourceCommand = async (
     );
   }
   if (data.LastModifiedTime !== undefined && data.LastModifiedTime !== null) {
-    contents.LastModifiedTime = new Date(Math.round(data.LastModifiedTime * 1000));
+    contents.LastModifiedTime = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.LastModifiedTime)));
   }
   if (data.SourceLocationName !== undefined && data.SourceLocationName !== null) {
     contents.SourceLocationName = __expectString(data.SourceLocationName);
@@ -3670,7 +3672,7 @@ const deserializeAws_restJson1Alert = (output: any, context: __SerdeContext): Al
     AlertMessage: __expectString(output.AlertMessage),
     LastModifiedTime:
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
-        ? new Date(Math.round(output.LastModifiedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastModifiedTime)))
         : undefined,
     RelatedResourceArns:
       output.RelatedResourceArns !== undefined && output.RelatedResourceArns !== null
@@ -3708,7 +3710,7 @@ const deserializeAws_restJson1Channel = (output: any, context: __SerdeContext): 
     ChannelState: __expectString(output.ChannelState),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     FillerSlate:
       output.FillerSlate !== undefined && output.FillerSlate !== null
@@ -3716,7 +3718,7 @@ const deserializeAws_restJson1Channel = (output: any, context: __SerdeContext): 
         : undefined,
     LastModifiedTime:
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
-        ? new Date(Math.round(output.LastModifiedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastModifiedTime)))
         : undefined,
     Outputs:
       output.Outputs !== undefined && output.Outputs !== null
@@ -3921,7 +3923,7 @@ const deserializeAws_restJson1ScheduleAdBreak = (output: any, context: __SerdeCo
     ApproximateDurationSeconds: __expectLong(output.ApproximateDurationSeconds),
     ApproximateStartTime:
       output.ApproximateStartTime !== undefined && output.ApproximateStartTime !== null
-        ? new Date(Math.round(output.ApproximateStartTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.ApproximateStartTime)))
         : undefined,
     SourceLocationName: __expectString(output.SourceLocationName),
     VodSourceName: __expectString(output.VodSourceName),
@@ -3933,7 +3935,7 @@ const deserializeAws_restJson1ScheduleEntry = (output: any, context: __SerdeCont
     ApproximateDurationSeconds: __expectLong(output.ApproximateDurationSeconds),
     ApproximateStartTime:
       output.ApproximateStartTime !== undefined && output.ApproximateStartTime !== null
-        ? new Date(Math.round(output.ApproximateStartTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.ApproximateStartTime)))
         : undefined,
     Arn: __expectString(output.Arn),
     ChannelName: __expectString(output.ChannelName),
@@ -3975,7 +3977,7 @@ const deserializeAws_restJson1SourceLocation = (output: any, context: __SerdeCon
     Arn: __expectString(output.Arn),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     DefaultSegmentDeliveryConfiguration:
       output.DefaultSegmentDeliveryConfiguration !== undefined && output.DefaultSegmentDeliveryConfiguration !== null
@@ -3990,7 +3992,7 @@ const deserializeAws_restJson1SourceLocation = (output: any, context: __SerdeCon
         : undefined,
     LastModifiedTime:
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
-        ? new Date(Math.round(output.LastModifiedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastModifiedTime)))
         : undefined,
     SourceLocationName: __expectString(output.SourceLocationName),
     Tags:
@@ -4014,7 +4016,7 @@ const deserializeAws_restJson1VodSource = (output: any, context: __SerdeContext)
     Arn: __expectString(output.Arn),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     HttpPackageConfigurations:
       output.HttpPackageConfigurations !== undefined && output.HttpPackageConfigurations !== null
@@ -4022,7 +4024,7 @@ const deserializeAws_restJson1VodSource = (output: any, context: __SerdeContext)
         : undefined,
     LastModifiedTime:
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
-        ? new Date(Math.round(output.LastModifiedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastModifiedTime)))
         : undefined,
     SourceLocationName: __expectString(output.SourceLocationName),
     Tags:

--- a/clients/client-memorydb/protocols/Aws_json1_1.ts
+++ b/clients/client-memorydb/protocols/Aws_json1_1.ts
@@ -220,8 +220,11 @@ import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@a
 import {
   expectBoolean as __expectBoolean,
   expectInt32 as __expectInt32,
+  expectNonNull as __expectNonNull,
+  expectNumber as __expectNumber,
   expectString as __expectString,
   limitedParseDouble as __limitedParseDouble,
+  parseEpochTimestamp as __parseEpochTimestamp,
 } from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
@@ -5790,7 +5793,10 @@ const deserializeAws_json1_1EngineVersionInfoList = (output: any, context: __Ser
 
 const deserializeAws_json1_1Event = (output: any, context: __SerdeContext): Event => {
   return {
-    Date: output.Date !== undefined && output.Date !== null ? new Date(Math.round(output.Date * 1000)) : undefined,
+    Date:
+      output.Date !== undefined && output.Date !== null
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.Date)))
+        : undefined,
     Message: __expectString(output.Message),
     SourceName: __expectString(output.SourceName),
     SourceType: __expectString(output.SourceType),
@@ -5955,7 +5961,7 @@ const deserializeAws_json1_1Node = (output: any, context: __SerdeContext): Node 
     AvailabilityZone: __expectString(output.AvailabilityZone),
     CreateTime:
       output.CreateTime !== undefined && output.CreateTime !== null
-        ? new Date(Math.round(output.CreateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreateTime)))
         : undefined,
     Endpoint:
       output.Endpoint !== undefined && output.Endpoint !== null
@@ -6163,14 +6169,14 @@ const deserializeAws_json1_1ServiceUpdate = (output: any, context: __SerdeContex
   return {
     AutoUpdateStartDate:
       output.AutoUpdateStartDate !== undefined && output.AutoUpdateStartDate !== null
-        ? new Date(Math.round(output.AutoUpdateStartDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.AutoUpdateStartDate)))
         : undefined,
     ClusterName: __expectString(output.ClusterName),
     Description: __expectString(output.Description),
     NodesUpdated: __expectString(output.NodesUpdated),
     ReleaseDate:
       output.ReleaseDate !== undefined && output.ReleaseDate !== null
-        ? new Date(Math.round(output.ReleaseDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.ReleaseDate)))
         : undefined,
     ServiceUpdateName: __expectString(output.ServiceUpdateName),
     Status: __expectString(output.Status),
@@ -6228,7 +6234,7 @@ const deserializeAws_json1_1ShardDetail = (output: any, context: __SerdeContext)
     Size: __expectString(output.Size),
     SnapshotCreationTime:
       output.SnapshotCreationTime !== undefined && output.SnapshotCreationTime !== null
-        ? new Date(Math.round(output.SnapshotCreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.SnapshotCreationTime)))
         : undefined,
   } as any;
 };

--- a/clients/client-migration-hub/protocols/Aws_json1_1.ts
+++ b/clients/client-migration-hub/protocols/Aws_json1_1.ts
@@ -118,7 +118,13 @@ import {
   UnauthorizedOperation,
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
-import { expectInt32 as __expectInt32, expectString as __expectString } from "@aws-sdk/smithy-client";
+import {
+  expectInt32 as __expectInt32,
+  expectNonNull as __expectNonNull,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
+  parseEpochTimestamp as __parseEpochTimestamp,
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   HeaderBag as __HeaderBag,
@@ -2697,7 +2703,7 @@ const deserializeAws_json1_1ApplicationState = (output: any, context: __SerdeCon
     ApplicationStatus: __expectString(output.ApplicationStatus),
     LastUpdatedTime:
       output.LastUpdatedTime !== undefined && output.LastUpdatedTime !== null
-        ? new Date(Math.round(output.LastUpdatedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastUpdatedTime)))
         : undefined,
   } as any;
 };
@@ -2767,7 +2773,7 @@ const deserializeAws_json1_1DescribeApplicationStateResult = (
     ApplicationStatus: __expectString(output.ApplicationStatus),
     LastUpdatedTime:
       output.LastUpdatedTime !== undefined && output.LastUpdatedTime !== null
-        ? new Date(Math.round(output.LastUpdatedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastUpdatedTime)))
         : undefined,
   } as any;
 };
@@ -2941,7 +2947,7 @@ const deserializeAws_json1_1MigrationTask = (output: any, context: __SerdeContex
       output.Task !== undefined && output.Task !== null ? deserializeAws_json1_1Task(output.Task, context) : undefined,
     UpdateDateTime:
       output.UpdateDateTime !== undefined && output.UpdateDateTime !== null
-        ? new Date(Math.round(output.UpdateDateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.UpdateDateTime)))
         : undefined,
   } as any;
 };
@@ -2955,7 +2961,7 @@ const deserializeAws_json1_1MigrationTaskSummary = (output: any, context: __Serd
     StatusDetail: __expectString(output.StatusDetail),
     UpdateDateTime:
       output.UpdateDateTime !== undefined && output.UpdateDateTime !== null
-        ? new Date(Math.round(output.UpdateDateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.UpdateDateTime)))
         : undefined,
   } as any;
 };

--- a/clients/client-migrationhub-config/protocols/Aws_json1_1.ts
+++ b/clients/client-migrationhub-config/protocols/Aws_json1_1.ts
@@ -24,7 +24,13 @@ import {
   ThrottlingException,
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
-import { expectInt32 as __expectInt32, expectString as __expectString } from "@aws-sdk/smithy-client";
+import {
+  expectInt32 as __expectInt32,
+  expectNonNull as __expectNonNull,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
+  parseEpochTimestamp as __parseEpochTimestamp,
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   HeaderBag as __HeaderBag,
@@ -515,7 +521,7 @@ const deserializeAws_json1_1HomeRegionControl = (output: any, context: __SerdeCo
     HomeRegion: __expectString(output.HomeRegion),
     RequestedTime:
       output.RequestedTime !== undefined && output.RequestedTime !== null
-        ? new Date(Math.round(output.RequestedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.RequestedTime)))
         : undefined,
     Target:
       output.Target !== undefined && output.Target !== null

--- a/clients/client-mobile/protocols/Aws_restJson1.ts
+++ b/clients/client-mobile/protocols/Aws_restJson1.ts
@@ -25,9 +25,11 @@ import {
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
   expectNonNull as __expectNonNull,
+  expectNumber as __expectNumber,
   expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
+  parseEpochTimestamp as __parseEpochTimestamp,
 } from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
@@ -1360,11 +1362,11 @@ const deserializeAws_restJson1ProjectDetails = (output: any, context: __SerdeCon
     consoleUrl: __expectString(output.consoleUrl),
     createdDate:
       output.createdDate !== undefined && output.createdDate !== null
-        ? new Date(Math.round(output.createdDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.createdDate)))
         : undefined,
     lastUpdatedDate:
       output.lastUpdatedDate !== undefined && output.lastUpdatedDate !== null
-        ? new Date(Math.round(output.lastUpdatedDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastUpdatedDate)))
         : undefined,
     name: __expectString(output.name),
     projectId: __expectString(output.projectId),

--- a/clients/client-mq/protocols/Aws_restJson1.ts
+++ b/clients/client-mq/protocols/Aws_restJson1.ts
@@ -79,6 +79,7 @@ import {
   expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
+  parseRfc3339DateTime as __parseRfc3339DateTime,
 } from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
@@ -975,7 +976,7 @@ export const deserializeAws_restJson1CreateConfigurationCommand = async (
     contents.AuthenticationStrategy = __expectString(data.authenticationStrategy);
   }
   if (data.created !== undefined && data.created !== null) {
-    contents.Created = new Date(data.created);
+    contents.Created = __expectNonNull(__parseRfc3339DateTime(data.created));
   }
   if (data.id !== undefined && data.id !== null) {
     contents.Id = __expectString(data.id);
@@ -1501,7 +1502,7 @@ export const deserializeAws_restJson1DescribeBrokerCommand = async (
     contents.Configurations = deserializeAws_restJson1Configurations(data.configurations, context);
   }
   if (data.created !== undefined && data.created !== null) {
-    contents.Created = new Date(data.created);
+    contents.Created = __expectNonNull(__parseRfc3339DateTime(data.created));
   }
   if (data.deploymentMode !== undefined && data.deploymentMode !== null) {
     contents.DeploymentMode = __expectString(data.deploymentMode);
@@ -1819,7 +1820,7 @@ export const deserializeAws_restJson1DescribeConfigurationCommand = async (
     contents.AuthenticationStrategy = __expectString(data.authenticationStrategy);
   }
   if (data.created !== undefined && data.created !== null) {
-    contents.Created = new Date(data.created);
+    contents.Created = __expectNonNull(__parseRfc3339DateTime(data.created));
   }
   if (data.description !== undefined && data.description !== null) {
     contents.Description = __expectString(data.description);
@@ -1925,7 +1926,7 @@ export const deserializeAws_restJson1DescribeConfigurationRevisionCommand = asyn
     contents.ConfigurationId = __expectString(data.configurationId);
   }
   if (data.created !== undefined && data.created !== null) {
-    contents.Created = new Date(data.created);
+    contents.Created = __expectNonNull(__parseRfc3339DateTime(data.created));
   }
   if (data.data !== undefined && data.data !== null) {
     contents.Data = __expectString(data.data);
@@ -2729,7 +2730,7 @@ export const deserializeAws_restJson1UpdateConfigurationCommand = async (
     contents.Arn = __expectString(data.arn);
   }
   if (data.created !== undefined && data.created !== null) {
-    contents.Created = new Date(data.created);
+    contents.Created = __expectNonNull(__parseRfc3339DateTime(data.created));
   }
   if (data.id !== undefined && data.id !== null) {
     contents.Id = __expectString(data.id);
@@ -3344,7 +3345,10 @@ const deserializeAws_restJson1BrokerSummary = (output: any, context: __SerdeCont
     BrokerId: __expectString(output.brokerId),
     BrokerName: __expectString(output.brokerName),
     BrokerState: __expectString(output.brokerState),
-    Created: output.created !== undefined && output.created !== null ? new Date(output.created) : undefined,
+    Created:
+      output.created !== undefined && output.created !== null
+        ? __expectNonNull(__parseRfc3339DateTime(output.created))
+        : undefined,
     DeploymentMode: __expectString(output.deploymentMode),
     EngineType: __expectString(output.engineType),
     HostInstanceType: __expectString(output.hostInstanceType),
@@ -3355,7 +3359,10 @@ const deserializeAws_restJson1Configuration = (output: any, context: __SerdeCont
   return {
     Arn: __expectString(output.arn),
     AuthenticationStrategy: __expectString(output.authenticationStrategy),
-    Created: output.created !== undefined && output.created !== null ? new Date(output.created) : undefined,
+    Created:
+      output.created !== undefined && output.created !== null
+        ? __expectNonNull(__parseRfc3339DateTime(output.created))
+        : undefined,
     Description: __expectString(output.description),
     EngineType: __expectString(output.engineType),
     EngineVersion: __expectString(output.engineVersion),
@@ -3381,7 +3388,10 @@ const deserializeAws_restJson1ConfigurationId = (output: any, context: __SerdeCo
 
 const deserializeAws_restJson1ConfigurationRevision = (output: any, context: __SerdeContext): ConfigurationRevision => {
   return {
-    Created: output.created !== undefined && output.created !== null ? new Date(output.created) : undefined,
+    Created:
+      output.created !== undefined && output.created !== null
+        ? __expectNonNull(__parseRfc3339DateTime(output.created))
+        : undefined,
     Description: __expectString(output.description),
     Revision: __expectInt32(output.revision),
   } as any;

--- a/clients/client-mturk/protocols/Aws_json1_1.ts
+++ b/clients/client-mturk/protocols/Aws_json1_1.ts
@@ -208,7 +208,10 @@ import {
   expectBoolean as __expectBoolean,
   expectInt32 as __expectInt32,
   expectLong as __expectLong,
+  expectNonNull as __expectNonNull,
+  expectNumber as __expectNumber,
   expectString as __expectString,
+  parseEpochTimestamp as __parseEpochTimestamp,
 } from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
@@ -3903,32 +3906,32 @@ const deserializeAws_json1_1Assignment = (output: any, context: __SerdeContext):
   return {
     AcceptTime:
       output.AcceptTime !== undefined && output.AcceptTime !== null
-        ? new Date(Math.round(output.AcceptTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.AcceptTime)))
         : undefined,
     Answer: __expectString(output.Answer),
     ApprovalTime:
       output.ApprovalTime !== undefined && output.ApprovalTime !== null
-        ? new Date(Math.round(output.ApprovalTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.ApprovalTime)))
         : undefined,
     AssignmentId: __expectString(output.AssignmentId),
     AssignmentStatus: __expectString(output.AssignmentStatus),
     AutoApprovalTime:
       output.AutoApprovalTime !== undefined && output.AutoApprovalTime !== null
-        ? new Date(Math.round(output.AutoApprovalTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.AutoApprovalTime)))
         : undefined,
     Deadline:
       output.Deadline !== undefined && output.Deadline !== null
-        ? new Date(Math.round(output.Deadline * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.Deadline)))
         : undefined,
     HITId: __expectString(output.HITId),
     RejectionTime:
       output.RejectionTime !== undefined && output.RejectionTime !== null
-        ? new Date(Math.round(output.RejectionTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.RejectionTime)))
         : undefined,
     RequesterFeedback: __expectString(output.RequesterFeedback),
     SubmitTime:
       output.SubmitTime !== undefined && output.SubmitTime !== null
-        ? new Date(Math.round(output.SubmitTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.SubmitTime)))
         : undefined,
     WorkerId: __expectString(output.WorkerId),
   } as any;
@@ -3958,7 +3961,7 @@ const deserializeAws_json1_1BonusPayment = (output: any, context: __SerdeContext
     BonusAmount: __expectString(output.BonusAmount),
     GrantTime:
       output.GrantTime !== undefined && output.GrantTime !== null
-        ? new Date(Math.round(output.GrantTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.GrantTime)))
         : undefined,
     Reason: __expectString(output.Reason),
     WorkerId: __expectString(output.WorkerId),
@@ -4113,12 +4116,12 @@ const deserializeAws_json1_1HIT = (output: any, context: __SerdeContext): HIT =>
     AutoApprovalDelayInSeconds: __expectLong(output.AutoApprovalDelayInSeconds),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     Description: __expectString(output.Description),
     Expiration:
       output.Expiration !== undefined && output.Expiration !== null
-        ? new Date(Math.round(output.Expiration * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.Expiration)))
         : undefined,
     HITGroupId: __expectString(output.HITGroupId),
     HITId: __expectString(output.HITId),
@@ -4415,7 +4418,7 @@ const deserializeAws_json1_1Qualification = (output: any, context: __SerdeContex
   return {
     GrantTime:
       output.GrantTime !== undefined && output.GrantTime !== null
-        ? new Date(Math.round(output.GrantTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.GrantTime)))
         : undefined,
     IntegerValue: __expectInt32(output.IntegerValue),
     LocaleValue:
@@ -4446,7 +4449,7 @@ const deserializeAws_json1_1QualificationRequest = (output: any, context: __Serd
     QualificationTypeId: __expectString(output.QualificationTypeId),
     SubmitTime:
       output.SubmitTime !== undefined && output.SubmitTime !== null
-        ? new Date(Math.round(output.SubmitTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.SubmitTime)))
         : undefined,
     Test: __expectString(output.Test),
     WorkerId: __expectString(output.WorkerId),
@@ -4508,7 +4511,7 @@ const deserializeAws_json1_1QualificationType = (output: any, context: __SerdeCo
     AutoGrantedValue: __expectInt32(output.AutoGrantedValue),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     Description: __expectString(output.Description),
     IsRequestable: __expectBoolean(output.IsRequestable),
@@ -4560,7 +4563,7 @@ const deserializeAws_json1_1ReviewActionDetail = (output: any, context: __SerdeC
     ActionName: __expectString(output.ActionName),
     CompleteTime:
       output.CompleteTime !== undefined && output.CompleteTime !== null
-        ? new Date(Math.round(output.CompleteTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CompleteTime)))
         : undefined,
     ErrorCode: __expectString(output.ErrorCode),
     Result: __expectString(output.Result),

--- a/clients/client-mwaa/protocols/Aws_restJson1.ts
+++ b/clients/client-mwaa/protocols/Aws_restJson1.ts
@@ -42,9 +42,11 @@ import {
   expectBoolean as __expectBoolean,
   expectInt32 as __expectInt32,
   expectNonNull as __expectNonNull,
+  expectNumber as __expectNumber,
   expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
+  parseEpochTimestamp as __parseEpochTimestamp,
   serializeFloat as __serializeFloat,
 } from "@aws-sdk/smithy-client";
 import {
@@ -1547,7 +1549,7 @@ const deserializeAws_restJson1Environment = (output: any, context: __SerdeContex
     Arn: __expectString(output.Arn),
     CreatedAt:
       output.CreatedAt !== undefined && output.CreatedAt !== null
-        ? new Date(Math.round(output.CreatedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreatedAt)))
         : undefined,
     DagS3Path: __expectString(output.DagS3Path),
     EnvironmentClass: __expectString(output.EnvironmentClass),
@@ -1601,7 +1603,7 @@ const deserializeAws_restJson1LastUpdate = (output: any, context: __SerdeContext
   return {
     CreatedAt:
       output.CreatedAt !== undefined && output.CreatedAt !== null
-        ? new Date(Math.round(output.CreatedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreatedAt)))
         : undefined,
     Error:
       output.Error !== undefined && output.Error !== null

--- a/clients/client-neptune/protocols/Aws_query.ts
+++ b/clients/client-neptune/protocols/Aws_query.ts
@@ -434,11 +434,13 @@ import {
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
+  expectNonNull as __expectNonNull,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   getArrayIfSingleItem as __getArrayIfSingleItem,
   getValueFromTextNode as __getValueFromTextNode,
   parseBoolean as __parseBoolean,
+  parseRfc3339DateTime as __parseRfc3339DateTime,
   strictParseFloat as __strictParseFloat,
   strictParseInt32 as __strictParseInt32,
 } from "@aws-sdk/smithy-client";
@@ -9602,7 +9604,7 @@ const deserializeAws_queryDBCluster = (output: any, context: __SerdeContext): DB
     contents.PercentProgress = __expectString(output["PercentProgress"]);
   }
   if (output["EarliestRestorableTime"] !== undefined) {
-    contents.EarliestRestorableTime = new Date(output["EarliestRestorableTime"]);
+    contents.EarliestRestorableTime = __expectNonNull(__parseRfc3339DateTime(output["EarliestRestorableTime"]));
   }
   if (output["Endpoint"] !== undefined) {
     contents.Endpoint = __expectString(output["Endpoint"]);
@@ -9620,7 +9622,7 @@ const deserializeAws_queryDBCluster = (output: any, context: __SerdeContext): DB
     contents.EngineVersion = __expectString(output["EngineVersion"]);
   }
   if (output["LatestRestorableTime"] !== undefined) {
-    contents.LatestRestorableTime = new Date(output["LatestRestorableTime"]);
+    contents.LatestRestorableTime = __expectNonNull(__parseRfc3339DateTime(output["LatestRestorableTime"]));
   }
   if (output["Port"] !== undefined) {
     contents.Port = __strictParseInt32(output["Port"]) as number;
@@ -9713,7 +9715,7 @@ const deserializeAws_queryDBCluster = (output: any, context: __SerdeContext): DB
     contents.CloneGroupId = __expectString(output["CloneGroupId"]);
   }
   if (output["ClusterCreateTime"] !== undefined) {
-    contents.ClusterCreateTime = new Date(output["ClusterCreateTime"]);
+    contents.ClusterCreateTime = __expectNonNull(__parseRfc3339DateTime(output["ClusterCreateTime"]));
   }
   if (output["CopyTagsToSnapshot"] !== undefined) {
     contents.CopyTagsToSnapshot = __parseBoolean(output["CopyTagsToSnapshot"]);
@@ -9737,7 +9739,7 @@ const deserializeAws_queryDBCluster = (output: any, context: __SerdeContext): DB
     contents.CrossAccountClone = __parseBoolean(output["CrossAccountClone"]);
   }
   if (output["AutomaticRestartTime"] !== undefined) {
-    contents.AutomaticRestartTime = new Date(output["AutomaticRestartTime"]);
+    contents.AutomaticRestartTime = __expectNonNull(__parseRfc3339DateTime(output["AutomaticRestartTime"]));
   }
   return contents;
 };
@@ -10225,7 +10227,7 @@ const deserializeAws_queryDBClusterSnapshot = (output: any, context: __SerdeCont
     contents.DBClusterIdentifier = __expectString(output["DBClusterIdentifier"]);
   }
   if (output["SnapshotCreateTime"] !== undefined) {
-    contents.SnapshotCreateTime = new Date(output["SnapshotCreateTime"]);
+    contents.SnapshotCreateTime = __expectNonNull(__parseRfc3339DateTime(output["SnapshotCreateTime"]));
   }
   if (output["Engine"] !== undefined) {
     contents.Engine = __expectString(output["Engine"]);
@@ -10243,7 +10245,7 @@ const deserializeAws_queryDBClusterSnapshot = (output: any, context: __SerdeCont
     contents.VpcId = __expectString(output["VpcId"]);
   }
   if (output["ClusterCreateTime"] !== undefined) {
-    contents.ClusterCreateTime = new Date(output["ClusterCreateTime"]);
+    contents.ClusterCreateTime = __expectNonNull(__parseRfc3339DateTime(output["ClusterCreateTime"]));
   }
   if (output["MasterUsername"] !== undefined) {
     contents.MasterUsername = __expectString(output["MasterUsername"]);
@@ -10594,7 +10596,7 @@ const deserializeAws_queryDBInstance = (output: any, context: __SerdeContext): D
     contents.AllocatedStorage = __strictParseInt32(output["AllocatedStorage"]) as number;
   }
   if (output["InstanceCreateTime"] !== undefined) {
-    contents.InstanceCreateTime = new Date(output["InstanceCreateTime"]);
+    contents.InstanceCreateTime = __expectNonNull(__parseRfc3339DateTime(output["InstanceCreateTime"]));
   }
   if (output["PreferredBackupWindow"] !== undefined) {
     contents.PreferredBackupWindow = __expectString(output["PreferredBackupWindow"]);
@@ -10648,7 +10650,7 @@ const deserializeAws_queryDBInstance = (output: any, context: __SerdeContext): D
     );
   }
   if (output["LatestRestorableTime"] !== undefined) {
-    contents.LatestRestorableTime = new Date(output["LatestRestorableTime"]);
+    contents.LatestRestorableTime = __expectNonNull(__parseRfc3339DateTime(output["LatestRestorableTime"]));
   }
   if (output["MultiAZ"] !== undefined) {
     contents.MultiAZ = __parseBoolean(output["MultiAZ"]);
@@ -11558,7 +11560,7 @@ const deserializeAws_queryEvent = (output: any, context: __SerdeContext): Event 
     );
   }
   if (output["Date"] !== undefined) {
-    contents.Date = new Date(output["Date"]);
+    contents.Date = __expectNonNull(__parseRfc3339DateTime(output["Date"]));
   }
   if (output["SourceArn"] !== undefined) {
     contents.SourceArn = __expectString(output["SourceArn"]);
@@ -12413,16 +12415,16 @@ const deserializeAws_queryPendingMaintenanceAction = (
     contents.Action = __expectString(output["Action"]);
   }
   if (output["AutoAppliedAfterDate"] !== undefined) {
-    contents.AutoAppliedAfterDate = new Date(output["AutoAppliedAfterDate"]);
+    contents.AutoAppliedAfterDate = __expectNonNull(__parseRfc3339DateTime(output["AutoAppliedAfterDate"]));
   }
   if (output["ForcedApplyDate"] !== undefined) {
-    contents.ForcedApplyDate = new Date(output["ForcedApplyDate"]);
+    contents.ForcedApplyDate = __expectNonNull(__parseRfc3339DateTime(output["ForcedApplyDate"]));
   }
   if (output["OptInStatus"] !== undefined) {
     contents.OptInStatus = __expectString(output["OptInStatus"]);
   }
   if (output["CurrentApplyDate"] !== undefined) {
-    contents.CurrentApplyDate = new Date(output["CurrentApplyDate"]);
+    contents.CurrentApplyDate = __expectNonNull(__parseRfc3339DateTime(output["CurrentApplyDate"]));
   }
   if (output["Description"] !== undefined) {
     contents.Description = __expectString(output["Description"]);

--- a/clients/client-networkmanager/protocols/Aws_restJson1.ts
+++ b/clients/client-networkmanager/protocols/Aws_restJson1.ts
@@ -106,9 +106,11 @@ import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@a
 import {
   expectInt32 as __expectInt32,
   expectNonNull as __expectNonNull,
+  expectNumber as __expectNumber,
   expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
+  parseEpochTimestamp as __parseEpochTimestamp,
   strictParseInt32 as __strictParseInt32,
 } from "@aws-sdk/smithy-client";
 import {
@@ -5058,7 +5060,7 @@ const deserializeAws_restJson1Connection = (output: any, context: __SerdeContext
     ConnectionId: __expectString(output.ConnectionId),
     CreatedAt:
       output.CreatedAt !== undefined && output.CreatedAt !== null
-        ? new Date(Math.round(output.CreatedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreatedAt)))
         : undefined,
     Description: __expectString(output.Description),
     DeviceId: __expectString(output.DeviceId),
@@ -5118,7 +5120,7 @@ const deserializeAws_restJson1Device = (output: any, context: __SerdeContext): D
         : undefined,
     CreatedAt:
       output.CreatedAt !== undefined && output.CreatedAt !== null
-        ? new Date(Math.round(output.CreatedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreatedAt)))
         : undefined,
     Description: __expectString(output.Description),
     DeviceArn: __expectString(output.DeviceArn),
@@ -5156,7 +5158,7 @@ const deserializeAws_restJson1GlobalNetwork = (output: any, context: __SerdeCont
   return {
     CreatedAt:
       output.CreatedAt !== undefined && output.CreatedAt !== null
-        ? new Date(Math.round(output.CreatedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreatedAt)))
         : undefined,
     Description: __expectString(output.Description),
     GlobalNetworkArn: __expectString(output.GlobalNetworkArn),
@@ -5188,7 +5190,7 @@ const deserializeAws_restJson1Link = (output: any, context: __SerdeContext): Lin
         : undefined,
     CreatedAt:
       output.CreatedAt !== undefined && output.CreatedAt !== null
-        ? new Date(Math.round(output.CreatedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreatedAt)))
         : undefined,
     Description: __expectString(output.Description),
     GlobalNetworkId: __expectString(output.GlobalNetworkId),
@@ -5248,7 +5250,7 @@ const deserializeAws_restJson1Site = (output: any, context: __SerdeContext): Sit
   return {
     CreatedAt:
       output.CreatedAt !== undefined && output.CreatedAt !== null
-        ? new Date(Math.round(output.CreatedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreatedAt)))
         : undefined,
     Description: __expectString(output.Description),
     GlobalNetworkId: __expectString(output.GlobalNetworkId),

--- a/clients/client-nimble/protocols/Aws_restJson1.ts
+++ b/clients/client-nimble/protocols/Aws_restJson1.ts
@@ -169,6 +169,7 @@ import {
   expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
+  parseRfc3339DateTime as __parseRfc3339DateTime,
 } from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
@@ -7251,16 +7252,25 @@ const deserializeAws_restJson1EC2SubnetIdList = (output: any, context: __SerdeCo
 const deserializeAws_restJson1Eula = (output: any, context: __SerdeContext): Eula => {
   return {
     content: __expectString(output.content),
-    createdAt: output.createdAt !== undefined && output.createdAt !== null ? new Date(output.createdAt) : undefined,
+    createdAt:
+      output.createdAt !== undefined && output.createdAt !== null
+        ? __expectNonNull(__parseRfc3339DateTime(output.createdAt))
+        : undefined,
     eulaId: __expectString(output.eulaId),
     name: __expectString(output.name),
-    updatedAt: output.updatedAt !== undefined && output.updatedAt !== null ? new Date(output.updatedAt) : undefined,
+    updatedAt:
+      output.updatedAt !== undefined && output.updatedAt !== null
+        ? __expectNonNull(__parseRfc3339DateTime(output.updatedAt))
+        : undefined,
   } as any;
 };
 
 const deserializeAws_restJson1EulaAcceptance = (output: any, context: __SerdeContext): EulaAcceptance => {
   return {
-    acceptedAt: output.acceptedAt !== undefined && output.acceptedAt !== null ? new Date(output.acceptedAt) : undefined,
+    acceptedAt:
+      output.acceptedAt !== undefined && output.acceptedAt !== null
+        ? __expectNonNull(__parseRfc3339DateTime(output.acceptedAt))
+        : undefined,
     acceptedBy: __expectString(output.acceptedBy),
     accepteeId: __expectString(output.accepteeId),
     eulaAcceptanceId: __expectString(output.eulaAcceptanceId),
@@ -7316,7 +7326,10 @@ const deserializeAws_restJson1ExceptionContext = (output: any, context: __SerdeC
 const deserializeAws_restJson1LaunchProfile = (output: any, context: __SerdeContext): LaunchProfile => {
   return {
     arn: __expectString(output.arn),
-    createdAt: output.createdAt !== undefined && output.createdAt !== null ? new Date(output.createdAt) : undefined,
+    createdAt:
+      output.createdAt !== undefined && output.createdAt !== null
+        ? __expectNonNull(__parseRfc3339DateTime(output.createdAt))
+        : undefined,
     createdBy: __expectString(output.createdBy),
     description: __expectString(output.description),
     ec2SubnetIds:
@@ -7344,7 +7357,10 @@ const deserializeAws_restJson1LaunchProfile = (output: any, context: __SerdeCont
       output.tags !== undefined && output.tags !== null
         ? deserializeAws_restJson1Tags(output.tags, context)
         : undefined,
-    updatedAt: output.updatedAt !== undefined && output.updatedAt !== null ? new Date(output.updatedAt) : undefined,
+    updatedAt:
+      output.updatedAt !== undefined && output.updatedAt !== null
+        ? __expectNonNull(__parseRfc3339DateTime(output.updatedAt))
+        : undefined,
     updatedBy: __expectString(output.updatedBy),
   } as any;
 };
@@ -7616,7 +7632,10 @@ const deserializeAws_restJson1StreamingInstanceTypeList = (
 const deserializeAws_restJson1StreamingSession = (output: any, context: __SerdeContext): StreamingSession => {
   return {
     arn: __expectString(output.arn),
-    createdAt: output.createdAt !== undefined && output.createdAt !== null ? new Date(output.createdAt) : undefined,
+    createdAt:
+      output.createdAt !== undefined && output.createdAt !== null
+        ? __expectNonNull(__parseRfc3339DateTime(output.createdAt))
+        : undefined,
     createdBy: __expectString(output.createdBy),
     ec2InstanceType: __expectString(output.ec2InstanceType),
     launchProfileId: __expectString(output.launchProfileId),
@@ -7631,8 +7650,13 @@ const deserializeAws_restJson1StreamingSession = (output: any, context: __SerdeC
         ? deserializeAws_restJson1Tags(output.tags, context)
         : undefined,
     terminateAt:
-      output.terminateAt !== undefined && output.terminateAt !== null ? new Date(output.terminateAt) : undefined,
-    updatedAt: output.updatedAt !== undefined && output.updatedAt !== null ? new Date(output.updatedAt) : undefined,
+      output.terminateAt !== undefined && output.terminateAt !== null
+        ? __expectNonNull(__parseRfc3339DateTime(output.terminateAt))
+        : undefined,
+    updatedAt:
+      output.updatedAt !== undefined && output.updatedAt !== null
+        ? __expectNonNull(__parseRfc3339DateTime(output.updatedAt))
+        : undefined,
     updatedBy: __expectString(output.updatedBy),
   } as any;
 };
@@ -7653,9 +7677,15 @@ const deserializeAws_restJson1StreamingSessionStream = (
   context: __SerdeContext
 ): StreamingSessionStream => {
   return {
-    createdAt: output.createdAt !== undefined && output.createdAt !== null ? new Date(output.createdAt) : undefined,
+    createdAt:
+      output.createdAt !== undefined && output.createdAt !== null
+        ? __expectNonNull(__parseRfc3339DateTime(output.createdAt))
+        : undefined,
     createdBy: __expectString(output.createdBy),
-    expiresAt: output.expiresAt !== undefined && output.expiresAt !== null ? new Date(output.expiresAt) : undefined,
+    expiresAt:
+      output.expiresAt !== undefined && output.expiresAt !== null
+        ? __expectNonNull(__parseRfc3339DateTime(output.expiresAt))
+        : undefined,
     ownedBy: __expectString(output.ownedBy),
     state: __expectString(output.state),
     statusCode: __expectString(output.statusCode),
@@ -7668,7 +7698,10 @@ const deserializeAws_restJson1Studio = (output: any, context: __SerdeContext): S
   return {
     adminRoleArn: __expectString(output.adminRoleArn),
     arn: __expectString(output.arn),
-    createdAt: output.createdAt !== undefined && output.createdAt !== null ? new Date(output.createdAt) : undefined,
+    createdAt:
+      output.createdAt !== undefined && output.createdAt !== null
+        ? __expectNonNull(__parseRfc3339DateTime(output.createdAt))
+        : undefined,
     displayName: __expectString(output.displayName),
     homeRegion: __expectString(output.homeRegion),
     ssoClientId: __expectString(output.ssoClientId),
@@ -7686,7 +7719,10 @@ const deserializeAws_restJson1Studio = (output: any, context: __SerdeContext): S
       output.tags !== undefined && output.tags !== null
         ? deserializeAws_restJson1Tags(output.tags, context)
         : undefined,
-    updatedAt: output.updatedAt !== undefined && output.updatedAt !== null ? new Date(output.updatedAt) : undefined,
+    updatedAt:
+      output.updatedAt !== undefined && output.updatedAt !== null
+        ? __expectNonNull(__parseRfc3339DateTime(output.updatedAt))
+        : undefined,
     userRoleArn: __expectString(output.userRoleArn),
   } as any;
 };
@@ -7698,7 +7734,10 @@ const deserializeAws_restJson1StudioComponent = (output: any, context: __SerdeCo
       output.configuration !== undefined && output.configuration !== null
         ? deserializeAws_restJson1StudioComponentConfiguration(output.configuration, context)
         : undefined,
-    createdAt: output.createdAt !== undefined && output.createdAt !== null ? new Date(output.createdAt) : undefined,
+    createdAt:
+      output.createdAt !== undefined && output.createdAt !== null
+        ? __expectNonNull(__parseRfc3339DateTime(output.createdAt))
+        : undefined,
     createdBy: __expectString(output.createdBy),
     description: __expectString(output.description),
     ec2SecurityGroupIds:
@@ -7724,7 +7763,10 @@ const deserializeAws_restJson1StudioComponent = (output: any, context: __SerdeCo
         ? deserializeAws_restJson1Tags(output.tags, context)
         : undefined,
     type: __expectString(output.type),
-    updatedAt: output.updatedAt !== undefined && output.updatedAt !== null ? new Date(output.updatedAt) : undefined,
+    updatedAt:
+      output.updatedAt !== undefined && output.updatedAt !== null
+        ? __expectNonNull(__parseRfc3339DateTime(output.updatedAt))
+        : undefined,
     updatedBy: __expectString(output.updatedBy),
   } as any;
 };
@@ -7820,14 +7862,20 @@ const deserializeAws_restJson1StudioComponentSummary = (
   context: __SerdeContext
 ): StudioComponentSummary => {
   return {
-    createdAt: output.createdAt !== undefined && output.createdAt !== null ? new Date(output.createdAt) : undefined,
+    createdAt:
+      output.createdAt !== undefined && output.createdAt !== null
+        ? __expectNonNull(__parseRfc3339DateTime(output.createdAt))
+        : undefined,
     createdBy: __expectString(output.createdBy),
     description: __expectString(output.description),
     name: __expectString(output.name),
     studioComponentId: __expectString(output.studioComponentId),
     subtype: __expectString(output.subtype),
     type: __expectString(output.type),
-    updatedAt: output.updatedAt !== undefined && output.updatedAt !== null ? new Date(output.updatedAt) : undefined,
+    updatedAt:
+      output.updatedAt !== undefined && output.updatedAt !== null
+        ? __expectNonNull(__parseRfc3339DateTime(output.updatedAt))
+        : undefined,
     updatedBy: __expectString(output.updatedBy),
   } as any;
 };

--- a/clients/client-opsworkscm/protocols/Aws_json1_1.ts
+++ b/clients/client-opsworkscm/protocols/Aws_json1_1.ts
@@ -88,7 +88,10 @@ import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@a
 import {
   expectBoolean as __expectBoolean,
   expectInt32 as __expectInt32,
+  expectNonNull as __expectNonNull,
+  expectNumber as __expectNumber,
   expectString as __expectString,
+  parseEpochTimestamp as __parseEpochTimestamp,
 } from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
@@ -2045,7 +2048,7 @@ const deserializeAws_json1_1Backup = (output: any, context: __SerdeContext): Bac
     BackupType: __expectString(output.BackupType),
     CreatedAt:
       output.CreatedAt !== undefined && output.CreatedAt !== null
-        ? new Date(Math.round(output.CreatedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreatedAt)))
         : undefined,
     Description: __expectString(output.Description),
     Engine: __expectString(output.Engine),
@@ -2282,7 +2285,7 @@ const deserializeAws_json1_1Server = (output: any, context: __SerdeContext): Ser
     CloudFormationStackArn: __expectString(output.CloudFormationStackArn),
     CreatedAt:
       output.CreatedAt !== undefined && output.CreatedAt !== null
-        ? new Date(Math.round(output.CreatedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreatedAt)))
         : undefined,
     CustomDomain: __expectString(output.CustomDomain),
     DisableAutomatedBackup: __expectBoolean(output.DisableAutomatedBackup),
@@ -2320,7 +2323,7 @@ const deserializeAws_json1_1ServerEvent = (output: any, context: __SerdeContext)
   return {
     CreatedAt:
       output.CreatedAt !== undefined && output.CreatedAt !== null
-        ? new Date(Math.round(output.CreatedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreatedAt)))
         : undefined,
     LogUrl: __expectString(output.LogUrl),
     Message: __expectString(output.Message),

--- a/clients/client-organizations/protocols/Aws_json1_1.ts
+++ b/clients/client-organizations/protocols/Aws_json1_1.ts
@@ -277,7 +277,13 @@ import {
   UpdatePolicyResponse,
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
-import { expectBoolean as __expectBoolean, expectString as __expectString } from "@aws-sdk/smithy-client";
+import {
+  expectBoolean as __expectBoolean,
+  expectNonNull as __expectNonNull,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
+  parseEpochTimestamp as __parseEpochTimestamp,
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   HeaderBag as __HeaderBag,
@@ -7726,7 +7732,7 @@ const deserializeAws_json1_1Account = (output: any, context: __SerdeContext): Ac
     JoinedMethod: __expectString(output.JoinedMethod),
     JoinedTimestamp:
       output.JoinedTimestamp !== undefined && output.JoinedTimestamp !== null
-        ? new Date(Math.round(output.JoinedTimestamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.JoinedTimestamp)))
         : undefined,
     Name: __expectString(output.Name),
     Status: __expectString(output.Status),
@@ -7868,14 +7874,14 @@ const deserializeAws_json1_1CreateAccountStatus = (output: any, context: __Serde
     AccountName: __expectString(output.AccountName),
     CompletedTimestamp:
       output.CompletedTimestamp !== undefined && output.CompletedTimestamp !== null
-        ? new Date(Math.round(output.CompletedTimestamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CompletedTimestamp)))
         : undefined,
     FailureReason: __expectString(output.FailureReason),
     GovCloudAccountId: __expectString(output.GovCloudAccountId),
     Id: __expectString(output.Id),
     RequestedTimestamp:
       output.RequestedTimestamp !== undefined && output.RequestedTimestamp !== null
-        ? new Date(Math.round(output.RequestedTimestamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.RequestedTimestamp)))
         : undefined,
     State: __expectString(output.State),
   } as any;
@@ -7963,14 +7969,14 @@ const deserializeAws_json1_1DelegatedAdministrator = (output: any, context: __Se
     Arn: __expectString(output.Arn),
     DelegationEnabledDate:
       output.DelegationEnabledDate !== undefined && output.DelegationEnabledDate !== null
-        ? new Date(Math.round(output.DelegationEnabledDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.DelegationEnabledDate)))
         : undefined,
     Email: __expectString(output.Email),
     Id: __expectString(output.Id),
     JoinedMethod: __expectString(output.JoinedMethod),
     JoinedTimestamp:
       output.JoinedTimestamp !== undefined && output.JoinedTimestamp !== null
-        ? new Date(Math.round(output.JoinedTimestamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.JoinedTimestamp)))
         : undefined,
     Name: __expectString(output.Name),
     Status: __expectString(output.Status),
@@ -7995,7 +8001,7 @@ const deserializeAws_json1_1DelegatedService = (output: any, context: __SerdeCon
   return {
     DelegationEnabledDate:
       output.DelegationEnabledDate !== undefined && output.DelegationEnabledDate !== null
-        ? new Date(Math.round(output.DelegationEnabledDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.DelegationEnabledDate)))
         : undefined,
     ServicePrincipal: __expectString(output.ServicePrincipal),
   } as any;
@@ -8161,7 +8167,7 @@ const deserializeAws_json1_1EffectivePolicy = (output: any, context: __SerdeCont
   return {
     LastUpdatedTimestamp:
       output.LastUpdatedTimestamp !== undefined && output.LastUpdatedTimestamp !== null
-        ? new Date(Math.round(output.LastUpdatedTimestamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastUpdatedTimestamp)))
         : undefined,
     PolicyContent: __expectString(output.PolicyContent),
     PolicyType: __expectString(output.PolicyType),
@@ -8197,7 +8203,7 @@ const deserializeAws_json1_1EnabledServicePrincipal = (
   return {
     DateEnabled:
       output.DateEnabled !== undefined && output.DateEnabled !== null
-        ? new Date(Math.round(output.DateEnabled * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.DateEnabled)))
         : undefined,
     ServicePrincipal: __expectString(output.ServicePrincipal),
   } as any;
@@ -8242,7 +8248,7 @@ const deserializeAws_json1_1Handshake = (output: any, context: __SerdeContext): 
     Arn: __expectString(output.Arn),
     ExpirationTimestamp:
       output.ExpirationTimestamp !== undefined && output.ExpirationTimestamp !== null
-        ? new Date(Math.round(output.ExpirationTimestamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.ExpirationTimestamp)))
         : undefined,
     Id: __expectString(output.Id),
     Parties:
@@ -8251,7 +8257,7 @@ const deserializeAws_json1_1Handshake = (output: any, context: __SerdeContext): 
         : undefined,
     RequestedTimestamp:
       output.RequestedTimestamp !== undefined && output.RequestedTimestamp !== null
-        ? new Date(Math.round(output.RequestedTimestamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.RequestedTimestamp)))
         : undefined,
     Resources:
       output.Resources !== undefined && output.Resources !== null

--- a/clients/client-personalize/protocols/Aws_json1_1.ts
+++ b/clients/client-personalize/protocols/Aws_json1_1.ts
@@ -242,8 +242,11 @@ import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@a
 import {
   expectBoolean as __expectBoolean,
   expectInt32 as __expectInt32,
+  expectNonNull as __expectNonNull,
+  expectNumber as __expectNumber,
   expectString as __expectString,
   limitedParseDouble as __limitedParseDouble,
+  parseEpochTimestamp as __parseEpochTimestamp,
   serializeFloat as __serializeFloat,
 } from "@aws-sdk/smithy-client";
 import {
@@ -4873,7 +4876,7 @@ const deserializeAws_json1_1Algorithm = (output: any, context: __SerdeContext): 
         : undefined,
     creationDateTime:
       output.creationDateTime !== undefined && output.creationDateTime !== null
-        ? new Date(Math.round(output.creationDateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.creationDateTime)))
         : undefined,
     defaultHyperParameterRanges:
       output.defaultHyperParameterRanges !== undefined && output.defaultHyperParameterRanges !== null
@@ -4889,7 +4892,7 @@ const deserializeAws_json1_1Algorithm = (output: any, context: __SerdeContext): 
         : undefined,
     lastUpdatedDateTime:
       output.lastUpdatedDateTime !== undefined && output.lastUpdatedDateTime !== null
-        ? new Date(Math.round(output.lastUpdatedDateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastUpdatedDateTime)))
         : undefined,
     name: __expectString(output.name),
     roleArn: __expectString(output.roleArn),
@@ -4940,7 +4943,7 @@ const deserializeAws_json1_1BatchInferenceJob = (output: any, context: __SerdeCo
         : undefined,
     creationDateTime:
       output.creationDateTime !== undefined && output.creationDateTime !== null
-        ? new Date(Math.round(output.creationDateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.creationDateTime)))
         : undefined,
     failureReason: __expectString(output.failureReason),
     filterArn: __expectString(output.filterArn),
@@ -4955,7 +4958,7 @@ const deserializeAws_json1_1BatchInferenceJob = (output: any, context: __SerdeCo
         : undefined,
     lastUpdatedDateTime:
       output.lastUpdatedDateTime !== undefined && output.lastUpdatedDateTime !== null
-        ? new Date(Math.round(output.lastUpdatedDateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastUpdatedDateTime)))
         : undefined,
     numResults: __expectInt32(output.numResults),
     roleArn: __expectString(output.roleArn),
@@ -5016,13 +5019,13 @@ const deserializeAws_json1_1BatchInferenceJobSummary = (
     batchInferenceJobArn: __expectString(output.batchInferenceJobArn),
     creationDateTime:
       output.creationDateTime !== undefined && output.creationDateTime !== null
-        ? new Date(Math.round(output.creationDateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.creationDateTime)))
         : undefined,
     failureReason: __expectString(output.failureReason),
     jobName: __expectString(output.jobName),
     lastUpdatedDateTime:
       output.lastUpdatedDateTime !== undefined && output.lastUpdatedDateTime !== null
-        ? new Date(Math.round(output.lastUpdatedDateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastUpdatedDateTime)))
         : undefined,
     solutionVersionArn: __expectString(output.solutionVersionArn),
     status: __expectString(output.status),
@@ -5038,12 +5041,12 @@ const deserializeAws_json1_1Campaign = (output: any, context: __SerdeContext): C
         : undefined,
     creationDateTime:
       output.creationDateTime !== undefined && output.creationDateTime !== null
-        ? new Date(Math.round(output.creationDateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.creationDateTime)))
         : undefined,
     failureReason: __expectString(output.failureReason),
     lastUpdatedDateTime:
       output.lastUpdatedDateTime !== undefined && output.lastUpdatedDateTime !== null
-        ? new Date(Math.round(output.lastUpdatedDateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastUpdatedDateTime)))
         : undefined,
     latestCampaignUpdate:
       output.latestCampaignUpdate !== undefined && output.latestCampaignUpdate !== null
@@ -5081,12 +5084,12 @@ const deserializeAws_json1_1CampaignSummary = (output: any, context: __SerdeCont
     campaignArn: __expectString(output.campaignArn),
     creationDateTime:
       output.creationDateTime !== undefined && output.creationDateTime !== null
-        ? new Date(Math.round(output.creationDateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.creationDateTime)))
         : undefined,
     failureReason: __expectString(output.failureReason),
     lastUpdatedDateTime:
       output.lastUpdatedDateTime !== undefined && output.lastUpdatedDateTime !== null
-        ? new Date(Math.round(output.lastUpdatedDateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastUpdatedDateTime)))
         : undefined,
     name: __expectString(output.name),
     status: __expectString(output.status),
@@ -5101,12 +5104,12 @@ const deserializeAws_json1_1CampaignUpdateSummary = (output: any, context: __Ser
         : undefined,
     creationDateTime:
       output.creationDateTime !== undefined && output.creationDateTime !== null
-        ? new Date(Math.round(output.creationDateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.creationDateTime)))
         : undefined,
     failureReason: __expectString(output.failureReason),
     lastUpdatedDateTime:
       output.lastUpdatedDateTime !== undefined && output.lastUpdatedDateTime !== null
-        ? new Date(Math.round(output.lastUpdatedDateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastUpdatedDateTime)))
         : undefined,
     minProvisionedTPS: __expectInt32(output.minProvisionedTPS),
     solutionVersionArn: __expectString(output.solutionVersionArn),
@@ -5266,14 +5269,14 @@ const deserializeAws_json1_1Dataset = (output: any, context: __SerdeContext): Da
   return {
     creationDateTime:
       output.creationDateTime !== undefined && output.creationDateTime !== null
-        ? new Date(Math.round(output.creationDateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.creationDateTime)))
         : undefined,
     datasetArn: __expectString(output.datasetArn),
     datasetGroupArn: __expectString(output.datasetGroupArn),
     datasetType: __expectString(output.datasetType),
     lastUpdatedDateTime:
       output.lastUpdatedDateTime !== undefined && output.lastUpdatedDateTime !== null
-        ? new Date(Math.round(output.lastUpdatedDateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastUpdatedDateTime)))
         : undefined,
     name: __expectString(output.name),
     schemaArn: __expectString(output.schemaArn),
@@ -5285,7 +5288,7 @@ const deserializeAws_json1_1DatasetExportJob = (output: any, context: __SerdeCon
   return {
     creationDateTime:
       output.creationDateTime !== undefined && output.creationDateTime !== null
-        ? new Date(Math.round(output.creationDateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.creationDateTime)))
         : undefined,
     datasetArn: __expectString(output.datasetArn),
     datasetExportJobArn: __expectString(output.datasetExportJobArn),
@@ -5298,7 +5301,7 @@ const deserializeAws_json1_1DatasetExportJob = (output: any, context: __SerdeCon
         : undefined,
     lastUpdatedDateTime:
       output.lastUpdatedDateTime !== undefined && output.lastUpdatedDateTime !== null
-        ? new Date(Math.round(output.lastUpdatedDateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastUpdatedDateTime)))
         : undefined,
     roleArn: __expectString(output.roleArn),
     status: __expectString(output.status),
@@ -5332,14 +5335,14 @@ const deserializeAws_json1_1DatasetExportJobSummary = (
   return {
     creationDateTime:
       output.creationDateTime !== undefined && output.creationDateTime !== null
-        ? new Date(Math.round(output.creationDateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.creationDateTime)))
         : undefined,
     datasetExportJobArn: __expectString(output.datasetExportJobArn),
     failureReason: __expectString(output.failureReason),
     jobName: __expectString(output.jobName),
     lastUpdatedDateTime:
       output.lastUpdatedDateTime !== undefined && output.lastUpdatedDateTime !== null
-        ? new Date(Math.round(output.lastUpdatedDateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastUpdatedDateTime)))
         : undefined,
     status: __expectString(output.status),
   } as any;
@@ -5349,14 +5352,14 @@ const deserializeAws_json1_1DatasetGroup = (output: any, context: __SerdeContext
   return {
     creationDateTime:
       output.creationDateTime !== undefined && output.creationDateTime !== null
-        ? new Date(Math.round(output.creationDateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.creationDateTime)))
         : undefined,
     datasetGroupArn: __expectString(output.datasetGroupArn),
     failureReason: __expectString(output.failureReason),
     kmsKeyArn: __expectString(output.kmsKeyArn),
     lastUpdatedDateTime:
       output.lastUpdatedDateTime !== undefined && output.lastUpdatedDateTime !== null
-        ? new Date(Math.round(output.lastUpdatedDateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastUpdatedDateTime)))
         : undefined,
     name: __expectString(output.name),
     roleArn: __expectString(output.roleArn),
@@ -5379,13 +5382,13 @@ const deserializeAws_json1_1DatasetGroupSummary = (output: any, context: __Serde
   return {
     creationDateTime:
       output.creationDateTime !== undefined && output.creationDateTime !== null
-        ? new Date(Math.round(output.creationDateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.creationDateTime)))
         : undefined,
     datasetGroupArn: __expectString(output.datasetGroupArn),
     failureReason: __expectString(output.failureReason),
     lastUpdatedDateTime:
       output.lastUpdatedDateTime !== undefined && output.lastUpdatedDateTime !== null
-        ? new Date(Math.round(output.lastUpdatedDateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastUpdatedDateTime)))
         : undefined,
     name: __expectString(output.name),
     status: __expectString(output.status),
@@ -5396,7 +5399,7 @@ const deserializeAws_json1_1DatasetImportJob = (output: any, context: __SerdeCon
   return {
     creationDateTime:
       output.creationDateTime !== undefined && output.creationDateTime !== null
-        ? new Date(Math.round(output.creationDateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.creationDateTime)))
         : undefined,
     dataSource:
       output.dataSource !== undefined && output.dataSource !== null
@@ -5408,7 +5411,7 @@ const deserializeAws_json1_1DatasetImportJob = (output: any, context: __SerdeCon
     jobName: __expectString(output.jobName),
     lastUpdatedDateTime:
       output.lastUpdatedDateTime !== undefined && output.lastUpdatedDateTime !== null
-        ? new Date(Math.round(output.lastUpdatedDateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastUpdatedDateTime)))
         : undefined,
     roleArn: __expectString(output.roleArn),
     status: __expectString(output.status),
@@ -5433,14 +5436,14 @@ const deserializeAws_json1_1DatasetImportJobSummary = (
   return {
     creationDateTime:
       output.creationDateTime !== undefined && output.creationDateTime !== null
-        ? new Date(Math.round(output.creationDateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.creationDateTime)))
         : undefined,
     datasetImportJobArn: __expectString(output.datasetImportJobArn),
     failureReason: __expectString(output.failureReason),
     jobName: __expectString(output.jobName),
     lastUpdatedDateTime:
       output.lastUpdatedDateTime !== undefined && output.lastUpdatedDateTime !== null
-        ? new Date(Math.round(output.lastUpdatedDateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastUpdatedDateTime)))
         : undefined,
     status: __expectString(output.status),
   } as any;
@@ -5461,11 +5464,11 @@ const deserializeAws_json1_1DatasetSchema = (output: any, context: __SerdeContex
   return {
     creationDateTime:
       output.creationDateTime !== undefined && output.creationDateTime !== null
-        ? new Date(Math.round(output.creationDateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.creationDateTime)))
         : undefined,
     lastUpdatedDateTime:
       output.lastUpdatedDateTime !== undefined && output.lastUpdatedDateTime !== null
-        ? new Date(Math.round(output.lastUpdatedDateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastUpdatedDateTime)))
         : undefined,
     name: __expectString(output.name),
     schema: __expectString(output.schema),
@@ -5477,11 +5480,11 @@ const deserializeAws_json1_1DatasetSchemaSummary = (output: any, context: __Serd
   return {
     creationDateTime:
       output.creationDateTime !== undefined && output.creationDateTime !== null
-        ? new Date(Math.round(output.creationDateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.creationDateTime)))
         : undefined,
     lastUpdatedDateTime:
       output.lastUpdatedDateTime !== undefined && output.lastUpdatedDateTime !== null
-        ? new Date(Math.round(output.lastUpdatedDateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastUpdatedDateTime)))
         : undefined,
     name: __expectString(output.name),
     schemaArn: __expectString(output.schemaArn),
@@ -5492,13 +5495,13 @@ const deserializeAws_json1_1DatasetSummary = (output: any, context: __SerdeConte
   return {
     creationDateTime:
       output.creationDateTime !== undefined && output.creationDateTime !== null
-        ? new Date(Math.round(output.creationDateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.creationDateTime)))
         : undefined,
     datasetArn: __expectString(output.datasetArn),
     datasetType: __expectString(output.datasetType),
     lastUpdatedDateTime:
       output.lastUpdatedDateTime !== undefined && output.lastUpdatedDateTime !== null
-        ? new Date(Math.round(output.lastUpdatedDateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastUpdatedDateTime)))
         : undefined,
     name: __expectString(output.name),
     status: __expectString(output.status),
@@ -5775,13 +5778,13 @@ const deserializeAws_json1_1EventTracker = (output: any, context: __SerdeContext
     accountId: __expectString(output.accountId),
     creationDateTime:
       output.creationDateTime !== undefined && output.creationDateTime !== null
-        ? new Date(Math.round(output.creationDateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.creationDateTime)))
         : undefined,
     datasetGroupArn: __expectString(output.datasetGroupArn),
     eventTrackerArn: __expectString(output.eventTrackerArn),
     lastUpdatedDateTime:
       output.lastUpdatedDateTime !== undefined && output.lastUpdatedDateTime !== null
-        ? new Date(Math.round(output.lastUpdatedDateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastUpdatedDateTime)))
         : undefined,
     name: __expectString(output.name),
     status: __expectString(output.status),
@@ -5804,12 +5807,12 @@ const deserializeAws_json1_1EventTrackerSummary = (output: any, context: __Serde
   return {
     creationDateTime:
       output.creationDateTime !== undefined && output.creationDateTime !== null
-        ? new Date(Math.round(output.creationDateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.creationDateTime)))
         : undefined,
     eventTrackerArn: __expectString(output.eventTrackerArn),
     lastUpdatedDateTime:
       output.lastUpdatedDateTime !== undefined && output.lastUpdatedDateTime !== null
-        ? new Date(Math.round(output.lastUpdatedDateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastUpdatedDateTime)))
         : undefined,
     name: __expectString(output.name),
     status: __expectString(output.status),
@@ -5820,7 +5823,7 @@ const deserializeAws_json1_1FeatureTransformation = (output: any, context: __Ser
   return {
     creationDateTime:
       output.creationDateTime !== undefined && output.creationDateTime !== null
-        ? new Date(Math.round(output.creationDateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.creationDateTime)))
         : undefined,
     defaultParameters:
       output.defaultParameters !== undefined && output.defaultParameters !== null
@@ -5829,7 +5832,7 @@ const deserializeAws_json1_1FeatureTransformation = (output: any, context: __Ser
     featureTransformationArn: __expectString(output.featureTransformationArn),
     lastUpdatedDateTime:
       output.lastUpdatedDateTime !== undefined && output.lastUpdatedDateTime !== null
-        ? new Date(Math.round(output.lastUpdatedDateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastUpdatedDateTime)))
         : undefined,
     name: __expectString(output.name),
     status: __expectString(output.status),
@@ -5870,7 +5873,7 @@ const deserializeAws_json1_1Filter = (output: any, context: __SerdeContext): Fil
   return {
     creationDateTime:
       output.creationDateTime !== undefined && output.creationDateTime !== null
-        ? new Date(Math.round(output.creationDateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.creationDateTime)))
         : undefined,
     datasetGroupArn: __expectString(output.datasetGroupArn),
     failureReason: __expectString(output.failureReason),
@@ -5878,7 +5881,7 @@ const deserializeAws_json1_1Filter = (output: any, context: __SerdeContext): Fil
     filterExpression: __expectString(output.filterExpression),
     lastUpdatedDateTime:
       output.lastUpdatedDateTime !== undefined && output.lastUpdatedDateTime !== null
-        ? new Date(Math.round(output.lastUpdatedDateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastUpdatedDateTime)))
         : undefined,
     name: __expectString(output.name),
     status: __expectString(output.status),
@@ -5900,14 +5903,14 @@ const deserializeAws_json1_1FilterSummary = (output: any, context: __SerdeContex
   return {
     creationDateTime:
       output.creationDateTime !== undefined && output.creationDateTime !== null
-        ? new Date(Math.round(output.creationDateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.creationDateTime)))
         : undefined,
     datasetGroupArn: __expectString(output.datasetGroupArn),
     failureReason: __expectString(output.failureReason),
     filterArn: __expectString(output.filterArn),
     lastUpdatedDateTime:
       output.lastUpdatedDateTime !== undefined && output.lastUpdatedDateTime !== null
-        ? new Date(Math.round(output.lastUpdatedDateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastUpdatedDateTime)))
         : undefined,
     name: __expectString(output.name),
     status: __expectString(output.status),
@@ -6196,13 +6199,13 @@ const deserializeAws_json1_1Recipe = (output: any, context: __SerdeContext): Rec
     algorithmArn: __expectString(output.algorithmArn),
     creationDateTime:
       output.creationDateTime !== undefined && output.creationDateTime !== null
-        ? new Date(Math.round(output.creationDateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.creationDateTime)))
         : undefined,
     description: __expectString(output.description),
     featureTransformationArn: __expectString(output.featureTransformationArn),
     lastUpdatedDateTime:
       output.lastUpdatedDateTime !== undefined && output.lastUpdatedDateTime !== null
-        ? new Date(Math.round(output.lastUpdatedDateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastUpdatedDateTime)))
         : undefined,
     name: __expectString(output.name),
     recipeArn: __expectString(output.recipeArn),
@@ -6226,11 +6229,11 @@ const deserializeAws_json1_1RecipeSummary = (output: any, context: __SerdeContex
   return {
     creationDateTime:
       output.creationDateTime !== undefined && output.creationDateTime !== null
-        ? new Date(Math.round(output.creationDateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.creationDateTime)))
         : undefined,
     lastUpdatedDateTime:
       output.lastUpdatedDateTime !== undefined && output.lastUpdatedDateTime !== null
-        ? new Date(Math.round(output.lastUpdatedDateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastUpdatedDateTime)))
         : undefined,
     name: __expectString(output.name),
     recipeArn: __expectString(output.recipeArn),
@@ -6300,13 +6303,13 @@ const deserializeAws_json1_1Solution = (output: any, context: __SerdeContext): S
         : undefined,
     creationDateTime:
       output.creationDateTime !== undefined && output.creationDateTime !== null
-        ? new Date(Math.round(output.creationDateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.creationDateTime)))
         : undefined,
     datasetGroupArn: __expectString(output.datasetGroupArn),
     eventType: __expectString(output.eventType),
     lastUpdatedDateTime:
       output.lastUpdatedDateTime !== undefined && output.lastUpdatedDateTime !== null
-        ? new Date(Math.round(output.lastUpdatedDateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastUpdatedDateTime)))
         : undefined,
     latestSolutionVersion:
       output.latestSolutionVersion !== undefined && output.latestSolutionVersion !== null
@@ -6366,11 +6369,11 @@ const deserializeAws_json1_1SolutionSummary = (output: any, context: __SerdeCont
   return {
     creationDateTime:
       output.creationDateTime !== undefined && output.creationDateTime !== null
-        ? new Date(Math.round(output.creationDateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.creationDateTime)))
         : undefined,
     lastUpdatedDateTime:
       output.lastUpdatedDateTime !== undefined && output.lastUpdatedDateTime !== null
-        ? new Date(Math.round(output.lastUpdatedDateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastUpdatedDateTime)))
         : undefined,
     name: __expectString(output.name),
     solutionArn: __expectString(output.solutionArn),
@@ -6382,14 +6385,14 @@ const deserializeAws_json1_1SolutionVersion = (output: any, context: __SerdeCont
   return {
     creationDateTime:
       output.creationDateTime !== undefined && output.creationDateTime !== null
-        ? new Date(Math.round(output.creationDateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.creationDateTime)))
         : undefined,
     datasetGroupArn: __expectString(output.datasetGroupArn),
     eventType: __expectString(output.eventType),
     failureReason: __expectString(output.failureReason),
     lastUpdatedDateTime:
       output.lastUpdatedDateTime !== undefined && output.lastUpdatedDateTime !== null
-        ? new Date(Math.round(output.lastUpdatedDateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastUpdatedDateTime)))
         : undefined,
     performAutoML: __expectBoolean(output.performAutoML),
     performHPO: __expectBoolean(output.performHPO),
@@ -6425,12 +6428,12 @@ const deserializeAws_json1_1SolutionVersionSummary = (output: any, context: __Se
   return {
     creationDateTime:
       output.creationDateTime !== undefined && output.creationDateTime !== null
-        ? new Date(Math.round(output.creationDateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.creationDateTime)))
         : undefined,
     failureReason: __expectString(output.failureReason),
     lastUpdatedDateTime:
       output.lastUpdatedDateTime !== undefined && output.lastUpdatedDateTime !== null
-        ? new Date(Math.round(output.lastUpdatedDateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastUpdatedDateTime)))
         : undefined,
     solutionVersionArn: __expectString(output.solutionVersionArn),
     status: __expectString(output.status),

--- a/clients/client-pi/protocols/Aws_json1_1.ts
+++ b/clients/client-pi/protocols/Aws_json1_1.ts
@@ -27,7 +27,13 @@ import {
   ResponseResourceMetricKey,
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
-import { expectString as __expectString, limitedParseDouble as __limitedParseDouble } from "@aws-sdk/smithy-client";
+import {
+  expectNonNull as __expectNonNull,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
+  limitedParseDouble as __limitedParseDouble,
+  parseEpochTimestamp as __parseEpochTimestamp,
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   HeaderBag as __HeaderBag,
@@ -463,7 +469,7 @@ const deserializeAws_json1_1DataPoint = (output: any, context: __SerdeContext): 
   return {
     Timestamp:
       output.Timestamp !== undefined && output.Timestamp !== null
-        ? new Date(Math.round(output.Timestamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.Timestamp)))
         : undefined,
     Value: __limitedParseDouble(output.Value),
   } as any;
@@ -487,11 +493,11 @@ const deserializeAws_json1_1DescribeDimensionKeysResponse = (
   return {
     AlignedEndTime:
       output.AlignedEndTime !== undefined && output.AlignedEndTime !== null
-        ? new Date(Math.round(output.AlignedEndTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.AlignedEndTime)))
         : undefined,
     AlignedStartTime:
       output.AlignedStartTime !== undefined && output.AlignedStartTime !== null
-        ? new Date(Math.round(output.AlignedStartTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.AlignedStartTime)))
         : undefined,
     Keys:
       output.Keys !== undefined && output.Keys !== null
@@ -586,11 +592,11 @@ const deserializeAws_json1_1GetResourceMetricsResponse = (
   return {
     AlignedEndTime:
       output.AlignedEndTime !== undefined && output.AlignedEndTime !== null
-        ? new Date(Math.round(output.AlignedEndTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.AlignedEndTime)))
         : undefined,
     AlignedStartTime:
       output.AlignedStartTime !== undefined && output.AlignedStartTime !== null
-        ? new Date(Math.round(output.AlignedStartTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.AlignedStartTime)))
         : undefined,
     Identifier: __expectString(output.Identifier),
     MetricList:

--- a/clients/client-pinpoint-email/protocols/Aws_restJson1.ts
+++ b/clients/client-pinpoint-email/protocols/Aws_restJson1.ts
@@ -200,10 +200,12 @@ import {
   expectInt32 as __expectInt32,
   expectLong as __expectLong,
   expectNonNull as __expectNonNull,
+  expectNumber as __expectNumber,
   expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   limitedParseDouble as __limitedParseDouble,
+  parseEpochTimestamp as __parseEpochTimestamp,
 } from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
@@ -2775,7 +2777,9 @@ export const deserializeAws_restJson1GetDeliverabilityDashboardOptionsCommand = 
     );
   }
   if (data.SubscriptionExpiryDate !== undefined && data.SubscriptionExpiryDate !== null) {
-    contents.SubscriptionExpiryDate = new Date(Math.round(data.SubscriptionExpiryDate * 1000));
+    contents.SubscriptionExpiryDate = __expectNonNull(
+      __parseEpochTimestamp(__expectNumber(data.SubscriptionExpiryDate))
+    );
   }
   return Promise.resolve(contents);
 };
@@ -5213,7 +5217,7 @@ const deserializeAws_restJson1BlacklistEntry = (output: any, context: __SerdeCon
     Description: __expectString(output.Description),
     ListingTime:
       output.ListingTime !== undefined && output.ListingTime !== null
-        ? new Date(Math.round(output.ListingTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.ListingTime)))
         : undefined,
     RblName: __expectString(output.RblName),
   } as any;
@@ -5287,7 +5291,7 @@ const deserializeAws_restJson1DailyVolume = (output: any, context: __SerdeContex
         : undefined,
     StartDate:
       output.StartDate !== undefined && output.StartDate !== null
-        ? new Date(Math.round(output.StartDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.StartDate)))
         : undefined,
     VolumeStatistics:
       output.VolumeStatistics !== undefined && output.VolumeStatistics !== null
@@ -5334,7 +5338,7 @@ const deserializeAws_restJson1DeliverabilityTestReport = (
   return {
     CreateDate:
       output.CreateDate !== undefined && output.CreateDate !== null
-        ? new Date(Math.round(output.CreateDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreateDate)))
         : undefined,
     DeliverabilityTestStatus: __expectString(output.DeliverabilityTestStatus),
     FromEmailAddress: __expectString(output.FromEmailAddress),
@@ -5400,14 +5404,14 @@ const deserializeAws_restJson1DomainDeliverabilityCampaign = (
         : undefined,
     FirstSeenDateTime:
       output.FirstSeenDateTime !== undefined && output.FirstSeenDateTime !== null
-        ? new Date(Math.round(output.FirstSeenDateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.FirstSeenDateTime)))
         : undefined,
     FromAddress: __expectString(output.FromAddress),
     ImageUrl: __expectString(output.ImageUrl),
     InboxCount: __expectLong(output.InboxCount),
     LastSeenDateTime:
       output.LastSeenDateTime !== undefined && output.LastSeenDateTime !== null
-        ? new Date(Math.round(output.LastSeenDateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastSeenDateTime)))
         : undefined,
     ProjectedVolume: __expectLong(output.ProjectedVolume),
     ReadDeleteRate: __limitedParseDouble(output.ReadDeleteRate),
@@ -5447,7 +5451,7 @@ const deserializeAws_restJson1DomainDeliverabilityTrackingOption = (
         : undefined,
     SubscriptionStartDate:
       output.SubscriptionStartDate !== undefined && output.SubscriptionStartDate !== null
-        ? new Date(Math.round(output.SubscriptionStartDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.SubscriptionStartDate)))
         : undefined,
   } as any;
 };
@@ -5685,7 +5689,7 @@ const deserializeAws_restJson1ReputationOptions = (output: any, context: __Serde
   return {
     LastFreshStart:
       output.LastFreshStart !== undefined && output.LastFreshStart !== null
-        ? new Date(Math.round(output.LastFreshStart * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastFreshStart)))
         : undefined,
     ReputationMetricsEnabled: __expectBoolean(output.ReputationMetricsEnabled),
   } as any;

--- a/clients/client-pinpoint/protocols/Aws_restJson1.ts
+++ b/clients/client-pinpoint/protocols/Aws_restJson1.ts
@@ -414,10 +414,12 @@ import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@a
 import {
   expectBoolean as __expectBoolean,
   expectInt32 as __expectInt32,
+  expectNonNull as __expectNonNull,
   expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   limitedParseDouble as __limitedParseDouble,
+  parseRfc3339DateTime as __parseRfc3339DateTime,
   serializeFloat as __serializeFloat,
 } from "@aws-sdk/smithy-client";
 import {
@@ -17799,14 +17801,20 @@ const deserializeAws_restJson1ApplicationDateRangeKpiResponse = (
 ): ApplicationDateRangeKpiResponse => {
   return {
     ApplicationId: __expectString(output.ApplicationId),
-    EndTime: output.EndTime !== undefined && output.EndTime !== null ? new Date(output.EndTime) : undefined,
+    EndTime:
+      output.EndTime !== undefined && output.EndTime !== null
+        ? __expectNonNull(__parseRfc3339DateTime(output.EndTime))
+        : undefined,
     KpiName: __expectString(output.KpiName),
     KpiResult:
       output.KpiResult !== undefined && output.KpiResult !== null
         ? deserializeAws_restJson1BaseKpiResult(output.KpiResult, context)
         : undefined,
     NextToken: __expectString(output.NextToken),
-    StartTime: output.StartTime !== undefined && output.StartTime !== null ? new Date(output.StartTime) : undefined,
+    StartTime:
+      output.StartTime !== undefined && output.StartTime !== null
+        ? __expectNonNull(__parseRfc3339DateTime(output.StartTime))
+        : undefined,
   } as any;
 };
 
@@ -17913,14 +17921,20 @@ const deserializeAws_restJson1CampaignDateRangeKpiResponse = (
   return {
     ApplicationId: __expectString(output.ApplicationId),
     CampaignId: __expectString(output.CampaignId),
-    EndTime: output.EndTime !== undefined && output.EndTime !== null ? new Date(output.EndTime) : undefined,
+    EndTime:
+      output.EndTime !== undefined && output.EndTime !== null
+        ? __expectNonNull(__parseRfc3339DateTime(output.EndTime))
+        : undefined,
     KpiName: __expectString(output.KpiName),
     KpiResult:
       output.KpiResult !== undefined && output.KpiResult !== null
         ? deserializeAws_restJson1BaseKpiResult(output.KpiResult, context)
         : undefined,
     NextToken: __expectString(output.NextToken),
-    StartTime: output.StartTime !== undefined && output.StartTime !== null ? new Date(output.StartTime) : undefined,
+    StartTime:
+      output.StartTime !== undefined && output.StartTime !== null
+        ? __expectNonNull(__parseRfc3339DateTime(output.StartTime))
+        : undefined,
   } as any;
 };
 
@@ -18529,7 +18543,10 @@ const deserializeAws_restJson1JourneyDateRangeKpiResponse = (
 ): JourneyDateRangeKpiResponse => {
   return {
     ApplicationId: __expectString(output.ApplicationId),
-    EndTime: output.EndTime !== undefined && output.EndTime !== null ? new Date(output.EndTime) : undefined,
+    EndTime:
+      output.EndTime !== undefined && output.EndTime !== null
+        ? __expectNonNull(__parseRfc3339DateTime(output.EndTime))
+        : undefined,
     JourneyId: __expectString(output.JourneyId),
     KpiName: __expectString(output.KpiName),
     KpiResult:
@@ -18537,7 +18554,10 @@ const deserializeAws_restJson1JourneyDateRangeKpiResponse = (
         ? deserializeAws_restJson1BaseKpiResult(output.KpiResult, context)
         : undefined,
     NextToken: __expectString(output.NextToken),
-    StartTime: output.StartTime !== undefined && output.StartTime !== null ? new Date(output.StartTime) : undefined,
+    StartTime:
+      output.StartTime !== undefined && output.StartTime !== null
+        ? __expectNonNull(__parseRfc3339DateTime(output.StartTime))
+        : undefined,
   } as any;
 };
 
@@ -18636,8 +18656,14 @@ const deserializeAws_restJson1JourneyResponse = (output: any, context: __SerdeCo
 
 const deserializeAws_restJson1JourneySchedule = (output: any, context: __SerdeContext): JourneySchedule => {
   return {
-    EndTime: output.EndTime !== undefined && output.EndTime !== null ? new Date(output.EndTime) : undefined,
-    StartTime: output.StartTime !== undefined && output.StartTime !== null ? new Date(output.StartTime) : undefined,
+    EndTime:
+      output.EndTime !== undefined && output.EndTime !== null
+        ? __expectNonNull(__parseRfc3339DateTime(output.EndTime))
+        : undefined,
+    StartTime:
+      output.StartTime !== undefined && output.StartTime !== null
+        ? __expectNonNull(__parseRfc3339DateTime(output.StartTime))
+        : undefined,
     Timezone: __expectString(output.Timezone),
   } as any;
 };

--- a/clients/client-polly/protocols/Aws_restJson1.ts
+++ b/clients/client-polly/protocols/Aws_restJson1.ts
@@ -51,9 +51,11 @@ import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@a
 import {
   expectInt32 as __expectInt32,
   expectNonNull as __expectNonNull,
+  expectNumber as __expectNumber,
   expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
+  parseEpochTimestamp as __parseEpochTimestamp,
   strictParseInt32 as __strictParseInt32,
 } from "@aws-sdk/smithy-client";
 import {
@@ -1518,7 +1520,7 @@ const deserializeAws_restJson1LexiconAttributes = (output: any, context: __Serde
     LanguageCode: __expectString(output.LanguageCode),
     LastModified:
       output.LastModified !== undefined && output.LastModified !== null
-        ? new Date(Math.round(output.LastModified * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastModified)))
         : undefined,
     LexemesCount: __expectInt32(output.LexemesCount),
     LexiconArn: __expectString(output.LexiconArn),
@@ -1576,7 +1578,7 @@ const deserializeAws_restJson1SynthesisTask = (output: any, context: __SerdeCont
   return {
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     Engine: __expectString(output.Engine),
     LanguageCode: __expectString(output.LanguageCode),

--- a/clients/client-proton/protocols/Aws_json1_0.ts
+++ b/clients/client-proton/protocols/Aws_json1_0.ts
@@ -282,7 +282,12 @@ import {
   ValidationException,
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
-import { expectString as __expectString } from "@aws-sdk/smithy-client";
+import {
+  expectNonNull as __expectNonNull,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
+  parseEpochTimestamp as __parseEpochTimestamp,
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   HeaderBag as __HeaderBag,
@@ -6414,7 +6419,7 @@ const deserializeAws_json1_0Environment = (output: any, context: __SerdeContext)
     arn: __expectString(output.arn),
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
-        ? new Date(Math.round(output.createdAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.createdAt)))
         : undefined,
     deploymentStatus: __expectString(output.deploymentStatus),
     deploymentStatusMessage: __expectString(output.deploymentStatusMessage),
@@ -6423,11 +6428,11 @@ const deserializeAws_json1_0Environment = (output: any, context: __SerdeContext)
     environmentAccountId: __expectString(output.environmentAccountId),
     lastDeploymentAttemptedAt:
       output.lastDeploymentAttemptedAt !== undefined && output.lastDeploymentAttemptedAt !== null
-        ? new Date(Math.round(output.lastDeploymentAttemptedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastDeploymentAttemptedAt)))
         : undefined,
     lastDeploymentSucceededAt:
       output.lastDeploymentSucceededAt !== undefined && output.lastDeploymentSucceededAt !== null
-        ? new Date(Math.round(output.lastDeploymentSucceededAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastDeploymentSucceededAt)))
         : undefined,
     name: __expectString(output.name),
     protonServiceRoleArn: __expectString(output.protonServiceRoleArn),
@@ -6450,12 +6455,12 @@ const deserializeAws_json1_0EnvironmentAccountConnection = (
     id: __expectString(output.id),
     lastModifiedAt:
       output.lastModifiedAt !== undefined && output.lastModifiedAt !== null
-        ? new Date(Math.round(output.lastModifiedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastModifiedAt)))
         : undefined,
     managementAccountId: __expectString(output.managementAccountId),
     requestedAt:
       output.requestedAt !== undefined && output.requestedAt !== null
-        ? new Date(Math.round(output.requestedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.requestedAt)))
         : undefined,
     roleArn: __expectString(output.roleArn),
     status: __expectString(output.status),
@@ -6473,12 +6478,12 @@ const deserializeAws_json1_0EnvironmentAccountConnectionSummary = (
     id: __expectString(output.id),
     lastModifiedAt:
       output.lastModifiedAt !== undefined && output.lastModifiedAt !== null
-        ? new Date(Math.round(output.lastModifiedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastModifiedAt)))
         : undefined,
     managementAccountId: __expectString(output.managementAccountId),
     requestedAt:
       output.requestedAt !== undefined && output.requestedAt !== null
-        ? new Date(Math.round(output.requestedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.requestedAt)))
         : undefined,
     roleArn: __expectString(output.roleArn),
     status: __expectString(output.status),
@@ -6504,7 +6509,7 @@ const deserializeAws_json1_0EnvironmentSummary = (output: any, context: __SerdeC
     arn: __expectString(output.arn),
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
-        ? new Date(Math.round(output.createdAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.createdAt)))
         : undefined,
     deploymentStatus: __expectString(output.deploymentStatus),
     deploymentStatusMessage: __expectString(output.deploymentStatusMessage),
@@ -6513,11 +6518,11 @@ const deserializeAws_json1_0EnvironmentSummary = (output: any, context: __SerdeC
     environmentAccountId: __expectString(output.environmentAccountId),
     lastDeploymentAttemptedAt:
       output.lastDeploymentAttemptedAt !== undefined && output.lastDeploymentAttemptedAt !== null
-        ? new Date(Math.round(output.lastDeploymentAttemptedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastDeploymentAttemptedAt)))
         : undefined,
     lastDeploymentSucceededAt:
       output.lastDeploymentSucceededAt !== undefined && output.lastDeploymentSucceededAt !== null
-        ? new Date(Math.round(output.lastDeploymentSucceededAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastDeploymentSucceededAt)))
         : undefined,
     name: __expectString(output.name),
     protonServiceRoleArn: __expectString(output.protonServiceRoleArn),
@@ -6544,14 +6549,14 @@ const deserializeAws_json1_0EnvironmentTemplate = (output: any, context: __Serde
     arn: __expectString(output.arn),
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
-        ? new Date(Math.round(output.createdAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.createdAt)))
         : undefined,
     description: __expectString(output.description),
     displayName: __expectString(output.displayName),
     encryptionKey: __expectString(output.encryptionKey),
     lastModifiedAt:
       output.lastModifiedAt !== undefined && output.lastModifiedAt !== null
-        ? new Date(Math.round(output.lastModifiedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastModifiedAt)))
         : undefined,
     name: __expectString(output.name),
     provisioning: __expectString(output.provisioning),
@@ -6567,13 +6572,13 @@ const deserializeAws_json1_0EnvironmentTemplateSummary = (
     arn: __expectString(output.arn),
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
-        ? new Date(Math.round(output.createdAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.createdAt)))
         : undefined,
     description: __expectString(output.description),
     displayName: __expectString(output.displayName),
     lastModifiedAt:
       output.lastModifiedAt !== undefined && output.lastModifiedAt !== null
-        ? new Date(Math.round(output.lastModifiedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastModifiedAt)))
         : undefined,
     name: __expectString(output.name),
     provisioning: __expectString(output.provisioning),
@@ -6603,12 +6608,12 @@ const deserializeAws_json1_0EnvironmentTemplateVersion = (
     arn: __expectString(output.arn),
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
-        ? new Date(Math.round(output.createdAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.createdAt)))
         : undefined,
     description: __expectString(output.description),
     lastModifiedAt:
       output.lastModifiedAt !== undefined && output.lastModifiedAt !== null
-        ? new Date(Math.round(output.lastModifiedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastModifiedAt)))
         : undefined,
     majorVersion: __expectString(output.majorVersion),
     minorVersion: __expectString(output.minorVersion),
@@ -6628,12 +6633,12 @@ const deserializeAws_json1_0EnvironmentTemplateVersionSummary = (
     arn: __expectString(output.arn),
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
-        ? new Date(Math.round(output.createdAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.createdAt)))
         : undefined,
     description: __expectString(output.description),
     lastModifiedAt:
       output.lastModifiedAt !== undefined && output.lastModifiedAt !== null
-        ? new Date(Math.round(output.lastModifiedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastModifiedAt)))
         : undefined,
     majorVersion: __expectString(output.majorVersion),
     minorVersion: __expectString(output.minorVersion),
@@ -6907,12 +6912,12 @@ const deserializeAws_json1_0Service = (output: any, context: __SerdeContext): Se
     branchName: __expectString(output.branchName),
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
-        ? new Date(Math.round(output.createdAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.createdAt)))
         : undefined,
     description: __expectString(output.description),
     lastModifiedAt:
       output.lastModifiedAt !== undefined && output.lastModifiedAt !== null
-        ? new Date(Math.round(output.lastModifiedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastModifiedAt)))
         : undefined,
     name: __expectString(output.name),
     pipeline:
@@ -6933,18 +6938,18 @@ const deserializeAws_json1_0ServiceInstance = (output: any, context: __SerdeCont
     arn: __expectString(output.arn),
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
-        ? new Date(Math.round(output.createdAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.createdAt)))
         : undefined,
     deploymentStatus: __expectString(output.deploymentStatus),
     deploymentStatusMessage: __expectString(output.deploymentStatusMessage),
     environmentName: __expectString(output.environmentName),
     lastDeploymentAttemptedAt:
       output.lastDeploymentAttemptedAt !== undefined && output.lastDeploymentAttemptedAt !== null
-        ? new Date(Math.round(output.lastDeploymentAttemptedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastDeploymentAttemptedAt)))
         : undefined,
     lastDeploymentSucceededAt:
       output.lastDeploymentSucceededAt !== undefined && output.lastDeploymentSucceededAt !== null
-        ? new Date(Math.round(output.lastDeploymentSucceededAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastDeploymentSucceededAt)))
         : undefined,
     name: __expectString(output.name),
     serviceName: __expectString(output.serviceName),
@@ -6960,18 +6965,18 @@ const deserializeAws_json1_0ServiceInstanceSummary = (output: any, context: __Se
     arn: __expectString(output.arn),
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
-        ? new Date(Math.round(output.createdAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.createdAt)))
         : undefined,
     deploymentStatus: __expectString(output.deploymentStatus),
     deploymentStatusMessage: __expectString(output.deploymentStatusMessage),
     environmentName: __expectString(output.environmentName),
     lastDeploymentAttemptedAt:
       output.lastDeploymentAttemptedAt !== undefined && output.lastDeploymentAttemptedAt !== null
-        ? new Date(Math.round(output.lastDeploymentAttemptedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastDeploymentAttemptedAt)))
         : undefined,
     lastDeploymentSucceededAt:
       output.lastDeploymentSucceededAt !== undefined && output.lastDeploymentSucceededAt !== null
-        ? new Date(Math.round(output.lastDeploymentSucceededAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastDeploymentSucceededAt)))
         : undefined,
     name: __expectString(output.name),
     serviceName: __expectString(output.serviceName),
@@ -7000,17 +7005,17 @@ const deserializeAws_json1_0ServicePipeline = (output: any, context: __SerdeCont
     arn: __expectString(output.arn),
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
-        ? new Date(Math.round(output.createdAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.createdAt)))
         : undefined,
     deploymentStatus: __expectString(output.deploymentStatus),
     deploymentStatusMessage: __expectString(output.deploymentStatusMessage),
     lastDeploymentAttemptedAt:
       output.lastDeploymentAttemptedAt !== undefined && output.lastDeploymentAttemptedAt !== null
-        ? new Date(Math.round(output.lastDeploymentAttemptedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastDeploymentAttemptedAt)))
         : undefined,
     lastDeploymentSucceededAt:
       output.lastDeploymentSucceededAt !== undefined && output.lastDeploymentSucceededAt !== null
-        ? new Date(Math.round(output.lastDeploymentSucceededAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastDeploymentSucceededAt)))
         : undefined,
     spec: __expectString(output.spec),
     templateMajorVersion: __expectString(output.templateMajorVersion),
@@ -7033,12 +7038,12 @@ const deserializeAws_json1_0ServiceSummary = (output: any, context: __SerdeConte
     arn: __expectString(output.arn),
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
-        ? new Date(Math.round(output.createdAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.createdAt)))
         : undefined,
     description: __expectString(output.description),
     lastModifiedAt:
       output.lastModifiedAt !== undefined && output.lastModifiedAt !== null
-        ? new Date(Math.round(output.lastModifiedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastModifiedAt)))
         : undefined,
     name: __expectString(output.name),
     status: __expectString(output.status),
@@ -7063,14 +7068,14 @@ const deserializeAws_json1_0ServiceTemplate = (output: any, context: __SerdeCont
     arn: __expectString(output.arn),
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
-        ? new Date(Math.round(output.createdAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.createdAt)))
         : undefined,
     description: __expectString(output.description),
     displayName: __expectString(output.displayName),
     encryptionKey: __expectString(output.encryptionKey),
     lastModifiedAt:
       output.lastModifiedAt !== undefined && output.lastModifiedAt !== null
-        ? new Date(Math.round(output.lastModifiedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastModifiedAt)))
         : undefined,
     name: __expectString(output.name),
     pipelineProvisioning: __expectString(output.pipelineProvisioning),
@@ -7083,13 +7088,13 @@ const deserializeAws_json1_0ServiceTemplateSummary = (output: any, context: __Se
     arn: __expectString(output.arn),
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
-        ? new Date(Math.round(output.createdAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.createdAt)))
         : undefined,
     description: __expectString(output.description),
     displayName: __expectString(output.displayName),
     lastModifiedAt:
       output.lastModifiedAt !== undefined && output.lastModifiedAt !== null
-        ? new Date(Math.round(output.lastModifiedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastModifiedAt)))
         : undefined,
     name: __expectString(output.name),
     pipelineProvisioning: __expectString(output.pipelineProvisioning),
@@ -7120,12 +7125,12 @@ const deserializeAws_json1_0ServiceTemplateVersion = (output: any, context: __Se
         : undefined,
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
-        ? new Date(Math.round(output.createdAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.createdAt)))
         : undefined,
     description: __expectString(output.description),
     lastModifiedAt:
       output.lastModifiedAt !== undefined && output.lastModifiedAt !== null
-        ? new Date(Math.round(output.lastModifiedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastModifiedAt)))
         : undefined,
     majorVersion: __expectString(output.majorVersion),
     minorVersion: __expectString(output.minorVersion),
@@ -7145,12 +7150,12 @@ const deserializeAws_json1_0ServiceTemplateVersionSummary = (
     arn: __expectString(output.arn),
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
-        ? new Date(Math.round(output.createdAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.createdAt)))
         : undefined,
     description: __expectString(output.description),
     lastModifiedAt:
       output.lastModifiedAt !== undefined && output.lastModifiedAt !== null
-        ? new Date(Math.round(output.lastModifiedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastModifiedAt)))
         : undefined,
     majorVersion: __expectString(output.majorVersion),
     minorVersion: __expectString(output.minorVersion),

--- a/clients/client-qldb/protocols/Aws_restJson1.ts
+++ b/clients/client-qldb/protocols/Aws_restJson1.ts
@@ -65,9 +65,11 @@ import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@a
 import {
   expectBoolean as __expectBoolean,
   expectNonNull as __expectNonNull,
+  expectNumber as __expectNumber,
   expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
+  parseEpochTimestamp as __parseEpochTimestamp,
 } from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
@@ -849,7 +851,7 @@ export const deserializeAws_restJson1CreateLedgerCommand = async (
     contents.Arn = __expectString(data.Arn);
   }
   if (data.CreationDateTime !== undefined && data.CreationDateTime !== null) {
-    contents.CreationDateTime = new Date(Math.round(data.CreationDateTime * 1000));
+    contents.CreationDateTime = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.CreationDateTime)));
   }
   if (data.DeletionProtection !== undefined && data.DeletionProtection !== null) {
     contents.DeletionProtection = __expectBoolean(data.DeletionProtection);
@@ -1153,7 +1155,7 @@ export const deserializeAws_restJson1DescribeLedgerCommand = async (
     contents.Arn = __expectString(data.Arn);
   }
   if (data.CreationDateTime !== undefined && data.CreationDateTime !== null) {
-    contents.CreationDateTime = new Date(Math.round(data.CreationDateTime * 1000));
+    contents.CreationDateTime = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.CreationDateTime)));
   }
   if (data.DeletionProtection !== undefined && data.DeletionProtection !== null) {
     contents.DeletionProtection = __expectBoolean(data.DeletionProtection);
@@ -2010,7 +2012,7 @@ export const deserializeAws_restJson1UpdateLedgerCommand = async (
     contents.Arn = __expectString(data.Arn);
   }
   if (data.CreationDateTime !== undefined && data.CreationDateTime !== null) {
-    contents.CreationDateTime = new Date(Math.round(data.CreationDateTime * 1000));
+    contents.CreationDateTime = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.CreationDateTime)));
   }
   if (data.DeletionProtection !== undefined && data.DeletionProtection !== null) {
     contents.DeletionProtection = __expectBoolean(data.DeletionProtection);
@@ -2347,16 +2349,16 @@ const deserializeAws_restJson1JournalKinesisStreamDescription = (
     Arn: __expectString(output.Arn),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     ErrorCause: __expectString(output.ErrorCause),
     ExclusiveEndTime:
       output.ExclusiveEndTime !== undefined && output.ExclusiveEndTime !== null
-        ? new Date(Math.round(output.ExclusiveEndTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.ExclusiveEndTime)))
         : undefined,
     InclusiveStartTime:
       output.InclusiveStartTime !== undefined && output.InclusiveStartTime !== null
-        ? new Date(Math.round(output.InclusiveStartTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.InclusiveStartTime)))
         : undefined,
     KinesisConfiguration:
       output.KinesisConfiguration !== undefined && output.KinesisConfiguration !== null
@@ -2391,16 +2393,16 @@ const deserializeAws_restJson1JournalS3ExportDescription = (
   return {
     ExclusiveEndTime:
       output.ExclusiveEndTime !== undefined && output.ExclusiveEndTime !== null
-        ? new Date(Math.round(output.ExclusiveEndTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.ExclusiveEndTime)))
         : undefined,
     ExportCreationTime:
       output.ExportCreationTime !== undefined && output.ExportCreationTime !== null
-        ? new Date(Math.round(output.ExportCreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.ExportCreationTime)))
         : undefined,
     ExportId: __expectString(output.ExportId),
     InclusiveStartTime:
       output.InclusiveStartTime !== undefined && output.InclusiveStartTime !== null
-        ? new Date(Math.round(output.InclusiveStartTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.InclusiveStartTime)))
         : undefined,
     LedgerName: __expectString(output.LedgerName),
     RoleArn: __expectString(output.RoleArn),
@@ -2441,7 +2443,7 @@ const deserializeAws_restJson1LedgerEncryptionDescription = (
     EncryptionStatus: __expectString(output.EncryptionStatus),
     InaccessibleKmsKeyDateTime:
       output.InaccessibleKmsKeyDateTime !== undefined && output.InaccessibleKmsKeyDateTime !== null
-        ? new Date(Math.round(output.InaccessibleKmsKeyDateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.InaccessibleKmsKeyDateTime)))
         : undefined,
     KmsKeyArn: __expectString(output.KmsKeyArn),
   } as any;
@@ -2462,7 +2464,7 @@ const deserializeAws_restJson1LedgerSummary = (output: any, context: __SerdeCont
   return {
     CreationDateTime:
       output.CreationDateTime !== undefined && output.CreationDateTime !== null
-        ? new Date(Math.round(output.CreationDateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationDateTime)))
         : undefined,
     Name: __expectString(output.Name),
     State: __expectString(output.State),

--- a/clients/client-quicksight/protocols/Aws_restJson1.ts
+++ b/clients/client-quicksight/protocols/Aws_restJson1.ts
@@ -416,9 +416,11 @@ import {
   expectInt32 as __expectInt32,
   expectLong as __expectLong,
   expectNonNull as __expectNonNull,
+  expectNumber as __expectNumber,
   expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
+  parseEpochTimestamp as __parseEpochTimestamp,
   serializeFloat as __serializeFloat,
 } from "@aws-sdk/smithy-client";
 import {
@@ -7892,7 +7894,7 @@ export const deserializeAws_restJson1DeleteAnalysisCommand = async (
     contents.Arn = __expectString(data.Arn);
   }
   if (data.DeletionTime !== undefined && data.DeletionTime !== null) {
-    contents.DeletionTime = new Date(Math.round(data.DeletionTime * 1000));
+    contents.DeletionTime = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.DeletionTime)));
   }
   if (data.RequestId !== undefined && data.RequestId !== null) {
     contents.RequestId = __expectString(data.RequestId);
@@ -20192,7 +20194,7 @@ const deserializeAws_restJson1Analysis = (output: any, context: __SerdeContext):
     Arn: __expectString(output.Arn),
     CreatedTime:
       output.CreatedTime !== undefined && output.CreatedTime !== null
-        ? new Date(Math.round(output.CreatedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreatedTime)))
         : undefined,
     DataSetArns:
       output.DataSetArns !== undefined && output.DataSetArns !== null
@@ -20204,7 +20206,7 @@ const deserializeAws_restJson1Analysis = (output: any, context: __SerdeContext):
         : undefined,
     LastUpdatedTime:
       output.LastUpdatedTime !== undefined && output.LastUpdatedTime !== null
-        ? new Date(Math.round(output.LastUpdatedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastUpdatedTime)))
         : undefined,
     Name: __expectString(output.Name),
     Sheets:
@@ -20240,11 +20242,11 @@ const deserializeAws_restJson1AnalysisSummary = (output: any, context: __SerdeCo
     Arn: __expectString(output.Arn),
     CreatedTime:
       output.CreatedTime !== undefined && output.CreatedTime !== null
-        ? new Date(Math.round(output.CreatedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreatedTime)))
         : undefined,
     LastUpdatedTime:
       output.LastUpdatedTime !== undefined && output.LastUpdatedTime !== null
-        ? new Date(Math.round(output.LastUpdatedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastUpdatedTime)))
         : undefined,
     Name: __expectString(output.Name),
     Status: __expectString(output.Status),
@@ -20545,16 +20547,16 @@ const deserializeAws_restJson1Dashboard = (output: any, context: __SerdeContext)
     Arn: __expectString(output.Arn),
     CreatedTime:
       output.CreatedTime !== undefined && output.CreatedTime !== null
-        ? new Date(Math.round(output.CreatedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreatedTime)))
         : undefined,
     DashboardId: __expectString(output.DashboardId),
     LastPublishedTime:
       output.LastPublishedTime !== undefined && output.LastPublishedTime !== null
-        ? new Date(Math.round(output.LastPublishedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastPublishedTime)))
         : undefined,
     LastUpdatedTime:
       output.LastUpdatedTime !== undefined && output.LastUpdatedTime !== null
-        ? new Date(Math.round(output.LastUpdatedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastUpdatedTime)))
         : undefined,
     Name: __expectString(output.Name),
     Version:
@@ -20587,16 +20589,16 @@ const deserializeAws_restJson1DashboardSummary = (output: any, context: __SerdeC
     Arn: __expectString(output.Arn),
     CreatedTime:
       output.CreatedTime !== undefined && output.CreatedTime !== null
-        ? new Date(Math.round(output.CreatedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreatedTime)))
         : undefined,
     DashboardId: __expectString(output.DashboardId),
     LastPublishedTime:
       output.LastPublishedTime !== undefined && output.LastPublishedTime !== null
-        ? new Date(Math.round(output.LastPublishedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastPublishedTime)))
         : undefined,
     LastUpdatedTime:
       output.LastUpdatedTime !== undefined && output.LastUpdatedTime !== null
-        ? new Date(Math.round(output.LastUpdatedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastUpdatedTime)))
         : undefined,
     Name: __expectString(output.Name),
     PublishedVersionNumber: __expectLong(output.PublishedVersionNumber),
@@ -20619,7 +20621,7 @@ const deserializeAws_restJson1DashboardVersion = (output: any, context: __SerdeC
     Arn: __expectString(output.Arn),
     CreatedTime:
       output.CreatedTime !== undefined && output.CreatedTime !== null
-        ? new Date(Math.round(output.CreatedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreatedTime)))
         : undefined,
     DataSetArns:
       output.DataSetArns !== undefined && output.DataSetArns !== null
@@ -20649,7 +20651,7 @@ const deserializeAws_restJson1DashboardVersionSummary = (
     Arn: __expectString(output.Arn),
     CreatedTime:
       output.CreatedTime !== undefined && output.CreatedTime !== null
-        ? new Date(Math.round(output.CreatedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreatedTime)))
         : undefined,
     Description: __expectString(output.Description),
     SourceEntityArn: __expectString(output.SourceEntityArn),
@@ -20700,7 +20702,7 @@ const deserializeAws_restJson1DataSet = (output: any, context: __SerdeContext): 
     ConsumedSpiceCapacityInBytes: __expectLong(output.ConsumedSpiceCapacityInBytes),
     CreatedTime:
       output.CreatedTime !== undefined && output.CreatedTime !== null
-        ? new Date(Math.round(output.CreatedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreatedTime)))
         : undefined,
     DataSetId: __expectString(output.DataSetId),
     DataSetUsageConfiguration:
@@ -20714,7 +20716,7 @@ const deserializeAws_restJson1DataSet = (output: any, context: __SerdeContext): 
     ImportMode: __expectString(output.ImportMode),
     LastUpdatedTime:
       output.LastUpdatedTime !== undefined && output.LastUpdatedTime !== null
-        ? new Date(Math.round(output.LastUpdatedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastUpdatedTime)))
         : undefined,
     LogicalTableMap:
       output.LogicalTableMap !== undefined && output.LogicalTableMap !== null
@@ -20794,13 +20796,13 @@ const deserializeAws_restJson1DataSetSummary = (output: any, context: __SerdeCon
     ColumnLevelPermissionRulesApplied: __expectBoolean(output.ColumnLevelPermissionRulesApplied),
     CreatedTime:
       output.CreatedTime !== undefined && output.CreatedTime !== null
-        ? new Date(Math.round(output.CreatedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreatedTime)))
         : undefined,
     DataSetId: __expectString(output.DataSetId),
     ImportMode: __expectString(output.ImportMode),
     LastUpdatedTime:
       output.LastUpdatedTime !== undefined && output.LastUpdatedTime !== null
-        ? new Date(Math.round(output.LastUpdatedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastUpdatedTime)))
         : undefined,
     Name: __expectString(output.Name),
     RowLevelPermissionDataSet:
@@ -20841,7 +20843,7 @@ const deserializeAws_restJson1DataSource = (output: any, context: __SerdeContext
     Arn: __expectString(output.Arn),
     CreatedTime:
       output.CreatedTime !== undefined && output.CreatedTime !== null
-        ? new Date(Math.round(output.CreatedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreatedTime)))
         : undefined,
     DataSourceId: __expectString(output.DataSourceId),
     DataSourceParameters:
@@ -20854,7 +20856,7 @@ const deserializeAws_restJson1DataSource = (output: any, context: __SerdeContext
         : undefined,
     LastUpdatedTime:
       output.LastUpdatedTime !== undefined && output.LastUpdatedTime !== null
-        ? new Date(Math.round(output.LastUpdatedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastUpdatedTime)))
         : undefined,
     Name: __expectString(output.Name),
     SslProperties:
@@ -21058,7 +21060,7 @@ const deserializeAws_restJson1Folder = (output: any, context: __SerdeContext): F
     Arn: __expectString(output.Arn),
     CreatedTime:
       output.CreatedTime !== undefined && output.CreatedTime !== null
-        ? new Date(Math.round(output.CreatedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreatedTime)))
         : undefined,
     FolderId: __expectString(output.FolderId),
     FolderPath:
@@ -21068,7 +21070,7 @@ const deserializeAws_restJson1Folder = (output: any, context: __SerdeContext): F
     FolderType: __expectString(output.FolderType),
     LastUpdatedTime:
       output.LastUpdatedTime !== undefined && output.LastUpdatedTime !== null
-        ? new Date(Math.round(output.LastUpdatedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastUpdatedTime)))
         : undefined,
     Name: __expectString(output.Name),
   } as any;
@@ -21108,13 +21110,13 @@ const deserializeAws_restJson1FolderSummary = (output: any, context: __SerdeCont
     Arn: __expectString(output.Arn),
     CreatedTime:
       output.CreatedTime !== undefined && output.CreatedTime !== null
-        ? new Date(Math.round(output.CreatedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreatedTime)))
         : undefined,
     FolderId: __expectString(output.FolderId),
     FolderType: __expectString(output.FolderType),
     LastUpdatedTime:
       output.LastUpdatedTime !== undefined && output.LastUpdatedTime !== null
-        ? new Date(Math.round(output.LastUpdatedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastUpdatedTime)))
         : undefined,
     Name: __expectString(output.Name),
   } as any;
@@ -21252,7 +21254,7 @@ const deserializeAws_restJson1Ingestion = (output: any, context: __SerdeContext)
     Arn: __expectString(output.Arn),
     CreatedTime:
       output.CreatedTime !== undefined && output.CreatedTime !== null
-        ? new Date(Math.round(output.CreatedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreatedTime)))
         : undefined,
     ErrorInfo:
       output.ErrorInfo !== undefined && output.ErrorInfo !== null
@@ -21805,11 +21807,11 @@ const deserializeAws_restJson1Template = (output: any, context: __SerdeContext):
     Arn: __expectString(output.Arn),
     CreatedTime:
       output.CreatedTime !== undefined && output.CreatedTime !== null
-        ? new Date(Math.round(output.CreatedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreatedTime)))
         : undefined,
     LastUpdatedTime:
       output.LastUpdatedTime !== undefined && output.LastUpdatedTime !== null
-        ? new Date(Math.round(output.LastUpdatedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastUpdatedTime)))
         : undefined,
     Name: __expectString(output.Name),
     TemplateId: __expectString(output.TemplateId),
@@ -21862,11 +21864,11 @@ const deserializeAws_restJson1TemplateSummary = (output: any, context: __SerdeCo
     Arn: __expectString(output.Arn),
     CreatedTime:
       output.CreatedTime !== undefined && output.CreatedTime !== null
-        ? new Date(Math.round(output.CreatedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreatedTime)))
         : undefined,
     LastUpdatedTime:
       output.LastUpdatedTime !== undefined && output.LastUpdatedTime !== null
-        ? new Date(Math.round(output.LastUpdatedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastUpdatedTime)))
         : undefined,
     LatestVersionNumber: __expectLong(output.LatestVersionNumber),
     Name: __expectString(output.Name),
@@ -21889,7 +21891,7 @@ const deserializeAws_restJson1TemplateVersion = (output: any, context: __SerdeCo
   return {
     CreatedTime:
       output.CreatedTime !== undefined && output.CreatedTime !== null
-        ? new Date(Math.round(output.CreatedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreatedTime)))
         : undefined,
     DataSetConfigurations:
       output.DataSetConfigurations !== undefined && output.DataSetConfigurations !== null
@@ -21919,7 +21921,7 @@ const deserializeAws_restJson1TemplateVersionSummary = (
     Arn: __expectString(output.Arn),
     CreatedTime:
       output.CreatedTime !== undefined && output.CreatedTime !== null
-        ? new Date(Math.round(output.CreatedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreatedTime)))
         : undefined,
     Description: __expectString(output.Description),
     Status: __expectString(output.Status),
@@ -21954,11 +21956,11 @@ const deserializeAws_restJson1Theme = (output: any, context: __SerdeContext): Th
     Arn: __expectString(output.Arn),
     CreatedTime:
       output.CreatedTime !== undefined && output.CreatedTime !== null
-        ? new Date(Math.round(output.CreatedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreatedTime)))
         : undefined,
     LastUpdatedTime:
       output.LastUpdatedTime !== undefined && output.LastUpdatedTime !== null
-        ? new Date(Math.round(output.LastUpdatedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastUpdatedTime)))
         : undefined,
     Name: __expectString(output.Name),
     ThemeId: __expectString(output.ThemeId),
@@ -22029,11 +22031,11 @@ const deserializeAws_restJson1ThemeSummary = (output: any, context: __SerdeConte
     Arn: __expectString(output.Arn),
     CreatedTime:
       output.CreatedTime !== undefined && output.CreatedTime !== null
-        ? new Date(Math.round(output.CreatedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreatedTime)))
         : undefined,
     LastUpdatedTime:
       output.LastUpdatedTime !== undefined && output.LastUpdatedTime !== null
-        ? new Date(Math.round(output.LastUpdatedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastUpdatedTime)))
         : undefined,
     LatestVersionNumber: __expectLong(output.LatestVersionNumber),
     Name: __expectString(output.Name),
@@ -22062,7 +22064,7 @@ const deserializeAws_restJson1ThemeVersion = (output: any, context: __SerdeConte
         : undefined,
     CreatedTime:
       output.CreatedTime !== undefined && output.CreatedTime !== null
-        ? new Date(Math.round(output.CreatedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreatedTime)))
         : undefined,
     Description: __expectString(output.Description),
     Errors:
@@ -22079,7 +22081,7 @@ const deserializeAws_restJson1ThemeVersionSummary = (output: any, context: __Ser
     Arn: __expectString(output.Arn),
     CreatedTime:
       output.CreatedTime !== undefined && output.CreatedTime !== null
-        ? new Date(Math.round(output.CreatedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreatedTime)))
         : undefined,
     Description: __expectString(output.Description),
     Status: __expectString(output.Status),

--- a/clients/client-ram/protocols/Aws_restJson1.ts
+++ b/clients/client-ram/protocols/Aws_restJson1.ts
@@ -107,9 +107,11 @@ import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@a
 import {
   expectBoolean as __expectBoolean,
   expectNonNull as __expectNonNull,
+  expectNumber as __expectNumber,
   expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
+  parseEpochTimestamp as __parseEpochTimestamp,
 } from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
@@ -3971,13 +3973,13 @@ const deserializeAws_restJson1Principal = (output: any, context: __SerdeContext)
   return {
     creationTime:
       output.creationTime !== undefined && output.creationTime !== null
-        ? new Date(Math.round(output.creationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.creationTime)))
         : undefined,
     external: __expectBoolean(output.external),
     id: __expectString(output.id),
     lastUpdatedTime:
       output.lastUpdatedTime !== undefined && output.lastUpdatedTime !== null
-        ? new Date(Math.round(output.lastUpdatedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastUpdatedTime)))
         : undefined,
     resourceShareArn: __expectString(output.resourceShareArn),
   } as any;
@@ -3999,11 +4001,11 @@ const deserializeAws_restJson1Resource = (output: any, context: __SerdeContext):
     arn: __expectString(output.arn),
     creationTime:
       output.creationTime !== undefined && output.creationTime !== null
-        ? new Date(Math.round(output.creationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.creationTime)))
         : undefined,
     lastUpdatedTime:
       output.lastUpdatedTime !== undefined && output.lastUpdatedTime !== null
-        ? new Date(Math.round(output.lastUpdatedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastUpdatedTime)))
         : undefined,
     resourceGroupArn: __expectString(output.resourceGroupArn),
     resourceShareArn: __expectString(output.resourceShareArn),
@@ -4029,12 +4031,12 @@ const deserializeAws_restJson1ResourceShare = (output: any, context: __SerdeCont
     allowExternalPrincipals: __expectBoolean(output.allowExternalPrincipals),
     creationTime:
       output.creationTime !== undefined && output.creationTime !== null
-        ? new Date(Math.round(output.creationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.creationTime)))
         : undefined,
     featureSet: __expectString(output.featureSet),
     lastUpdatedTime:
       output.lastUpdatedTime !== undefined && output.lastUpdatedTime !== null
-        ? new Date(Math.round(output.lastUpdatedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastUpdatedTime)))
         : undefined,
     name: __expectString(output.name),
     owningAccountId: __expectString(output.owningAccountId),
@@ -4057,12 +4059,12 @@ const deserializeAws_restJson1ResourceShareAssociation = (
     associationType: __expectString(output.associationType),
     creationTime:
       output.creationTime !== undefined && output.creationTime !== null
-        ? new Date(Math.round(output.creationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.creationTime)))
         : undefined,
     external: __expectBoolean(output.external),
     lastUpdatedTime:
       output.lastUpdatedTime !== undefined && output.lastUpdatedTime !== null
-        ? new Date(Math.round(output.lastUpdatedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastUpdatedTime)))
         : undefined,
     resourceShareArn: __expectString(output.resourceShareArn),
     resourceShareName: __expectString(output.resourceShareName),
@@ -4092,7 +4094,7 @@ const deserializeAws_restJson1ResourceShareInvitation = (
   return {
     invitationTimestamp:
       output.invitationTimestamp !== undefined && output.invitationTimestamp !== null
-        ? new Date(Math.round(output.invitationTimestamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.invitationTimestamp)))
         : undefined,
     receiverAccountId: __expectString(output.receiverAccountId),
     receiverArn: __expectString(output.receiverArn),
@@ -4141,13 +4143,13 @@ const deserializeAws_restJson1ResourceSharePermissionDetail = (
     arn: __expectString(output.arn),
     creationTime:
       output.creationTime !== undefined && output.creationTime !== null
-        ? new Date(Math.round(output.creationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.creationTime)))
         : undefined,
     defaultVersion: __expectBoolean(output.defaultVersion),
     isResourceTypeDefault: __expectBoolean(output.isResourceTypeDefault),
     lastUpdatedTime:
       output.lastUpdatedTime !== undefined && output.lastUpdatedTime !== null
-        ? new Date(Math.round(output.lastUpdatedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastUpdatedTime)))
         : undefined,
     name: __expectString(output.name),
     permission: __expectString(output.permission),
@@ -4178,13 +4180,13 @@ const deserializeAws_restJson1ResourceSharePermissionSummary = (
     arn: __expectString(output.arn),
     creationTime:
       output.creationTime !== undefined && output.creationTime !== null
-        ? new Date(Math.round(output.creationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.creationTime)))
         : undefined,
     defaultVersion: __expectBoolean(output.defaultVersion),
     isResourceTypeDefault: __expectBoolean(output.isResourceTypeDefault),
     lastUpdatedTime:
       output.lastUpdatedTime !== undefined && output.lastUpdatedTime !== null
-        ? new Date(Math.round(output.lastUpdatedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastUpdatedTime)))
         : undefined,
     name: __expectString(output.name),
     resourceType: __expectString(output.resourceType),

--- a/clients/client-rds/protocols/Aws_query.ts
+++ b/clients/client-rds/protocols/Aws_query.ts
@@ -908,11 +908,13 @@ import {
 } from "../models/models_1";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
+  expectNonNull as __expectNonNull,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   getArrayIfSingleItem as __getArrayIfSingleItem,
   getValueFromTextNode as __getValueFromTextNode,
   parseBoolean as __parseBoolean,
+  parseRfc3339DateTime as __parseRfc3339DateTime,
   strictParseFloat as __strictParseFloat,
   strictParseInt32 as __strictParseInt32,
   strictParseLong as __strictParseLong,
@@ -20303,10 +20305,10 @@ const deserializeAws_queryCertificate = (output: any, context: __SerdeContext): 
     contents.Thumbprint = __expectString(output["Thumbprint"]);
   }
   if (output["ValidFrom"] !== undefined) {
-    contents.ValidFrom = new Date(output["ValidFrom"]);
+    contents.ValidFrom = __expectNonNull(__parseRfc3339DateTime(output["ValidFrom"]));
   }
   if (output["ValidTill"] !== undefined) {
-    contents.ValidTill = new Date(output["ValidTill"]);
+    contents.ValidTill = __expectNonNull(__parseRfc3339DateTime(output["ValidTill"]));
   }
   if (output["CertificateArn"] !== undefined) {
     contents.CertificateArn = __expectString(output["CertificateArn"]);
@@ -20315,7 +20317,7 @@ const deserializeAws_queryCertificate = (output: any, context: __SerdeContext): 
     contents.CustomerOverride = __parseBoolean(output["CustomerOverride"]);
   }
   if (output["CustomerOverrideValidTill"] !== undefined) {
-    contents.CustomerOverrideValidTill = new Date(output["CustomerOverrideValidTill"]);
+    contents.CustomerOverrideValidTill = __expectNonNull(__parseRfc3339DateTime(output["CustomerOverrideValidTill"]));
   }
   return contents;
 };
@@ -20888,13 +20890,13 @@ const deserializeAws_queryDBCluster = (output: any, context: __SerdeContext): DB
     contents.Status = __expectString(output["Status"]);
   }
   if (output["AutomaticRestartTime"] !== undefined) {
-    contents.AutomaticRestartTime = new Date(output["AutomaticRestartTime"]);
+    contents.AutomaticRestartTime = __expectNonNull(__parseRfc3339DateTime(output["AutomaticRestartTime"]));
   }
   if (output["PercentProgress"] !== undefined) {
     contents.PercentProgress = __expectString(output["PercentProgress"]);
   }
   if (output["EarliestRestorableTime"] !== undefined) {
-    contents.EarliestRestorableTime = new Date(output["EarliestRestorableTime"]);
+    contents.EarliestRestorableTime = __expectNonNull(__parseRfc3339DateTime(output["EarliestRestorableTime"]));
   }
   if (output["Endpoint"] !== undefined) {
     contents.Endpoint = __expectString(output["Endpoint"]);
@@ -20921,7 +20923,7 @@ const deserializeAws_queryDBCluster = (output: any, context: __SerdeContext): DB
     contents.EngineVersion = __expectString(output["EngineVersion"]);
   }
   if (output["LatestRestorableTime"] !== undefined) {
-    contents.LatestRestorableTime = new Date(output["LatestRestorableTime"]);
+    contents.LatestRestorableTime = __expectNonNull(__parseRfc3339DateTime(output["LatestRestorableTime"]));
   }
   if (output["Port"] !== undefined) {
     contents.Port = __strictParseInt32(output["Port"]) as number;
@@ -21014,10 +21016,10 @@ const deserializeAws_queryDBCluster = (output: any, context: __SerdeContext): DB
     contents.CloneGroupId = __expectString(output["CloneGroupId"]);
   }
   if (output["ClusterCreateTime"] !== undefined) {
-    contents.ClusterCreateTime = new Date(output["ClusterCreateTime"]);
+    contents.ClusterCreateTime = __expectNonNull(__parseRfc3339DateTime(output["ClusterCreateTime"]));
   }
   if (output["EarliestBacktrackTime"] !== undefined) {
-    contents.EarliestBacktrackTime = new Date(output["EarliestBacktrackTime"]);
+    contents.EarliestBacktrackTime = __expectNonNull(__parseRfc3339DateTime(output["EarliestBacktrackTime"]));
   }
   if (output["BacktrackWindow"] !== undefined) {
     contents.BacktrackWindow = __strictParseLong(output["BacktrackWindow"]) as number;
@@ -21132,13 +21134,15 @@ const deserializeAws_queryDBClusterBacktrack = (output: any, context: __SerdeCon
     contents.BacktrackIdentifier = __expectString(output["BacktrackIdentifier"]);
   }
   if (output["BacktrackTo"] !== undefined) {
-    contents.BacktrackTo = new Date(output["BacktrackTo"]);
+    contents.BacktrackTo = __expectNonNull(__parseRfc3339DateTime(output["BacktrackTo"]));
   }
   if (output["BacktrackedFrom"] !== undefined) {
-    contents.BacktrackedFrom = new Date(output["BacktrackedFrom"]);
+    contents.BacktrackedFrom = __expectNonNull(__parseRfc3339DateTime(output["BacktrackedFrom"]));
   }
   if (output["BacktrackRequestCreationTime"] !== undefined) {
-    contents.BacktrackRequestCreationTime = new Date(output["BacktrackRequestCreationTime"]);
+    contents.BacktrackRequestCreationTime = __expectNonNull(
+      __parseRfc3339DateTime(output["BacktrackRequestCreationTime"])
+    );
   }
   if (output["Status"] !== undefined) {
     contents.Status = __expectString(output["Status"]);
@@ -21694,7 +21698,7 @@ const deserializeAws_queryDBClusterSnapshot = (output: any, context: __SerdeCont
     contents.DBClusterIdentifier = __expectString(output["DBClusterIdentifier"]);
   }
   if (output["SnapshotCreateTime"] !== undefined) {
-    contents.SnapshotCreateTime = new Date(output["SnapshotCreateTime"]);
+    contents.SnapshotCreateTime = __expectNonNull(__parseRfc3339DateTime(output["SnapshotCreateTime"]));
   }
   if (output["Engine"] !== undefined) {
     contents.Engine = __expectString(output["Engine"]);
@@ -21715,7 +21719,7 @@ const deserializeAws_queryDBClusterSnapshot = (output: any, context: __SerdeCont
     contents.VpcId = __expectString(output["VpcId"]);
   }
   if (output["ClusterCreateTime"] !== undefined) {
-    contents.ClusterCreateTime = new Date(output["ClusterCreateTime"]);
+    contents.ClusterCreateTime = __expectNonNull(__parseRfc3339DateTime(output["ClusterCreateTime"]));
   }
   if (output["MasterUsername"] !== undefined) {
     contents.MasterUsername = __expectString(output["MasterUsername"]);
@@ -22122,7 +22126,7 @@ const deserializeAws_queryDBInstance = (output: any, context: __SerdeContext): D
     contents.DBInstanceStatus = __expectString(output["DBInstanceStatus"]);
   }
   if (output["AutomaticRestartTime"] !== undefined) {
-    contents.AutomaticRestartTime = new Date(output["AutomaticRestartTime"]);
+    contents.AutomaticRestartTime = __expectNonNull(__parseRfc3339DateTime(output["AutomaticRestartTime"]));
   }
   if (output["MasterUsername"] !== undefined) {
     contents.MasterUsername = __expectString(output["MasterUsername"]);
@@ -22137,7 +22141,7 @@ const deserializeAws_queryDBInstance = (output: any, context: __SerdeContext): D
     contents.AllocatedStorage = __strictParseInt32(output["AllocatedStorage"]) as number;
   }
   if (output["InstanceCreateTime"] !== undefined) {
-    contents.InstanceCreateTime = new Date(output["InstanceCreateTime"]);
+    contents.InstanceCreateTime = __expectNonNull(__parseRfc3339DateTime(output["InstanceCreateTime"]));
   }
   if (output["PreferredBackupWindow"] !== undefined) {
     contents.PreferredBackupWindow = __expectString(output["PreferredBackupWindow"]);
@@ -22191,7 +22195,7 @@ const deserializeAws_queryDBInstance = (output: any, context: __SerdeContext): D
     );
   }
   if (output["LatestRestorableTime"] !== undefined) {
-    contents.LatestRestorableTime = new Date(output["LatestRestorableTime"]);
+    contents.LatestRestorableTime = __expectNonNull(__parseRfc3339DateTime(output["LatestRestorableTime"]));
   }
   if (output["MultiAZ"] !== undefined) {
     contents.MultiAZ = __parseBoolean(output["MultiAZ"]);
@@ -22498,7 +22502,7 @@ const deserializeAws_queryDBInstanceAutomatedBackup = (
     contents.VpcId = __expectString(output["VpcId"]);
   }
   if (output["InstanceCreateTime"] !== undefined) {
-    contents.InstanceCreateTime = new Date(output["InstanceCreateTime"]);
+    contents.InstanceCreateTime = __expectNonNull(__parseRfc3339DateTime(output["InstanceCreateTime"]));
   }
   if (output["MasterUsername"] !== undefined) {
     contents.MasterUsername = __expectString(output["MasterUsername"]);
@@ -23034,10 +23038,10 @@ const deserializeAws_queryDBProxy = (output: any, context: __SerdeContext): DBPr
     contents.DebugLogging = __parseBoolean(output["DebugLogging"]);
   }
   if (output["CreatedDate"] !== undefined) {
-    contents.CreatedDate = new Date(output["CreatedDate"]);
+    contents.CreatedDate = __expectNonNull(__parseRfc3339DateTime(output["CreatedDate"]));
   }
   if (output["UpdatedDate"] !== undefined) {
-    contents.UpdatedDate = new Date(output["UpdatedDate"]);
+    contents.UpdatedDate = __expectNonNull(__parseRfc3339DateTime(output["UpdatedDate"]));
   }
   return contents;
 };
@@ -23106,7 +23110,7 @@ const deserializeAws_queryDBProxyEndpoint = (output: any, context: __SerdeContex
     contents.Endpoint = __expectString(output["Endpoint"]);
   }
   if (output["CreatedDate"] !== undefined) {
-    contents.CreatedDate = new Date(output["CreatedDate"]);
+    contents.CreatedDate = __expectNonNull(__parseRfc3339DateTime(output["CreatedDate"]));
   }
   if (output["TargetRole"] !== undefined) {
     contents.TargetRole = __expectString(output["TargetRole"]);
@@ -23285,10 +23289,10 @@ const deserializeAws_queryDBProxyTargetGroup = (output: any, context: __SerdeCon
     );
   }
   if (output["CreatedDate"] !== undefined) {
-    contents.CreatedDate = new Date(output["CreatedDate"]);
+    contents.CreatedDate = __expectNonNull(__parseRfc3339DateTime(output["CreatedDate"]));
   }
   if (output["UpdatedDate"] !== undefined) {
-    contents.UpdatedDate = new Date(output["UpdatedDate"]);
+    contents.UpdatedDate = __expectNonNull(__parseRfc3339DateTime(output["UpdatedDate"]));
   }
   return contents;
 };
@@ -23516,7 +23520,7 @@ const deserializeAws_queryDBSnapshot = (output: any, context: __SerdeContext): D
     contents.DBInstanceIdentifier = __expectString(output["DBInstanceIdentifier"]);
   }
   if (output["SnapshotCreateTime"] !== undefined) {
-    contents.SnapshotCreateTime = new Date(output["SnapshotCreateTime"]);
+    contents.SnapshotCreateTime = __expectNonNull(__parseRfc3339DateTime(output["SnapshotCreateTime"]));
   }
   if (output["Engine"] !== undefined) {
     contents.Engine = __expectString(output["Engine"]);
@@ -23537,7 +23541,7 @@ const deserializeAws_queryDBSnapshot = (output: any, context: __SerdeContext): D
     contents.VpcId = __expectString(output["VpcId"]);
   }
   if (output["InstanceCreateTime"] !== undefined) {
-    contents.InstanceCreateTime = new Date(output["InstanceCreateTime"]);
+    contents.InstanceCreateTime = __expectNonNull(__parseRfc3339DateTime(output["InstanceCreateTime"]));
   }
   if (output["MasterUsername"] !== undefined) {
     contents.MasterUsername = __expectString(output["MasterUsername"]);
@@ -23606,7 +23610,7 @@ const deserializeAws_queryDBSnapshot = (output: any, context: __SerdeContext): D
     contents.TagList = deserializeAws_queryTagList(__getArrayIfSingleItem(output["TagList"]["Tag"]), context);
   }
   if (output["OriginalSnapshotCreateTime"] !== undefined) {
-    contents.OriginalSnapshotCreateTime = new Date(output["OriginalSnapshotCreateTime"]);
+    contents.OriginalSnapshotCreateTime = __expectNonNull(__parseRfc3339DateTime(output["OriginalSnapshotCreateTime"]));
   }
   return contents;
 };
@@ -24436,7 +24440,7 @@ const deserializeAws_queryEvent = (output: any, context: __SerdeContext): Event 
     );
   }
   if (output["Date"] !== undefined) {
-    contents.Date = new Date(output["Date"]);
+    contents.Date = __expectNonNull(__parseRfc3339DateTime(output["Date"]));
   }
   if (output["SourceArn"] !== undefined) {
     contents.SourceArn = __expectString(output["SourceArn"]);
@@ -24675,13 +24679,13 @@ const deserializeAws_queryExportTask = (output: any, context: __SerdeContext): E
     );
   }
   if (output["SnapshotTime"] !== undefined) {
-    contents.SnapshotTime = new Date(output["SnapshotTime"]);
+    contents.SnapshotTime = __expectNonNull(__parseRfc3339DateTime(output["SnapshotTime"]));
   }
   if (output["TaskStartTime"] !== undefined) {
-    contents.TaskStartTime = new Date(output["TaskStartTime"]);
+    contents.TaskStartTime = __expectNonNull(__parseRfc3339DateTime(output["TaskStartTime"]));
   }
   if (output["TaskEndTime"] !== undefined) {
-    contents.TaskEndTime = new Date(output["TaskEndTime"]);
+    contents.TaskEndTime = __expectNonNull(__parseRfc3339DateTime(output["TaskEndTime"]));
   }
   if (output["S3Bucket"] !== undefined) {
     contents.S3Bucket = __expectString(output["S3Bucket"]);
@@ -26553,16 +26557,16 @@ const deserializeAws_queryPendingMaintenanceAction = (
     contents.Action = __expectString(output["Action"]);
   }
   if (output["AutoAppliedAfterDate"] !== undefined) {
-    contents.AutoAppliedAfterDate = new Date(output["AutoAppliedAfterDate"]);
+    contents.AutoAppliedAfterDate = __expectNonNull(__parseRfc3339DateTime(output["AutoAppliedAfterDate"]));
   }
   if (output["ForcedApplyDate"] !== undefined) {
-    contents.ForcedApplyDate = new Date(output["ForcedApplyDate"]);
+    contents.ForcedApplyDate = __expectNonNull(__parseRfc3339DateTime(output["ForcedApplyDate"]));
   }
   if (output["OptInStatus"] !== undefined) {
     contents.OptInStatus = __expectString(output["OptInStatus"]);
   }
   if (output["CurrentApplyDate"] !== undefined) {
-    contents.CurrentApplyDate = new Date(output["CurrentApplyDate"]);
+    contents.CurrentApplyDate = __expectNonNull(__parseRfc3339DateTime(output["CurrentApplyDate"]));
   }
   if (output["Description"] !== undefined) {
     contents.Description = __expectString(output["Description"]);
@@ -26975,7 +26979,7 @@ const deserializeAws_queryReservedDBInstance = (output: any, context: __SerdeCon
     contents.DBInstanceClass = __expectString(output["DBInstanceClass"]);
   }
   if (output["StartTime"] !== undefined) {
-    contents.StartTime = new Date(output["StartTime"]);
+    contents.StartTime = __expectNonNull(__parseRfc3339DateTime(output["StartTime"]));
   }
   if (output["Duration"] !== undefined) {
     contents.Duration = __strictParseInt32(output["Duration"]) as number;
@@ -27326,10 +27330,10 @@ const deserializeAws_queryRestoreWindow = (output: any, context: __SerdeContext)
     LatestTime: undefined,
   };
   if (output["EarliestTime"] !== undefined) {
-    contents.EarliestTime = new Date(output["EarliestTime"]);
+    contents.EarliestTime = __expectNonNull(__parseRfc3339DateTime(output["EarliestTime"]));
   }
   if (output["LatestTime"] !== undefined) {
-    contents.LatestTime = new Date(output["LatestTime"]);
+    contents.LatestTime = __expectNonNull(__parseRfc3339DateTime(output["LatestTime"]));
   }
   return contents;
 };

--- a/clients/client-redshift-data/protocols/Aws_json1_1.ts
+++ b/clients/client-redshift-data/protocols/Aws_json1_1.ts
@@ -50,8 +50,11 @@ import {
   expectBoolean as __expectBoolean,
   expectInt32 as __expectInt32,
   expectLong as __expectLong,
+  expectNonNull as __expectNonNull,
+  expectNumber as __expectNumber,
   expectString as __expectString,
   limitedParseDouble as __limitedParseDouble,
+  parseEpochTimestamp as __parseEpochTimestamp,
 } from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
@@ -1123,7 +1126,7 @@ const deserializeAws_json1_1BatchExecuteStatementOutput = (
     ClusterIdentifier: __expectString(output.ClusterIdentifier),
     CreatedAt:
       output.CreatedAt !== undefined && output.CreatedAt !== null
-        ? new Date(Math.round(output.CreatedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreatedAt)))
         : undefined,
     Database: __expectString(output.Database),
     DbUser: __expectString(output.DbUser),
@@ -1200,7 +1203,7 @@ const deserializeAws_json1_1DescribeStatementResponse = (
     ClusterIdentifier: __expectString(output.ClusterIdentifier),
     CreatedAt:
       output.CreatedAt !== undefined && output.CreatedAt !== null
-        ? new Date(Math.round(output.CreatedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreatedAt)))
         : undefined,
     Database: __expectString(output.Database),
     DbUser: __expectString(output.DbUser),
@@ -1225,7 +1228,7 @@ const deserializeAws_json1_1DescribeStatementResponse = (
         : undefined,
     UpdatedAt:
       output.UpdatedAt !== undefined && output.UpdatedAt !== null
-        ? new Date(Math.round(output.UpdatedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.UpdatedAt)))
         : undefined,
   } as any;
 };
@@ -1256,7 +1259,7 @@ const deserializeAws_json1_1ExecuteStatementOutput = (output: any, context: __Se
     ClusterIdentifier: __expectString(output.ClusterIdentifier),
     CreatedAt:
       output.CreatedAt !== undefined && output.CreatedAt !== null
-        ? new Date(Math.round(output.CreatedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreatedAt)))
         : undefined,
     Database: __expectString(output.Database),
     DbUser: __expectString(output.DbUser),
@@ -1421,7 +1424,7 @@ const deserializeAws_json1_1StatementData = (output: any, context: __SerdeContex
   return {
     CreatedAt:
       output.CreatedAt !== undefined && output.CreatedAt !== null
-        ? new Date(Math.round(output.CreatedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreatedAt)))
         : undefined,
     Id: __expectString(output.Id),
     IsBatchStatement: __expectBoolean(output.IsBatchStatement),
@@ -1439,7 +1442,7 @@ const deserializeAws_json1_1StatementData = (output: any, context: __SerdeContex
     Status: __expectString(output.Status),
     UpdatedAt:
       output.UpdatedAt !== undefined && output.UpdatedAt !== null
-        ? new Date(Math.round(output.UpdatedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.UpdatedAt)))
         : undefined,
   } as any;
 };
@@ -1470,7 +1473,7 @@ const deserializeAws_json1_1SubStatementData = (output: any, context: __SerdeCon
   return {
     CreatedAt:
       output.CreatedAt !== undefined && output.CreatedAt !== null
-        ? new Date(Math.round(output.CreatedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreatedAt)))
         : undefined,
     Duration: __expectLong(output.Duration),
     Error: __expectString(output.Error),
@@ -1483,7 +1486,7 @@ const deserializeAws_json1_1SubStatementData = (output: any, context: __SerdeCon
     Status: __expectString(output.Status),
     UpdatedAt:
       output.UpdatedAt !== undefined && output.UpdatedAt !== null
-        ? new Date(Math.round(output.UpdatedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.UpdatedAt)))
         : undefined,
   } as any;
 };

--- a/clients/client-redshift/protocols/Aws_query.ts
+++ b/clients/client-redshift/protocols/Aws_query.ts
@@ -776,11 +776,13 @@ import {
 } from "../models/models_1";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
+  expectNonNull as __expectNonNull,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   getArrayIfSingleItem as __getArrayIfSingleItem,
   getValueFromTextNode as __getValueFromTextNode,
   parseBoolean as __parseBoolean,
+  parseRfc3339DateTime as __parseRfc3339DateTime,
   strictParseFloat as __strictParseFloat,
   strictParseInt32 as __strictParseInt32,
   strictParseLong as __strictParseLong,
@@ -16747,7 +16749,7 @@ const deserializeAws_queryCluster = (output: any, context: __SerdeContext): Clus
     contents.Endpoint = deserializeAws_queryEndpoint(output["Endpoint"], context);
   }
   if (output["ClusterCreateTime"] !== undefined) {
-    contents.ClusterCreateTime = new Date(output["ClusterCreateTime"]);
+    contents.ClusterCreateTime = __expectNonNull(__parseRfc3339DateTime(output["ClusterCreateTime"]));
   }
   if (output["AutomatedSnapshotRetentionPeriod"] !== undefined) {
     contents.AutomatedSnapshotRetentionPeriod = __strictParseInt32(
@@ -16911,13 +16913,17 @@ const deserializeAws_queryCluster = (output: any, context: __SerdeContext): Clus
     contents.SnapshotScheduleState = __expectString(output["SnapshotScheduleState"]);
   }
   if (output["ExpectedNextSnapshotScheduleTime"] !== undefined) {
-    contents.ExpectedNextSnapshotScheduleTime = new Date(output["ExpectedNextSnapshotScheduleTime"]);
+    contents.ExpectedNextSnapshotScheduleTime = __expectNonNull(
+      __parseRfc3339DateTime(output["ExpectedNextSnapshotScheduleTime"])
+    );
   }
   if (output["ExpectedNextSnapshotScheduleTimeStatus"] !== undefined) {
     contents.ExpectedNextSnapshotScheduleTimeStatus = __expectString(output["ExpectedNextSnapshotScheduleTimeStatus"]);
   }
   if (output["NextMaintenanceWindowStartTime"] !== undefined) {
-    contents.NextMaintenanceWindowStartTime = new Date(output["NextMaintenanceWindowStartTime"]);
+    contents.NextMaintenanceWindowStartTime = __expectNonNull(
+      __parseRfc3339DateTime(output["NextMaintenanceWindowStartTime"])
+    );
   }
   if (output["ResizeInfo"] !== undefined) {
     contents.ResizeInfo = deserializeAws_queryResizeInfo(output["ResizeInfo"], context);
@@ -16980,7 +16986,7 @@ const deserializeAws_queryClusterCredentials = (output: any, context: __SerdeCon
     contents.DbPassword = __expectString(output["DbPassword"]);
   }
   if (output["Expiration"] !== undefined) {
-    contents.Expiration = new Date(output["Expiration"]);
+    contents.Expiration = __expectNonNull(__parseRfc3339DateTime(output["Expiration"]));
   }
   return contents;
 };
@@ -16999,7 +17005,9 @@ const deserializeAws_queryClusterDbRevision = (output: any, context: __SerdeCont
     contents.CurrentDatabaseRevision = __expectString(output["CurrentDatabaseRevision"]);
   }
   if (output["DatabaseRevisionReleaseDate"] !== undefined) {
-    contents.DatabaseRevisionReleaseDate = new Date(output["DatabaseRevisionReleaseDate"]);
+    contents.DatabaseRevisionReleaseDate = __expectNonNull(
+      __parseRfc3339DateTime(output["DatabaseRevisionReleaseDate"])
+    );
   }
   if (output.RevisionTargets === "") {
     contents.RevisionTargets = [];
@@ -17969,10 +17977,10 @@ const deserializeAws_queryDataShareAssociation = (output: any, context: __SerdeC
     contents.Status = __expectString(output["Status"]);
   }
   if (output["CreatedDate"] !== undefined) {
-    contents.CreatedDate = new Date(output["CreatedDate"]);
+    contents.CreatedDate = __expectNonNull(__parseRfc3339DateTime(output["CreatedDate"]));
   }
   if (output["StatusChangeDate"] !== undefined) {
-    contents.StatusChangeDate = new Date(output["StatusChangeDate"]);
+    contents.StatusChangeDate = __expectNonNull(__parseRfc3339DateTime(output["StatusChangeDate"]));
   }
   return contents;
 };
@@ -18071,10 +18079,10 @@ const deserializeAws_queryDeferredMaintenanceWindow = (
     contents.DeferMaintenanceIdentifier = __expectString(output["DeferMaintenanceIdentifier"]);
   }
   if (output["DeferMaintenanceStartTime"] !== undefined) {
-    contents.DeferMaintenanceStartTime = new Date(output["DeferMaintenanceStartTime"]);
+    contents.DeferMaintenanceStartTime = __expectNonNull(__parseRfc3339DateTime(output["DeferMaintenanceStartTime"]));
   }
   if (output["DeferMaintenanceEndTime"] !== undefined) {
-    contents.DeferMaintenanceEndTime = new Date(output["DeferMaintenanceEndTime"]);
+    contents.DeferMaintenanceEndTime = __expectNonNull(__parseRfc3339DateTime(output["DeferMaintenanceEndTime"]));
   }
   return contents;
 };
@@ -18444,7 +18452,7 @@ const deserializeAws_queryEndpointAccess = (output: any, context: __SerdeContext
     contents.EndpointName = __expectString(output["EndpointName"]);
   }
   if (output["EndpointCreateTime"] !== undefined) {
-    contents.EndpointCreateTime = new Date(output["EndpointCreateTime"]);
+    contents.EndpointCreateTime = __expectNonNull(__parseRfc3339DateTime(output["EndpointCreateTime"]));
   }
   if (output["Port"] !== undefined) {
     contents.Port = __strictParseInt32(output["Port"]) as number;
@@ -18533,7 +18541,7 @@ const deserializeAws_queryEndpointAuthorization = (output: any, context: __Serde
     contents.ClusterIdentifier = __expectString(output["ClusterIdentifier"]);
   }
   if (output["AuthorizeTime"] !== undefined) {
-    contents.AuthorizeTime = new Date(output["AuthorizeTime"]);
+    contents.AuthorizeTime = __expectNonNull(__parseRfc3339DateTime(output["AuthorizeTime"]));
   }
   if (output["ClusterStatus"] !== undefined) {
     contents.ClusterStatus = __expectString(output["ClusterStatus"]);
@@ -18703,7 +18711,7 @@ const deserializeAws_queryEvent = (output: any, context: __SerdeContext): Event 
     contents.Severity = __expectString(output["Severity"]);
   }
   if (output["Date"] !== undefined) {
-    contents.Date = new Date(output["Date"]);
+    contents.Date = __expectNonNull(__parseRfc3339DateTime(output["Date"]));
   }
   if (output["EventId"] !== undefined) {
     contents.EventId = __expectString(output["EventId"]);
@@ -18866,7 +18874,7 @@ const deserializeAws_queryEventSubscription = (output: any, context: __SerdeCont
     contents.Status = __expectString(output["Status"]);
   }
   if (output["SubscriptionCreationTime"] !== undefined) {
-    contents.SubscriptionCreationTime = new Date(output["SubscriptionCreationTime"]);
+    contents.SubscriptionCreationTime = __expectNonNull(__parseRfc3339DateTime(output["SubscriptionCreationTime"]));
   }
   if (output["SourceType"] !== undefined) {
     contents.SourceType = __expectString(output["SourceType"]);
@@ -19703,10 +19711,10 @@ const deserializeAws_queryLoggingStatus = (output: any, context: __SerdeContext)
     contents.S3KeyPrefix = __expectString(output["S3KeyPrefix"]);
   }
   if (output["LastSuccessfulDeliveryTime"] !== undefined) {
-    contents.LastSuccessfulDeliveryTime = new Date(output["LastSuccessfulDeliveryTime"]);
+    contents.LastSuccessfulDeliveryTime = __expectNonNull(__parseRfc3339DateTime(output["LastSuccessfulDeliveryTime"]));
   }
   if (output["LastFailureTime"] !== undefined) {
-    contents.LastFailureTime = new Date(output["LastFailureTime"]);
+    contents.LastFailureTime = __expectNonNull(__parseRfc3339DateTime(output["LastFailureTime"]));
   }
   if (output["LastFailureMessage"] !== undefined) {
     contents.LastFailureMessage = __expectString(output["LastFailureMessage"]);
@@ -20141,10 +20149,10 @@ const deserializeAws_queryPartnerIntegrationInfo = (output: any, context: __Serd
     contents.StatusMessage = __expectString(output["StatusMessage"]);
   }
   if (output["CreatedAt"] !== undefined) {
-    contents.CreatedAt = new Date(output["CreatedAt"]);
+    contents.CreatedAt = __expectNonNull(__parseRfc3339DateTime(output["CreatedAt"]));
   }
   if (output["UpdatedAt"] !== undefined) {
-    contents.UpdatedAt = new Date(output["UpdatedAt"]);
+    contents.UpdatedAt = __expectNonNull(__parseRfc3339DateTime(output["UpdatedAt"]));
   }
   return contents;
 };
@@ -20347,7 +20355,7 @@ const deserializeAws_queryReservedNode = (output: any, context: __SerdeContext):
     contents.NodeType = __expectString(output["NodeType"]);
   }
   if (output["StartTime"] !== undefined) {
-    contents.StartTime = new Date(output["StartTime"]);
+    contents.StartTime = __expectNonNull(__parseRfc3339DateTime(output["StartTime"]));
   }
   if (output["Duration"] !== undefined) {
     contents.Duration = __strictParseInt32(output["Duration"]) as number;
@@ -20832,7 +20840,9 @@ const deserializeAws_queryRevisionTarget = (output: any, context: __SerdeContext
     contents.Description = __expectString(output["Description"]);
   }
   if (output["DatabaseRevisionReleaseDate"] !== undefined) {
-    contents.DatabaseRevisionReleaseDate = new Date(output["DatabaseRevisionReleaseDate"]);
+    contents.DatabaseRevisionReleaseDate = __expectNonNull(
+      __parseRfc3339DateTime(output["DatabaseRevisionReleaseDate"])
+    );
   }
   return contents;
 };
@@ -20927,10 +20937,10 @@ const deserializeAws_queryScheduledAction = (output: any, context: __SerdeContex
     );
   }
   if (output["StartTime"] !== undefined) {
-    contents.StartTime = new Date(output["StartTime"]);
+    contents.StartTime = __expectNonNull(__parseRfc3339DateTime(output["StartTime"]));
   }
   if (output["EndTime"] !== undefined) {
-    contents.EndTime = new Date(output["EndTime"]);
+    contents.EndTime = __expectNonNull(__parseRfc3339DateTime(output["EndTime"]));
   }
   return contents;
 };
@@ -21012,7 +21022,7 @@ const deserializeAws_queryScheduledActionTimeList = (output: any, context: __Ser
       if (entry === null) {
         return null as any;
       }
-      return new Date(entry);
+      return __expectNonNull(__parseRfc3339DateTime(entry));
     });
 };
 
@@ -21078,7 +21088,7 @@ const deserializeAws_queryScheduledSnapshotTimeList = (output: any, context: __S
       if (entry === null) {
         return null as any;
       }
-      return new Date(entry);
+      return __expectNonNull(__parseRfc3339DateTime(entry));
     });
 };
 
@@ -21126,7 +21136,7 @@ const deserializeAws_querySnapshot = (output: any, context: __SerdeContext): Sna
     contents.ClusterIdentifier = __expectString(output["ClusterIdentifier"]);
   }
   if (output["SnapshotCreateTime"] !== undefined) {
-    contents.SnapshotCreateTime = new Date(output["SnapshotCreateTime"]);
+    contents.SnapshotCreateTime = __expectNonNull(__parseRfc3339DateTime(output["SnapshotCreateTime"]));
   }
   if (output["Status"] !== undefined) {
     contents.Status = __expectString(output["Status"]);
@@ -21138,7 +21148,7 @@ const deserializeAws_querySnapshot = (output: any, context: __SerdeContext): Sna
     contents.AvailabilityZone = __expectString(output["AvailabilityZone"]);
   }
   if (output["ClusterCreateTime"] !== undefined) {
-    contents.ClusterCreateTime = new Date(output["ClusterCreateTime"]);
+    contents.ClusterCreateTime = __expectNonNull(__parseRfc3339DateTime(output["ClusterCreateTime"]));
   }
   if (output["MasterUsername"] !== undefined) {
     contents.MasterUsername = __expectString(output["MasterUsername"]);
@@ -21241,7 +21251,7 @@ const deserializeAws_querySnapshot = (output: any, context: __SerdeContext): Sna
     contents.ManualSnapshotRemainingDays = __strictParseInt32(output["ManualSnapshotRemainingDays"]) as number;
   }
   if (output["SnapshotRetentionStartTime"] !== undefined) {
-    contents.SnapshotRetentionStartTime = new Date(output["SnapshotRetentionStartTime"]);
+    contents.SnapshotRetentionStartTime = __expectNonNull(__parseRfc3339DateTime(output["SnapshotRetentionStartTime"]));
   }
   return contents;
 };
@@ -21817,7 +21827,7 @@ const deserializeAws_queryTableRestoreStatus = (output: any, context: __SerdeCon
     contents.Message = __expectString(output["Message"]);
   }
   if (output["RequestTime"] !== undefined) {
-    contents.RequestTime = new Date(output["RequestTime"]);
+    contents.RequestTime = __expectNonNull(__parseRfc3339DateTime(output["RequestTime"]));
   }
   if (output["ProgressInMegaBytes"] !== undefined) {
     contents.ProgressInMegaBytes = __strictParseLong(output["ProgressInMegaBytes"]) as number;

--- a/clients/client-rekognition/protocols/Aws_json1_1.ts
+++ b/clients/client-rekognition/protocols/Aws_json1_1.ts
@@ -335,8 +335,11 @@ import {
   expectBoolean as __expectBoolean,
   expectInt32 as __expectInt32,
   expectLong as __expectLong,
+  expectNonNull as __expectNonNull,
+  expectNumber as __expectNumber,
   expectString as __expectString,
   limitedParseFloat32 as __limitedParseFloat32,
+  parseEpochTimestamp as __parseEpochTimestamp,
   serializeFloat as __serializeFloat,
 } from "@aws-sdk/smithy-client";
 import {
@@ -8065,7 +8068,7 @@ const deserializeAws_json1_1DescribeCollectionResponse = (
     CollectionARN: __expectString(output.CollectionARN),
     CreationTimestamp:
       output.CreationTimestamp !== undefined && output.CreationTimestamp !== null
-        ? new Date(Math.round(output.CreationTimestamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTimestamp)))
         : undefined,
     FaceCount: __expectLong(output.FaceCount),
     FaceModelVersion: __expectString(output.FaceModelVersion),
@@ -8105,7 +8108,7 @@ const deserializeAws_json1_1DescribeStreamProcessorResponse = (
   return {
     CreationTimestamp:
       output.CreationTimestamp !== undefined && output.CreationTimestamp !== null
-        ? new Date(Math.round(output.CreationTimestamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTimestamp)))
         : undefined,
     Input:
       output.Input !== undefined && output.Input !== null
@@ -8113,7 +8116,7 @@ const deserializeAws_json1_1DescribeStreamProcessorResponse = (
         : undefined,
     LastUpdateTimestamp:
       output.LastUpdateTimestamp !== undefined && output.LastUpdateTimestamp !== null
-        ? new Date(Math.round(output.LastUpdateTimestamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastUpdateTimestamp)))
         : undefined,
     Name: __expectString(output.Name),
     Output:
@@ -9115,7 +9118,7 @@ const deserializeAws_json1_1ProjectDescription = (output: any, context: __SerdeC
   return {
     CreationTimestamp:
       output.CreationTimestamp !== undefined && output.CreationTimestamp !== null
-        ? new Date(Math.round(output.CreationTimestamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTimestamp)))
         : undefined,
     ProjectArn: __expectString(output.ProjectArn),
     Status: __expectString(output.Status),
@@ -9141,7 +9144,7 @@ const deserializeAws_json1_1ProjectVersionDescription = (
     BillableTrainingTimeInSeconds: __expectLong(output.BillableTrainingTimeInSeconds),
     CreationTimestamp:
       output.CreationTimestamp !== undefined && output.CreationTimestamp !== null
-        ? new Date(Math.round(output.CreationTimestamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTimestamp)))
         : undefined,
     EvaluationResult:
       output.EvaluationResult !== undefined && output.EvaluationResult !== null
@@ -9170,7 +9173,7 @@ const deserializeAws_json1_1ProjectVersionDescription = (
         : undefined,
     TrainingEndTimestamp:
       output.TrainingEndTimestamp !== undefined && output.TrainingEndTimestamp !== null
-        ? new Date(Math.round(output.TrainingEndTimestamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.TrainingEndTimestamp)))
         : undefined,
   } as any;
 };

--- a/clients/client-robomaker/protocols/Aws_restJson1.ts
+++ b/clients/client-robomaker/protocols/Aws_restJson1.ts
@@ -236,10 +236,12 @@ import {
   expectInt32 as __expectInt32,
   expectLong as __expectLong,
   expectNonNull as __expectNonNull,
+  expectNumber as __expectNumber,
   expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   limitedParseFloat32 as __limitedParseFloat32,
+  parseEpochTimestamp as __parseEpochTimestamp,
 } from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
@@ -2394,7 +2396,7 @@ export const deserializeAws_restJson1CreateDeploymentJobCommand = async (
     contents.arn = __expectString(data.arn);
   }
   if (data.createdAt !== undefined && data.createdAt !== null) {
-    contents.createdAt = new Date(Math.round(data.createdAt * 1000));
+    contents.createdAt = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.createdAt)));
   }
   if (data.deploymentApplicationConfigs !== undefined && data.deploymentApplicationConfigs !== null) {
     contents.deploymentApplicationConfigs = deserializeAws_restJson1DeploymentApplicationConfigs(
@@ -2527,7 +2529,7 @@ export const deserializeAws_restJson1CreateFleetCommand = async (
     contents.arn = __expectString(data.arn);
   }
   if (data.createdAt !== undefined && data.createdAt !== null) {
-    contents.createdAt = new Date(Math.round(data.createdAt * 1000));
+    contents.createdAt = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.createdAt)));
   }
   if (data.name !== undefined && data.name !== null) {
     contents.name = __expectString(data.name);
@@ -2623,7 +2625,7 @@ export const deserializeAws_restJson1CreateRobotCommand = async (
     contents.arn = __expectString(data.arn);
   }
   if (data.createdAt !== undefined && data.createdAt !== null) {
-    contents.createdAt = new Date(Math.round(data.createdAt * 1000));
+    contents.createdAt = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.createdAt)));
   }
   if (data.greengrassGroupId !== undefined && data.greengrassGroupId !== null) {
     contents.greengrassGroupId = __expectString(data.greengrassGroupId);
@@ -2729,7 +2731,7 @@ export const deserializeAws_restJson1CreateRobotApplicationCommand = async (
     contents.arn = __expectString(data.arn);
   }
   if (data.lastUpdatedAt !== undefined && data.lastUpdatedAt !== null) {
-    contents.lastUpdatedAt = new Date(Math.round(data.lastUpdatedAt * 1000));
+    contents.lastUpdatedAt = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.lastUpdatedAt)));
   }
   if (data.name !== undefined && data.name !== null) {
     contents.name = __expectString(data.name);
@@ -2851,7 +2853,7 @@ export const deserializeAws_restJson1CreateRobotApplicationVersionCommand = asyn
     contents.arn = __expectString(data.arn);
   }
   if (data.lastUpdatedAt !== undefined && data.lastUpdatedAt !== null) {
-    contents.lastUpdatedAt = new Date(Math.round(data.lastUpdatedAt * 1000));
+    contents.lastUpdatedAt = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.lastUpdatedAt)));
   }
   if (data.name !== undefined && data.name !== null) {
     contents.name = __expectString(data.name);
@@ -2965,7 +2967,7 @@ export const deserializeAws_restJson1CreateSimulationApplicationCommand = async 
     contents.arn = __expectString(data.arn);
   }
   if (data.lastUpdatedAt !== undefined && data.lastUpdatedAt !== null) {
-    contents.lastUpdatedAt = new Date(Math.round(data.lastUpdatedAt * 1000));
+    contents.lastUpdatedAt = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.lastUpdatedAt)));
   }
   if (data.name !== undefined && data.name !== null) {
     contents.name = __expectString(data.name);
@@ -3098,7 +3100,7 @@ export const deserializeAws_restJson1CreateSimulationApplicationVersionCommand =
     contents.arn = __expectString(data.arn);
   }
   if (data.lastUpdatedAt !== undefined && data.lastUpdatedAt !== null) {
-    contents.lastUpdatedAt = new Date(Math.round(data.lastUpdatedAt * 1000));
+    contents.lastUpdatedAt = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.lastUpdatedAt)));
   }
   if (data.name !== undefined && data.name !== null) {
     contents.name = __expectString(data.name);
@@ -3247,10 +3249,10 @@ export const deserializeAws_restJson1CreateSimulationJobCommand = async (
     contents.iamRole = __expectString(data.iamRole);
   }
   if (data.lastStartedAt !== undefined && data.lastStartedAt !== null) {
-    contents.lastStartedAt = new Date(Math.round(data.lastStartedAt * 1000));
+    contents.lastStartedAt = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.lastStartedAt)));
   }
   if (data.lastUpdatedAt !== undefined && data.lastUpdatedAt !== null) {
-    contents.lastUpdatedAt = new Date(Math.round(data.lastUpdatedAt * 1000));
+    contents.lastUpdatedAt = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.lastUpdatedAt)));
   }
   if (data.loggingConfig !== undefined && data.loggingConfig !== null) {
     contents.loggingConfig = deserializeAws_restJson1LoggingConfig(data.loggingConfig, context);
@@ -3396,7 +3398,7 @@ export const deserializeAws_restJson1CreateWorldExportJobCommand = async (
     contents.clientRequestToken = __expectString(data.clientRequestToken);
   }
   if (data.createdAt !== undefined && data.createdAt !== null) {
-    contents.createdAt = new Date(Math.round(data.createdAt * 1000));
+    contents.createdAt = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.createdAt)));
   }
   if (data.failureCode !== undefined && data.failureCode !== null) {
     contents.failureCode = __expectString(data.failureCode);
@@ -3520,7 +3522,7 @@ export const deserializeAws_restJson1CreateWorldGenerationJobCommand = async (
     contents.clientRequestToken = __expectString(data.clientRequestToken);
   }
   if (data.createdAt !== undefined && data.createdAt !== null) {
-    contents.createdAt = new Date(Math.round(data.createdAt * 1000));
+    contents.createdAt = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.createdAt)));
   }
   if (data.failureCode !== undefined && data.failureCode !== null) {
     contents.failureCode = __expectString(data.failureCode);
@@ -3651,7 +3653,7 @@ export const deserializeAws_restJson1CreateWorldTemplateCommand = async (
     contents.clientRequestToken = __expectString(data.clientRequestToken);
   }
   if (data.createdAt !== undefined && data.createdAt !== null) {
-    contents.createdAt = new Date(Math.round(data.createdAt * 1000));
+    contents.createdAt = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.createdAt)));
   }
   if (data.name !== undefined && data.name !== null) {
     contents.name = __expectString(data.name);
@@ -4190,7 +4192,7 @@ export const deserializeAws_restJson1DescribeDeploymentJobCommand = async (
     contents.arn = __expectString(data.arn);
   }
   if (data.createdAt !== undefined && data.createdAt !== null) {
-    contents.createdAt = new Date(Math.round(data.createdAt * 1000));
+    contents.createdAt = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.createdAt)));
   }
   if (data.deploymentApplicationConfigs !== undefined && data.deploymentApplicationConfigs !== null) {
     contents.deploymentApplicationConfigs = deserializeAws_restJson1DeploymentApplicationConfigs(
@@ -4309,7 +4311,7 @@ export const deserializeAws_restJson1DescribeFleetCommand = async (
     contents.arn = __expectString(data.arn);
   }
   if (data.createdAt !== undefined && data.createdAt !== null) {
-    contents.createdAt = new Date(Math.round(data.createdAt * 1000));
+    contents.createdAt = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.createdAt)));
   }
   if (data.lastDeploymentJob !== undefined && data.lastDeploymentJob !== null) {
     contents.lastDeploymentJob = __expectString(data.lastDeploymentJob);
@@ -4318,7 +4320,7 @@ export const deserializeAws_restJson1DescribeFleetCommand = async (
     contents.lastDeploymentStatus = __expectString(data.lastDeploymentStatus);
   }
   if (data.lastDeploymentTime !== undefined && data.lastDeploymentTime !== null) {
-    contents.lastDeploymentTime = new Date(Math.round(data.lastDeploymentTime * 1000));
+    contents.lastDeploymentTime = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.lastDeploymentTime)));
   }
   if (data.name !== undefined && data.name !== null) {
     contents.name = __expectString(data.name);
@@ -4421,7 +4423,7 @@ export const deserializeAws_restJson1DescribeRobotCommand = async (
     contents.arn = __expectString(data.arn);
   }
   if (data.createdAt !== undefined && data.createdAt !== null) {
-    contents.createdAt = new Date(Math.round(data.createdAt * 1000));
+    contents.createdAt = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.createdAt)));
   }
   if (data.fleetArn !== undefined && data.fleetArn !== null) {
     contents.fleetArn = __expectString(data.fleetArn);
@@ -4433,7 +4435,7 @@ export const deserializeAws_restJson1DescribeRobotCommand = async (
     contents.lastDeploymentJob = __expectString(data.lastDeploymentJob);
   }
   if (data.lastDeploymentTime !== undefined && data.lastDeploymentTime !== null) {
-    contents.lastDeploymentTime = new Date(Math.round(data.lastDeploymentTime * 1000));
+    contents.lastDeploymentTime = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.lastDeploymentTime)));
   }
   if (data.name !== undefined && data.name !== null) {
     contents.name = __expectString(data.name);
@@ -4531,7 +4533,7 @@ export const deserializeAws_restJson1DescribeRobotApplicationCommand = async (
     contents.arn = __expectString(data.arn);
   }
   if (data.lastUpdatedAt !== undefined && data.lastUpdatedAt !== null) {
-    contents.lastUpdatedAt = new Date(Math.round(data.lastUpdatedAt * 1000));
+    contents.lastUpdatedAt = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.lastUpdatedAt)));
   }
   if (data.name !== undefined && data.name !== null) {
     contents.name = __expectString(data.name);
@@ -4640,7 +4642,7 @@ export const deserializeAws_restJson1DescribeSimulationApplicationCommand = asyn
     contents.arn = __expectString(data.arn);
   }
   if (data.lastUpdatedAt !== undefined && data.lastUpdatedAt !== null) {
-    contents.lastUpdatedAt = new Date(Math.round(data.lastUpdatedAt * 1000));
+    contents.lastUpdatedAt = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.lastUpdatedAt)));
   }
   if (data.name !== undefined && data.name !== null) {
     contents.name = __expectString(data.name);
@@ -4790,10 +4792,10 @@ export const deserializeAws_restJson1DescribeSimulationJobCommand = async (
     contents.iamRole = __expectString(data.iamRole);
   }
   if (data.lastStartedAt !== undefined && data.lastStartedAt !== null) {
-    contents.lastStartedAt = new Date(Math.round(data.lastStartedAt * 1000));
+    contents.lastStartedAt = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.lastStartedAt)));
   }
   if (data.lastUpdatedAt !== undefined && data.lastUpdatedAt !== null) {
-    contents.lastUpdatedAt = new Date(Math.round(data.lastUpdatedAt * 1000));
+    contents.lastUpdatedAt = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.lastUpdatedAt)));
   }
   if (data.loggingConfig !== undefined && data.loggingConfig !== null) {
     contents.loggingConfig = deserializeAws_restJson1LoggingConfig(data.loggingConfig, context);
@@ -4928,7 +4930,7 @@ export const deserializeAws_restJson1DescribeSimulationJobBatchCommand = async (
     contents.clientRequestToken = __expectString(data.clientRequestToken);
   }
   if (data.createdAt !== undefined && data.createdAt !== null) {
-    contents.createdAt = new Date(Math.round(data.createdAt * 1000));
+    contents.createdAt = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.createdAt)));
   }
   if (data.createdRequests !== undefined && data.createdRequests !== null) {
     contents.createdRequests = deserializeAws_restJson1SimulationJobSummaries(data.createdRequests, context);
@@ -4943,7 +4945,7 @@ export const deserializeAws_restJson1DescribeSimulationJobBatchCommand = async (
     contents.failureReason = __expectString(data.failureReason);
   }
   if (data.lastUpdatedAt !== undefined && data.lastUpdatedAt !== null) {
-    contents.lastUpdatedAt = new Date(Math.round(data.lastUpdatedAt * 1000));
+    contents.lastUpdatedAt = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.lastUpdatedAt)));
   }
   if (data.pendingRequests !== undefined && data.pendingRequests !== null) {
     contents.pendingRequests = deserializeAws_restJson1CreateSimulationJobRequests(data.pendingRequests, context);
@@ -5031,7 +5033,7 @@ export const deserializeAws_restJson1DescribeWorldCommand = async (
     contents.arn = __expectString(data.arn);
   }
   if (data.createdAt !== undefined && data.createdAt !== null) {
-    contents.createdAt = new Date(Math.round(data.createdAt * 1000));
+    contents.createdAt = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.createdAt)));
   }
   if (data.generationJob !== undefined && data.generationJob !== null) {
     contents.generationJob = __expectString(data.generationJob);
@@ -5137,7 +5139,7 @@ export const deserializeAws_restJson1DescribeWorldExportJobCommand = async (
     contents.clientRequestToken = __expectString(data.clientRequestToken);
   }
   if (data.createdAt !== undefined && data.createdAt !== null) {
-    contents.createdAt = new Date(Math.round(data.createdAt * 1000));
+    contents.createdAt = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.createdAt)));
   }
   if (data.failureCode !== undefined && data.failureCode !== null) {
     contents.failureCode = __expectString(data.failureCode);
@@ -5253,7 +5255,7 @@ export const deserializeAws_restJson1DescribeWorldGenerationJobCommand = async (
     contents.clientRequestToken = __expectString(data.clientRequestToken);
   }
   if (data.createdAt !== undefined && data.createdAt !== null) {
-    contents.createdAt = new Date(Math.round(data.createdAt * 1000));
+    contents.createdAt = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.createdAt)));
   }
   if (data.failureCode !== undefined && data.failureCode !== null) {
     contents.failureCode = __expectString(data.failureCode);
@@ -5368,10 +5370,10 @@ export const deserializeAws_restJson1DescribeWorldTemplateCommand = async (
     contents.clientRequestToken = __expectString(data.clientRequestToken);
   }
   if (data.createdAt !== undefined && data.createdAt !== null) {
-    contents.createdAt = new Date(Math.round(data.createdAt * 1000));
+    contents.createdAt = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.createdAt)));
   }
   if (data.lastUpdatedAt !== undefined && data.lastUpdatedAt !== null) {
-    contents.lastUpdatedAt = new Date(Math.round(data.lastUpdatedAt * 1000));
+    contents.lastUpdatedAt = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.lastUpdatedAt)));
   }
   if (data.name !== undefined && data.name !== null) {
     contents.name = __expectString(data.name);
@@ -6669,7 +6671,7 @@ export const deserializeAws_restJson1StartSimulationJobBatchCommand = async (
     contents.clientRequestToken = __expectString(data.clientRequestToken);
   }
   if (data.createdAt !== undefined && data.createdAt !== null) {
-    contents.createdAt = new Date(Math.round(data.createdAt * 1000));
+    contents.createdAt = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.createdAt)));
   }
   if (data.createdRequests !== undefined && data.createdRequests !== null) {
     contents.createdRequests = deserializeAws_restJson1SimulationJobSummaries(data.createdRequests, context);
@@ -6787,7 +6789,7 @@ export const deserializeAws_restJson1SyncDeploymentJobCommand = async (
     contents.arn = __expectString(data.arn);
   }
   if (data.createdAt !== undefined && data.createdAt !== null) {
-    contents.createdAt = new Date(Math.round(data.createdAt * 1000));
+    contents.createdAt = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.createdAt)));
   }
   if (data.deploymentApplicationConfigs !== undefined && data.deploymentApplicationConfigs !== null) {
     contents.deploymentApplicationConfigs = deserializeAws_restJson1DeploymentApplicationConfigs(
@@ -7070,7 +7072,7 @@ export const deserializeAws_restJson1UpdateRobotApplicationCommand = async (
     contents.arn = __expectString(data.arn);
   }
   if (data.lastUpdatedAt !== undefined && data.lastUpdatedAt !== null) {
-    contents.lastUpdatedAt = new Date(Math.round(data.lastUpdatedAt * 1000));
+    contents.lastUpdatedAt = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.lastUpdatedAt)));
   }
   if (data.name !== undefined && data.name !== null) {
     contents.name = __expectString(data.name);
@@ -7183,7 +7185,7 @@ export const deserializeAws_restJson1UpdateSimulationApplicationCommand = async 
     contents.arn = __expectString(data.arn);
   }
   if (data.lastUpdatedAt !== undefined && data.lastUpdatedAt !== null) {
-    contents.lastUpdatedAt = new Date(Math.round(data.lastUpdatedAt * 1000));
+    contents.lastUpdatedAt = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.lastUpdatedAt)));
   }
   if (data.name !== undefined && data.name !== null) {
     contents.name = __expectString(data.name);
@@ -7300,10 +7302,10 @@ export const deserializeAws_restJson1UpdateWorldTemplateCommand = async (
     contents.arn = __expectString(data.arn);
   }
   if (data.createdAt !== undefined && data.createdAt !== null) {
-    contents.createdAt = new Date(Math.round(data.createdAt * 1000));
+    contents.createdAt = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.createdAt)));
   }
   if (data.lastUpdatedAt !== undefined && data.lastUpdatedAt !== null) {
-    contents.lastUpdatedAt = new Date(Math.round(data.lastUpdatedAt * 1000));
+    contents.lastUpdatedAt = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.lastUpdatedAt)));
   }
   if (data.name !== undefined && data.name !== null) {
     contents.name = __expectString(data.name);
@@ -8198,7 +8200,7 @@ const deserializeAws_restJson1DeploymentJob = (output: any, context: __SerdeCont
     arn: __expectString(output.arn),
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
-        ? new Date(Math.round(output.createdAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.createdAt)))
         : undefined,
     deploymentApplicationConfigs:
       output.deploymentApplicationConfigs !== undefined && output.deploymentApplicationConfigs !== null
@@ -8264,7 +8266,7 @@ const deserializeAws_restJson1FailedCreateSimulationJobRequest = (
   return {
     failedAt:
       output.failedAt !== undefined && output.failedAt !== null
-        ? new Date(Math.round(output.failedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.failedAt)))
         : undefined,
     failureCode: __expectString(output.failureCode),
     failureReason: __expectString(output.failureReason),
@@ -8318,13 +8320,13 @@ const deserializeAws_restJson1Fleet = (output: any, context: __SerdeContext): Fl
     arn: __expectString(output.arn),
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
-        ? new Date(Math.round(output.createdAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.createdAt)))
         : undefined,
     lastDeploymentJob: __expectString(output.lastDeploymentJob),
     lastDeploymentStatus: __expectString(output.lastDeploymentStatus),
     lastDeploymentTime:
       output.lastDeploymentTime !== undefined && output.lastDeploymentTime !== null
-        ? new Date(Math.round(output.lastDeploymentTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastDeploymentTime)))
         : undefined,
     name: __expectString(output.name),
   } as any;
@@ -8428,14 +8430,14 @@ const deserializeAws_restJson1Robot = (output: any, context: __SerdeContext): Ro
     arn: __expectString(output.arn),
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
-        ? new Date(Math.round(output.createdAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.createdAt)))
         : undefined,
     fleetArn: __expectString(output.fleetArn),
     greenGrassGroupId: __expectString(output.greenGrassGroupId),
     lastDeploymentJob: __expectString(output.lastDeploymentJob),
     lastDeploymentTime:
       output.lastDeploymentTime !== undefined && output.lastDeploymentTime !== null
-        ? new Date(Math.round(output.lastDeploymentTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastDeploymentTime)))
         : undefined,
     name: __expectString(output.name),
     status: __expectString(output.status),
@@ -8513,7 +8515,7 @@ const deserializeAws_restJson1RobotApplicationSummary = (
     arn: __expectString(output.arn),
     lastUpdatedAt:
       output.lastUpdatedAt !== undefined && output.lastUpdatedAt !== null
-        ? new Date(Math.round(output.lastUpdatedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastUpdatedAt)))
         : undefined,
     name: __expectString(output.name),
     robotSoftwareSuite:
@@ -8529,11 +8531,11 @@ const deserializeAws_restJson1RobotDeployment = (output: any, context: __SerdeCo
     arn: __expectString(output.arn),
     deploymentFinishTime:
       output.deploymentFinishTime !== undefined && output.deploymentFinishTime !== null
-        ? new Date(Math.round(output.deploymentFinishTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.deploymentFinishTime)))
         : undefined,
     deploymentStartTime:
       output.deploymentStartTime !== undefined && output.deploymentStartTime !== null
-        ? new Date(Math.round(output.deploymentStartTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.deploymentStartTime)))
         : undefined,
     failureCode: __expectString(output.failureCode),
     failureReason: __expectString(output.failureReason),
@@ -8697,7 +8699,7 @@ const deserializeAws_restJson1SimulationApplicationSummary = (
     arn: __expectString(output.arn),
     lastUpdatedAt:
       output.lastUpdatedAt !== undefined && output.lastUpdatedAt !== null
-        ? new Date(Math.round(output.lastUpdatedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastUpdatedAt)))
         : undefined,
     name: __expectString(output.name),
     robotSoftwareSuite:
@@ -8730,11 +8732,11 @@ const deserializeAws_restJson1SimulationJob = (output: any, context: __SerdeCont
     iamRole: __expectString(output.iamRole),
     lastStartedAt:
       output.lastStartedAt !== undefined && output.lastStartedAt !== null
-        ? new Date(Math.round(output.lastStartedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastStartedAt)))
         : undefined,
     lastUpdatedAt:
       output.lastUpdatedAt !== undefined && output.lastUpdatedAt !== null
-        ? new Date(Math.round(output.lastUpdatedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastUpdatedAt)))
         : undefined,
     loggingConfig:
       output.loggingConfig !== undefined && output.loggingConfig !== null
@@ -8793,13 +8795,13 @@ const deserializeAws_restJson1SimulationJobBatchSummary = (
     arn: __expectString(output.arn),
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
-        ? new Date(Math.round(output.createdAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.createdAt)))
         : undefined,
     createdRequestCount: __expectInt32(output.createdRequestCount),
     failedRequestCount: __expectInt32(output.failedRequestCount),
     lastUpdatedAt:
       output.lastUpdatedAt !== undefined && output.lastUpdatedAt !== null
-        ? new Date(Math.round(output.lastUpdatedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastUpdatedAt)))
         : undefined,
     pendingRequestCount: __expectInt32(output.pendingRequestCount),
     status: __expectString(output.status),
@@ -8881,7 +8883,7 @@ const deserializeAws_restJson1SimulationJobSummary = (output: any, context: __Se
         : undefined,
     lastUpdatedAt:
       output.lastUpdatedAt !== undefined && output.lastUpdatedAt !== null
-        ? new Date(Math.round(output.lastUpdatedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastUpdatedAt)))
         : undefined,
     name: __expectString(output.name),
     robotApplicationNames:
@@ -8965,11 +8967,11 @@ const deserializeAws_restJson1TemplateSummary = (output: any, context: __SerdeCo
     arn: __expectString(output.arn),
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
-        ? new Date(Math.round(output.createdAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.createdAt)))
         : undefined,
     lastUpdatedAt:
       output.lastUpdatedAt !== undefined && output.lastUpdatedAt !== null
-        ? new Date(Math.round(output.lastUpdatedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastUpdatedAt)))
         : undefined,
     name: __expectString(output.name),
     version: __expectString(output.version),
@@ -9088,7 +9090,7 @@ const deserializeAws_restJson1WorldExportJobSummary = (output: any, context: __S
     arn: __expectString(output.arn),
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
-        ? new Date(Math.round(output.createdAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.createdAt)))
         : undefined,
     status: __expectString(output.status),
     worlds:
@@ -9139,7 +9141,7 @@ const deserializeAws_restJson1WorldGenerationJobSummary = (
     arn: __expectString(output.arn),
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
-        ? new Date(Math.round(output.createdAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.createdAt)))
         : undefined,
     failedWorldCount: __expectInt32(output.failedWorldCount),
     status: __expectString(output.status),
@@ -9168,7 +9170,7 @@ const deserializeAws_restJson1WorldSummary = (output: any, context: __SerdeConte
     arn: __expectString(output.arn),
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
-        ? new Date(Math.round(output.createdAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.createdAt)))
         : undefined,
     generationJob: __expectString(output.generationJob),
     template: __expectString(output.template),

--- a/clients/client-route-53-domains/protocols/Aws_json1_1.ts
+++ b/clients/client-route-53-domains/protocols/Aws_json1_1.ts
@@ -159,8 +159,11 @@ import {
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
   expectBoolean as __expectBoolean,
+  expectNonNull as __expectNonNull,
+  expectNumber as __expectNumber,
   expectString as __expectString,
   limitedParseDouble as __limitedParseDouble,
+  parseEpochTimestamp as __parseEpochTimestamp,
 } from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
@@ -3023,7 +3026,7 @@ const deserializeAws_json1_1BillingRecord = (output: any, context: __SerdeContex
   return {
     BillDate:
       output.BillDate !== undefined && output.BillDate !== null
-        ? new Date(Math.round(output.BillDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.BillDate)))
         : undefined,
     DomainName: __expectString(output.DomainName),
     InvoiceId: __expectString(output.InvoiceId),
@@ -3158,7 +3161,9 @@ const deserializeAws_json1_1DomainSummary = (output: any, context: __SerdeContex
     AutoRenew: __expectBoolean(output.AutoRenew),
     DomainName: __expectString(output.DomainName),
     Expiry:
-      output.Expiry !== undefined && output.Expiry !== null ? new Date(Math.round(output.Expiry * 1000)) : undefined,
+      output.Expiry !== undefined && output.Expiry !== null
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.Expiry)))
+        : undefined,
     TransferLock: __expectBoolean(output.TransferLock),
   } as any;
 };
@@ -3245,13 +3250,13 @@ const deserializeAws_json1_1GetDomainDetailResponse = (
     AutoRenew: __expectBoolean(output.AutoRenew),
     CreationDate:
       output.CreationDate !== undefined && output.CreationDate !== null
-        ? new Date(Math.round(output.CreationDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationDate)))
         : undefined,
     DnsSec: __expectString(output.DnsSec),
     DomainName: __expectString(output.DomainName),
     ExpirationDate:
       output.ExpirationDate !== undefined && output.ExpirationDate !== null
-        ? new Date(Math.round(output.ExpirationDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.ExpirationDate)))
         : undefined,
     Nameservers:
       output.Nameservers !== undefined && output.Nameservers !== null
@@ -3277,7 +3282,7 @@ const deserializeAws_json1_1GetDomainDetailResponse = (
     TechPrivacy: __expectBoolean(output.TechPrivacy),
     UpdatedDate:
       output.UpdatedDate !== undefined && output.UpdatedDate !== null
-        ? new Date(Math.round(output.UpdatedDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.UpdatedDate)))
         : undefined,
     WhoIsServer: __expectString(output.WhoIsServer),
   } as any;
@@ -3306,7 +3311,7 @@ const deserializeAws_json1_1GetOperationDetailResponse = (
     Status: __expectString(output.Status),
     SubmittedDate:
       output.SubmittedDate !== undefined && output.SubmittedDate !== null
-        ? new Date(Math.round(output.SubmittedDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.SubmittedDate)))
         : undefined,
     Type: __expectString(output.Type),
   } as any;
@@ -3394,7 +3399,7 @@ const deserializeAws_json1_1OperationSummary = (output: any, context: __SerdeCon
     Status: __expectString(output.Status),
     SubmittedDate:
       output.SubmittedDate !== undefined && output.SubmittedDate !== null
-        ? new Date(Math.round(output.SubmittedDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.SubmittedDate)))
         : undefined,
     Type: __expectString(output.Type),
   } as any;

--- a/clients/client-route-53/protocols/Aws_restXml.ts
+++ b/clients/client-route-53/protocols/Aws_restXml.ts
@@ -306,6 +306,7 @@ import {
   getArrayIfSingleItem as __getArrayIfSingleItem,
   getValueFromTextNode as __getValueFromTextNode,
   parseBoolean as __parseBoolean,
+  parseRfc3339DateTime as __parseRfc3339DateTime,
   strictParseFloat as __strictParseFloat,
   strictParseInt32 as __strictParseInt32,
   strictParseLong as __strictParseLong,
@@ -9391,7 +9392,7 @@ const deserializeAws_restXmlChangeInfo = (output: any, context: __SerdeContext):
     contents.Status = __expectString(output["Status"]);
   }
   if (output["SubmittedAt"] !== undefined) {
-    contents.SubmittedAt = new Date(output["SubmittedAt"]);
+    contents.SubmittedAt = __expectNonNull(__parseRfc3339DateTime(output["SubmittedAt"]));
   }
   if (output["Comment"] !== undefined) {
     contents.Comment = __expectString(output["Comment"]);
@@ -9977,10 +9978,10 @@ const deserializeAws_restXmlKeySigningKey = (output: any, context: __SerdeContex
     contents.StatusMessage = __expectString(output["StatusMessage"]);
   }
   if (output["CreatedDate"] !== undefined) {
-    contents.CreatedDate = new Date(output["CreatedDate"]);
+    contents.CreatedDate = __expectNonNull(__parseRfc3339DateTime(output["CreatedDate"]));
   }
   if (output["LastModifiedDate"] !== undefined) {
-    contents.LastModifiedDate = new Date(output["LastModifiedDate"]);
+    contents.LastModifiedDate = __expectNonNull(__parseRfc3339DateTime(output["LastModifiedDate"]));
   }
   return contents;
 };
@@ -10204,7 +10205,7 @@ const deserializeAws_restXmlStatusReport = (output: any, context: __SerdeContext
     contents.Status = __expectString(output["Status"]);
   }
   if (output["CheckedTime"] !== undefined) {
-    contents.CheckedTime = new Date(output["CheckedTime"]);
+    contents.CheckedTime = __expectNonNull(__parseRfc3339DateTime(output["CheckedTime"]));
   }
   return contents;
 };

--- a/clients/client-route53-recovery-readiness/protocols/Aws_restJson1.ts
+++ b/clients/client-route53-recovery-readiness/protocols/Aws_restJson1.ts
@@ -107,6 +107,7 @@ import {
   expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
+  parseRfc3339DateTime as __parseRfc3339DateTime,
 } from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
@@ -1991,7 +1992,7 @@ export const deserializeAws_restJson1GetArchitectureRecommendationsCommand = asy
   };
   const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.lastAuditTimestamp !== undefined && data.lastAuditTimestamp !== null) {
-    contents.LastAuditTimestamp = new Date(data.lastAuditTimestamp);
+    contents.LastAuditTimestamp = __expectNonNull(__parseRfc3339DateTime(data.lastAuditTimestamp));
   }
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.NextToken = __expectString(data.nextToken);
@@ -4431,7 +4432,7 @@ const deserializeAws_restJson1ResourceResult = (output: any, context: __SerdeCon
     ComponentId: __expectString(output.componentId),
     LastCheckedTimestamp:
       output.lastCheckedTimestamp !== undefined && output.lastCheckedTimestamp !== null
-        ? new Date(output.lastCheckedTimestamp)
+        ? __expectNonNull(__parseRfc3339DateTime(output.lastCheckedTimestamp))
         : undefined,
     Readiness: __expectString(output.readiness),
     ResourceArn: __expectString(output.resourceArn),
@@ -4458,7 +4459,7 @@ const deserializeAws_restJson1RuleResult = (output: any, context: __SerdeContext
   return {
     LastCheckedTimestamp:
       output.lastCheckedTimestamp !== undefined && output.lastCheckedTimestamp !== null
-        ? new Date(output.lastCheckedTimestamp)
+        ? __expectNonNull(__parseRfc3339DateTime(output.lastCheckedTimestamp))
         : undefined,
     Messages:
       output.messages !== undefined && output.messages !== null

--- a/clients/client-s3-control/protocols/Aws_restXml.ts
+++ b/clients/client-s3-control/protocols/Aws_restXml.ts
@@ -275,6 +275,7 @@ import {
   getArrayIfSingleItem as __getArrayIfSingleItem,
   getValueFromTextNode as __getValueFromTextNode,
   parseBoolean as __parseBoolean,
+  parseRfc3339DateTime as __parseRfc3339DateTime,
   strictParseFloat as __strictParseFloat,
   strictParseInt32 as __strictParseInt32,
   strictParseLong as __strictParseLong,
@@ -3924,7 +3925,7 @@ export const deserializeAws_restXmlGetAccessPointCommand = async (
     contents.Bucket = __expectString(data["Bucket"]);
   }
   if (data["CreationDate"] !== undefined) {
-    contents.CreationDate = new Date(data["CreationDate"]);
+    contents.CreationDate = __expectNonNull(__parseRfc3339DateTime(data["CreationDate"]));
   }
   if (data.Endpoints === "") {
     contents.Endpoints = {};
@@ -4041,7 +4042,7 @@ export const deserializeAws_restXmlGetAccessPointForObjectLambdaCommand = async 
   };
   const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["CreationDate"] !== undefined) {
-    contents.CreationDate = new Date(data["CreationDate"]);
+    contents.CreationDate = __expectNonNull(__parseRfc3339DateTime(data["CreationDate"]));
   }
   if (data["Name"] !== undefined) {
     contents.Name = __expectString(data["Name"]);
@@ -4290,7 +4291,7 @@ export const deserializeAws_restXmlGetBucketCommand = async (
     contents.Bucket = __expectString(data["Bucket"]);
   }
   if (data["CreationDate"] !== undefined) {
-    contents.CreationDate = new Date(data["CreationDate"]);
+    contents.CreationDate = __expectNonNull(__parseRfc3339DateTime(data["CreationDate"]));
   }
   if (data["PublicAccessBlockEnabled"] !== undefined) {
     contents.PublicAccessBlockEnabled = __parseBoolean(data["PublicAccessBlockEnabled"]);
@@ -7589,7 +7590,7 @@ const deserializeAws_restXmlAsyncOperation = (output: any, context: __SerdeConte
     ResponseDetails: undefined,
   };
   if (output["CreationTime"] !== undefined) {
-    contents.CreationTime = new Date(output["CreationTime"]);
+    contents.CreationTime = __expectNonNull(__parseRfc3339DateTime(output["CreationTime"]));
   }
   if (output["Operation"] !== undefined) {
     contents.Operation = __expectString(output["Operation"]);
@@ -7866,16 +7867,16 @@ const deserializeAws_restXmlJobDescriptor = (output: any, context: __SerdeContex
     contents.Report = deserializeAws_restXmlJobReport(output["Report"], context);
   }
   if (output["CreationTime"] !== undefined) {
-    contents.CreationTime = new Date(output["CreationTime"]);
+    contents.CreationTime = __expectNonNull(__parseRfc3339DateTime(output["CreationTime"]));
   }
   if (output["TerminationDate"] !== undefined) {
-    contents.TerminationDate = new Date(output["TerminationDate"]);
+    contents.TerminationDate = __expectNonNull(__parseRfc3339DateTime(output["TerminationDate"]));
   }
   if (output["RoleArn"] !== undefined) {
     contents.RoleArn = __expectString(output["RoleArn"]);
   }
   if (output["SuspendedDate"] !== undefined) {
-    contents.SuspendedDate = new Date(output["SuspendedDate"]);
+    contents.SuspendedDate = __expectNonNull(__parseRfc3339DateTime(output["SuspendedDate"]));
   }
   if (output["SuspendedCause"] !== undefined) {
     contents.SuspendedCause = __expectString(output["SuspendedCause"]);
@@ -7935,10 +7936,10 @@ const deserializeAws_restXmlJobListDescriptor = (output: any, context: __SerdeCo
     contents.Status = __expectString(output["Status"]);
   }
   if (output["CreationTime"] !== undefined) {
-    contents.CreationTime = new Date(output["CreationTime"]);
+    contents.CreationTime = __expectNonNull(__parseRfc3339DateTime(output["CreationTime"]));
   }
   if (output["TerminationDate"] !== undefined) {
-    contents.TerminationDate = new Date(output["TerminationDate"]);
+    contents.TerminationDate = __expectNonNull(__parseRfc3339DateTime(output["TerminationDate"]));
   }
   if (output["ProgressSummary"] !== undefined) {
     contents.ProgressSummary = deserializeAws_restXmlJobProgressSummary(output["ProgressSummary"], context);
@@ -8137,7 +8138,7 @@ const deserializeAws_restXmlLifecycleExpiration = (output: any, context: __Serde
     ExpiredObjectDeleteMarker: undefined,
   };
   if (output["Date"] !== undefined) {
-    contents.Date = new Date(output["Date"]);
+    contents.Date = __expectNonNull(__parseRfc3339DateTime(output["Date"]));
   }
   if (output["Days"] !== undefined) {
     contents.Days = __strictParseInt32(output["Days"]) as number;
@@ -8351,7 +8352,7 @@ const deserializeAws_restXmlMultiRegionAccessPointReport = (
     contents.Alias = __expectString(output["Alias"]);
   }
   if (output["CreatedAt"] !== undefined) {
-    contents.CreatedAt = new Date(output["CreatedAt"]);
+    contents.CreatedAt = __expectNonNull(__parseRfc3339DateTime(output["CreatedAt"]));
   }
   if (output["PublicAccessBlock"] !== undefined) {
     contents.PublicAccessBlock = deserializeAws_restXmlPublicAccessBlockConfiguration(
@@ -8722,7 +8723,7 @@ const deserializeAws_restXmlRegionalBucket = (output: any, context: __SerdeConte
     contents.PublicAccessBlockEnabled = __parseBoolean(output["PublicAccessBlockEnabled"]);
   }
   if (output["CreationDate"] !== undefined) {
-    contents.CreationDate = new Date(output["CreationDate"]);
+    contents.CreationDate = __expectNonNull(__parseRfc3339DateTime(output["CreationDate"]));
   }
   if (output["OutpostId"] !== undefined) {
     contents.OutpostId = __expectString(output["OutpostId"]);
@@ -8888,7 +8889,7 @@ const deserializeAws_restXmlS3CopyObjectOperation = (output: any, context: __Ser
     contents.MetadataDirective = __expectString(output["MetadataDirective"]);
   }
   if (output["ModifiedSinceConstraint"] !== undefined) {
-    contents.ModifiedSinceConstraint = new Date(output["ModifiedSinceConstraint"]);
+    contents.ModifiedSinceConstraint = __expectNonNull(__parseRfc3339DateTime(output["ModifiedSinceConstraint"]));
   }
   if (output["NewObjectMetadata"] !== undefined) {
     contents.NewObjectMetadata = deserializeAws_restXmlS3ObjectMetadata(output["NewObjectMetadata"], context);
@@ -8912,7 +8913,7 @@ const deserializeAws_restXmlS3CopyObjectOperation = (output: any, context: __Ser
     contents.StorageClass = __expectString(output["StorageClass"]);
   }
   if (output["UnModifiedSinceConstraint"] !== undefined) {
-    contents.UnModifiedSinceConstraint = new Date(output["UnModifiedSinceConstraint"]);
+    contents.UnModifiedSinceConstraint = __expectNonNull(__parseRfc3339DateTime(output["UnModifiedSinceConstraint"]));
   }
   if (output["SSEAwsKmsKeyId"] !== undefined) {
     contents.SSEAwsKmsKeyId = __expectString(output["SSEAwsKmsKeyId"]);
@@ -8927,7 +8928,7 @@ const deserializeAws_restXmlS3CopyObjectOperation = (output: any, context: __Ser
     contents.ObjectLockMode = __expectString(output["ObjectLockMode"]);
   }
   if (output["ObjectLockRetainUntilDate"] !== undefined) {
-    contents.ObjectLockRetainUntilDate = new Date(output["ObjectLockRetainUntilDate"]);
+    contents.ObjectLockRetainUntilDate = __expectNonNull(__parseRfc3339DateTime(output["ObjectLockRetainUntilDate"]));
   }
   if (output["BucketKeyEnabled"] !== undefined) {
     contents.BucketKeyEnabled = __parseBoolean(output["BucketKeyEnabled"]);
@@ -9058,7 +9059,7 @@ const deserializeAws_restXmlS3ObjectMetadata = (output: any, context: __SerdeCon
     contents.ContentType = __expectString(output["ContentType"]);
   }
   if (output["HttpExpiresDate"] !== undefined) {
-    contents.HttpExpiresDate = new Date(output["HttpExpiresDate"]);
+    contents.HttpExpiresDate = __expectNonNull(__parseRfc3339DateTime(output["HttpExpiresDate"]));
   }
   if (output["RequesterCharged"] !== undefined) {
     contents.RequesterCharged = __parseBoolean(output["RequesterCharged"]);
@@ -9089,7 +9090,7 @@ const deserializeAws_restXmlS3Retention = (output: any, context: __SerdeContext)
     Mode: undefined,
   };
   if (output["RetainUntilDate"] !== undefined) {
-    contents.RetainUntilDate = new Date(output["RetainUntilDate"]);
+    contents.RetainUntilDate = __expectNonNull(__parseRfc3339DateTime(output["RetainUntilDate"]));
   }
   if (output["Mode"] !== undefined) {
     contents.Mode = __expectString(output["Mode"]);
@@ -9350,7 +9351,7 @@ const deserializeAws_restXmlTransition = (output: any, context: __SerdeContext):
     StorageClass: undefined,
   };
   if (output["Date"] !== undefined) {
-    contents.Date = new Date(output["Date"]);
+    contents.Date = __expectNonNull(__parseRfc3339DateTime(output["Date"]));
   }
   if (output["Days"] !== undefined) {
     contents.Days = __strictParseInt32(output["Days"]) as number;

--- a/clients/client-s3/protocols/Aws_restXml.ts
+++ b/clients/client-s3/protocols/Aws_restXml.ts
@@ -399,6 +399,8 @@ import {
   getArrayIfSingleItem as __getArrayIfSingleItem,
   getValueFromTextNode as __getValueFromTextNode,
   parseBoolean as __parseBoolean,
+  parseRfc3339DateTime as __parseRfc3339DateTime,
+  parseRfc7231DateTime as __parseRfc7231DateTime,
   strictParseInt32 as __strictParseInt32,
   strictParseLong as __strictParseLong,
 } from "@aws-sdk/smithy-client";
@@ -5243,7 +5245,7 @@ export const deserializeAws_restXmlCreateMultipartUploadCommand = async (
     UploadId: undefined,
   };
   if (output.headers["x-amz-abort-date"] !== undefined) {
-    contents.AbortDate = new Date(output.headers["x-amz-abort-date"]);
+    contents.AbortDate = __expectNonNull(__parseRfc7231DateTime(output.headers["x-amz-abort-date"]));
   }
   if (output.headers["x-amz-abort-rule-id"] !== undefined) {
     contents.AbortRuleId = output.headers["x-amz-abort-rule-id"];
@@ -7120,7 +7122,7 @@ export const deserializeAws_restXmlGetObjectCommand = async (
     contents.Restore = output.headers["x-amz-restore"];
   }
   if (output.headers["last-modified"] !== undefined) {
-    contents.LastModified = new Date(output.headers["last-modified"]);
+    contents.LastModified = __expectNonNull(__parseRfc7231DateTime(output.headers["last-modified"]));
   }
   if (output.headers["content-length"] !== undefined) {
     contents.ContentLength = __strictParseLong(output.headers["content-length"]);
@@ -7153,7 +7155,7 @@ export const deserializeAws_restXmlGetObjectCommand = async (
     contents.ContentType = output.headers["content-type"];
   }
   if (output.headers["expires"] !== undefined) {
-    contents.Expires = new Date(output.headers["expires"]);
+    contents.Expires = __expectNonNull(__parseRfc7231DateTime(output.headers["expires"]));
   }
   if (output.headers["x-amz-website-redirect-location"] !== undefined) {
     contents.WebsiteRedirectLocation = output.headers["x-amz-website-redirect-location"];
@@ -7192,7 +7194,9 @@ export const deserializeAws_restXmlGetObjectCommand = async (
     contents.ObjectLockMode = output.headers["x-amz-object-lock-mode"];
   }
   if (output.headers["x-amz-object-lock-retain-until-date"] !== undefined) {
-    contents.ObjectLockRetainUntilDate = new Date(output.headers["x-amz-object-lock-retain-until-date"]);
+    contents.ObjectLockRetainUntilDate = __expectNonNull(
+      __parseRfc3339DateTime(output.headers["x-amz-object-lock-retain-until-date"])
+    );
   }
   if (output.headers["x-amz-object-lock-legal-hold"] !== undefined) {
     contents.ObjectLockLegalHoldStatus = output.headers["x-amz-object-lock-legal-hold"];
@@ -7711,7 +7715,7 @@ export const deserializeAws_restXmlHeadObjectCommand = async (
     contents.ArchiveStatus = output.headers["x-amz-archive-status"];
   }
   if (output.headers["last-modified"] !== undefined) {
-    contents.LastModified = new Date(output.headers["last-modified"]);
+    contents.LastModified = __expectNonNull(__parseRfc7231DateTime(output.headers["last-modified"]));
   }
   if (output.headers["content-length"] !== undefined) {
     contents.ContentLength = __strictParseLong(output.headers["content-length"]);
@@ -7741,7 +7745,7 @@ export const deserializeAws_restXmlHeadObjectCommand = async (
     contents.ContentType = output.headers["content-type"];
   }
   if (output.headers["expires"] !== undefined) {
-    contents.Expires = new Date(output.headers["expires"]);
+    contents.Expires = __expectNonNull(__parseRfc7231DateTime(output.headers["expires"]));
   }
   if (output.headers["x-amz-website-redirect-location"] !== undefined) {
     contents.WebsiteRedirectLocation = output.headers["x-amz-website-redirect-location"];
@@ -7777,7 +7781,9 @@ export const deserializeAws_restXmlHeadObjectCommand = async (
     contents.ObjectLockMode = output.headers["x-amz-object-lock-mode"];
   }
   if (output.headers["x-amz-object-lock-retain-until-date"] !== undefined) {
-    contents.ObjectLockRetainUntilDate = new Date(output.headers["x-amz-object-lock-retain-until-date"]);
+    contents.ObjectLockRetainUntilDate = __expectNonNull(
+      __parseRfc3339DateTime(output.headers["x-amz-object-lock-retain-until-date"])
+    );
   }
   if (output.headers["x-amz-object-lock-legal-hold"] !== undefined) {
     contents.ObjectLockLegalHoldStatus = output.headers["x-amz-object-lock-legal-hold"];
@@ -8585,7 +8591,7 @@ export const deserializeAws_restXmlListPartsCommand = async (
     UploadId: undefined,
   };
   if (output.headers["x-amz-abort-date"] !== undefined) {
-    contents.AbortDate = new Date(output.headers["x-amz-abort-date"]);
+    contents.AbortDate = __expectNonNull(__parseRfc7231DateTime(output.headers["x-amz-abort-date"]));
   }
   if (output.headers["x-amz-abort-rule-id"] !== undefined) {
     contents.AbortRuleId = output.headers["x-amz-abort-rule-id"];
@@ -12708,7 +12714,7 @@ const deserializeAws_restXmlBucket = (output: any, context: __SerdeContext): Buc
     contents.Name = __expectString(output["Name"]);
   }
   if (output["CreationDate"] !== undefined) {
-    contents.CreationDate = new Date(output["CreationDate"]);
+    contents.CreationDate = __expectNonNull(__parseRfc3339DateTime(output["CreationDate"]));
   }
   return contents;
 };
@@ -12773,7 +12779,7 @@ const deserializeAws_restXmlCopyObjectResult = (output: any, context: __SerdeCon
     contents.ETag = __expectString(output["ETag"]);
   }
   if (output["LastModified"] !== undefined) {
-    contents.LastModified = new Date(output["LastModified"]);
+    contents.LastModified = __expectNonNull(__parseRfc3339DateTime(output["LastModified"]));
   }
   return contents;
 };
@@ -12787,7 +12793,7 @@ const deserializeAws_restXmlCopyPartResult = (output: any, context: __SerdeConte
     contents.ETag = __expectString(output["ETag"]);
   }
   if (output["LastModified"] !== undefined) {
-    contents.LastModified = new Date(output["LastModified"]);
+    contents.LastModified = __expectNonNull(__parseRfc3339DateTime(output["LastModified"]));
   }
   return contents;
 };
@@ -12929,7 +12935,7 @@ const deserializeAws_restXmlDeleteMarkerEntry = (output: any, context: __SerdeCo
     contents.IsLatest = __parseBoolean(output["IsLatest"]);
   }
   if (output["LastModified"] !== undefined) {
-    contents.LastModified = new Date(output["LastModified"]);
+    contents.LastModified = __expectNonNull(__parseRfc3339DateTime(output["LastModified"]));
   }
   return contents;
 };
@@ -13470,7 +13476,7 @@ const deserializeAws_restXmlLifecycleExpiration = (output: any, context: __Serde
     ExpiredObjectDeleteMarker: undefined,
   };
   if (output["Date"] !== undefined) {
-    contents.Date = new Date(output["Date"]);
+    contents.Date = __expectNonNull(__parseRfc3339DateTime(output["Date"]));
   }
   if (output["Days"] !== undefined) {
     contents.Days = __strictParseInt32(output["Days"]) as number;
@@ -13706,7 +13712,7 @@ const deserializeAws_restXmlMultipartUpload = (output: any, context: __SerdeCont
     contents.Key = __expectString(output["Key"]);
   }
   if (output["Initiated"] !== undefined) {
-    contents.Initiated = new Date(output["Initiated"]);
+    contents.Initiated = __expectNonNull(__parseRfc3339DateTime(output["Initiated"]));
   }
   if (output["StorageClass"] !== undefined) {
     contents.StorageClass = __expectString(output["StorageClass"]);
@@ -13801,7 +13807,7 @@ const deserializeAws_restXml_Object = (output: any, context: __SerdeContext): _O
     contents.Key = __expectString(output["Key"]);
   }
   if (output["LastModified"] !== undefined) {
-    contents.LastModified = new Date(output["LastModified"]);
+    contents.LastModified = __expectNonNull(__parseRfc3339DateTime(output["LastModified"]));
   }
   if (output["ETag"] !== undefined) {
     contents.ETag = __expectString(output["ETag"]);
@@ -13865,7 +13871,7 @@ const deserializeAws_restXmlObjectLockRetention = (output: any, context: __Serde
     contents.Mode = __expectString(output["Mode"]);
   }
   if (output["RetainUntilDate"] !== undefined) {
-    contents.RetainUntilDate = new Date(output["RetainUntilDate"]);
+    contents.RetainUntilDate = __expectNonNull(__parseRfc3339DateTime(output["RetainUntilDate"]));
   }
   return contents;
 };
@@ -13910,7 +13916,7 @@ const deserializeAws_restXmlObjectVersion = (output: any, context: __SerdeContex
     contents.IsLatest = __parseBoolean(output["IsLatest"]);
   }
   if (output["LastModified"] !== undefined) {
-    contents.LastModified = new Date(output["LastModified"]);
+    contents.LastModified = __expectNonNull(__parseRfc3339DateTime(output["LastModified"]));
   }
   if (output["Owner"] !== undefined) {
     contents.Owner = deserializeAws_restXmlOwner(output["Owner"], context);
@@ -13991,7 +13997,7 @@ const deserializeAws_restXmlPart = (output: any, context: __SerdeContext): Part 
     contents.PartNumber = __strictParseInt32(output["PartNumber"]) as number;
   }
   if (output["LastModified"] !== undefined) {
-    contents.LastModified = new Date(output["LastModified"]);
+    contents.LastModified = __expectNonNull(__parseRfc3339DateTime(output["LastModified"]));
   }
   if (output["ETag"] !== undefined) {
     contents.ETag = __expectString(output["ETag"]);
@@ -14672,7 +14678,7 @@ const deserializeAws_restXmlTransition = (output: any, context: __SerdeContext):
     StorageClass: undefined,
   };
   if (output["Date"] !== undefined) {
-    contents.Date = new Date(output["Date"]);
+    contents.Date = __expectNonNull(__parseRfc3339DateTime(output["Date"]));
   }
   if (output["Days"] !== undefined) {
     contents.Days = __strictParseInt32(output["Days"]) as number;

--- a/clients/client-s3outposts/protocols/Aws_restJson1.ts
+++ b/clients/client-s3outposts/protocols/Aws_restJson1.ts
@@ -13,9 +13,11 @@ import {
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
   expectNonNull as __expectNonNull,
+  expectNumber as __expectNumber,
   expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
+  parseEpochTimestamp as __parseEpochTimestamp,
 } from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
@@ -442,7 +444,7 @@ const deserializeAws_restJson1Endpoint = (output: any, context: __SerdeContext):
     CidrBlock: __expectString(output.CidrBlock),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     CustomerOwnedIpv4Pool: __expectString(output.CustomerOwnedIpv4Pool),
     EndpointArn: __expectString(output.EndpointArn),

--- a/clients/client-sagemaker-a2i-runtime/protocols/Aws_restJson1.ts
+++ b/clients/client-sagemaker-a2i-runtime/protocols/Aws_restJson1.ts
@@ -19,9 +19,11 @@ import {
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
   expectNonNull as __expectNonNull,
+  expectNumber as __expectNumber,
   expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
+  parseEpochTimestamp as __parseEpochTimestamp,
 } from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
@@ -274,7 +276,7 @@ export const deserializeAws_restJson1DescribeHumanLoopCommand = async (
   };
   const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CreationTime !== undefined && data.CreationTime !== null) {
-    contents.CreationTime = new Date(Math.round(data.CreationTime * 1000));
+    contents.CreationTime = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.CreationTime)));
   }
   if (data.FailureCode !== undefined && data.FailureCode !== null) {
     contents.FailureCode = __expectString(data.FailureCode);
@@ -761,7 +763,7 @@ const deserializeAws_restJson1HumanLoopSummary = (output: any, context: __SerdeC
   return {
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     FailureReason: __expectString(output.FailureReason),
     FlowDefinitionArn: __expectString(output.FlowDefinitionArn),

--- a/clients/client-sagemaker/protocols/Aws_json1_1.ts
+++ b/clients/client-sagemaker/protocols/Aws_json1_1.ts
@@ -1359,9 +1359,12 @@ import {
   expectBoolean as __expectBoolean,
   expectInt32 as __expectInt32,
   expectLong as __expectLong,
+  expectNonNull as __expectNonNull,
+  expectNumber as __expectNumber,
   expectString as __expectString,
   limitedParseDouble as __limitedParseDouble,
   limitedParseFloat32 as __limitedParseFloat32,
+  parseEpochTimestamp as __parseEpochTimestamp,
   serializeFloat as __serializeFloat,
 } from "@aws-sdk/smithy-client";
 import {
@@ -24135,11 +24138,11 @@ const deserializeAws_json1_1ActionSummary = (output: any, context: __SerdeContex
     ActionType: __expectString(output.ActionType),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     LastModifiedTime:
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
-        ? new Date(Math.round(output.LastModifiedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastModifiedTime)))
         : undefined,
     Source:
       output.Source !== undefined && output.Source !== null
@@ -24264,7 +24267,7 @@ const deserializeAws_json1_1AlgorithmSummary = (output: any, context: __SerdeCon
     AlgorithmStatus: __expectString(output.AlgorithmStatus),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
   } as any;
 };
@@ -24339,7 +24342,7 @@ const deserializeAws_json1_1AppDetails = (output: any, context: __SerdeContext):
     AppType: __expectString(output.AppType),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     DomainId: __expectString(output.DomainId),
     Status: __expectString(output.Status),
@@ -24353,7 +24356,7 @@ const deserializeAws_json1_1AppImageConfigDetails = (output: any, context: __Ser
     AppImageConfigName: __expectString(output.AppImageConfigName),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     KernelGatewayImageConfig:
       output.KernelGatewayImageConfig !== undefined && output.KernelGatewayImageConfig !== null
@@ -24361,7 +24364,7 @@ const deserializeAws_json1_1AppImageConfigDetails = (output: any, context: __Ser
         : undefined,
     LastModifiedTime:
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
-        ? new Date(Math.round(output.LastModifiedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastModifiedTime)))
         : undefined,
   } as any;
 };
@@ -24448,11 +24451,11 @@ const deserializeAws_json1_1ArtifactSummary = (output: any, context: __SerdeCont
     ArtifactType: __expectString(output.ArtifactType),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     LastModifiedTime:
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
-        ? new Date(Math.round(output.LastModifiedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastModifiedTime)))
         : undefined,
     Source:
       output.Source !== undefined && output.Source !== null
@@ -24491,7 +24494,7 @@ const deserializeAws_json1_1AssociationSummary = (output: any, context: __SerdeC
         : undefined,
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     DestinationArn: __expectString(output.DestinationArn),
     DestinationName: __expectString(output.DestinationName),
@@ -24589,10 +24592,12 @@ const deserializeAws_json1_1AutoMLCandidate = (output: any, context: __SerdeCont
         : undefined,
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     EndTime:
-      output.EndTime !== undefined && output.EndTime !== null ? new Date(Math.round(output.EndTime * 1000)) : undefined,
+      output.EndTime !== undefined && output.EndTime !== null
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.EndTime)))
+        : undefined,
     FailureReason: __expectString(output.FailureReason),
     FinalAutoMLJobObjectiveMetric:
       output.FinalAutoMLJobObjectiveMetric !== undefined && output.FinalAutoMLJobObjectiveMetric !== null
@@ -24604,7 +24609,7 @@ const deserializeAws_json1_1AutoMLCandidate = (output: any, context: __SerdeCont
         : undefined,
     LastModifiedTime:
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
-        ? new Date(Math.round(output.LastModifiedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastModifiedTime)))
         : undefined,
     ObjectiveStatus: __expectString(output.ObjectiveStatus),
   } as any;
@@ -24744,14 +24749,16 @@ const deserializeAws_json1_1AutoMLJobSummary = (output: any, context: __SerdeCon
     AutoMLJobStatus: __expectString(output.AutoMLJobStatus),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     EndTime:
-      output.EndTime !== undefined && output.EndTime !== null ? new Date(Math.round(output.EndTime * 1000)) : undefined,
+      output.EndTime !== undefined && output.EndTime !== null
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.EndTime)))
+        : undefined,
     FailureReason: __expectString(output.FailureReason),
     LastModifiedTime:
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
-        ? new Date(Math.round(output.LastModifiedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastModifiedTime)))
         : undefined,
     PartialFailureReasons:
       output.PartialFailureReasons !== undefined && output.PartialFailureReasons !== null
@@ -25039,7 +25046,7 @@ const deserializeAws_json1_1CodeRepositorySummary = (output: any, context: __Ser
     CodeRepositoryName: __expectString(output.CodeRepositoryName),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     GitConfig:
       output.GitConfig !== undefined && output.GitConfig !== null
@@ -25047,7 +25054,7 @@ const deserializeAws_json1_1CodeRepositorySummary = (output: any, context: __Ser
         : undefined,
     LastModifiedTime:
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
-        ? new Date(Math.round(output.LastModifiedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastModifiedTime)))
         : undefined,
   } as any;
 };
@@ -25144,14 +25151,14 @@ const deserializeAws_json1_1CompilationJobSummary = (output: any, context: __Ser
   return {
     CompilationEndTime:
       output.CompilationEndTime !== undefined && output.CompilationEndTime !== null
-        ? new Date(Math.round(output.CompilationEndTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CompilationEndTime)))
         : undefined,
     CompilationJobArn: __expectString(output.CompilationJobArn),
     CompilationJobName: __expectString(output.CompilationJobName),
     CompilationJobStatus: __expectString(output.CompilationJobStatus),
     CompilationStartTime:
       output.CompilationStartTime !== undefined && output.CompilationStartTime !== null
-        ? new Date(Math.round(output.CompilationStartTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CompilationStartTime)))
         : undefined,
     CompilationTargetDevice: __expectString(output.CompilationTargetDevice),
     CompilationTargetPlatformAccelerator: __expectString(output.CompilationTargetPlatformAccelerator),
@@ -25159,11 +25166,11 @@ const deserializeAws_json1_1CompilationJobSummary = (output: any, context: __Ser
     CompilationTargetPlatformOs: __expectString(output.CompilationTargetPlatformOs),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     LastModifiedTime:
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
-        ? new Date(Math.round(output.LastModifiedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastModifiedTime)))
         : undefined,
   } as any;
 };
@@ -25297,11 +25304,11 @@ const deserializeAws_json1_1ContextSummary = (output: any, context: __SerdeConte
     ContextType: __expectString(output.ContextType),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     LastModifiedTime:
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
-        ? new Date(Math.round(output.LastModifiedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastModifiedTime)))
         : undefined,
     Source:
       output.Source !== undefined && output.Source !== null
@@ -25892,7 +25899,7 @@ const deserializeAws_json1_1DebugRuleEvaluationStatus = (
   return {
     LastModifiedTime:
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
-        ? new Date(Math.round(output.LastModifiedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastModifiedTime)))
         : undefined,
     RuleConfigurationName: __expectString(output.RuleConfigurationName),
     RuleEvaluationJobArn: __expectString(output.RuleEvaluationJobArn),
@@ -26019,7 +26026,7 @@ const deserializeAws_json1_1DeployedImage = (output: any, context: __SerdeContex
   return {
     ResolutionTime:
       output.ResolutionTime !== undefined && output.ResolutionTime !== null
-        ? new Date(Math.round(output.ResolutionTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.ResolutionTime)))
         : undefined,
     ResolvedImage: __expectString(output.ResolvedImage),
     SpecifiedImage: __expectString(output.SpecifiedImage),
@@ -26061,7 +26068,7 @@ const deserializeAws_json1_1DescribeActionResponse = (output: any, context: __Se
         : undefined,
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     Description: __expectString(output.Description),
     LastModifiedBy:
@@ -26070,7 +26077,7 @@ const deserializeAws_json1_1DescribeActionResponse = (output: any, context: __Se
         : undefined,
     LastModifiedTime:
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
-        ? new Date(Math.round(output.LastModifiedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastModifiedTime)))
         : undefined,
     MetadataProperties:
       output.MetadataProperties !== undefined && output.MetadataProperties !== null
@@ -26104,7 +26111,7 @@ const deserializeAws_json1_1DescribeAlgorithmOutput = (
     CertifyForMarketplace: __expectBoolean(output.CertifyForMarketplace),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     InferenceSpecification:
       output.InferenceSpecification !== undefined && output.InferenceSpecification !== null
@@ -26131,7 +26138,7 @@ const deserializeAws_json1_1DescribeAppImageConfigResponse = (
     AppImageConfigName: __expectString(output.AppImageConfigName),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     KernelGatewayImageConfig:
       output.KernelGatewayImageConfig !== undefined && output.KernelGatewayImageConfig !== null
@@ -26139,7 +26146,7 @@ const deserializeAws_json1_1DescribeAppImageConfigResponse = (
         : undefined,
     LastModifiedTime:
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
-        ? new Date(Math.round(output.LastModifiedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastModifiedTime)))
         : undefined,
   } as any;
 };
@@ -26151,17 +26158,17 @@ const deserializeAws_json1_1DescribeAppResponse = (output: any, context: __Serde
     AppType: __expectString(output.AppType),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     DomainId: __expectString(output.DomainId),
     FailureReason: __expectString(output.FailureReason),
     LastHealthCheckTimestamp:
       output.LastHealthCheckTimestamp !== undefined && output.LastHealthCheckTimestamp !== null
-        ? new Date(Math.round(output.LastHealthCheckTimestamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastHealthCheckTimestamp)))
         : undefined,
     LastUserActivityTimestamp:
       output.LastUserActivityTimestamp !== undefined && output.LastUserActivityTimestamp !== null
-        ? new Date(Math.round(output.LastUserActivityTimestamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastUserActivityTimestamp)))
         : undefined,
     ResourceSpec:
       output.ResourceSpec !== undefined && output.ResourceSpec !== null
@@ -26186,7 +26193,7 @@ const deserializeAws_json1_1DescribeArtifactResponse = (
         : undefined,
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     LastModifiedBy:
       output.LastModifiedBy !== undefined && output.LastModifiedBy !== null
@@ -26194,7 +26201,7 @@ const deserializeAws_json1_1DescribeArtifactResponse = (
         : undefined,
     LastModifiedTime:
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
-        ? new Date(Math.round(output.LastModifiedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastModifiedTime)))
         : undefined,
     MetadataProperties:
       output.MetadataProperties !== undefined && output.MetadataProperties !== null
@@ -26238,10 +26245,12 @@ const deserializeAws_json1_1DescribeAutoMLJobResponse = (
         : undefined,
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     EndTime:
-      output.EndTime !== undefined && output.EndTime !== null ? new Date(Math.round(output.EndTime * 1000)) : undefined,
+      output.EndTime !== undefined && output.EndTime !== null
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.EndTime)))
+        : undefined,
     FailureReason: __expectString(output.FailureReason),
     GenerateCandidateDefinitionsOnly: __expectBoolean(output.GenerateCandidateDefinitionsOnly),
     InputDataConfig:
@@ -26250,7 +26259,7 @@ const deserializeAws_json1_1DescribeAutoMLJobResponse = (
         : undefined,
     LastModifiedTime:
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
-        ? new Date(Math.round(output.LastModifiedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastModifiedTime)))
         : undefined,
     ModelDeployConfig:
       output.ModelDeployConfig !== undefined && output.ModelDeployConfig !== null
@@ -26286,7 +26295,7 @@ const deserializeAws_json1_1DescribeCodeRepositoryOutput = (
     CodeRepositoryName: __expectString(output.CodeRepositoryName),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     GitConfig:
       output.GitConfig !== undefined && output.GitConfig !== null
@@ -26294,7 +26303,7 @@ const deserializeAws_json1_1DescribeCodeRepositoryOutput = (
         : undefined,
     LastModifiedTime:
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
-        ? new Date(Math.round(output.LastModifiedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastModifiedTime)))
         : undefined,
   } as any;
 };
@@ -26306,18 +26315,18 @@ const deserializeAws_json1_1DescribeCompilationJobResponse = (
   return {
     CompilationEndTime:
       output.CompilationEndTime !== undefined && output.CompilationEndTime !== null
-        ? new Date(Math.round(output.CompilationEndTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CompilationEndTime)))
         : undefined,
     CompilationJobArn: __expectString(output.CompilationJobArn),
     CompilationJobName: __expectString(output.CompilationJobName),
     CompilationJobStatus: __expectString(output.CompilationJobStatus),
     CompilationStartTime:
       output.CompilationStartTime !== undefined && output.CompilationStartTime !== null
-        ? new Date(Math.round(output.CompilationStartTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CompilationStartTime)))
         : undefined,
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     FailureReason: __expectString(output.FailureReason),
     InferenceImage: __expectString(output.InferenceImage),
@@ -26327,7 +26336,7 @@ const deserializeAws_json1_1DescribeCompilationJobResponse = (
         : undefined,
     LastModifiedTime:
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
-        ? new Date(Math.round(output.LastModifiedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastModifiedTime)))
         : undefined,
     ModelArtifacts:
       output.ModelArtifacts !== undefined && output.ModelArtifacts !== null
@@ -26367,7 +26376,7 @@ const deserializeAws_json1_1DescribeContextResponse = (
         : undefined,
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     Description: __expectString(output.Description),
     LastModifiedBy:
@@ -26376,7 +26385,7 @@ const deserializeAws_json1_1DescribeContextResponse = (
         : undefined,
     LastModifiedTime:
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
-        ? new Date(Math.round(output.LastModifiedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastModifiedTime)))
         : undefined,
     Properties:
       output.Properties !== undefined && output.Properties !== null
@@ -26396,7 +26405,7 @@ const deserializeAws_json1_1DescribeDataQualityJobDefinitionResponse = (
   return {
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     DataQualityAppSpecification:
       output.DataQualityAppSpecification !== undefined && output.DataQualityAppSpecification !== null
@@ -26439,7 +26448,7 @@ const deserializeAws_json1_1DescribeDeviceFleetResponse = (
   return {
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     Description: __expectString(output.Description),
     DeviceFleetArn: __expectString(output.DeviceFleetArn),
@@ -26447,7 +26456,7 @@ const deserializeAws_json1_1DescribeDeviceFleetResponse = (
     IotRoleAlias: __expectString(output.IotRoleAlias),
     LastModifiedTime:
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
-        ? new Date(Math.round(output.LastModifiedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastModifiedTime)))
         : undefined,
     OutputConfig:
       output.OutputConfig !== undefined && output.OutputConfig !== null
@@ -26466,7 +26475,7 @@ const deserializeAws_json1_1DescribeDeviceResponse = (output: any, context: __Se
     IotThingName: __expectString(output.IotThingName),
     LatestHeartbeat:
       output.LatestHeartbeat !== undefined && output.LatestHeartbeat !== null
-        ? new Date(Math.round(output.LatestHeartbeat * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LatestHeartbeat)))
         : undefined,
     MaxModels: __expectInt32(output.MaxModels),
     Models:
@@ -26476,7 +26485,7 @@ const deserializeAws_json1_1DescribeDeviceResponse = (output: any, context: __Se
     NextToken: __expectString(output.NextToken),
     RegistrationTime:
       output.RegistrationTime !== undefined && output.RegistrationTime !== null
-        ? new Date(Math.round(output.RegistrationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.RegistrationTime)))
         : undefined,
   } as any;
 };
@@ -26487,7 +26496,7 @@ const deserializeAws_json1_1DescribeDomainResponse = (output: any, context: __Se
     AuthMode: __expectString(output.AuthMode),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     DefaultUserSettings:
       output.DefaultUserSettings !== undefined && output.DefaultUserSettings !== null
@@ -26502,7 +26511,7 @@ const deserializeAws_json1_1DescribeDomainResponse = (output: any, context: __Se
     KmsKeyId: __expectString(output.KmsKeyId),
     LastModifiedTime:
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
-        ? new Date(Math.round(output.LastModifiedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastModifiedTime)))
         : undefined,
     SingleSignOnManagedApplicationInstanceId: __expectString(output.SingleSignOnManagedApplicationInstanceId),
     Status: __expectString(output.Status),
@@ -26523,7 +26532,7 @@ const deserializeAws_json1_1DescribeEdgePackagingJobResponse = (
     CompilationJobName: __expectString(output.CompilationJobName),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     EdgePackagingJobArn: __expectString(output.EdgePackagingJobArn),
     EdgePackagingJobName: __expectString(output.EdgePackagingJobName),
@@ -26531,7 +26540,7 @@ const deserializeAws_json1_1DescribeEdgePackagingJobResponse = (
     EdgePackagingJobStatusMessage: __expectString(output.EdgePackagingJobStatusMessage),
     LastModifiedTime:
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
-        ? new Date(Math.round(output.LastModifiedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastModifiedTime)))
         : undefined,
     ModelArtifact: __expectString(output.ModelArtifact),
     ModelName: __expectString(output.ModelName),
@@ -26561,7 +26570,7 @@ const deserializeAws_json1_1DescribeEndpointConfigOutput = (
         : undefined,
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     DataCaptureConfig:
       output.DataCaptureConfig !== undefined && output.DataCaptureConfig !== null
@@ -26585,7 +26594,7 @@ const deserializeAws_json1_1DescribeEndpointOutput = (output: any, context: __Se
         : undefined,
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     DataCaptureConfig:
       output.DataCaptureConfig !== undefined && output.DataCaptureConfig !== null
@@ -26602,7 +26611,7 @@ const deserializeAws_json1_1DescribeEndpointOutput = (output: any, context: __Se
         : undefined,
     LastModifiedTime:
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
-        ? new Date(Math.round(output.LastModifiedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastModifiedTime)))
         : undefined,
     ProductionVariants:
       output.ProductionVariants !== undefined && output.ProductionVariants !== null
@@ -26622,7 +26631,7 @@ const deserializeAws_json1_1DescribeExperimentResponse = (
         : undefined,
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     Description: __expectString(output.Description),
     DisplayName: __expectString(output.DisplayName),
@@ -26634,7 +26643,7 @@ const deserializeAws_json1_1DescribeExperimentResponse = (
         : undefined,
     LastModifiedTime:
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
-        ? new Date(Math.round(output.LastModifiedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastModifiedTime)))
         : undefined,
     Source:
       output.Source !== undefined && output.Source !== null
@@ -26650,7 +26659,7 @@ const deserializeAws_json1_1DescribeFeatureGroupResponse = (
   return {
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     Description: __expectString(output.Description),
     EventTimeFeatureName: __expectString(output.EventTimeFeatureName),
@@ -26687,7 +26696,7 @@ const deserializeAws_json1_1DescribeFlowDefinitionResponse = (
   return {
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     FailureReason: __expectString(output.FailureReason),
     FlowDefinitionArn: __expectString(output.FlowDefinitionArn),
@@ -26720,7 +26729,7 @@ const deserializeAws_json1_1DescribeHumanTaskUiResponse = (
   return {
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     HumanTaskUiArn: __expectString(output.HumanTaskUiArn),
     HumanTaskUiName: __expectString(output.HumanTaskUiName),
@@ -26743,12 +26752,12 @@ const deserializeAws_json1_1DescribeHyperParameterTuningJobResponse = (
         : undefined,
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     FailureReason: __expectString(output.FailureReason),
     HyperParameterTuningEndTime:
       output.HyperParameterTuningEndTime !== undefined && output.HyperParameterTuningEndTime !== null
-        ? new Date(Math.round(output.HyperParameterTuningEndTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.HyperParameterTuningEndTime)))
         : undefined,
     HyperParameterTuningJobArn: __expectString(output.HyperParameterTuningJobArn),
     HyperParameterTuningJobConfig:
@@ -26759,7 +26768,7 @@ const deserializeAws_json1_1DescribeHyperParameterTuningJobResponse = (
     HyperParameterTuningJobStatus: __expectString(output.HyperParameterTuningJobStatus),
     LastModifiedTime:
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
-        ? new Date(Math.round(output.LastModifiedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastModifiedTime)))
         : undefined,
     ObjectiveStatusCounters:
       output.ObjectiveStatusCounters !== undefined && output.ObjectiveStatusCounters !== null
@@ -26792,7 +26801,7 @@ const deserializeAws_json1_1DescribeImageResponse = (output: any, context: __Ser
   return {
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     Description: __expectString(output.Description),
     DisplayName: __expectString(output.DisplayName),
@@ -26802,7 +26811,7 @@ const deserializeAws_json1_1DescribeImageResponse = (output: any, context: __Ser
     ImageStatus: __expectString(output.ImageStatus),
     LastModifiedTime:
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
-        ? new Date(Math.round(output.LastModifiedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastModifiedTime)))
         : undefined,
     RoleArn: __expectString(output.RoleArn),
   } as any;
@@ -26817,7 +26826,7 @@ const deserializeAws_json1_1DescribeImageVersionResponse = (
     ContainerImage: __expectString(output.ContainerImage),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     FailureReason: __expectString(output.FailureReason),
     ImageArn: __expectString(output.ImageArn),
@@ -26825,7 +26834,7 @@ const deserializeAws_json1_1DescribeImageVersionResponse = (
     ImageVersionStatus: __expectString(output.ImageVersionStatus),
     LastModifiedTime:
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
-        ? new Date(Math.round(output.LastModifiedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastModifiedTime)))
         : undefined,
     Version: __expectInt32(output.Version),
   } as any;
@@ -26838,7 +26847,7 @@ const deserializeAws_json1_1DescribeLabelingJobResponse = (
   return {
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     FailureReason: __expectString(output.FailureReason),
     HumanTaskConfig:
@@ -26869,7 +26878,7 @@ const deserializeAws_json1_1DescribeLabelingJobResponse = (
     LabelingJobStatus: __expectString(output.LabelingJobStatus),
     LastModifiedTime:
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
-        ? new Date(Math.round(output.LastModifiedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastModifiedTime)))
         : undefined,
     OutputConfig:
       output.OutputConfig !== undefined && output.OutputConfig !== null
@@ -26894,7 +26903,7 @@ const deserializeAws_json1_1DescribeModelBiasJobDefinitionResponse = (
   return {
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     JobDefinitionArn: __expectString(output.JobDefinitionArn),
     JobDefinitionName: __expectString(output.JobDefinitionName),
@@ -26937,7 +26946,7 @@ const deserializeAws_json1_1DescribeModelExplainabilityJobDefinitionResponse = (
   return {
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     JobDefinitionArn: __expectString(output.JobDefinitionArn),
     JobDefinitionName: __expectString(output.JobDefinitionName),
@@ -26981,7 +26990,7 @@ const deserializeAws_json1_1DescribeModelOutput = (output: any, context: __Serde
         : undefined,
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     EnableNetworkIsolation: __expectBoolean(output.EnableNetworkIsolation),
     ExecutionRoleArn: __expectString(output.ExecutionRoleArn),
@@ -27013,7 +27022,7 @@ const deserializeAws_json1_1DescribeModelPackageGroupOutput = (
         : undefined,
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     ModelPackageGroupArn: __expectString(output.ModelPackageGroupArn),
     ModelPackageGroupDescription: __expectString(output.ModelPackageGroupDescription),
@@ -27035,7 +27044,7 @@ const deserializeAws_json1_1DescribeModelPackageOutput = (
         : undefined,
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     InferenceSpecification:
       output.InferenceSpecification !== undefined && output.InferenceSpecification !== null
@@ -27047,7 +27056,7 @@ const deserializeAws_json1_1DescribeModelPackageOutput = (
         : undefined,
     LastModifiedTime:
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
-        ? new Date(Math.round(output.LastModifiedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastModifiedTime)))
         : undefined,
     MetadataProperties:
       output.MetadataProperties !== undefined && output.MetadataProperties !== null
@@ -27086,7 +27095,7 @@ const deserializeAws_json1_1DescribeModelQualityJobDefinitionResponse = (
   return {
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     JobDefinitionArn: __expectString(output.JobDefinitionArn),
     JobDefinitionName: __expectString(output.JobDefinitionName),
@@ -27129,13 +27138,13 @@ const deserializeAws_json1_1DescribeMonitoringScheduleResponse = (
   return {
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     EndpointName: __expectString(output.EndpointName),
     FailureReason: __expectString(output.FailureReason),
     LastModifiedTime:
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
-        ? new Date(Math.round(output.LastModifiedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastModifiedTime)))
         : undefined,
     LastMonitoringExecutionSummary:
       output.LastMonitoringExecutionSummary !== undefined && output.LastMonitoringExecutionSummary !== null
@@ -27159,11 +27168,11 @@ const deserializeAws_json1_1DescribeNotebookInstanceLifecycleConfigOutput = (
   return {
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     LastModifiedTime:
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
-        ? new Date(Math.round(output.LastModifiedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastModifiedTime)))
         : undefined,
     NotebookInstanceLifecycleConfigArn: __expectString(output.NotebookInstanceLifecycleConfigArn),
     NotebookInstanceLifecycleConfigName: __expectString(output.NotebookInstanceLifecycleConfigName),
@@ -27193,7 +27202,7 @@ const deserializeAws_json1_1DescribeNotebookInstanceOutput = (
         : undefined,
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     DefaultCodeRepository: __expectString(output.DefaultCodeRepository),
     DirectInternetAccess: __expectString(output.DirectInternetAccess),
@@ -27202,7 +27211,7 @@ const deserializeAws_json1_1DescribeNotebookInstanceOutput = (
     KmsKeyId: __expectString(output.KmsKeyId),
     LastModifiedTime:
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
-        ? new Date(Math.round(output.LastModifiedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastModifiedTime)))
         : undefined,
     NetworkInterfaceId: __expectString(output.NetworkInterfaceId),
     NotebookInstanceArn: __expectString(output.NotebookInstanceArn),
@@ -27229,7 +27238,7 @@ const deserializeAws_json1_1DescribePipelineDefinitionForExecutionResponse = (
   return {
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     PipelineDefinition: __expectString(output.PipelineDefinition),
   } as any;
@@ -27246,7 +27255,7 @@ const deserializeAws_json1_1DescribePipelineExecutionResponse = (
         : undefined,
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     FailureReason: __expectString(output.FailureReason),
     LastModifiedBy:
@@ -27255,7 +27264,7 @@ const deserializeAws_json1_1DescribePipelineExecutionResponse = (
         : undefined,
     LastModifiedTime:
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
-        ? new Date(Math.round(output.LastModifiedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastModifiedTime)))
         : undefined,
     PipelineArn: __expectString(output.PipelineArn),
     PipelineExecutionArn: __expectString(output.PipelineExecutionArn),
@@ -27280,7 +27289,7 @@ const deserializeAws_json1_1DescribePipelineResponse = (
         : undefined,
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     LastModifiedBy:
       output.LastModifiedBy !== undefined && output.LastModifiedBy !== null
@@ -27288,11 +27297,11 @@ const deserializeAws_json1_1DescribePipelineResponse = (
         : undefined,
     LastModifiedTime:
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
-        ? new Date(Math.round(output.LastModifiedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastModifiedTime)))
         : undefined,
     LastRunTime:
       output.LastRunTime !== undefined && output.LastRunTime !== null
-        ? new Date(Math.round(output.LastRunTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastRunTime)))
         : undefined,
     PipelineArn: __expectString(output.PipelineArn),
     PipelineDefinition: __expectString(output.PipelineDefinition),
@@ -27316,7 +27325,7 @@ const deserializeAws_json1_1DescribeProcessingJobResponse = (
     AutoMLJobArn: __expectString(output.AutoMLJobArn),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     Environment:
       output.Environment !== undefined && output.Environment !== null
@@ -27330,7 +27339,7 @@ const deserializeAws_json1_1DescribeProcessingJobResponse = (
     FailureReason: __expectString(output.FailureReason),
     LastModifiedTime:
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
-        ? new Date(Math.round(output.LastModifiedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastModifiedTime)))
         : undefined,
     MonitoringScheduleArn: __expectString(output.MonitoringScheduleArn),
     NetworkConfig:
@@ -27339,7 +27348,7 @@ const deserializeAws_json1_1DescribeProcessingJobResponse = (
         : undefined,
     ProcessingEndTime:
       output.ProcessingEndTime !== undefined && output.ProcessingEndTime !== null
-        ? new Date(Math.round(output.ProcessingEndTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.ProcessingEndTime)))
         : undefined,
     ProcessingInputs:
       output.ProcessingInputs !== undefined && output.ProcessingInputs !== null
@@ -27358,7 +27367,7 @@ const deserializeAws_json1_1DescribeProcessingJobResponse = (
         : undefined,
     ProcessingStartTime:
       output.ProcessingStartTime !== undefined && output.ProcessingStartTime !== null
-        ? new Date(Math.round(output.ProcessingStartTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.ProcessingStartTime)))
         : undefined,
     RoleArn: __expectString(output.RoleArn),
     StoppingCondition:
@@ -27377,7 +27386,7 @@ const deserializeAws_json1_1DescribeProjectOutput = (output: any, context: __Ser
         : undefined,
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     ProjectArn: __expectString(output.ProjectArn),
     ProjectDescription: __expectString(output.ProjectDescription),
@@ -27428,7 +27437,7 @@ const deserializeAws_json1_1DescribeTrainingJobResponse = (
         : undefined,
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     DebugHookConfig:
       output.DebugHookConfig !== undefined && output.DebugHookConfig !== null
@@ -27469,7 +27478,7 @@ const deserializeAws_json1_1DescribeTrainingJobResponse = (
     LabelingJobArn: __expectString(output.LabelingJobArn),
     LastModifiedTime:
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
-        ? new Date(Math.round(output.LastModifiedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastModifiedTime)))
         : undefined,
     ModelArtifacts:
       output.ModelArtifacts !== undefined && output.ModelArtifacts !== null
@@ -27516,14 +27525,14 @@ const deserializeAws_json1_1DescribeTrainingJobResponse = (
         : undefined,
     TrainingEndTime:
       output.TrainingEndTime !== undefined && output.TrainingEndTime !== null
-        ? new Date(Math.round(output.TrainingEndTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.TrainingEndTime)))
         : undefined,
     TrainingJobArn: __expectString(output.TrainingJobArn),
     TrainingJobName: __expectString(output.TrainingJobName),
     TrainingJobStatus: __expectString(output.TrainingJobStatus),
     TrainingStartTime:
       output.TrainingStartTime !== undefined && output.TrainingStartTime !== null
-        ? new Date(Math.round(output.TrainingStartTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.TrainingStartTime)))
         : undefined,
     TrainingTimeInSeconds: __expectInt32(output.TrainingTimeInSeconds),
     TuningJobArn: __expectString(output.TuningJobArn),
@@ -27543,7 +27552,7 @@ const deserializeAws_json1_1DescribeTransformJobResponse = (
     BatchStrategy: __expectString(output.BatchStrategy),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     DataProcessing:
       output.DataProcessing !== undefined && output.DataProcessing !== null
@@ -27568,7 +27577,7 @@ const deserializeAws_json1_1DescribeTransformJobResponse = (
     ModelName: __expectString(output.ModelName),
     TransformEndTime:
       output.TransformEndTime !== undefined && output.TransformEndTime !== null
-        ? new Date(Math.round(output.TransformEndTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.TransformEndTime)))
         : undefined,
     TransformInput:
       output.TransformInput !== undefined && output.TransformInput !== null
@@ -27587,7 +27596,7 @@ const deserializeAws_json1_1DescribeTransformJobResponse = (
         : undefined,
     TransformStartTime:
       output.TransformStartTime !== undefined && output.TransformStartTime !== null
-        ? new Date(Math.round(output.TransformStartTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.TransformStartTime)))
         : undefined,
   } as any;
 };
@@ -27603,11 +27612,13 @@ const deserializeAws_json1_1DescribeTrialComponentResponse = (
         : undefined,
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     DisplayName: __expectString(output.DisplayName),
     EndTime:
-      output.EndTime !== undefined && output.EndTime !== null ? new Date(Math.round(output.EndTime * 1000)) : undefined,
+      output.EndTime !== undefined && output.EndTime !== null
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.EndTime)))
+        : undefined,
     InputArtifacts:
       output.InputArtifacts !== undefined && output.InputArtifacts !== null
         ? deserializeAws_json1_1TrialComponentArtifacts(output.InputArtifacts, context)
@@ -27618,7 +27629,7 @@ const deserializeAws_json1_1DescribeTrialComponentResponse = (
         : undefined,
     LastModifiedTime:
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
-        ? new Date(Math.round(output.LastModifiedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastModifiedTime)))
         : undefined,
     MetadataProperties:
       output.MetadataProperties !== undefined && output.MetadataProperties !== null
@@ -27642,7 +27653,7 @@ const deserializeAws_json1_1DescribeTrialComponentResponse = (
         : undefined,
     StartTime:
       output.StartTime !== undefined && output.StartTime !== null
-        ? new Date(Math.round(output.StartTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.StartTime)))
         : undefined,
     Status:
       output.Status !== undefined && output.Status !== null
@@ -27661,7 +27672,7 @@ const deserializeAws_json1_1DescribeTrialResponse = (output: any, context: __Ser
         : undefined,
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     DisplayName: __expectString(output.DisplayName),
     ExperimentName: __expectString(output.ExperimentName),
@@ -27671,7 +27682,7 @@ const deserializeAws_json1_1DescribeTrialResponse = (output: any, context: __Ser
         : undefined,
     LastModifiedTime:
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
-        ? new Date(Math.round(output.LastModifiedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastModifiedTime)))
         : undefined,
     MetadataProperties:
       output.MetadataProperties !== undefined && output.MetadataProperties !== null
@@ -27693,14 +27704,14 @@ const deserializeAws_json1_1DescribeUserProfileResponse = (
   return {
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     DomainId: __expectString(output.DomainId),
     FailureReason: __expectString(output.FailureReason),
     HomeEfsFileSystemUid: __expectString(output.HomeEfsFileSystemUid),
     LastModifiedTime:
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
-        ? new Date(Math.round(output.LastModifiedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastModifiedTime)))
         : undefined,
     SingleSignOnUserIdentifier: __expectString(output.SingleSignOnUserIdentifier),
     SingleSignOnUserValue: __expectString(output.SingleSignOnUserValue),
@@ -27753,13 +27764,13 @@ const deserializeAws_json1_1DeviceFleetSummary = (output: any, context: __SerdeC
   return {
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     DeviceFleetArn: __expectString(output.DeviceFleetArn),
     DeviceFleetName: __expectString(output.DeviceFleetName),
     LastModifiedTime:
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
-        ? new Date(Math.round(output.LastModifiedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastModifiedTime)))
         : undefined,
   } as any;
 };
@@ -27791,7 +27802,7 @@ const deserializeAws_json1_1DeviceSummary = (output: any, context: __SerdeContex
     IotThingName: __expectString(output.IotThingName),
     LatestHeartbeat:
       output.LatestHeartbeat !== undefined && output.LatestHeartbeat !== null
-        ? new Date(Math.round(output.LatestHeartbeat * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LatestHeartbeat)))
         : undefined,
     Models:
       output.Models !== undefined && output.Models !== null
@@ -27799,7 +27810,7 @@ const deserializeAws_json1_1DeviceSummary = (output: any, context: __SerdeContex
         : undefined,
     RegistrationTime:
       output.RegistrationTime !== undefined && output.RegistrationTime !== null
-        ? new Date(Math.round(output.RegistrationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.RegistrationTime)))
         : undefined,
   } as any;
 };
@@ -27825,14 +27836,14 @@ const deserializeAws_json1_1DomainDetails = (output: any, context: __SerdeContex
   return {
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     DomainArn: __expectString(output.DomainArn),
     DomainId: __expectString(output.DomainId),
     DomainName: __expectString(output.DomainName),
     LastModifiedTime:
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
-        ? new Date(Math.round(output.LastModifiedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastModifiedTime)))
         : undefined,
     Status: __expectString(output.Status),
     Url: __expectString(output.Url),
@@ -27854,11 +27865,11 @@ const deserializeAws_json1_1EdgeModel = (output: any, context: __SerdeContext): 
   return {
     LatestInference:
       output.LatestInference !== undefined && output.LatestInference !== null
-        ? new Date(Math.round(output.LatestInference * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LatestInference)))
         : undefined,
     LatestSampleTime:
       output.LatestSampleTime !== undefined && output.LatestSampleTime !== null
-        ? new Date(Math.round(output.LatestSampleTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LatestSampleTime)))
         : undefined,
     ModelName: __expectString(output.ModelName),
     ModelVersion: __expectString(output.ModelVersion),
@@ -27947,14 +27958,14 @@ const deserializeAws_json1_1EdgePackagingJobSummary = (
     CompilationJobName: __expectString(output.CompilationJobName),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     EdgePackagingJobArn: __expectString(output.EdgePackagingJobArn),
     EdgePackagingJobName: __expectString(output.EdgePackagingJobName),
     EdgePackagingJobStatus: __expectString(output.EdgePackagingJobStatus),
     LastModifiedTime:
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
-        ? new Date(Math.round(output.LastModifiedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastModifiedTime)))
         : undefined,
     ModelName: __expectString(output.ModelName),
     ModelVersion: __expectString(output.ModelVersion),
@@ -27984,7 +27995,7 @@ const deserializeAws_json1_1Endpoint = (output: any, context: __SerdeContext): E
   return {
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     DataCaptureConfig:
       output.DataCaptureConfig !== undefined && output.DataCaptureConfig !== null
@@ -27997,7 +28008,7 @@ const deserializeAws_json1_1Endpoint = (output: any, context: __SerdeContext): E
     FailureReason: __expectString(output.FailureReason),
     LastModifiedTime:
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
-        ? new Date(Math.round(output.LastModifiedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastModifiedTime)))
         : undefined,
     MonitoringSchedules:
       output.MonitoringSchedules !== undefined && output.MonitoringSchedules !== null
@@ -28018,7 +28029,7 @@ const deserializeAws_json1_1EndpointConfigSummary = (output: any, context: __Ser
   return {
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     EndpointConfigArn: __expectString(output.EndpointConfigArn),
     EndpointConfigName: __expectString(output.EndpointConfigName),
@@ -28058,14 +28069,14 @@ const deserializeAws_json1_1EndpointSummary = (output: any, context: __SerdeCont
   return {
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     EndpointArn: __expectString(output.EndpointArn),
     EndpointName: __expectString(output.EndpointName),
     EndpointStatus: __expectString(output.EndpointStatus),
     LastModifiedTime:
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
-        ? new Date(Math.round(output.LastModifiedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastModifiedTime)))
         : undefined,
   } as any;
 };
@@ -28101,7 +28112,7 @@ const deserializeAws_json1_1Experiment = (output: any, context: __SerdeContext):
         : undefined,
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     Description: __expectString(output.Description),
     DisplayName: __expectString(output.DisplayName),
@@ -28113,7 +28124,7 @@ const deserializeAws_json1_1Experiment = (output: any, context: __SerdeContext):
         : undefined,
     LastModifiedTime:
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
-        ? new Date(Math.round(output.LastModifiedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastModifiedTime)))
         : undefined,
     Source:
       output.Source !== undefined && output.Source !== null
@@ -28156,7 +28167,7 @@ const deserializeAws_json1_1ExperimentSummary = (output: any, context: __SerdeCo
   return {
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     DisplayName: __expectString(output.DisplayName),
     ExperimentArn: __expectString(output.ExperimentArn),
@@ -28167,7 +28178,7 @@ const deserializeAws_json1_1ExperimentSummary = (output: any, context: __SerdeCo
         : undefined,
     LastModifiedTime:
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
-        ? new Date(Math.round(output.LastModifiedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastModifiedTime)))
         : undefined,
   } as any;
 };
@@ -28203,7 +28214,7 @@ const deserializeAws_json1_1FeatureGroup = (output: any, context: __SerdeContext
   return {
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     Description: __expectString(output.Description),
     EventTimeFeatureName: __expectString(output.EventTimeFeatureName),
@@ -28251,7 +28262,7 @@ const deserializeAws_json1_1FeatureGroupSummary = (output: any, context: __Serde
   return {
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     FeatureGroupArn: __expectString(output.FeatureGroupArn),
     FeatureGroupName: __expectString(output.FeatureGroupName),
@@ -28341,7 +28352,7 @@ const deserializeAws_json1_1FlowDefinitionSummary = (output: any, context: __Ser
   return {
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     FailureReason: __expectString(output.FailureReason),
     FlowDefinitionArn: __expectString(output.FlowDefinitionArn),
@@ -28387,7 +28398,7 @@ const deserializeAws_json1_1GetDeviceFleetReportResponse = (
         : undefined,
     ReportGenerated:
       output.ReportGenerated !== undefined && output.ReportGenerated !== null
-        ? new Date(Math.round(output.ReportGenerated * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.ReportGenerated)))
         : undefined,
   } as any;
 };
@@ -28547,7 +28558,7 @@ const deserializeAws_json1_1HumanTaskUiSummary = (output: any, context: __SerdeC
   return {
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     HumanTaskUiArn: __expectString(output.HumanTaskUiArn),
     HumanTaskUiName: __expectString(output.HumanTaskUiName),
@@ -28705,7 +28716,7 @@ const deserializeAws_json1_1HyperParameterTrainingJobSummary = (
   return {
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     FailureReason: __expectString(output.FailureReason),
     FinalHyperParameterTuningJobObjectiveMetric:
@@ -28719,7 +28730,7 @@ const deserializeAws_json1_1HyperParameterTrainingJobSummary = (
     ObjectiveStatus: __expectString(output.ObjectiveStatus),
     TrainingEndTime:
       output.TrainingEndTime !== undefined && output.TrainingEndTime !== null
-        ? new Date(Math.round(output.TrainingEndTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.TrainingEndTime)))
         : undefined,
     TrainingJobArn: __expectString(output.TrainingJobArn),
     TrainingJobDefinitionName: __expectString(output.TrainingJobDefinitionName),
@@ -28727,7 +28738,7 @@ const deserializeAws_json1_1HyperParameterTrainingJobSummary = (
     TrainingJobStatus: __expectString(output.TrainingJobStatus),
     TrainingStartTime:
       output.TrainingStartTime !== undefined && output.TrainingStartTime !== null
-        ? new Date(Math.round(output.TrainingStartTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.TrainingStartTime)))
         : undefined,
     TunedHyperParameters:
       output.TunedHyperParameters !== undefined && output.TunedHyperParameters !== null
@@ -28808,18 +28819,18 @@ const deserializeAws_json1_1HyperParameterTuningJobSummary = (
   return {
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     HyperParameterTuningEndTime:
       output.HyperParameterTuningEndTime !== undefined && output.HyperParameterTuningEndTime !== null
-        ? new Date(Math.round(output.HyperParameterTuningEndTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.HyperParameterTuningEndTime)))
         : undefined,
     HyperParameterTuningJobArn: __expectString(output.HyperParameterTuningJobArn),
     HyperParameterTuningJobName: __expectString(output.HyperParameterTuningJobName),
     HyperParameterTuningJobStatus: __expectString(output.HyperParameterTuningJobStatus),
     LastModifiedTime:
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
-        ? new Date(Math.round(output.LastModifiedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastModifiedTime)))
         : undefined,
     ObjectiveStatusCounters:
       output.ObjectiveStatusCounters !== undefined && output.ObjectiveStatusCounters !== null
@@ -28854,7 +28865,7 @@ const deserializeAws_json1_1Image = (output: any, context: __SerdeContext): Imag
   return {
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     Description: __expectString(output.Description),
     DisplayName: __expectString(output.DisplayName),
@@ -28864,7 +28875,7 @@ const deserializeAws_json1_1Image = (output: any, context: __SerdeContext): Imag
     ImageStatus: __expectString(output.ImageStatus),
     LastModifiedTime:
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
-        ? new Date(Math.round(output.LastModifiedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastModifiedTime)))
         : undefined,
   } as any;
 };
@@ -28894,7 +28905,7 @@ const deserializeAws_json1_1ImageVersion = (output: any, context: __SerdeContext
   return {
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     FailureReason: __expectString(output.FailureReason),
     ImageArn: __expectString(output.ImageArn),
@@ -28902,7 +28913,7 @@ const deserializeAws_json1_1ImageVersion = (output: any, context: __SerdeContext
     ImageVersionStatus: __expectString(output.ImageVersionStatus),
     LastModifiedTime:
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
-        ? new Date(Math.round(output.LastModifiedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastModifiedTime)))
         : undefined,
     Version: __expectInt32(output.Version),
   } as any;
@@ -29158,7 +29169,7 @@ const deserializeAws_json1_1LabelingJobForWorkteamSummary = (
   return {
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     JobReferenceCode: __expectString(output.JobReferenceCode),
     LabelCounters:
@@ -29258,7 +29269,7 @@ const deserializeAws_json1_1LabelingJobSummary = (output: any, context: __SerdeC
     AnnotationConsolidationLambdaArn: __expectString(output.AnnotationConsolidationLambdaArn),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     FailureReason: __expectString(output.FailureReason),
     InputConfig:
@@ -29278,7 +29289,7 @@ const deserializeAws_json1_1LabelingJobSummary = (output: any, context: __SerdeC
     LabelingJobStatus: __expectString(output.LabelingJobStatus),
     LastModifiedTime:
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
-        ? new Date(Math.round(output.LastModifiedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastModifiedTime)))
         : undefined,
     PreHumanTaskLambdaArn: __expectString(output.PreHumanTaskLambdaArn),
     WorkteamArn: __expectString(output.WorkteamArn),
@@ -30000,7 +30011,7 @@ const deserializeAws_json1_1MetricData = (output: any, context: __SerdeContext):
     MetricName: __expectString(output.MetricName),
     Timestamp:
       output.Timestamp !== undefined && output.Timestamp !== null
-        ? new Date(Math.round(output.Timestamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.Timestamp)))
         : undefined,
     Value: __limitedParseFloat32(output.Value),
   } as any;
@@ -30204,7 +30215,7 @@ const deserializeAws_json1_1ModelPackage = (output: any, context: __SerdeContext
         : undefined,
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     InferenceSpecification:
       output.InferenceSpecification !== undefined && output.InferenceSpecification !== null
@@ -30216,7 +30227,7 @@ const deserializeAws_json1_1ModelPackage = (output: any, context: __SerdeContext
         : undefined,
     LastModifiedTime:
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
-        ? new Date(Math.round(output.LastModifiedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastModifiedTime)))
         : undefined,
     MetadataProperties:
       output.MetadataProperties !== undefined && output.MetadataProperties !== null
@@ -30291,7 +30302,7 @@ const deserializeAws_json1_1ModelPackageGroup = (output: any, context: __SerdeCo
         : undefined,
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     ModelPackageGroupArn: __expectString(output.ModelPackageGroupArn),
     ModelPackageGroupDescription: __expectString(output.ModelPackageGroupDescription),
@@ -30311,7 +30322,7 @@ const deserializeAws_json1_1ModelPackageGroupSummary = (
   return {
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     ModelPackageGroupArn: __expectString(output.ModelPackageGroupArn),
     ModelPackageGroupDescription: __expectString(output.ModelPackageGroupDescription),
@@ -30376,7 +30387,7 @@ const deserializeAws_json1_1ModelPackageSummary = (output: any, context: __Serde
   return {
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     ModelApprovalStatus: __expectString(output.ModelApprovalStatus),
     ModelPackageArn: __expectString(output.ModelPackageArn),
@@ -30512,7 +30523,7 @@ const deserializeAws_json1_1ModelSummary = (output: any, context: __SerdeContext
   return {
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     ModelArn: __expectString(output.ModelArn),
     ModelName: __expectString(output.ModelName),
@@ -30620,13 +30631,13 @@ const deserializeAws_json1_1MonitoringExecutionSummary = (
   return {
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     EndpointName: __expectString(output.EndpointName),
     FailureReason: __expectString(output.FailureReason),
     LastModifiedTime:
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
-        ? new Date(Math.round(output.LastModifiedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastModifiedTime)))
         : undefined,
     MonitoringExecutionStatus: __expectString(output.MonitoringExecutionStatus),
     MonitoringJobDefinitionName: __expectString(output.MonitoringJobDefinitionName),
@@ -30635,7 +30646,7 @@ const deserializeAws_json1_1MonitoringExecutionSummary = (
     ProcessingJobArn: __expectString(output.ProcessingJobArn),
     ScheduledTime:
       output.ScheduledTime !== undefined && output.ScheduledTime !== null
-        ? new Date(Math.round(output.ScheduledTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.ScheduledTime)))
         : undefined,
   } as any;
 };
@@ -30731,7 +30742,7 @@ const deserializeAws_json1_1MonitoringJobDefinitionSummary = (
   return {
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     EndpointName: __expectString(output.EndpointName),
     MonitoringJobDefinitionArn: __expectString(output.MonitoringJobDefinitionArn),
@@ -30818,13 +30829,13 @@ const deserializeAws_json1_1MonitoringSchedule = (output: any, context: __SerdeC
   return {
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     EndpointName: __expectString(output.EndpointName),
     FailureReason: __expectString(output.FailureReason),
     LastModifiedTime:
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
-        ? new Date(Math.round(output.LastModifiedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastModifiedTime)))
         : undefined,
     LastMonitoringExecutionSummary:
       output.LastMonitoringExecutionSummary !== undefined && output.LastMonitoringExecutionSummary !== null
@@ -30881,12 +30892,12 @@ const deserializeAws_json1_1MonitoringScheduleSummary = (
   return {
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     EndpointName: __expectString(output.EndpointName),
     LastModifiedTime:
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
-        ? new Date(Math.round(output.LastModifiedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastModifiedTime)))
         : undefined,
     MonitoringJobDefinitionName: __expectString(output.MonitoringJobDefinitionName),
     MonitoringScheduleArn: __expectString(output.MonitoringScheduleArn),
@@ -31015,11 +31026,11 @@ const deserializeAws_json1_1NotebookInstanceLifecycleConfigSummary = (
   return {
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     LastModifiedTime:
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
-        ? new Date(Math.round(output.LastModifiedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastModifiedTime)))
         : undefined,
     NotebookInstanceLifecycleConfigArn: __expectString(output.NotebookInstanceLifecycleConfigArn),
     NotebookInstanceLifecycleConfigName: __expectString(output.NotebookInstanceLifecycleConfigName),
@@ -31060,13 +31071,13 @@ const deserializeAws_json1_1NotebookInstanceSummary = (
         : undefined,
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     DefaultCodeRepository: __expectString(output.DefaultCodeRepository),
     InstanceType: __expectString(output.InstanceType),
     LastModifiedTime:
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
-        ? new Date(Math.round(output.LastModifiedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastModifiedTime)))
         : undefined,
     NotebookInstanceArn: __expectString(output.NotebookInstanceArn),
     NotebookInstanceLifecycleConfigName: __expectString(output.NotebookInstanceLifecycleConfigName),
@@ -31329,7 +31340,7 @@ const deserializeAws_json1_1Pipeline = (output: any, context: __SerdeContext): P
         : undefined,
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     LastModifiedBy:
       output.LastModifiedBy !== undefined && output.LastModifiedBy !== null
@@ -31337,11 +31348,11 @@ const deserializeAws_json1_1Pipeline = (output: any, context: __SerdeContext): P
         : undefined,
     LastModifiedTime:
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
-        ? new Date(Math.round(output.LastModifiedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastModifiedTime)))
         : undefined,
     LastRunTime:
       output.LastRunTime !== undefined && output.LastRunTime !== null
-        ? new Date(Math.round(output.LastRunTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastRunTime)))
         : undefined,
     PipelineArn: __expectString(output.PipelineArn),
     PipelineDescription: __expectString(output.PipelineDescription),
@@ -31364,7 +31375,7 @@ const deserializeAws_json1_1PipelineExecution = (output: any, context: __SerdeCo
         : undefined,
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     FailureReason: __expectString(output.FailureReason),
     LastModifiedBy:
@@ -31373,7 +31384,7 @@ const deserializeAws_json1_1PipelineExecution = (output: any, context: __SerdeCo
         : undefined,
     LastModifiedTime:
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
-        ? new Date(Math.round(output.LastModifiedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastModifiedTime)))
         : undefined,
     PipelineArn: __expectString(output.PipelineArn),
     PipelineExecutionArn: __expectString(output.PipelineExecutionArn),
@@ -31398,7 +31409,9 @@ const deserializeAws_json1_1PipelineExecutionStep = (output: any, context: __Ser
         ? deserializeAws_json1_1CacheHitResult(output.CacheHitResult, context)
         : undefined,
     EndTime:
-      output.EndTime !== undefined && output.EndTime !== null ? new Date(Math.round(output.EndTime * 1000)) : undefined,
+      output.EndTime !== undefined && output.EndTime !== null
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.EndTime)))
+        : undefined,
     FailureReason: __expectString(output.FailureReason),
     Metadata:
       output.Metadata !== undefined && output.Metadata !== null
@@ -31406,7 +31419,7 @@ const deserializeAws_json1_1PipelineExecutionStep = (output: any, context: __Ser
         : undefined,
     StartTime:
       output.StartTime !== undefined && output.StartTime !== null
-        ? new Date(Math.round(output.StartTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.StartTime)))
         : undefined,
     StepName: __expectString(output.StepName),
     StepStatus: __expectString(output.StepStatus),
@@ -31482,7 +31495,7 @@ const deserializeAws_json1_1PipelineExecutionSummary = (
     PipelineExecutionStatus: __expectString(output.PipelineExecutionStatus),
     StartTime:
       output.StartTime !== undefined && output.StartTime !== null
-        ? new Date(Math.round(output.StartTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.StartTime)))
         : undefined,
   } as any;
 };
@@ -31515,15 +31528,15 @@ const deserializeAws_json1_1PipelineSummary = (output: any, context: __SerdeCont
   return {
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     LastExecutionTime:
       output.LastExecutionTime !== undefined && output.LastExecutionTime !== null
-        ? new Date(Math.round(output.LastExecutionTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastExecutionTime)))
         : undefined,
     LastModifiedTime:
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
-        ? new Date(Math.round(output.LastModifiedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastModifiedTime)))
         : undefined,
     PipelineArn: __expectString(output.PipelineArn),
     PipelineDescription: __expectString(output.PipelineDescription),
@@ -31615,7 +31628,7 @@ const deserializeAws_json1_1ProcessingJob = (output: any, context: __SerdeContex
     AutoMLJobArn: __expectString(output.AutoMLJobArn),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     Environment:
       output.Environment !== undefined && output.Environment !== null
@@ -31629,7 +31642,7 @@ const deserializeAws_json1_1ProcessingJob = (output: any, context: __SerdeContex
     FailureReason: __expectString(output.FailureReason),
     LastModifiedTime:
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
-        ? new Date(Math.round(output.LastModifiedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastModifiedTime)))
         : undefined,
     MonitoringScheduleArn: __expectString(output.MonitoringScheduleArn),
     NetworkConfig:
@@ -31638,7 +31651,7 @@ const deserializeAws_json1_1ProcessingJob = (output: any, context: __SerdeContex
         : undefined,
     ProcessingEndTime:
       output.ProcessingEndTime !== undefined && output.ProcessingEndTime !== null
-        ? new Date(Math.round(output.ProcessingEndTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.ProcessingEndTime)))
         : undefined,
     ProcessingInputs:
       output.ProcessingInputs !== undefined && output.ProcessingInputs !== null
@@ -31657,7 +31670,7 @@ const deserializeAws_json1_1ProcessingJob = (output: any, context: __SerdeContex
         : undefined,
     ProcessingStartTime:
       output.ProcessingStartTime !== undefined && output.ProcessingStartTime !== null
-        ? new Date(Math.round(output.ProcessingStartTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.ProcessingStartTime)))
         : undefined,
     RoleArn: __expectString(output.RoleArn),
     StoppingCondition:
@@ -31696,17 +31709,17 @@ const deserializeAws_json1_1ProcessingJobSummary = (output: any, context: __Serd
   return {
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     ExitMessage: __expectString(output.ExitMessage),
     FailureReason: __expectString(output.FailureReason),
     LastModifiedTime:
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
-        ? new Date(Math.round(output.LastModifiedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastModifiedTime)))
         : undefined,
     ProcessingEndTime:
       output.ProcessingEndTime !== undefined && output.ProcessingEndTime !== null
-        ? new Date(Math.round(output.ProcessingEndTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.ProcessingEndTime)))
         : undefined,
     ProcessingJobArn: __expectString(output.ProcessingJobArn),
     ProcessingJobName: __expectString(output.ProcessingJobName),
@@ -31915,7 +31928,7 @@ const deserializeAws_json1_1ProfilerRuleEvaluationStatus = (
   return {
     LastModifiedTime:
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
-        ? new Date(Math.round(output.LastModifiedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastModifiedTime)))
         : undefined,
     RuleConfigurationName: __expectString(output.RuleConfigurationName),
     RuleEvaluationJobArn: __expectString(output.RuleEvaluationJobArn),
@@ -31954,7 +31967,7 @@ const deserializeAws_json1_1ProjectSummary = (output: any, context: __SerdeConte
   return {
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     ProjectArn: __expectString(output.ProjectArn),
     ProjectDescription: __expectString(output.ProjectDescription),
@@ -32297,10 +32310,12 @@ const deserializeAws_json1_1SecondaryStatusTransition = (
 ): SecondaryStatusTransition => {
   return {
     EndTime:
-      output.EndTime !== undefined && output.EndTime !== null ? new Date(Math.round(output.EndTime * 1000)) : undefined,
+      output.EndTime !== undefined && output.EndTime !== null
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.EndTime)))
+        : undefined,
     StartTime:
       output.StartTime !== undefined && output.StartTime !== null
-        ? new Date(Math.round(output.StartTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.StartTime)))
         : undefined,
     Status: __expectString(output.Status),
     StatusMessage: __expectString(output.StatusMessage),
@@ -32595,7 +32610,7 @@ const deserializeAws_json1_1TrainingJob = (output: any, context: __SerdeContext)
         : undefined,
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     DebugHookConfig:
       output.DebugHookConfig !== undefined && output.DebugHookConfig !== null
@@ -32636,7 +32651,7 @@ const deserializeAws_json1_1TrainingJob = (output: any, context: __SerdeContext)
     LabelingJobArn: __expectString(output.LabelingJobArn),
     LastModifiedTime:
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
-        ? new Date(Math.round(output.LastModifiedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastModifiedTime)))
         : undefined,
     ModelArtifacts:
       output.ModelArtifacts !== undefined && output.ModelArtifacts !== null
@@ -32674,14 +32689,14 @@ const deserializeAws_json1_1TrainingJob = (output: any, context: __SerdeContext)
         : undefined,
     TrainingEndTime:
       output.TrainingEndTime !== undefined && output.TrainingEndTime !== null
-        ? new Date(Math.round(output.TrainingEndTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.TrainingEndTime)))
         : undefined,
     TrainingJobArn: __expectString(output.TrainingJobArn),
     TrainingJobName: __expectString(output.TrainingJobName),
     TrainingJobStatus: __expectString(output.TrainingJobStatus),
     TrainingStartTime:
       output.TrainingStartTime !== undefined && output.TrainingStartTime !== null
-        ? new Date(Math.round(output.TrainingStartTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.TrainingStartTime)))
         : undefined,
     TrainingTimeInSeconds: __expectInt32(output.TrainingTimeInSeconds),
     TuningJobArn: __expectString(output.TuningJobArn),
@@ -32755,15 +32770,15 @@ const deserializeAws_json1_1TrainingJobSummary = (output: any, context: __SerdeC
   return {
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     LastModifiedTime:
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
-        ? new Date(Math.round(output.LastModifiedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastModifiedTime)))
         : undefined,
     TrainingEndTime:
       output.TrainingEndTime !== undefined && output.TrainingEndTime !== null
-        ? new Date(Math.round(output.TrainingEndTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.TrainingEndTime)))
         : undefined,
     TrainingJobArn: __expectString(output.TrainingJobArn),
     TrainingJobName: __expectString(output.TrainingJobName),
@@ -32855,7 +32870,7 @@ const deserializeAws_json1_1TransformJob = (output: any, context: __SerdeContext
     BatchStrategy: __expectString(output.BatchStrategy),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     DataProcessing:
       output.DataProcessing !== undefined && output.DataProcessing !== null
@@ -32884,7 +32899,7 @@ const deserializeAws_json1_1TransformJob = (output: any, context: __SerdeContext
         : undefined,
     TransformEndTime:
       output.TransformEndTime !== undefined && output.TransformEndTime !== null
-        ? new Date(Math.round(output.TransformEndTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.TransformEndTime)))
         : undefined,
     TransformInput:
       output.TransformInput !== undefined && output.TransformInput !== null
@@ -32903,7 +32918,7 @@ const deserializeAws_json1_1TransformJob = (output: any, context: __SerdeContext
         : undefined,
     TransformStartTime:
       output.TransformStartTime !== undefined && output.TransformStartTime !== null
-        ? new Date(Math.round(output.TransformStartTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.TransformStartTime)))
         : undefined,
   } as any;
 };
@@ -32956,16 +32971,16 @@ const deserializeAws_json1_1TransformJobSummary = (output: any, context: __Serde
   return {
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     FailureReason: __expectString(output.FailureReason),
     LastModifiedTime:
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
-        ? new Date(Math.round(output.LastModifiedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastModifiedTime)))
         : undefined,
     TransformEndTime:
       output.TransformEndTime !== undefined && output.TransformEndTime !== null
-        ? new Date(Math.round(output.TransformEndTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.TransformEndTime)))
         : undefined,
     TransformJobArn: __expectString(output.TransformJobArn),
     TransformJobName: __expectString(output.TransformJobName),
@@ -33005,7 +33020,7 @@ const deserializeAws_json1_1Trial = (output: any, context: __SerdeContext): Tria
         : undefined,
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     DisplayName: __expectString(output.DisplayName),
     ExperimentName: __expectString(output.ExperimentName),
@@ -33015,7 +33030,7 @@ const deserializeAws_json1_1Trial = (output: any, context: __SerdeContext): Tria
         : undefined,
     LastModifiedTime:
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
-        ? new Date(Math.round(output.LastModifiedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastModifiedTime)))
         : undefined,
     MetadataProperties:
       output.MetadataProperties !== undefined && output.MetadataProperties !== null
@@ -33046,11 +33061,13 @@ const deserializeAws_json1_1TrialComponent = (output: any, context: __SerdeConte
         : undefined,
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     DisplayName: __expectString(output.DisplayName),
     EndTime:
-      output.EndTime !== undefined && output.EndTime !== null ? new Date(Math.round(output.EndTime * 1000)) : undefined,
+      output.EndTime !== undefined && output.EndTime !== null
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.EndTime)))
+        : undefined,
     InputArtifacts:
       output.InputArtifacts !== undefined && output.InputArtifacts !== null
         ? deserializeAws_json1_1TrialComponentArtifacts(output.InputArtifacts, context)
@@ -33061,7 +33078,7 @@ const deserializeAws_json1_1TrialComponent = (output: any, context: __SerdeConte
         : undefined,
     LastModifiedTime:
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
-        ? new Date(Math.round(output.LastModifiedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastModifiedTime)))
         : undefined,
     MetadataProperties:
       output.MetadataProperties !== undefined && output.MetadataProperties !== null
@@ -33093,7 +33110,7 @@ const deserializeAws_json1_1TrialComponent = (output: any, context: __SerdeConte
         : undefined,
     StartTime:
       output.StartTime !== undefined && output.StartTime !== null
-        ? new Date(Math.round(output.StartTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.StartTime)))
         : undefined,
     Status:
       output.Status !== undefined && output.Status !== null
@@ -33162,7 +33179,7 @@ const deserializeAws_json1_1TrialComponentMetricSummary = (
     StdDev: __limitedParseDouble(output.StdDev),
     TimeStamp:
       output.TimeStamp !== undefined && output.TimeStamp !== null
-        ? new Date(Math.round(output.TimeStamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.TimeStamp)))
         : undefined,
   } as any;
 };
@@ -33223,7 +33240,7 @@ const deserializeAws_json1_1TrialComponentSimpleSummary = (
         : undefined,
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     TrialComponentArn: __expectString(output.TrialComponentArn),
     TrialComponentName: __expectString(output.TrialComponentName),
@@ -33291,22 +33308,24 @@ const deserializeAws_json1_1TrialComponentSummary = (output: any, context: __Ser
         : undefined,
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     DisplayName: __expectString(output.DisplayName),
     EndTime:
-      output.EndTime !== undefined && output.EndTime !== null ? new Date(Math.round(output.EndTime * 1000)) : undefined,
+      output.EndTime !== undefined && output.EndTime !== null
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.EndTime)))
+        : undefined,
     LastModifiedBy:
       output.LastModifiedBy !== undefined && output.LastModifiedBy !== null
         ? deserializeAws_json1_1UserContext(output.LastModifiedBy, context)
         : undefined,
     LastModifiedTime:
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
-        ? new Date(Math.round(output.LastModifiedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastModifiedTime)))
         : undefined,
     StartTime:
       output.StartTime !== undefined && output.StartTime !== null
-        ? new Date(Math.round(output.StartTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.StartTime)))
         : undefined,
     Status:
       output.Status !== undefined && output.Status !== null
@@ -33343,12 +33362,12 @@ const deserializeAws_json1_1TrialSummary = (output: any, context: __SerdeContext
   return {
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     DisplayName: __expectString(output.DisplayName),
     LastModifiedTime:
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
-        ? new Date(Math.round(output.LastModifiedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastModifiedTime)))
         : undefined,
     TrialArn: __expectString(output.TrialArn),
     TrialName: __expectString(output.TrialName),
@@ -33581,12 +33600,12 @@ const deserializeAws_json1_1UserProfileDetails = (output: any, context: __SerdeC
   return {
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     DomainId: __expectString(output.DomainId),
     LastModifiedTime:
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
-        ? new Date(Math.round(output.LastModifiedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastModifiedTime)))
         : undefined,
     Status: __expectString(output.Status),
     UserProfileName: __expectString(output.UserProfileName),
@@ -33662,11 +33681,11 @@ const deserializeAws_json1_1Workforce = (output: any, context: __SerdeContext): 
         : undefined,
     CreateDate:
       output.CreateDate !== undefined && output.CreateDate !== null
-        ? new Date(Math.round(output.CreateDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreateDate)))
         : undefined,
     LastUpdatedDate:
       output.LastUpdatedDate !== undefined && output.LastUpdatedDate !== null
-        ? new Date(Math.round(output.LastUpdatedDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastUpdatedDate)))
         : undefined,
     OidcConfig:
       output.OidcConfig !== undefined && output.OidcConfig !== null
@@ -33697,12 +33716,12 @@ const deserializeAws_json1_1Workteam = (output: any, context: __SerdeContext): W
   return {
     CreateDate:
       output.CreateDate !== undefined && output.CreateDate !== null
-        ? new Date(Math.round(output.CreateDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreateDate)))
         : undefined,
     Description: __expectString(output.Description),
     LastUpdatedDate:
       output.LastUpdatedDate !== undefined && output.LastUpdatedDate !== null
-        ? new Date(Math.round(output.LastUpdatedDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastUpdatedDate)))
         : undefined,
     MemberDefinitions:
       output.MemberDefinitions !== undefined && output.MemberDefinitions !== null

--- a/clients/client-schemas/protocols/Aws_restJson1.ts
+++ b/clients/client-schemas/protocols/Aws_restJson1.ts
@@ -74,6 +74,7 @@ import {
   expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
+  parseRfc3339DateTime as __parseRfc3339DateTime,
 } from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
@@ -1426,7 +1427,7 @@ export const deserializeAws_restJson1CreateSchemaCommand = async (
     contents.Description = __expectString(data.Description);
   }
   if (data.LastModified !== undefined && data.LastModified !== null) {
-    contents.LastModified = new Date(data.LastModified);
+    contents.LastModified = __expectNonNull(__parseRfc3339DateTime(data.LastModified));
   }
   if (data.SchemaArn !== undefined && data.SchemaArn !== null) {
     contents.SchemaArn = __expectString(data.SchemaArn);
@@ -1444,7 +1445,7 @@ export const deserializeAws_restJson1CreateSchemaCommand = async (
     contents.Type = __expectString(data.Type);
   }
   if (data.VersionCreatedDate !== undefined && data.VersionCreatedDate !== null) {
-    contents.VersionCreatedDate = new Date(data.VersionCreatedDate);
+    contents.VersionCreatedDate = __expectNonNull(__parseRfc3339DateTime(data.VersionCreatedDate));
   }
   return Promise.resolve(contents);
 };
@@ -1981,10 +1982,10 @@ export const deserializeAws_restJson1DescribeCodeBindingCommand = async (
   };
   const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CreationDate !== undefined && data.CreationDate !== null) {
-    contents.CreationDate = new Date(data.CreationDate);
+    contents.CreationDate = __expectNonNull(__parseRfc3339DateTime(data.CreationDate));
   }
   if (data.LastModified !== undefined && data.LastModified !== null) {
-    contents.LastModified = new Date(data.LastModified);
+    contents.LastModified = __expectNonNull(__parseRfc3339DateTime(data.LastModified));
   }
   if (data.SchemaVersion !== undefined && data.SchemaVersion !== null) {
     contents.SchemaVersion = __expectString(data.SchemaVersion);
@@ -2325,7 +2326,7 @@ export const deserializeAws_restJson1DescribeSchemaCommand = async (
     contents.Description = __expectString(data.Description);
   }
   if (data.LastModified !== undefined && data.LastModified !== null) {
-    contents.LastModified = new Date(data.LastModified);
+    contents.LastModified = __expectNonNull(__parseRfc3339DateTime(data.LastModified));
   }
   if (data.SchemaArn !== undefined && data.SchemaArn !== null) {
     contents.SchemaArn = __expectString(data.SchemaArn);
@@ -2343,7 +2344,7 @@ export const deserializeAws_restJson1DescribeSchemaCommand = async (
     contents.Type = __expectString(data.Type);
   }
   if (data.VersionCreatedDate !== undefined && data.VersionCreatedDate !== null) {
-    contents.VersionCreatedDate = new Date(data.VersionCreatedDate);
+    contents.VersionCreatedDate = __expectNonNull(__parseRfc3339DateTime(data.VersionCreatedDate));
   }
   return Promise.resolve(contents);
 };
@@ -3290,10 +3291,10 @@ export const deserializeAws_restJson1PutCodeBindingCommand = async (
   };
   const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CreationDate !== undefined && data.CreationDate !== null) {
-    contents.CreationDate = new Date(data.CreationDate);
+    contents.CreationDate = __expectNonNull(__parseRfc3339DateTime(data.CreationDate));
   }
   if (data.LastModified !== undefined && data.LastModified !== null) {
-    contents.LastModified = new Date(data.LastModified);
+    contents.LastModified = __expectNonNull(__parseRfc3339DateTime(data.LastModified));
   }
   if (data.SchemaVersion !== undefined && data.SchemaVersion !== null) {
     contents.SchemaVersion = __expectString(data.SchemaVersion);
@@ -4184,7 +4185,7 @@ export const deserializeAws_restJson1UpdateSchemaCommand = async (
     contents.Description = __expectString(data.Description);
   }
   if (data.LastModified !== undefined && data.LastModified !== null) {
-    contents.LastModified = new Date(data.LastModified);
+    contents.LastModified = __expectNonNull(__parseRfc3339DateTime(data.LastModified));
   }
   if (data.SchemaArn !== undefined && data.SchemaArn !== null) {
     contents.SchemaArn = __expectString(data.SchemaArn);
@@ -4202,7 +4203,7 @@ export const deserializeAws_restJson1UpdateSchemaCommand = async (
     contents.Type = __expectString(data.Type);
   }
   if (data.VersionCreatedDate !== undefined && data.VersionCreatedDate !== null) {
-    contents.VersionCreatedDate = new Date(data.VersionCreatedDate);
+    contents.VersionCreatedDate = __expectNonNull(__parseRfc3339DateTime(data.VersionCreatedDate));
   }
   return Promise.resolve(contents);
 };
@@ -4618,7 +4619,9 @@ const deserializeAws_restJson1RegistrySummary = (output: any, context: __SerdeCo
 const deserializeAws_restJson1SchemaSummary = (output: any, context: __SerdeContext): SchemaSummary => {
   return {
     LastModified:
-      output.LastModified !== undefined && output.LastModified !== null ? new Date(output.LastModified) : undefined,
+      output.LastModified !== undefined && output.LastModified !== null
+        ? __expectNonNull(__parseRfc3339DateTime(output.LastModified))
+        : undefined,
     SchemaArn: __expectString(output.SchemaArn),
     SchemaName: __expectString(output.SchemaName),
     Tags:
@@ -4656,7 +4659,9 @@ const deserializeAws_restJson1SearchSchemaVersionSummary = (
 ): SearchSchemaVersionSummary => {
   return {
     CreatedDate:
-      output.CreatedDate !== undefined && output.CreatedDate !== null ? new Date(output.CreatedDate) : undefined,
+      output.CreatedDate !== undefined && output.CreatedDate !== null
+        ? __expectNonNull(__parseRfc3339DateTime(output.CreatedDate))
+        : undefined,
     SchemaVersion: __expectString(output.SchemaVersion),
     Type: __expectString(output.Type),
   } as any;

--- a/clients/client-secrets-manager/protocols/Aws_json1_1.ts
+++ b/clients/client-secrets-manager/protocols/Aws_json1_1.ts
@@ -109,7 +109,10 @@ import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@a
 import {
   expectBoolean as __expectBoolean,
   expectLong as __expectLong,
+  expectNonNull as __expectNonNull,
+  expectNumber as __expectNumber,
   expectString as __expectString,
+  parseEpochTimestamp as __parseEpochTimestamp,
 } from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
@@ -2820,7 +2823,7 @@ const deserializeAws_json1_1DeleteSecretResponse = (output: any, context: __Serd
     ARN: __expectString(output.ARN),
     DeletionDate:
       output.DeletionDate !== undefined && output.DeletionDate !== null
-        ? new Date(Math.round(output.DeletionDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.DeletionDate)))
         : undefined,
     Name: __expectString(output.Name),
   } as any;
@@ -2831,25 +2834,25 @@ const deserializeAws_json1_1DescribeSecretResponse = (output: any, context: __Se
     ARN: __expectString(output.ARN),
     CreatedDate:
       output.CreatedDate !== undefined && output.CreatedDate !== null
-        ? new Date(Math.round(output.CreatedDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreatedDate)))
         : undefined,
     DeletedDate:
       output.DeletedDate !== undefined && output.DeletedDate !== null
-        ? new Date(Math.round(output.DeletedDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.DeletedDate)))
         : undefined,
     Description: __expectString(output.Description),
     KmsKeyId: __expectString(output.KmsKeyId),
     LastAccessedDate:
       output.LastAccessedDate !== undefined && output.LastAccessedDate !== null
-        ? new Date(Math.round(output.LastAccessedDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastAccessedDate)))
         : undefined,
     LastChangedDate:
       output.LastChangedDate !== undefined && output.LastChangedDate !== null
-        ? new Date(Math.round(output.LastChangedDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastChangedDate)))
         : undefined,
     LastRotatedDate:
       output.LastRotatedDate !== undefined && output.LastRotatedDate !== null
-        ? new Date(Math.round(output.LastRotatedDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastRotatedDate)))
         : undefined,
     Name: __expectString(output.Name),
     OwningService: __expectString(output.OwningService),
@@ -2906,7 +2909,7 @@ const deserializeAws_json1_1GetSecretValueResponse = (output: any, context: __Se
     ARN: __expectString(output.ARN),
     CreatedDate:
       output.CreatedDate !== undefined && output.CreatedDate !== null
-        ? new Date(Math.round(output.CreatedDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreatedDate)))
         : undefined,
     Name: __expectString(output.Name),
     SecretBinary:
@@ -3088,7 +3091,7 @@ const deserializeAws_json1_1ReplicationStatusType = (output: any, context: __Ser
     KmsKeyId: __expectString(output.KmsKeyId),
     LastAccessedDate:
       output.LastAccessedDate !== undefined && output.LastAccessedDate !== null
-        ? new Date(Math.round(output.LastAccessedDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastAccessedDate)))
         : undefined,
     Region: __expectString(output.Region),
     Status: __expectString(output.Status),
@@ -3140,25 +3143,25 @@ const deserializeAws_json1_1SecretListEntry = (output: any, context: __SerdeCont
     ARN: __expectString(output.ARN),
     CreatedDate:
       output.CreatedDate !== undefined && output.CreatedDate !== null
-        ? new Date(Math.round(output.CreatedDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreatedDate)))
         : undefined,
     DeletedDate:
       output.DeletedDate !== undefined && output.DeletedDate !== null
-        ? new Date(Math.round(output.DeletedDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.DeletedDate)))
         : undefined,
     Description: __expectString(output.Description),
     KmsKeyId: __expectString(output.KmsKeyId),
     LastAccessedDate:
       output.LastAccessedDate !== undefined && output.LastAccessedDate !== null
-        ? new Date(Math.round(output.LastAccessedDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastAccessedDate)))
         : undefined,
     LastChangedDate:
       output.LastChangedDate !== undefined && output.LastChangedDate !== null
-        ? new Date(Math.round(output.LastChangedDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastChangedDate)))
         : undefined,
     LastRotatedDate:
       output.LastRotatedDate !== undefined && output.LastRotatedDate !== null
-        ? new Date(Math.round(output.LastRotatedDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastRotatedDate)))
         : undefined,
     Name: __expectString(output.Name),
     OwningService: __expectString(output.OwningService),
@@ -3198,7 +3201,7 @@ const deserializeAws_json1_1SecretVersionsListEntry = (
   return {
     CreatedDate:
       output.CreatedDate !== undefined && output.CreatedDate !== null
-        ? new Date(Math.round(output.CreatedDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreatedDate)))
         : undefined,
     KmsKeyIds:
       output.KmsKeyIds !== undefined && output.KmsKeyIds !== null
@@ -3206,7 +3209,7 @@ const deserializeAws_json1_1SecretVersionsListEntry = (
         : undefined,
     LastAccessedDate:
       output.LastAccessedDate !== undefined && output.LastAccessedDate !== null
-        ? new Date(Math.round(output.LastAccessedDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastAccessedDate)))
         : undefined,
     VersionId: __expectString(output.VersionId),
     VersionStages:

--- a/clients/client-securityhub/protocols/Aws_restJson1.ts
+++ b/clients/client-securityhub/protocols/Aws_restJson1.ts
@@ -494,6 +494,7 @@ import {
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   limitedParseDouble as __limitedParseDouble,
+  parseRfc3339DateTime as __parseRfc3339DateTime,
   serializeFloat as __serializeFloat,
 } from "@aws-sdk/smithy-client";
 import {
@@ -21566,7 +21567,10 @@ const deserializeAws_restJson1Invitation = (output: any, context: __SerdeContext
   return {
     AccountId: __expectString(output.AccountId),
     InvitationId: __expectString(output.InvitationId),
-    InvitedAt: output.InvitedAt !== undefined && output.InvitedAt !== null ? new Date(output.InvitedAt) : undefined,
+    InvitedAt:
+      output.InvitedAt !== undefined && output.InvitedAt !== null
+        ? __expectNonNull(__parseRfc3339DateTime(output.InvitedAt))
+        : undefined,
     MemberStatus: __expectString(output.MemberStatus),
   } as any;
 };
@@ -21701,10 +21705,16 @@ const deserializeAws_restJson1Member = (output: any, context: __SerdeContext): M
     AccountId: __expectString(output.AccountId),
     AdministratorId: __expectString(output.AdministratorId),
     Email: __expectString(output.Email),
-    InvitedAt: output.InvitedAt !== undefined && output.InvitedAt !== null ? new Date(output.InvitedAt) : undefined,
+    InvitedAt:
+      output.InvitedAt !== undefined && output.InvitedAt !== null
+        ? __expectNonNull(__parseRfc3339DateTime(output.InvitedAt))
+        : undefined,
     MasterId: __expectString(output.MasterId),
     MemberStatus: __expectString(output.MemberStatus),
-    UpdatedAt: output.UpdatedAt !== undefined && output.UpdatedAt !== null ? new Date(output.UpdatedAt) : undefined,
+    UpdatedAt:
+      output.UpdatedAt !== undefined && output.UpdatedAt !== null
+        ? __expectNonNull(__parseRfc3339DateTime(output.UpdatedAt))
+        : undefined,
   } as any;
 };
 
@@ -22512,7 +22522,7 @@ const deserializeAws_restJson1StandardsControl = (output: any, context: __SerdeC
     ControlStatus: __expectString(output.ControlStatus),
     ControlStatusUpdatedAt:
       output.ControlStatusUpdatedAt !== undefined && output.ControlStatusUpdatedAt !== null
-        ? new Date(output.ControlStatusUpdatedAt)
+        ? __expectNonNull(__parseRfc3339DateTime(output.ControlStatusUpdatedAt))
         : undefined,
     Description: __expectString(output.Description),
     DisabledReason: __expectString(output.DisabledReason),

--- a/clients/client-service-catalog-appregistry/protocols/Aws_restJson1.ts
+++ b/clients/client-service-catalog-appregistry/protocols/Aws_restJson1.ts
@@ -75,6 +75,7 @@ import {
   expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
+  parseRfc3339DateTime as __parseRfc3339DateTime,
 } from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
@@ -1424,7 +1425,7 @@ export const deserializeAws_restJson1GetApplicationCommand = async (
     contents.associatedResourceCount = __expectInt32(data.associatedResourceCount);
   }
   if (data.creationTime !== undefined && data.creationTime !== null) {
-    contents.creationTime = new Date(data.creationTime);
+    contents.creationTime = __expectNonNull(__parseRfc3339DateTime(data.creationTime));
   }
   if (data.description !== undefined && data.description !== null) {
     contents.description = __expectString(data.description);
@@ -1436,7 +1437,7 @@ export const deserializeAws_restJson1GetApplicationCommand = async (
     contents.integrations = deserializeAws_restJson1Integrations(data.integrations, context);
   }
   if (data.lastUpdateTime !== undefined && data.lastUpdateTime !== null) {
-    contents.lastUpdateTime = new Date(data.lastUpdateTime);
+    contents.lastUpdateTime = __expectNonNull(__parseRfc3339DateTime(data.lastUpdateTime));
   }
   if (data.name !== undefined && data.name !== null) {
     contents.name = __expectString(data.name);
@@ -1597,7 +1598,7 @@ export const deserializeAws_restJson1GetAttributeGroupCommand = async (
     contents.attributes = __expectString(data.attributes);
   }
   if (data.creationTime !== undefined && data.creationTime !== null) {
-    contents.creationTime = new Date(data.creationTime);
+    contents.creationTime = __expectNonNull(__parseRfc3339DateTime(data.creationTime));
   }
   if (data.description !== undefined && data.description !== null) {
     contents.description = __expectString(data.description);
@@ -1606,7 +1607,7 @@ export const deserializeAws_restJson1GetAttributeGroupCommand = async (
     contents.id = __expectString(data.id);
   }
   if (data.lastUpdateTime !== undefined && data.lastUpdateTime !== null) {
-    contents.lastUpdateTime = new Date(data.lastUpdateTime);
+    contents.lastUpdateTime = __expectNonNull(__parseRfc3339DateTime(data.lastUpdateTime));
   }
   if (data.name !== undefined && data.name !== null) {
     contents.name = __expectString(data.name);
@@ -2489,12 +2490,14 @@ const deserializeAws_restJson1Application = (output: any, context: __SerdeContex
   return {
     arn: __expectString(output.arn),
     creationTime:
-      output.creationTime !== undefined && output.creationTime !== null ? new Date(output.creationTime) : undefined,
+      output.creationTime !== undefined && output.creationTime !== null
+        ? __expectNonNull(__parseRfc3339DateTime(output.creationTime))
+        : undefined,
     description: __expectString(output.description),
     id: __expectString(output.id),
     lastUpdateTime:
       output.lastUpdateTime !== undefined && output.lastUpdateTime !== null
-        ? new Date(output.lastUpdateTime)
+        ? __expectNonNull(__parseRfc3339DateTime(output.lastUpdateTime))
         : undefined,
     name: __expectString(output.name),
     tags:
@@ -2519,12 +2522,14 @@ const deserializeAws_restJson1ApplicationSummary = (output: any, context: __Serd
   return {
     arn: __expectString(output.arn),
     creationTime:
-      output.creationTime !== undefined && output.creationTime !== null ? new Date(output.creationTime) : undefined,
+      output.creationTime !== undefined && output.creationTime !== null
+        ? __expectNonNull(__parseRfc3339DateTime(output.creationTime))
+        : undefined,
     description: __expectString(output.description),
     id: __expectString(output.id),
     lastUpdateTime:
       output.lastUpdateTime !== undefined && output.lastUpdateTime !== null
-        ? new Date(output.lastUpdateTime)
+        ? __expectNonNull(__parseRfc3339DateTime(output.lastUpdateTime))
         : undefined,
     name: __expectString(output.name),
   } as any;
@@ -2534,12 +2539,14 @@ const deserializeAws_restJson1AttributeGroup = (output: any, context: __SerdeCon
   return {
     arn: __expectString(output.arn),
     creationTime:
-      output.creationTime !== undefined && output.creationTime !== null ? new Date(output.creationTime) : undefined,
+      output.creationTime !== undefined && output.creationTime !== null
+        ? __expectNonNull(__parseRfc3339DateTime(output.creationTime))
+        : undefined,
     description: __expectString(output.description),
     id: __expectString(output.id),
     lastUpdateTime:
       output.lastUpdateTime !== undefined && output.lastUpdateTime !== null
-        ? new Date(output.lastUpdateTime)
+        ? __expectNonNull(__parseRfc3339DateTime(output.lastUpdateTime))
         : undefined,
     name: __expectString(output.name),
     tags:
@@ -2578,12 +2585,14 @@ const deserializeAws_restJson1AttributeGroupSummary = (output: any, context: __S
   return {
     arn: __expectString(output.arn),
     creationTime:
-      output.creationTime !== undefined && output.creationTime !== null ? new Date(output.creationTime) : undefined,
+      output.creationTime !== undefined && output.creationTime !== null
+        ? __expectNonNull(__parseRfc3339DateTime(output.creationTime))
+        : undefined,
     description: __expectString(output.description),
     id: __expectString(output.id),
     lastUpdateTime:
       output.lastUpdateTime !== undefined && output.lastUpdateTime !== null
-        ? new Date(output.lastUpdateTime)
+        ? __expectNonNull(__parseRfc3339DateTime(output.lastUpdateTime))
         : undefined,
     name: __expectString(output.name),
   } as any;
@@ -2603,7 +2612,7 @@ const deserializeAws_restJson1Resource = (output: any, context: __SerdeContext):
     arn: __expectString(output.arn),
     associationTime:
       output.associationTime !== undefined && output.associationTime !== null
-        ? new Date(output.associationTime)
+        ? __expectNonNull(__parseRfc3339DateTime(output.associationTime))
         : undefined,
     integrations:
       output.integrations !== undefined && output.integrations !== null

--- a/clients/client-service-catalog/protocols/Aws_json1_1.ts
+++ b/clients/client-service-catalog/protocols/Aws_json1_1.ts
@@ -519,7 +519,10 @@ import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@a
 import {
   expectBoolean as __expectBoolean,
   expectInt32 as __expectInt32,
+  expectNonNull as __expectNonNull,
+  expectNumber as __expectNumber,
   expectString as __expectString,
+  parseEpochTimestamp as __parseEpochTimestamp,
 } from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
@@ -10173,7 +10176,7 @@ const deserializeAws_json1_1PortfolioDetail = (output: any, context: __SerdeCont
     ARN: __expectString(output.ARN),
     CreatedTime:
       output.CreatedTime !== undefined && output.CreatedTime !== null
-        ? new Date(Math.round(output.CreatedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreatedTime)))
         : undefined,
     Description: __expectString(output.Description),
     DisplayName: __expectString(output.DisplayName),
@@ -10277,7 +10280,7 @@ const deserializeAws_json1_1ProductViewDetail = (output: any, context: __SerdeCo
   return {
     CreatedTime:
       output.CreatedTime !== undefined && output.CreatedTime !== null
-        ? new Date(Math.round(output.CreatedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreatedTime)))
         : undefined,
     ProductARN: __expectString(output.ProductARN),
     ProductViewSummary:
@@ -10334,7 +10337,7 @@ const deserializeAws_json1_1ProvisionedProductAttribute = (
     Arn: __expectString(output.Arn),
     CreatedTime:
       output.CreatedTime !== undefined && output.CreatedTime !== null
-        ? new Date(Math.round(output.CreatedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreatedTime)))
         : undefined,
     Id: __expectString(output.Id),
     IdempotencyToken: __expectString(output.IdempotencyToken),
@@ -10379,7 +10382,7 @@ const deserializeAws_json1_1ProvisionedProductDetail = (
     Arn: __expectString(output.Arn),
     CreatedTime:
       output.CreatedTime !== undefined && output.CreatedTime !== null
-        ? new Date(Math.round(output.CreatedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreatedTime)))
         : undefined,
     Id: __expectString(output.Id),
     IdempotencyToken: __expectString(output.IdempotencyToken),
@@ -10417,7 +10420,7 @@ const deserializeAws_json1_1ProvisionedProductPlanDetails = (
   return {
     CreatedTime:
       output.CreatedTime !== undefined && output.CreatedTime !== null
-        ? new Date(Math.round(output.CreatedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreatedTime)))
         : undefined,
     NotificationArns:
       output.NotificationArns !== undefined && output.NotificationArns !== null
@@ -10441,7 +10444,7 @@ const deserializeAws_json1_1ProvisionedProductPlanDetails = (
       output.Tags !== undefined && output.Tags !== null ? deserializeAws_json1_1Tags(output.Tags, context) : undefined,
     UpdatedTime:
       output.UpdatedTime !== undefined && output.UpdatedTime !== null
-        ? new Date(Math.round(output.UpdatedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.UpdatedTime)))
         : undefined,
   } as any;
 };
@@ -10493,7 +10496,7 @@ const deserializeAws_json1_1ProvisioningArtifact = (output: any, context: __Serd
   return {
     CreatedTime:
       output.CreatedTime !== undefined && output.CreatedTime !== null
-        ? new Date(Math.round(output.CreatedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreatedTime)))
         : undefined,
     Description: __expectString(output.Description),
     Guidance: __expectString(output.Guidance),
@@ -10510,7 +10513,7 @@ const deserializeAws_json1_1ProvisioningArtifactDetail = (
     Active: __expectBoolean(output.Active),
     CreatedTime:
       output.CreatedTime !== undefined && output.CreatedTime !== null
-        ? new Date(Math.round(output.CreatedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreatedTime)))
         : undefined,
     Description: __expectString(output.Description),
     Guidance: __expectString(output.Guidance),
@@ -10652,7 +10655,7 @@ const deserializeAws_json1_1ProvisioningArtifactSummary = (
   return {
     CreatedTime:
       output.CreatedTime !== undefined && output.CreatedTime !== null
-        ? new Date(Math.round(output.CreatedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreatedTime)))
         : undefined,
     Description: __expectString(output.Description),
     Id: __expectString(output.Id),
@@ -10707,7 +10710,7 @@ const deserializeAws_json1_1RecordDetail = (output: any, context: __SerdeContext
   return {
     CreatedTime:
       output.CreatedTime !== undefined && output.CreatedTime !== null
-        ? new Date(Math.round(output.CreatedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreatedTime)))
         : undefined,
     LaunchRoleArn: __expectString(output.LaunchRoleArn),
     PathId: __expectString(output.PathId),
@@ -10729,7 +10732,7 @@ const deserializeAws_json1_1RecordDetail = (output: any, context: __SerdeContext
     Status: __expectString(output.Status),
     UpdatedTime:
       output.UpdatedTime !== undefined && output.UpdatedTime !== null
-        ? new Date(Math.round(output.UpdatedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.UpdatedTime)))
         : undefined,
   } as any;
 };
@@ -10863,7 +10866,7 @@ const deserializeAws_json1_1ResourceDetail = (output: any, context: __SerdeConte
     ARN: __expectString(output.ARN),
     CreatedTime:
       output.CreatedTime !== undefined && output.CreatedTime !== null
-        ? new Date(Math.round(output.CreatedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreatedTime)))
         : undefined,
     Description: __expectString(output.Description),
     Id: __expectString(output.Id),

--- a/clients/client-service-quotas/protocols/Aws_json1_1.ts
+++ b/clients/client-service-quotas/protocols/Aws_json1_1.ts
@@ -128,8 +128,11 @@ import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@a
 import {
   expectBoolean as __expectBoolean,
   expectInt32 as __expectInt32,
+  expectNonNull as __expectNonNull,
+  expectNumber as __expectNumber,
   expectString as __expectString,
   limitedParseDouble as __limitedParseDouble,
+  parseEpochTimestamp as __parseEpochTimestamp,
   serializeFloat as __serializeFloat,
 } from "@aws-sdk/smithy-client";
 import {
@@ -3103,13 +3106,15 @@ const deserializeAws_json1_1RequestedServiceQuotaChange = (
   return {
     CaseId: __expectString(output.CaseId),
     Created:
-      output.Created !== undefined && output.Created !== null ? new Date(Math.round(output.Created * 1000)) : undefined,
+      output.Created !== undefined && output.Created !== null
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.Created)))
+        : undefined,
     DesiredValue: __limitedParseDouble(output.DesiredValue),
     GlobalQuota: __expectBoolean(output.GlobalQuota),
     Id: __expectString(output.Id),
     LastUpdated:
       output.LastUpdated !== undefined && output.LastUpdated !== null
-        ? new Date(Math.round(output.LastUpdated * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastUpdated)))
         : undefined,
     QuotaArn: __expectString(output.QuotaArn),
     QuotaCode: __expectString(output.QuotaCode),

--- a/clients/client-servicediscovery/protocols/Aws_json1_1.ts
+++ b/clients/client-servicediscovery/protocols/Aws_json1_1.ts
@@ -163,7 +163,10 @@ import {
 import {
   expectInt32 as __expectInt32,
   expectLong as __expectLong,
+  expectNonNull as __expectNonNull,
+  expectNumber as __expectNumber,
   expectString as __expectString,
+  parseEpochTimestamp as __parseEpochTimestamp,
 } from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
@@ -3525,7 +3528,7 @@ const deserializeAws_json1_1Namespace = (output: any, context: __SerdeContext): 
     Arn: __expectString(output.Arn),
     CreateDate:
       output.CreateDate !== undefined && output.CreateDate !== null
-        ? new Date(Math.round(output.CreateDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreateDate)))
         : undefined,
     CreatorRequestId: __expectString(output.CreatorRequestId),
     Description: __expectString(output.Description),
@@ -3583,7 +3586,7 @@ const deserializeAws_json1_1NamespaceSummary = (output: any, context: __SerdeCon
     Arn: __expectString(output.Arn),
     CreateDate:
       output.CreateDate !== undefined && output.CreateDate !== null
-        ? new Date(Math.round(output.CreateDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreateDate)))
         : undefined,
     Description: __expectString(output.Description),
     Id: __expectString(output.Id),
@@ -3601,7 +3604,7 @@ const deserializeAws_json1_1Operation = (output: any, context: __SerdeContext): 
   return {
     CreateDate:
       output.CreateDate !== undefined && output.CreateDate !== null
-        ? new Date(Math.round(output.CreateDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreateDate)))
         : undefined,
     ErrorCode: __expectString(output.ErrorCode),
     ErrorMessage: __expectString(output.ErrorMessage),
@@ -3614,7 +3617,7 @@ const deserializeAws_json1_1Operation = (output: any, context: __SerdeContext): 
     Type: __expectString(output.Type),
     UpdateDate:
       output.UpdateDate !== undefined && output.UpdateDate !== null
-        ? new Date(Math.round(output.UpdateDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.UpdateDate)))
         : undefined,
   } as any;
 };
@@ -3699,7 +3702,7 @@ const deserializeAws_json1_1Service = (output: any, context: __SerdeContext): Se
     Arn: __expectString(output.Arn),
     CreateDate:
       output.CreateDate !== undefined && output.CreateDate !== null
-        ? new Date(Math.round(output.CreateDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreateDate)))
         : undefined,
     CreatorRequestId: __expectString(output.CreatorRequestId),
     Description: __expectString(output.Description),
@@ -3753,7 +3756,7 @@ const deserializeAws_json1_1ServiceSummary = (output: any, context: __SerdeConte
     Arn: __expectString(output.Arn),
     CreateDate:
       output.CreateDate !== undefined && output.CreateDate !== null
-        ? new Date(Math.round(output.CreateDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreateDate)))
         : undefined,
     Description: __expectString(output.Description),
     DnsConfig:

--- a/clients/client-ses/protocols/Aws_query.ts
+++ b/clients/client-ses/protocols/Aws_query.ts
@@ -430,11 +430,13 @@ import {
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
+  expectNonNull as __expectNonNull,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   getArrayIfSingleItem as __getArrayIfSingleItem,
   getValueFromTextNode as __getValueFromTextNode,
   parseBoolean as __parseBoolean,
+  parseRfc3339DateTime as __parseRfc3339DateTime,
   strictParseFloat as __strictParseFloat,
   strictParseLong as __strictParseLong,
 } from "@aws-sdk/smithy-client";
@@ -9714,7 +9716,7 @@ const deserializeAws_queryReceiptRuleSetMetadata = (output: any, context: __Serd
     contents.Name = __expectString(output["Name"]);
   }
   if (output["CreatedTimestamp"] !== undefined) {
-    contents.CreatedTimestamp = new Date(output["CreatedTimestamp"]);
+    contents.CreatedTimestamp = __expectNonNull(__parseRfc3339DateTime(output["CreatedTimestamp"]));
   }
   return contents;
 };
@@ -9773,7 +9775,7 @@ const deserializeAws_queryReputationOptions = (output: any, context: __SerdeCont
     contents.ReputationMetricsEnabled = __parseBoolean(output["ReputationMetricsEnabled"]);
   }
   if (output["LastFreshStart"] !== undefined) {
-    contents.LastFreshStart = new Date(output["LastFreshStart"]);
+    contents.LastFreshStart = __expectNonNull(__parseRfc3339DateTime(output["LastFreshStart"]));
   }
   return contents;
 };
@@ -9885,7 +9887,7 @@ const deserializeAws_querySendDataPoint = (output: any, context: __SerdeContext)
     Rejects: undefined,
   };
   if (output["Timestamp"] !== undefined) {
-    contents.Timestamp = new Date(output["Timestamp"]);
+    contents.Timestamp = __expectNonNull(__parseRfc3339DateTime(output["Timestamp"]));
   }
   if (output["DeliveryAttempts"] !== undefined) {
     contents.DeliveryAttempts = __strictParseLong(output["DeliveryAttempts"]) as number;
@@ -10088,7 +10090,7 @@ const deserializeAws_queryTemplateMetadata = (output: any, context: __SerdeConte
     contents.Name = __expectString(output["Name"]);
   }
   if (output["CreatedTimestamp"] !== undefined) {
-    contents.CreatedTimestamp = new Date(output["CreatedTimestamp"]);
+    contents.CreatedTimestamp = __expectNonNull(__parseRfc3339DateTime(output["CreatedTimestamp"]));
   }
   return contents;
 };

--- a/clients/client-sesv2/protocols/Aws_restJson1.ts
+++ b/clients/client-sesv2/protocols/Aws_restJson1.ts
@@ -337,10 +337,12 @@ import {
   expectInt32 as __expectInt32,
   expectLong as __expectLong,
   expectNonNull as __expectNonNull,
+  expectNumber as __expectNumber,
   expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   limitedParseDouble as __limitedParseDouble,
+  parseEpochTimestamp as __parseEpochTimestamp,
 } from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
@@ -5010,13 +5012,13 @@ export const deserializeAws_restJson1GetContactCommand = async (
     contents.ContactListName = __expectString(data.ContactListName);
   }
   if (data.CreatedTimestamp !== undefined && data.CreatedTimestamp !== null) {
-    contents.CreatedTimestamp = new Date(Math.round(data.CreatedTimestamp * 1000));
+    contents.CreatedTimestamp = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.CreatedTimestamp)));
   }
   if (data.EmailAddress !== undefined && data.EmailAddress !== null) {
     contents.EmailAddress = __expectString(data.EmailAddress);
   }
   if (data.LastUpdatedTimestamp !== undefined && data.LastUpdatedTimestamp !== null) {
-    contents.LastUpdatedTimestamp = new Date(Math.round(data.LastUpdatedTimestamp * 1000));
+    contents.LastUpdatedTimestamp = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.LastUpdatedTimestamp)));
   }
   if (data.TopicDefaultPreferences !== undefined && data.TopicDefaultPreferences !== null) {
     contents.TopicDefaultPreferences = deserializeAws_restJson1TopicPreferenceList(
@@ -5107,13 +5109,13 @@ export const deserializeAws_restJson1GetContactListCommand = async (
     contents.ContactListName = __expectString(data.ContactListName);
   }
   if (data.CreatedTimestamp !== undefined && data.CreatedTimestamp !== null) {
-    contents.CreatedTimestamp = new Date(Math.round(data.CreatedTimestamp * 1000));
+    contents.CreatedTimestamp = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.CreatedTimestamp)));
   }
   if (data.Description !== undefined && data.Description !== null) {
     contents.Description = __expectString(data.Description);
   }
   if (data.LastUpdatedTimestamp !== undefined && data.LastUpdatedTimestamp !== null) {
-    contents.LastUpdatedTimestamp = new Date(Math.round(data.LastUpdatedTimestamp * 1000));
+    contents.LastUpdatedTimestamp = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.LastUpdatedTimestamp)));
   }
   if (data.Tags !== undefined && data.Tags !== null) {
     contents.Tags = deserializeAws_restJson1TagList(data.Tags, context);
@@ -5449,7 +5451,9 @@ export const deserializeAws_restJson1GetDeliverabilityDashboardOptionsCommand = 
     );
   }
   if (data.SubscriptionExpiryDate !== undefined && data.SubscriptionExpiryDate !== null) {
-    contents.SubscriptionExpiryDate = new Date(Math.round(data.SubscriptionExpiryDate * 1000));
+    contents.SubscriptionExpiryDate = __expectNonNull(
+      __parseEpochTimestamp(__expectNumber(data.SubscriptionExpiryDate))
+    );
   }
   return Promise.resolve(contents);
 };
@@ -6012,10 +6016,10 @@ export const deserializeAws_restJson1GetImportJobCommand = async (
   };
   const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CompletedTimestamp !== undefined && data.CompletedTimestamp !== null) {
-    contents.CompletedTimestamp = new Date(Math.round(data.CompletedTimestamp * 1000));
+    contents.CompletedTimestamp = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.CompletedTimestamp)));
   }
   if (data.CreatedTimestamp !== undefined && data.CreatedTimestamp !== null) {
-    contents.CreatedTimestamp = new Date(Math.round(data.CreatedTimestamp * 1000));
+    contents.CreatedTimestamp = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.CreatedTimestamp)));
   }
   if (data.FailedRecordsCount !== undefined && data.FailedRecordsCount !== null) {
     contents.FailedRecordsCount = __expectInt32(data.FailedRecordsCount);
@@ -9947,7 +9951,7 @@ const deserializeAws_restJson1BlacklistEntry = (output: any, context: __SerdeCon
     Description: __expectString(output.Description),
     ListingTime:
       output.ListingTime !== undefined && output.ListingTime !== null
-        ? new Date(Math.round(output.ListingTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.ListingTime)))
         : undefined,
     RblName: __expectString(output.RblName),
   } as any;
@@ -10040,7 +10044,7 @@ const deserializeAws_restJson1Contact = (output: any, context: __SerdeContext): 
     EmailAddress: __expectString(output.EmailAddress),
     LastUpdatedTimestamp:
       output.LastUpdatedTimestamp !== undefined && output.LastUpdatedTimestamp !== null
-        ? new Date(Math.round(output.LastUpdatedTimestamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastUpdatedTimestamp)))
         : undefined,
     TopicDefaultPreferences:
       output.TopicDefaultPreferences !== undefined && output.TopicDefaultPreferences !== null
@@ -10059,7 +10063,7 @@ const deserializeAws_restJson1ContactList = (output: any, context: __SerdeContex
     ContactListName: __expectString(output.ContactListName),
     LastUpdatedTimestamp:
       output.LastUpdatedTimestamp !== undefined && output.LastUpdatedTimestamp !== null
-        ? new Date(Math.round(output.LastUpdatedTimestamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastUpdatedTimestamp)))
         : undefined,
   } as any;
 };
@@ -10109,7 +10113,7 @@ const deserializeAws_restJson1DailyVolume = (output: any, context: __SerdeContex
         : undefined,
     StartDate:
       output.StartDate !== undefined && output.StartDate !== null
-        ? new Date(Math.round(output.StartDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.StartDate)))
         : undefined,
     VolumeStatistics:
       output.VolumeStatistics !== undefined && output.VolumeStatistics !== null
@@ -10156,7 +10160,7 @@ const deserializeAws_restJson1DeliverabilityTestReport = (
   return {
     CreateDate:
       output.CreateDate !== undefined && output.CreateDate !== null
-        ? new Date(Math.round(output.CreateDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreateDate)))
         : undefined,
     DeliverabilityTestStatus: __expectString(output.DeliverabilityTestStatus),
     FromEmailAddress: __expectString(output.FromEmailAddress),
@@ -10223,14 +10227,14 @@ const deserializeAws_restJson1DomainDeliverabilityCampaign = (
         : undefined,
     FirstSeenDateTime:
       output.FirstSeenDateTime !== undefined && output.FirstSeenDateTime !== null
-        ? new Date(Math.round(output.FirstSeenDateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.FirstSeenDateTime)))
         : undefined,
     FromAddress: __expectString(output.FromAddress),
     ImageUrl: __expectString(output.ImageUrl),
     InboxCount: __expectLong(output.InboxCount),
     LastSeenDateTime:
       output.LastSeenDateTime !== undefined && output.LastSeenDateTime !== null
-        ? new Date(Math.round(output.LastSeenDateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastSeenDateTime)))
         : undefined,
     ProjectedVolume: __expectLong(output.ProjectedVolume),
     ReadDeleteRate: __limitedParseDouble(output.ReadDeleteRate),
@@ -10270,7 +10274,7 @@ const deserializeAws_restJson1DomainDeliverabilityTrackingOption = (
         : undefined,
     SubscriptionStartDate:
       output.SubscriptionStartDate !== undefined && output.SubscriptionStartDate !== null
-        ? new Date(Math.round(output.SubscriptionStartDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.SubscriptionStartDate)))
         : undefined,
   } as any;
 };
@@ -10322,7 +10326,7 @@ const deserializeAws_restJson1EmailTemplateMetadata = (output: any, context: __S
   return {
     CreatedTimestamp:
       output.CreatedTimestamp !== undefined && output.CreatedTimestamp !== null
-        ? new Date(Math.round(output.CreatedTimestamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreatedTimestamp)))
         : undefined,
     TemplateName: __expectString(output.TemplateName),
   } as any;
@@ -10452,7 +10456,7 @@ const deserializeAws_restJson1ImportJobSummary = (output: any, context: __SerdeC
   return {
     CreatedTimestamp:
       output.CreatedTimestamp !== undefined && output.CreatedTimestamp !== null
-        ? new Date(Math.round(output.CreatedTimestamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreatedTimestamp)))
         : undefined,
     ImportDestination:
       output.ImportDestination !== undefined && output.ImportDestination !== null
@@ -10627,7 +10631,7 @@ const deserializeAws_restJson1ReputationOptions = (output: any, context: __Serde
   return {
     LastFreshStart:
       output.LastFreshStart !== undefined && output.LastFreshStart !== null
-        ? new Date(Math.round(output.LastFreshStart * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastFreshStart)))
         : undefined,
     ReputationMetricsEnabled: __expectBoolean(output.ReputationMetricsEnabled),
   } as any;
@@ -10669,7 +10673,7 @@ const deserializeAws_restJson1SuppressedDestination = (output: any, context: __S
     EmailAddress: __expectString(output.EmailAddress),
     LastUpdateTime:
       output.LastUpdateTime !== undefined && output.LastUpdateTime !== null
-        ? new Date(Math.round(output.LastUpdateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastUpdateTime)))
         : undefined,
     Reason: __expectString(output.Reason),
   } as any;
@@ -10707,7 +10711,7 @@ const deserializeAws_restJson1SuppressedDestinationSummary = (
     EmailAddress: __expectString(output.EmailAddress),
     LastUpdateTime:
       output.LastUpdateTime !== undefined && output.LastUpdateTime !== null
-        ? new Date(Math.round(output.LastUpdateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastUpdateTime)))
         : undefined,
     Reason: __expectString(output.Reason),
   } as any;

--- a/clients/client-sfn/protocols/Aws_json1_0.ts
+++ b/clients/client-sfn/protocols/Aws_json1_0.ts
@@ -155,7 +155,10 @@ import {
   expectBoolean as __expectBoolean,
   expectInt32 as __expectInt32,
   expectLong as __expectLong,
+  expectNonNull as __expectNonNull,
+  expectNumber as __expectNumber,
   expectString as __expectString,
+  parseEpochTimestamp as __parseEpochTimestamp,
 } from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
@@ -2797,7 +2800,7 @@ const deserializeAws_json1_0ActivityListItem = (output: any, context: __SerdeCon
     activityArn: __expectString(output.activityArn),
     creationDate:
       output.creationDate !== undefined && output.creationDate !== null
-        ? new Date(Math.round(output.creationDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.creationDate)))
         : undefined,
     name: __expectString(output.name),
   } as any;
@@ -2897,7 +2900,7 @@ const deserializeAws_json1_0CreateActivityOutput = (output: any, context: __Serd
     activityArn: __expectString(output.activityArn),
     creationDate:
       output.creationDate !== undefined && output.creationDate !== null
-        ? new Date(Math.round(output.creationDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.creationDate)))
         : undefined,
   } as any;
 };
@@ -2909,7 +2912,7 @@ const deserializeAws_json1_0CreateStateMachineOutput = (
   return {
     creationDate:
       output.creationDate !== undefined && output.creationDate !== null
-        ? new Date(Math.round(output.creationDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.creationDate)))
         : undefined,
     stateMachineArn: __expectString(output.stateMachineArn),
   } as any;
@@ -2931,7 +2934,7 @@ const deserializeAws_json1_0DescribeActivityOutput = (output: any, context: __Se
     activityArn: __expectString(output.activityArn),
     creationDate:
       output.creationDate !== undefined && output.creationDate !== null
-        ? new Date(Math.round(output.creationDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.creationDate)))
         : undefined,
     name: __expectString(output.name),
   } as any;
@@ -2956,13 +2959,13 @@ const deserializeAws_json1_0DescribeExecutionOutput = (
         : undefined,
     startDate:
       output.startDate !== undefined && output.startDate !== null
-        ? new Date(Math.round(output.startDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.startDate)))
         : undefined,
     stateMachineArn: __expectString(output.stateMachineArn),
     status: __expectString(output.status),
     stopDate:
       output.stopDate !== undefined && output.stopDate !== null
-        ? new Date(Math.round(output.stopDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.stopDate)))
         : undefined,
     traceHeader: __expectString(output.traceHeader),
   } as any;
@@ -2987,7 +2990,7 @@ const deserializeAws_json1_0DescribeStateMachineForExecutionOutput = (
         : undefined,
     updateDate:
       output.updateDate !== undefined && output.updateDate !== null
-        ? new Date(Math.round(output.updateDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.updateDate)))
         : undefined,
   } as any;
 };
@@ -2999,7 +3002,7 @@ const deserializeAws_json1_0DescribeStateMachineOutput = (
   return {
     creationDate:
       output.creationDate !== undefined && output.creationDate !== null
-        ? new Date(Math.round(output.creationDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.creationDate)))
         : undefined,
     definition: __expectString(output.definition),
     loggingConfiguration:
@@ -3073,13 +3076,13 @@ const deserializeAws_json1_0ExecutionListItem = (output: any, context: __SerdeCo
     name: __expectString(output.name),
     startDate:
       output.startDate !== undefined && output.startDate !== null
-        ? new Date(Math.round(output.startDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.startDate)))
         : undefined,
     stateMachineArn: __expectString(output.stateMachineArn),
     status: __expectString(output.status),
     stopDate:
       output.stopDate !== undefined && output.stopDate !== null
-        ? new Date(Math.round(output.stopDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.stopDate)))
         : undefined,
   } as any;
 };
@@ -3283,7 +3286,7 @@ const deserializeAws_json1_0HistoryEvent = (output: any, context: __SerdeContext
         : undefined,
     timestamp:
       output.timestamp !== undefined && output.timestamp !== null
-        ? new Date(Math.round(output.timestamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.timestamp)))
         : undefined,
     type: __expectString(output.type),
   } as any;
@@ -3562,7 +3565,7 @@ const deserializeAws_json1_0StartExecutionOutput = (output: any, context: __Serd
     executionArn: __expectString(output.executionArn),
     startDate:
       output.startDate !== undefined && output.startDate !== null
-        ? new Date(Math.round(output.startDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.startDate)))
         : undefined,
   } as any;
 };
@@ -3592,13 +3595,13 @@ const deserializeAws_json1_0StartSyncExecutionOutput = (
         : undefined,
     startDate:
       output.startDate !== undefined && output.startDate !== null
-        ? new Date(Math.round(output.startDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.startDate)))
         : undefined,
     stateMachineArn: __expectString(output.stateMachineArn),
     status: __expectString(output.status),
     stopDate:
       output.stopDate !== undefined && output.stopDate !== null
-        ? new Date(Math.round(output.stopDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.stopDate)))
         : undefined,
     traceHeader: __expectString(output.traceHeader),
   } as any;
@@ -3680,7 +3683,7 @@ const deserializeAws_json1_0StateMachineListItem = (output: any, context: __Serd
   return {
     creationDate:
       output.creationDate !== undefined && output.creationDate !== null
-        ? new Date(Math.round(output.creationDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.creationDate)))
         : undefined,
     name: __expectString(output.name),
     stateMachineArn: __expectString(output.stateMachineArn),
@@ -3701,7 +3704,7 @@ const deserializeAws_json1_0StopExecutionOutput = (output: any, context: __Serde
   return {
     stopDate:
       output.stopDate !== undefined && output.stopDate !== null
-        ? new Date(Math.round(output.stopDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.stopDate)))
         : undefined,
   } as any;
 };
@@ -3863,7 +3866,7 @@ const deserializeAws_json1_0UpdateStateMachineOutput = (
   return {
     updateDate:
       output.updateDate !== undefined && output.updateDate !== null
-        ? new Date(Math.round(output.updateDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.updateDate)))
         : undefined,
   } as any;
 };

--- a/clients/client-shield/protocols/Aws_json1_1.ts
+++ b/clients/client-shield/protocols/Aws_json1_1.ts
@@ -201,8 +201,11 @@ import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@a
 import {
   expectInt32 as __expectInt32,
   expectLong as __expectLong,
+  expectNonNull as __expectNonNull,
+  expectNumber as __expectNumber,
   expectString as __expectString,
   limitedParseDouble as __limitedParseDouble,
+  parseEpochTimestamp as __parseEpochTimestamp,
 } from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
@@ -3779,7 +3782,9 @@ const deserializeAws_json1_1AttackDetail = (output: any, context: __SerdeContext
         ? deserializeAws_json1_1AttackProperties(output.AttackProperties, context)
         : undefined,
     EndTime:
-      output.EndTime !== undefined && output.EndTime !== null ? new Date(Math.round(output.EndTime * 1000)) : undefined,
+      output.EndTime !== undefined && output.EndTime !== null
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.EndTime)))
+        : undefined,
     Mitigations:
       output.Mitigations !== undefined && output.Mitigations !== null
         ? deserializeAws_json1_1MitigationList(output.Mitigations, context)
@@ -3787,7 +3792,7 @@ const deserializeAws_json1_1AttackDetail = (output: any, context: __SerdeContext
     ResourceArn: __expectString(output.ResourceArn),
     StartTime:
       output.StartTime !== undefined && output.StartTime !== null
-        ? new Date(Math.round(output.StartTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.StartTime)))
         : undefined,
     SubResources:
       output.SubResources !== undefined && output.SubResources !== null
@@ -3866,11 +3871,13 @@ const deserializeAws_json1_1AttackSummary = (output: any, context: __SerdeContex
         ? deserializeAws_json1_1AttackVectorDescriptionList(output.AttackVectors, context)
         : undefined,
     EndTime:
-      output.EndTime !== undefined && output.EndTime !== null ? new Date(Math.round(output.EndTime * 1000)) : undefined,
+      output.EndTime !== undefined && output.EndTime !== null
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.EndTime)))
+        : undefined,
     ResourceArn: __expectString(output.ResourceArn),
     StartTime:
       output.StartTime !== undefined && output.StartTime !== null
-        ? new Date(Math.round(output.StartTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.StartTime)))
         : undefined,
   } as any;
 };
@@ -4485,7 +4492,9 @@ const deserializeAws_json1_1Subscription = (output: any, context: __SerdeContext
   return {
     AutoRenew: __expectString(output.AutoRenew),
     EndTime:
-      output.EndTime !== undefined && output.EndTime !== null ? new Date(Math.round(output.EndTime * 1000)) : undefined,
+      output.EndTime !== undefined && output.EndTime !== null
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.EndTime)))
+        : undefined,
     Limits:
       output.Limits !== undefined && output.Limits !== null
         ? deserializeAws_json1_1Limits(output.Limits, context)
@@ -4493,7 +4502,7 @@ const deserializeAws_json1_1Subscription = (output: any, context: __SerdeContext
     ProactiveEngagementStatus: __expectString(output.ProactiveEngagementStatus),
     StartTime:
       output.StartTime !== undefined && output.StartTime !== null
-        ? new Date(Math.round(output.StartTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.StartTime)))
         : undefined,
     SubscriptionArn: __expectString(output.SubscriptionArn),
     SubscriptionLimits:
@@ -4589,11 +4598,11 @@ const deserializeAws_json1_1TimeRange = (output: any, context: __SerdeContext): 
   return {
     FromInclusive:
       output.FromInclusive !== undefined && output.FromInclusive !== null
-        ? new Date(Math.round(output.FromInclusive * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.FromInclusive)))
         : undefined,
     ToExclusive:
       output.ToExclusive !== undefined && output.ToExclusive !== null
-        ? new Date(Math.round(output.ToExclusive * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.ToExclusive)))
         : undefined,
   } as any;
 };

--- a/clients/client-signer/protocols/Aws_restJson1.ts
+++ b/clients/client-signer/protocols/Aws_restJson1.ts
@@ -79,9 +79,11 @@ import {
   expectBoolean as __expectBoolean,
   expectInt32 as __expectInt32,
   expectNonNull as __expectNonNull,
+  expectNumber as __expectNumber,
   expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
+  parseEpochTimestamp as __parseEpochTimestamp,
 } from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
@@ -873,10 +875,10 @@ export const deserializeAws_restJson1DescribeSigningJobCommand = async (
   };
   const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.completedAt !== undefined && data.completedAt !== null) {
-    contents.completedAt = new Date(Math.round(data.completedAt * 1000));
+    contents.completedAt = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.completedAt)));
   }
   if (data.createdAt !== undefined && data.createdAt !== null) {
-    contents.createdAt = new Date(Math.round(data.createdAt * 1000));
+    contents.createdAt = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.createdAt)));
   }
   if (data.jobId !== undefined && data.jobId !== null) {
     contents.jobId = __expectString(data.jobId);
@@ -909,7 +911,7 @@ export const deserializeAws_restJson1DescribeSigningJobCommand = async (
     contents.revocationRecord = deserializeAws_restJson1SigningJobRevocationRecord(data.revocationRecord, context);
   }
   if (data.signatureExpiresAt !== undefined && data.signatureExpiresAt !== null) {
-    contents.signatureExpiresAt = new Date(Math.round(data.signatureExpiresAt * 1000));
+    contents.signatureExpiresAt = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.signatureExpiresAt)));
   }
   if (data.signedObject !== undefined && data.signedObject !== null) {
     contents.signedObject = deserializeAws_restJson1SignedObject(data.signedObject, context);
@@ -2715,7 +2717,7 @@ const deserializeAws_restJson1SigningJob = (output: any, context: __SerdeContext
   return {
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
-        ? new Date(Math.round(output.createdAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.createdAt)))
         : undefined,
     isRevoked: __expectBoolean(output.isRevoked),
     jobId: __expectString(output.jobId),
@@ -2727,7 +2729,7 @@ const deserializeAws_restJson1SigningJob = (output: any, context: __SerdeContext
     profileVersion: __expectString(output.profileVersion),
     signatureExpiresAt:
       output.signatureExpiresAt !== undefined && output.signatureExpiresAt !== null
-        ? new Date(Math.round(output.signatureExpiresAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.signatureExpiresAt)))
         : undefined,
     signedObject:
       output.signedObject !== undefined && output.signedObject !== null
@@ -2753,7 +2755,7 @@ const deserializeAws_restJson1SigningJobRevocationRecord = (
     reason: __expectString(output.reason),
     revokedAt:
       output.revokedAt !== undefined && output.revokedAt !== null
-        ? new Date(Math.round(output.revokedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.revokedAt)))
         : undefined,
     revokedBy: __expectString(output.revokedBy),
   } as any;
@@ -2867,11 +2869,11 @@ const deserializeAws_restJson1SigningProfileRevocationRecord = (
   return {
     revocationEffectiveFrom:
       output.revocationEffectiveFrom !== undefined && output.revocationEffectiveFrom !== null
-        ? new Date(Math.round(output.revocationEffectiveFrom * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.revocationEffectiveFrom)))
         : undefined,
     revokedAt:
       output.revokedAt !== undefined && output.revokedAt !== null
-        ? new Date(Math.round(output.revokedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.revokedAt)))
         : undefined,
     revokedBy: __expectString(output.revokedBy),
   } as any;

--- a/clients/client-sms/protocols/Aws_json1_1.ts
+++ b/clients/client-sms/protocols/Aws_json1_1.ts
@@ -211,7 +211,10 @@ import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@a
 import {
   expectBoolean as __expectBoolean,
   expectInt32 as __expectInt32,
+  expectNonNull as __expectNonNull,
+  expectNumber as __expectNumber,
   expectString as __expectString,
+  parseEpochTimestamp as __parseEpochTimestamp,
 } from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
@@ -4640,17 +4643,17 @@ const deserializeAws_json1_1AppSummary = (output: any, context: __SerdeContext):
     appId: __expectString(output.appId),
     creationTime:
       output.creationTime !== undefined && output.creationTime !== null
-        ? new Date(Math.round(output.creationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.creationTime)))
         : undefined,
     description: __expectString(output.description),
     importedAppId: __expectString(output.importedAppId),
     lastModified:
       output.lastModified !== undefined && output.lastModified !== null
-        ? new Date(Math.round(output.lastModified * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastModified)))
         : undefined,
     latestReplicationTime:
       output.latestReplicationTime !== undefined && output.latestReplicationTime !== null
-        ? new Date(Math.round(output.latestReplicationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.latestReplicationTime)))
         : undefined,
     launchConfigurationStatus: __expectString(output.launchConfigurationStatus),
     launchDetails:
@@ -4713,7 +4716,7 @@ const deserializeAws_json1_1Connector = (output: any, context: __SerdeContext): 
   return {
     associatedOn:
       output.associatedOn !== undefined && output.associatedOn !== null
-        ? new Date(Math.round(output.associatedOn * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.associatedOn)))
         : undefined,
     capabilityList:
       output.capabilityList !== undefined && output.capabilityList !== null
@@ -4975,7 +4978,7 @@ const deserializeAws_json1_1GetServersResponse = (output: any, context: __SerdeC
   return {
     lastModifiedOn:
       output.lastModifiedOn !== undefined && output.lastModifiedOn !== null
-        ? new Date(Math.round(output.lastModifiedOn * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastModifiedOn)))
         : undefined,
     nextToken: __expectString(output.nextToken),
     serverCatalogStatus: __expectString(output.serverCatalogStatus),
@@ -5023,7 +5026,7 @@ const deserializeAws_json1_1LaunchDetails = (output: any, context: __SerdeContex
   return {
     latestLaunchTime:
       output.latestLaunchTime !== undefined && output.latestLaunchTime !== null
-        ? new Date(Math.round(output.latestLaunchTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.latestLaunchTime)))
         : undefined,
     stackId: __expectString(output.stackId),
     stackName: __expectString(output.stackName),
@@ -5103,7 +5106,7 @@ const deserializeAws_json1_1ReplicationJob = (output: any, context: __SerdeConte
     licenseType: __expectString(output.licenseType),
     nextReplicationRunStartTime:
       output.nextReplicationRunStartTime !== undefined && output.nextReplicationRunStartTime !== null
-        ? new Date(Math.round(output.nextReplicationRunStartTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.nextReplicationRunStartTime)))
         : undefined,
     numberOfRecentAmisToKeep: __expectInt32(output.numberOfRecentAmisToKeep),
     replicationJobId: __expectString(output.replicationJobId),
@@ -5115,7 +5118,7 @@ const deserializeAws_json1_1ReplicationJob = (output: any, context: __SerdeConte
     runOnce: __expectBoolean(output.runOnce),
     seedReplicationTime:
       output.seedReplicationTime !== undefined && output.seedReplicationTime !== null
-        ? new Date(Math.round(output.seedReplicationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.seedReplicationTime)))
         : undefined,
     serverId: __expectString(output.serverId),
     serverType: __expectString(output.serverType),
@@ -5162,7 +5165,7 @@ const deserializeAws_json1_1ReplicationRun = (output: any, context: __SerdeConte
     amiId: __expectString(output.amiId),
     completedTime:
       output.completedTime !== undefined && output.completedTime !== null
-        ? new Date(Math.round(output.completedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.completedTime)))
         : undefined,
     description: __expectString(output.description),
     encrypted: __expectBoolean(output.encrypted),
@@ -5170,7 +5173,7 @@ const deserializeAws_json1_1ReplicationRun = (output: any, context: __SerdeConte
     replicationRunId: __expectString(output.replicationRunId),
     scheduledStartTime:
       output.scheduledStartTime !== undefined && output.scheduledStartTime !== null
-        ? new Date(Math.round(output.scheduledStartTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.scheduledStartTime)))
         : undefined,
     stageDetails:
       output.stageDetails !== undefined && output.stageDetails !== null
@@ -5442,7 +5445,7 @@ const deserializeAws_json1_1ServerReplicationParameters = (
     runOnce: __expectBoolean(output.runOnce),
     seedTime:
       output.seedTime !== undefined && output.seedTime !== null
-        ? new Date(Math.round(output.seedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.seedTime)))
         : undefined,
   } as any;
 };
@@ -5644,7 +5647,7 @@ const deserializeAws_json1_1ValidationOutput = (output: any, context: __SerdeCon
         : undefined,
     latestValidationTime:
       output.latestValidationTime !== undefined && output.latestValidationTime !== null
-        ? new Date(Math.round(output.latestValidationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.latestValidationTime)))
         : undefined,
     name: __expectString(output.name),
     serverValidationOutput:

--- a/clients/client-snow-device-management/protocols/Aws_restJson1.ts
+++ b/clients/client-snow-device-management/protocols/Aws_restJson1.ts
@@ -51,9 +51,11 @@ import {
   expectInt32 as __expectInt32,
   expectLong as __expectLong,
   expectNonNull as __expectNonNull,
+  expectNumber as __expectNumber,
   expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
+  parseEpochTimestamp as __parseEpochTimestamp,
 } from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
@@ -681,10 +683,10 @@ export const deserializeAws_restJson1DescribeDeviceCommand = async (
     contents.deviceType = __expectString(data.deviceType);
   }
   if (data.lastReachedOutAt !== undefined && data.lastReachedOutAt !== null) {
-    contents.lastReachedOutAt = new Date(Math.round(data.lastReachedOutAt * 1000));
+    contents.lastReachedOutAt = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.lastReachedOutAt)));
   }
   if (data.lastUpdatedAt !== undefined && data.lastUpdatedAt !== null) {
-    contents.lastUpdatedAt = new Date(Math.round(data.lastUpdatedAt * 1000));
+    contents.lastUpdatedAt = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.lastUpdatedAt)));
   }
   if (data.managedDeviceArn !== undefined && data.managedDeviceArn !== null) {
     contents.managedDeviceArn = __expectString(data.managedDeviceArn);
@@ -884,13 +886,13 @@ export const deserializeAws_restJson1DescribeExecutionCommand = async (
     contents.executionId = __expectString(data.executionId);
   }
   if (data.lastUpdatedAt !== undefined && data.lastUpdatedAt !== null) {
-    contents.lastUpdatedAt = new Date(Math.round(data.lastUpdatedAt * 1000));
+    contents.lastUpdatedAt = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.lastUpdatedAt)));
   }
   if (data.managedDeviceId !== undefined && data.managedDeviceId !== null) {
     contents.managedDeviceId = __expectString(data.managedDeviceId);
   }
   if (data.startedAt !== undefined && data.startedAt !== null) {
-    contents.startedAt = new Date(Math.round(data.startedAt * 1000));
+    contents.startedAt = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.startedAt)));
   }
   if (data.state !== undefined && data.state !== null) {
     contents.state = __expectString(data.state);
@@ -991,16 +993,16 @@ export const deserializeAws_restJson1DescribeTaskCommand = async (
   };
   const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.completedAt !== undefined && data.completedAt !== null) {
-    contents.completedAt = new Date(Math.round(data.completedAt * 1000));
+    contents.completedAt = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.completedAt)));
   }
   if (data.createdAt !== undefined && data.createdAt !== null) {
-    contents.createdAt = new Date(Math.round(data.createdAt * 1000));
+    contents.createdAt = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.createdAt)));
   }
   if (data.description !== undefined && data.description !== null) {
     contents.description = __expectString(data.description);
   }
   if (data.lastUpdatedAt !== undefined && data.lastUpdatedAt !== null) {
-    contents.lastUpdatedAt = new Date(Math.round(data.lastUpdatedAt * 1000));
+    contents.lastUpdatedAt = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.lastUpdatedAt)));
   }
   if (data.state !== undefined && data.state !== null) {
     contents.state = __expectString(data.state);
@@ -1856,7 +1858,7 @@ const deserializeAws_restJson1EbsInstanceBlockDevice = (
   return {
     attachTime:
       output.attachTime !== undefined && output.attachTime !== null
-        ? new Date(Math.round(output.attachTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.attachTime)))
         : undefined,
     deleteOnTermination: __expectBoolean(output.deleteOnTermination),
     status: __expectString(output.status),
@@ -1897,7 +1899,7 @@ const deserializeAws_restJson1Instance = (output: any, context: __SerdeContext):
         : undefined,
     createdAt:
       output.createdAt !== undefined && output.createdAt !== null
-        ? new Date(Math.round(output.createdAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.createdAt)))
         : undefined,
     imageId: __expectString(output.imageId),
     instanceId: __expectString(output.instanceId),
@@ -1915,7 +1917,7 @@ const deserializeAws_restJson1Instance = (output: any, context: __SerdeContext):
         : undefined,
     updatedAt:
       output.updatedAt !== undefined && output.updatedAt !== null
-        ? new Date(Math.round(output.updatedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.updatedAt)))
         : undefined,
   } as any;
 };
@@ -1962,7 +1964,7 @@ const deserializeAws_restJson1InstanceSummary = (output: any, context: __SerdeCo
         : undefined,
     lastUpdatedAt:
       output.lastUpdatedAt !== undefined && output.lastUpdatedAt !== null
-        ? new Date(Math.round(output.lastUpdatedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastUpdatedAt)))
         : undefined,
   } as any;
 };

--- a/clients/client-snowball/protocols/Aws_json1_1.ts
+++ b/clients/client-snowball/protocols/Aws_json1_1.ts
@@ -139,7 +139,10 @@ import {
   expectBoolean as __expectBoolean,
   expectInt32 as __expectInt32,
   expectLong as __expectLong,
+  expectNonNull as __expectNonNull,
+  expectNumber as __expectNumber,
   expectString as __expectString,
+  parseEpochTimestamp as __parseEpochTimestamp,
 } from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
@@ -2840,7 +2843,7 @@ const deserializeAws_json1_1ClusterListEntry = (output: any, context: __SerdeCon
     ClusterState: __expectString(output.ClusterState),
     CreationDate:
       output.CreationDate !== undefined && output.CreationDate !== null
-        ? new Date(Math.round(output.CreationDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationDate)))
         : undefined,
     Description: __expectString(output.Description),
   } as any;
@@ -2864,7 +2867,7 @@ const deserializeAws_json1_1ClusterMetadata = (output: any, context: __SerdeCont
     ClusterState: __expectString(output.ClusterState),
     CreationDate:
       output.CreationDate !== undefined && output.CreationDate !== null
-        ? new Date(Math.round(output.CreationDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationDate)))
         : undefined,
     Description: __expectString(output.Description),
     ForwardingAddressId: __expectString(output.ForwardingAddressId),
@@ -3013,7 +3016,7 @@ const deserializeAws_json1_1DescribeReturnShippingLabelResult = (
   return {
     ExpirationDate:
       output.ExpirationDate !== undefined && output.ExpirationDate !== null
-        ? new Date(Math.round(output.ExpirationDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.ExpirationDate)))
         : undefined,
     Status: __expectString(output.Status),
   } as any;
@@ -3159,7 +3162,7 @@ const deserializeAws_json1_1JobListEntry = (output: any, context: __SerdeContext
   return {
     CreationDate:
       output.CreationDate !== undefined && output.CreationDate !== null
-        ? new Date(Math.round(output.CreationDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationDate)))
         : undefined,
     Description: __expectString(output.Description),
     IsMaster: __expectBoolean(output.IsMaster),
@@ -3195,7 +3198,7 @@ const deserializeAws_json1_1JobMetadata = (output: any, context: __SerdeContext)
     ClusterId: __expectString(output.ClusterId),
     CreationDate:
       output.CreationDate !== undefined && output.CreationDate !== null
-        ? new Date(Math.round(output.CreationDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationDate)))
         : undefined,
     DataTransferProgress:
       output.DataTransferProgress !== undefined && output.DataTransferProgress !== null
@@ -3413,12 +3416,12 @@ const deserializeAws_json1_1LongTermPricingListEntry = (
         : undefined,
     LongTermPricingEndDate:
       output.LongTermPricingEndDate !== undefined && output.LongTermPricingEndDate !== null
-        ? new Date(Math.round(output.LongTermPricingEndDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LongTermPricingEndDate)))
         : undefined,
     LongTermPricingId: __expectString(output.LongTermPricingId),
     LongTermPricingStartDate:
       output.LongTermPricingStartDate !== undefined && output.LongTermPricingStartDate !== null
-        ? new Date(Math.round(output.LongTermPricingStartDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LongTermPricingStartDate)))
         : undefined,
     LongTermPricingStatus: __expectString(output.LongTermPricingStatus),
     LongTermPricingType: __expectString(output.LongTermPricingType),

--- a/clients/client-sns/protocols/Aws_query.ts
+++ b/clients/client-sns/protocols/Aws_query.ts
@@ -211,11 +211,13 @@ import {
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
+  expectNonNull as __expectNonNull,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   getArrayIfSingleItem as __getArrayIfSingleItem,
   getValueFromTextNode as __getValueFromTextNode,
   parseBoolean as __parseBoolean,
+  parseRfc3339DateTime as __parseRfc3339DateTime,
 } from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
@@ -5907,7 +5909,7 @@ const deserializeAws_queryPhoneNumberInformation = (output: any, context: __Serd
     NumberCapabilities: undefined,
   };
   if (output["CreatedAt"] !== undefined) {
-    contents.CreatedAt = new Date(output["CreatedAt"]);
+    contents.CreatedAt = __expectNonNull(__parseRfc3339DateTime(output["CreatedAt"]));
   }
   if (output["PhoneNumber"] !== undefined) {
     contents.PhoneNumber = __expectString(output["PhoneNumber"]);

--- a/clients/client-ssm-contacts/protocols/Aws_json1_1.ts
+++ b/clients/client-ssm-contacts/protocols/Aws_json1_1.ts
@@ -131,7 +131,10 @@ import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@a
 import {
   expectBoolean as __expectBoolean,
   expectInt32 as __expectInt32,
+  expectNonNull as __expectNonNull,
+  expectNumber as __expectNumber,
   expectString as __expectString,
+  parseEpochTimestamp as __parseEpochTimestamp,
 } from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
@@ -3576,11 +3579,11 @@ const deserializeAws_json1_1DescribeEngagementResult = (
     Sender: __expectString(output.Sender),
     StartTime:
       output.StartTime !== undefined && output.StartTime !== null
-        ? new Date(Math.round(output.StartTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.StartTime)))
         : undefined,
     StopTime:
       output.StopTime !== undefined && output.StopTime !== null
-        ? new Date(Math.round(output.StopTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.StopTime)))
         : undefined,
     Subject: __expectString(output.Subject),
   } as any;
@@ -3592,7 +3595,7 @@ const deserializeAws_json1_1DescribePageResult = (output: any, context: __SerdeC
     Content: __expectString(output.Content),
     DeliveryTime:
       output.DeliveryTime !== undefined && output.DeliveryTime !== null
-        ? new Date(Math.round(output.DeliveryTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.DeliveryTime)))
         : undefined,
     EngagementArn: __expectString(output.EngagementArn),
     IncidentId: __expectString(output.IncidentId),
@@ -3601,12 +3604,12 @@ const deserializeAws_json1_1DescribePageResult = (output: any, context: __SerdeC
     PublicSubject: __expectString(output.PublicSubject),
     ReadTime:
       output.ReadTime !== undefined && output.ReadTime !== null
-        ? new Date(Math.round(output.ReadTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.ReadTime)))
         : undefined,
     Sender: __expectString(output.Sender),
     SentTime:
       output.SentTime !== undefined && output.SentTime !== null
-        ? new Date(Math.round(output.SentTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.SentTime)))
         : undefined,
     Subject: __expectString(output.Subject),
   } as any;
@@ -3620,11 +3623,11 @@ const deserializeAws_json1_1Engagement = (output: any, context: __SerdeContext):
     Sender: __expectString(output.Sender),
     StartTime:
       output.StartTime !== undefined && output.StartTime !== null
-        ? new Date(Math.round(output.StartTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.StartTime)))
         : undefined,
     StopTime:
       output.StopTime !== undefined && output.StopTime !== null
-        ? new Date(Math.round(output.StopTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.StopTime)))
         : undefined,
   } as any;
 };
@@ -3771,19 +3774,19 @@ const deserializeAws_json1_1Page = (output: any, context: __SerdeContext): Page 
     ContactArn: __expectString(output.ContactArn),
     DeliveryTime:
       output.DeliveryTime !== undefined && output.DeliveryTime !== null
-        ? new Date(Math.round(output.DeliveryTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.DeliveryTime)))
         : undefined,
     EngagementArn: __expectString(output.EngagementArn),
     IncidentId: __expectString(output.IncidentId),
     PageArn: __expectString(output.PageArn),
     ReadTime:
       output.ReadTime !== undefined && output.ReadTime !== null
-        ? new Date(Math.round(output.ReadTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.ReadTime)))
         : undefined,
     Sender: __expectString(output.Sender),
     SentTime:
       output.SentTime !== undefined && output.SentTime !== null
-        ? new Date(Math.round(output.SentTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.SentTime)))
         : undefined,
   } as any;
 };
@@ -3818,7 +3821,7 @@ const deserializeAws_json1_1Receipt = (output: any, context: __SerdeContext): Re
     ReceiptInfo: __expectString(output.ReceiptInfo),
     ReceiptTime:
       output.ReceiptTime !== undefined && output.ReceiptTime !== null
-        ? new Date(Math.round(output.ReceiptTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.ReceiptTime)))
         : undefined,
     ReceiptType: __expectString(output.ReceiptType),
   } as any;

--- a/clients/client-ssm-incidents/protocols/Aws_restJson1.ts
+++ b/clients/client-ssm-incidents/protocols/Aws_restJson1.ts
@@ -111,9 +111,11 @@ import {
   expectBoolean as __expectBoolean,
   expectInt32 as __expectInt32,
   expectNonNull as __expectNonNull,
+  expectNumber as __expectNumber,
   expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
+  parseEpochTimestamp as __parseEpochTimestamp,
 } from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
@@ -4046,12 +4048,12 @@ const deserializeAws_restJson1EventSummary = (output: any, context: __SerdeConte
     eventId: __expectString(output.eventId),
     eventTime:
       output.eventTime !== undefined && output.eventTime !== null
-        ? new Date(Math.round(output.eventTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.eventTime)))
         : undefined,
     eventType: __expectString(output.eventType),
     eventUpdatedTime:
       output.eventUpdatedTime !== undefined && output.eventUpdatedTime !== null
-        ? new Date(Math.round(output.eventUpdatedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.eventUpdatedTime)))
         : undefined,
     incidentRecordArn: __expectString(output.incidentRecordArn),
   } as any;
@@ -4081,7 +4083,7 @@ const deserializeAws_restJson1IncidentRecord = (output: any, context: __SerdeCon
         : undefined,
     creationTime:
       output.creationTime !== undefined && output.creationTime !== null
-        ? new Date(Math.round(output.creationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.creationTime)))
         : undefined,
     dedupeString: __expectString(output.dedupeString),
     impact: __expectInt32(output.impact),
@@ -4092,7 +4094,7 @@ const deserializeAws_restJson1IncidentRecord = (output: any, context: __SerdeCon
     lastModifiedBy: __expectString(output.lastModifiedBy),
     lastModifiedTime:
       output.lastModifiedTime !== undefined && output.lastModifiedTime !== null
-        ? new Date(Math.round(output.lastModifiedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastModifiedTime)))
         : undefined,
     notificationTargets:
       output.notificationTargets !== undefined && output.notificationTargets !== null
@@ -4100,7 +4102,7 @@ const deserializeAws_restJson1IncidentRecord = (output: any, context: __SerdeCon
         : undefined,
     resolvedTime:
       output.resolvedTime !== undefined && output.resolvedTime !== null
-        ? new Date(Math.round(output.resolvedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.resolvedTime)))
         : undefined,
     status: __expectString(output.status),
     summary: __expectString(output.summary),
@@ -4122,7 +4124,7 @@ const deserializeAws_restJson1IncidentRecordSummary = (output: any, context: __S
     arn: __expectString(output.arn),
     creationTime:
       output.creationTime !== undefined && output.creationTime !== null
-        ? new Date(Math.round(output.creationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.creationTime)))
         : undefined,
     impact: __expectInt32(output.impact),
     incidentRecordSource:
@@ -4131,7 +4133,7 @@ const deserializeAws_restJson1IncidentRecordSummary = (output: any, context: __S
         : undefined,
     resolvedTime:
       output.resolvedTime !== undefined && output.resolvedTime !== null
-        ? new Date(Math.round(output.resolvedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.resolvedTime)))
         : undefined,
     status: __expectString(output.status),
     title: __expectString(output.title),
@@ -4219,7 +4221,7 @@ const deserializeAws_restJson1RegionInfo = (output: any, context: __SerdeContext
     statusMessage: __expectString(output.statusMessage),
     statusUpdateDateTime:
       output.statusUpdateDateTime !== undefined && output.statusUpdateDateTime !== null
-        ? new Date(Math.round(output.statusUpdateDateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.statusUpdateDateTime)))
         : undefined,
   } as any;
 };
@@ -4263,13 +4265,13 @@ const deserializeAws_restJson1ReplicationSet = (output: any, context: __SerdeCon
     createdBy: __expectString(output.createdBy),
     createdTime:
       output.createdTime !== undefined && output.createdTime !== null
-        ? new Date(Math.round(output.createdTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.createdTime)))
         : undefined,
     deletionProtected: __expectBoolean(output.deletionProtected),
     lastModifiedBy: __expectString(output.lastModifiedBy),
     lastModifiedTime:
       output.lastModifiedTime !== undefined && output.lastModifiedTime !== null
-        ? new Date(Math.round(output.lastModifiedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.lastModifiedTime)))
         : undefined,
     regionMap:
       output.regionMap !== undefined && output.regionMap !== null
@@ -4385,12 +4387,12 @@ const deserializeAws_restJson1TimelineEvent = (output: any, context: __SerdeCont
     eventId: __expectString(output.eventId),
     eventTime:
       output.eventTime !== undefined && output.eventTime !== null
-        ? new Date(Math.round(output.eventTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.eventTime)))
         : undefined,
     eventType: __expectString(output.eventType),
     eventUpdatedTime:
       output.eventUpdatedTime !== undefined && output.eventUpdatedTime !== null
-        ? new Date(Math.round(output.eventUpdatedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.eventUpdatedTime)))
         : undefined,
     incidentRecordArn: __expectString(output.incidentRecordArn),
   } as any;

--- a/clients/client-ssm/protocols/Aws_json1_1.ts
+++ b/clients/client-ssm/protocols/Aws_json1_1.ts
@@ -956,7 +956,10 @@ import {
   expectBoolean as __expectBoolean,
   expectInt32 as __expectInt32,
   expectLong as __expectLong,
+  expectNonNull as __expectNonNull,
+  expectNumber as __expectNumber,
   expectString as __expectString,
+  parseEpochTimestamp as __parseEpochTimestamp,
 } from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
@@ -18682,13 +18685,13 @@ const deserializeAws_json1_1Activation = (output: any, context: __SerdeContext):
     ActivationId: __expectString(output.ActivationId),
     CreatedDate:
       output.CreatedDate !== undefined && output.CreatedDate !== null
-        ? new Date(Math.round(output.CreatedDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreatedDate)))
         : undefined,
     DefaultInstanceName: __expectString(output.DefaultInstanceName),
     Description: __expectString(output.Description),
     ExpirationDate:
       output.ExpirationDate !== undefined && output.ExpirationDate !== null
-        ? new Date(Math.round(output.ExpirationDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.ExpirationDate)))
         : undefined,
     Expired: __expectBoolean(output.Expired),
     IamRole: __expectString(output.IamRole),
@@ -18747,7 +18750,7 @@ const deserializeAws_json1_1Association = (output: any, context: __SerdeContext)
     InstanceId: __expectString(output.InstanceId),
     LastExecutionDate:
       output.LastExecutionDate !== undefined && output.LastExecutionDate !== null
-        ? new Date(Math.round(output.LastExecutionDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastExecutionDate)))
         : undefined,
     Name: __expectString(output.Name),
     Overview:
@@ -18781,20 +18784,23 @@ const deserializeAws_json1_1AssociationDescription = (output: any, context: __Se
         ? deserializeAws_json1_1CalendarNameOrARNList(output.CalendarNames, context)
         : undefined,
     ComplianceSeverity: __expectString(output.ComplianceSeverity),
-    Date: output.Date !== undefined && output.Date !== null ? new Date(Math.round(output.Date * 1000)) : undefined,
+    Date:
+      output.Date !== undefined && output.Date !== null
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.Date)))
+        : undefined,
     DocumentVersion: __expectString(output.DocumentVersion),
     InstanceId: __expectString(output.InstanceId),
     LastExecutionDate:
       output.LastExecutionDate !== undefined && output.LastExecutionDate !== null
-        ? new Date(Math.round(output.LastExecutionDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastExecutionDate)))
         : undefined,
     LastSuccessfulExecutionDate:
       output.LastSuccessfulExecutionDate !== undefined && output.LastSuccessfulExecutionDate !== null
-        ? new Date(Math.round(output.LastSuccessfulExecutionDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastSuccessfulExecutionDate)))
         : undefined,
     LastUpdateAssociationDate:
       output.LastUpdateAssociationDate !== undefined && output.LastUpdateAssociationDate !== null
-        ? new Date(Math.round(output.LastUpdateAssociationDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastUpdateAssociationDate)))
         : undefined,
     MaxConcurrency: __expectString(output.MaxConcurrency),
     MaxErrors: __expectString(output.MaxErrors),
@@ -18857,13 +18863,13 @@ const deserializeAws_json1_1AssociationExecution = (output: any, context: __Serd
     AssociationVersion: __expectString(output.AssociationVersion),
     CreatedTime:
       output.CreatedTime !== undefined && output.CreatedTime !== null
-        ? new Date(Math.round(output.CreatedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreatedTime)))
         : undefined,
     DetailedStatus: __expectString(output.DetailedStatus),
     ExecutionId: __expectString(output.ExecutionId),
     LastExecutionDate:
       output.LastExecutionDate !== undefined && output.LastExecutionDate !== null
-        ? new Date(Math.round(output.LastExecutionDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastExecutionDate)))
         : undefined,
     ResourceCountByStatus: __expectString(output.ResourceCountByStatus),
     Status: __expectString(output.Status),
@@ -18904,7 +18910,7 @@ const deserializeAws_json1_1AssociationExecutionTarget = (
     ExecutionId: __expectString(output.ExecutionId),
     LastExecutionDate:
       output.LastExecutionDate !== undefined && output.LastExecutionDate !== null
-        ? new Date(Math.round(output.LastExecutionDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastExecutionDate)))
         : undefined,
     OutputSource:
       output.OutputSource !== undefined && output.OutputSource !== null
@@ -18962,7 +18968,10 @@ const deserializeAws_json1_1AssociationOverview = (output: any, context: __Serde
 const deserializeAws_json1_1AssociationStatus = (output: any, context: __SerdeContext): AssociationStatus => {
   return {
     AdditionalInfo: __expectString(output.AdditionalInfo),
-    Date: output.Date !== undefined && output.Date !== null ? new Date(Math.round(output.Date * 1000)) : undefined,
+    Date:
+      output.Date !== undefined && output.Date !== null
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.Date)))
+        : undefined,
     Message: __expectString(output.Message),
     Name: __expectString(output.Name),
   } as any;
@@ -18996,7 +19005,7 @@ const deserializeAws_json1_1AssociationVersionInfo = (output: any, context: __Se
     ComplianceSeverity: __expectString(output.ComplianceSeverity),
     CreatedDate:
       output.CreatedDate !== undefined && output.CreatedDate !== null
-        ? new Date(Math.round(output.CreatedDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreatedDate)))
         : undefined,
     DocumentVersion: __expectString(output.DocumentVersion),
     MaxConcurrency: __expectString(output.MaxConcurrency),
@@ -19128,11 +19137,11 @@ const deserializeAws_json1_1AutomationExecution = (output: any, context: __Serde
     ExecutedBy: __expectString(output.ExecutedBy),
     ExecutionEndTime:
       output.ExecutionEndTime !== undefined && output.ExecutionEndTime !== null
-        ? new Date(Math.round(output.ExecutionEndTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.ExecutionEndTime)))
         : undefined,
     ExecutionStartTime:
       output.ExecutionStartTime !== undefined && output.ExecutionStartTime !== null
-        ? new Date(Math.round(output.ExecutionStartTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.ExecutionStartTime)))
         : undefined,
     FailureMessage: __expectString(output.FailureMessage),
     MaxConcurrency: __expectString(output.MaxConcurrency),
@@ -19162,7 +19171,7 @@ const deserializeAws_json1_1AutomationExecution = (output: any, context: __Serde
         : undefined,
     ScheduledTime:
       output.ScheduledTime !== undefined && output.ScheduledTime !== null
-        ? new Date(Math.round(output.ScheduledTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.ScheduledTime)))
         : undefined,
     StepExecutions:
       output.StepExecutions !== undefined && output.StepExecutions !== null
@@ -19213,11 +19222,11 @@ const deserializeAws_json1_1AutomationExecutionMetadata = (
     ExecutedBy: __expectString(output.ExecutedBy),
     ExecutionEndTime:
       output.ExecutionEndTime !== undefined && output.ExecutionEndTime !== null
-        ? new Date(Math.round(output.ExecutionEndTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.ExecutionEndTime)))
         : undefined,
     ExecutionStartTime:
       output.ExecutionStartTime !== undefined && output.ExecutionStartTime !== null
-        ? new Date(Math.round(output.ExecutionStartTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.ExecutionStartTime)))
         : undefined,
     FailureMessage: __expectString(output.FailureMessage),
     LogFile: __expectString(output.LogFile),
@@ -19240,7 +19249,7 @@ const deserializeAws_json1_1AutomationExecutionMetadata = (
         : undefined,
     ScheduledTime:
       output.ScheduledTime !== undefined && output.ScheduledTime !== null
-        ? new Date(Math.round(output.ScheduledTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.ScheduledTime)))
         : undefined,
     Target: __expectString(output.Target),
     TargetMaps:
@@ -19359,7 +19368,7 @@ const deserializeAws_json1_1Command = (output: any, context: __SerdeContext): Co
     ErrorCount: __expectInt32(output.ErrorCount),
     ExpiresAfter:
       output.ExpiresAfter !== undefined && output.ExpiresAfter !== null
-        ? new Date(Math.round(output.ExpiresAfter * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.ExpiresAfter)))
         : undefined,
     InstanceIds:
       output.InstanceIds !== undefined && output.InstanceIds !== null
@@ -19380,7 +19389,7 @@ const deserializeAws_json1_1Command = (output: any, context: __SerdeContext): Co
         : undefined,
     RequestedDateTime:
       output.RequestedDateTime !== undefined && output.RequestedDateTime !== null
-        ? new Date(Math.round(output.RequestedDateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.RequestedDateTime)))
         : undefined,
     ServiceRole: __expectString(output.ServiceRole),
     Status: __expectString(output.Status),
@@ -19416,7 +19425,7 @@ const deserializeAws_json1_1CommandInvocation = (output: any, context: __SerdeCo
         : undefined,
     RequestedDateTime:
       output.RequestedDateTime !== undefined && output.RequestedDateTime !== null
-        ? new Date(Math.round(output.RequestedDateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.RequestedDateTime)))
         : undefined,
     ServiceRole: __expectString(output.ServiceRole),
     StandardErrorUrl: __expectString(output.StandardErrorUrl),
@@ -19459,11 +19468,11 @@ const deserializeAws_json1_1CommandPlugin = (output: any, context: __SerdeContex
     ResponseCode: __expectInt32(output.ResponseCode),
     ResponseFinishDateTime:
       output.ResponseFinishDateTime !== undefined && output.ResponseFinishDateTime !== null
-        ? new Date(Math.round(output.ResponseFinishDateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.ResponseFinishDateTime)))
         : undefined,
     ResponseStartDateTime:
       output.ResponseStartDateTime !== undefined && output.ResponseStartDateTime !== null
-        ? new Date(Math.round(output.ResponseStartDateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.ResponseStartDateTime)))
         : undefined,
     StandardErrorUrl: __expectString(output.StandardErrorUrl),
     StandardOutputUrl: __expectString(output.StandardOutputUrl),
@@ -19491,7 +19500,7 @@ const deserializeAws_json1_1ComplianceExecutionSummary = (
     ExecutionId: __expectString(output.ExecutionId),
     ExecutionTime:
       output.ExecutionTime !== undefined && output.ExecutionTime !== null
-        ? new Date(Math.round(output.ExecutionTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.ExecutionTime)))
         : undefined,
     ExecutionType: __expectString(output.ExecutionType),
   } as any;
@@ -20297,7 +20306,7 @@ const deserializeAws_json1_1DocumentDescription = (output: any, context: __Serde
     Author: __expectString(output.Author),
     CreatedDate:
       output.CreatedDate !== undefined && output.CreatedDate !== null
-        ? new Date(Math.round(output.CreatedDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreatedDate)))
         : undefined,
     DefaultVersion: __expectString(output.DefaultVersion),
     Description: __expectString(output.Description),
@@ -20346,7 +20355,7 @@ const deserializeAws_json1_1DocumentIdentifier = (output: any, context: __SerdeC
     Author: __expectString(output.Author),
     CreatedDate:
       output.CreatedDate !== undefined && output.CreatedDate !== null
-        ? new Date(Math.round(output.CreatedDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreatedDate)))
         : undefined,
     DisplayName: __expectString(output.DisplayName),
     DocumentFormat: __expectString(output.DocumentFormat),
@@ -20498,13 +20507,13 @@ const deserializeAws_json1_1DocumentReviewerResponseSource = (
         : undefined,
     CreateTime:
       output.CreateTime !== undefined && output.CreateTime !== null
-        ? new Date(Math.round(output.CreateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreateTime)))
         : undefined,
     ReviewStatus: __expectString(output.ReviewStatus),
     Reviewer: __expectString(output.Reviewer),
     UpdatedTime:
       output.UpdatedTime !== undefined && output.UpdatedTime !== null
-        ? new Date(Math.round(output.UpdatedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.UpdatedTime)))
         : undefined,
   } as any;
 };
@@ -20513,7 +20522,7 @@ const deserializeAws_json1_1DocumentVersionInfo = (output: any, context: __Serde
   return {
     CreatedDate:
       output.CreatedDate !== undefined && output.CreatedDate !== null
-        ? new Date(Math.round(output.CreatedDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreatedDate)))
         : undefined,
     DisplayName: __expectString(output.DisplayName),
     DocumentFormat: __expectString(output.DocumentFormat),
@@ -20739,7 +20748,7 @@ const deserializeAws_json1_1GetDocumentResult = (output: any, context: __SerdeCo
     Content: __expectString(output.Content),
     CreatedDate:
       output.CreatedDate !== undefined && output.CreatedDate !== null
-        ? new Date(Math.round(output.CreatedDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreatedDate)))
         : undefined,
     DisplayName: __expectString(output.DisplayName),
     DocumentFormat: __expectString(output.DocumentFormat),
@@ -20786,10 +20795,12 @@ const deserializeAws_json1_1GetMaintenanceWindowExecutionResult = (
 ): GetMaintenanceWindowExecutionResult => {
   return {
     EndTime:
-      output.EndTime !== undefined && output.EndTime !== null ? new Date(Math.round(output.EndTime * 1000)) : undefined,
+      output.EndTime !== undefined && output.EndTime !== null
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.EndTime)))
+        : undefined,
     StartTime:
       output.StartTime !== undefined && output.StartTime !== null
-        ? new Date(Math.round(output.StartTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.StartTime)))
         : undefined,
     Status: __expectString(output.Status),
     StatusDetails: __expectString(output.StatusDetails),
@@ -20807,14 +20818,16 @@ const deserializeAws_json1_1GetMaintenanceWindowExecutionTaskInvocationResult = 
 ): GetMaintenanceWindowExecutionTaskInvocationResult => {
   return {
     EndTime:
-      output.EndTime !== undefined && output.EndTime !== null ? new Date(Math.round(output.EndTime * 1000)) : undefined,
+      output.EndTime !== undefined && output.EndTime !== null
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.EndTime)))
+        : undefined,
     ExecutionId: __expectString(output.ExecutionId),
     InvocationId: __expectString(output.InvocationId),
     OwnerInformation: __expectString(output.OwnerInformation),
     Parameters: __expectString(output.Parameters),
     StartTime:
       output.StartTime !== undefined && output.StartTime !== null
-        ? new Date(Math.round(output.StartTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.StartTime)))
         : undefined,
     Status: __expectString(output.Status),
     StatusDetails: __expectString(output.StatusDetails),
@@ -20831,14 +20844,16 @@ const deserializeAws_json1_1GetMaintenanceWindowExecutionTaskResult = (
 ): GetMaintenanceWindowExecutionTaskResult => {
   return {
     EndTime:
-      output.EndTime !== undefined && output.EndTime !== null ? new Date(Math.round(output.EndTime * 1000)) : undefined,
+      output.EndTime !== undefined && output.EndTime !== null
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.EndTime)))
+        : undefined,
     MaxConcurrency: __expectString(output.MaxConcurrency),
     MaxErrors: __expectString(output.MaxErrors),
     Priority: __expectInt32(output.Priority),
     ServiceRole: __expectString(output.ServiceRole),
     StartTime:
       output.StartTime !== undefined && output.StartTime !== null
-        ? new Date(Math.round(output.StartTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.StartTime)))
         : undefined,
     Status: __expectString(output.Status),
     StatusDetails: __expectString(output.StatusDetails),
@@ -20861,7 +20876,7 @@ const deserializeAws_json1_1GetMaintenanceWindowResult = (
     AllowUnassociatedTargets: __expectBoolean(output.AllowUnassociatedTargets),
     CreatedDate:
       output.CreatedDate !== undefined && output.CreatedDate !== null
-        ? new Date(Math.round(output.CreatedDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreatedDate)))
         : undefined,
     Cutoff: __expectInt32(output.Cutoff),
     Description: __expectString(output.Description),
@@ -20870,7 +20885,7 @@ const deserializeAws_json1_1GetMaintenanceWindowResult = (
     EndDate: __expectString(output.EndDate),
     ModifiedDate:
       output.ModifiedDate !== undefined && output.ModifiedDate !== null
-        ? new Date(Math.round(output.ModifiedDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.ModifiedDate)))
         : undefined,
     Name: __expectString(output.Name),
     NextExecutionTime: __expectString(output.NextExecutionTime),
@@ -21020,7 +21035,7 @@ const deserializeAws_json1_1GetPatchBaselineResult = (output: any, context: __Se
     BaselineId: __expectString(output.BaselineId),
     CreatedDate:
       output.CreatedDate !== undefined && output.CreatedDate !== null
-        ? new Date(Math.round(output.CreatedDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreatedDate)))
         : undefined,
     Description: __expectString(output.Description),
     GlobalFilters:
@@ -21029,7 +21044,7 @@ const deserializeAws_json1_1GetPatchBaselineResult = (output: any, context: __Se
         : undefined,
     ModifiedDate:
       output.ModifiedDate !== undefined && output.ModifiedDate !== null
-        ? new Date(Math.round(output.ModifiedDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.ModifiedDate)))
         : undefined,
     Name: __expectString(output.Name),
     OperatingSystem: __expectString(output.OperatingSystem),
@@ -21186,7 +21201,7 @@ const deserializeAws_json1_1InstanceAssociationStatusInfo = (
     ErrorCode: __expectString(output.ErrorCode),
     ExecutionDate:
       output.ExecutionDate !== undefined && output.ExecutionDate !== null
-        ? new Date(Math.round(output.ExecutionDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.ExecutionDate)))
         : undefined,
     ExecutionSummary: __expectString(output.ExecutionSummary),
     InstanceId: __expectString(output.InstanceId),
@@ -21240,16 +21255,16 @@ const deserializeAws_json1_1InstanceInformation = (output: any, context: __Serde
     IsLatestVersion: __expectBoolean(output.IsLatestVersion),
     LastAssociationExecutionDate:
       output.LastAssociationExecutionDate !== undefined && output.LastAssociationExecutionDate !== null
-        ? new Date(Math.round(output.LastAssociationExecutionDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastAssociationExecutionDate)))
         : undefined,
     LastPingDateTime:
       output.LastPingDateTime !== undefined && output.LastPingDateTime !== null
-        ? new Date(Math.round(output.LastPingDateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastPingDateTime)))
         : undefined,
     LastSuccessfulAssociationExecutionDate:
       output.LastSuccessfulAssociationExecutionDate !== undefined &&
       output.LastSuccessfulAssociationExecutionDate !== null
-        ? new Date(Math.round(output.LastSuccessfulAssociationExecutionDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastSuccessfulAssociationExecutionDate)))
         : undefined,
     Name: __expectString(output.Name),
     PingStatus: __expectString(output.PingStatus),
@@ -21258,7 +21273,7 @@ const deserializeAws_json1_1InstanceInformation = (output: any, context: __Serde
     PlatformVersion: __expectString(output.PlatformVersion),
     RegistrationDate:
       output.RegistrationDate !== undefined && output.RegistrationDate !== null
-        ? new Date(Math.round(output.RegistrationDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.RegistrationDate)))
         : undefined,
     ResourceType: __expectString(output.ResourceType),
   } as any;
@@ -21288,18 +21303,18 @@ const deserializeAws_json1_1InstancePatchState = (output: any, context: __SerdeC
     InstanceId: __expectString(output.InstanceId),
     LastNoRebootInstallOperationTime:
       output.LastNoRebootInstallOperationTime !== undefined && output.LastNoRebootInstallOperationTime !== null
-        ? new Date(Math.round(output.LastNoRebootInstallOperationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastNoRebootInstallOperationTime)))
         : undefined,
     MissingCount: __expectInt32(output.MissingCount),
     NotApplicableCount: __expectInt32(output.NotApplicableCount),
     Operation: __expectString(output.Operation),
     OperationEndTime:
       output.OperationEndTime !== undefined && output.OperationEndTime !== null
-        ? new Date(Math.round(output.OperationEndTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.OperationEndTime)))
         : undefined,
     OperationStartTime:
       output.OperationStartTime !== undefined && output.OperationStartTime !== null
-        ? new Date(Math.round(output.OperationStartTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.OperationStartTime)))
         : undefined,
     OtherNonCompliantCount: __expectInt32(output.OtherNonCompliantCount),
     OwnerInformation: __expectString(output.OwnerInformation),
@@ -21690,7 +21705,7 @@ const deserializeAws_json1_1InventoryDeletionStatusItem = (
     DeletionId: __expectString(output.DeletionId),
     DeletionStartTime:
       output.DeletionStartTime !== undefined && output.DeletionStartTime !== null
-        ? new Date(Math.round(output.DeletionStartTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.DeletionStartTime)))
         : undefined,
     DeletionSummary:
       output.DeletionSummary !== undefined && output.DeletionSummary !== null
@@ -21700,7 +21715,7 @@ const deserializeAws_json1_1InventoryDeletionStatusItem = (
     LastStatusMessage: __expectString(output.LastStatusMessage),
     LastStatusUpdateTime:
       output.LastStatusUpdateTime !== undefined && output.LastStatusUpdateTime !== null
-        ? new Date(Math.round(output.LastStatusUpdateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastStatusUpdateTime)))
         : undefined,
     TypeName: __expectString(output.TypeName),
   } as any;
@@ -22136,10 +22151,12 @@ const deserializeAws_json1_1MaintenanceWindowExecution = (
 ): MaintenanceWindowExecution => {
   return {
     EndTime:
-      output.EndTime !== undefined && output.EndTime !== null ? new Date(Math.round(output.EndTime * 1000)) : undefined,
+      output.EndTime !== undefined && output.EndTime !== null
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.EndTime)))
+        : undefined,
     StartTime:
       output.StartTime !== undefined && output.StartTime !== null
-        ? new Date(Math.round(output.StartTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.StartTime)))
         : undefined,
     Status: __expectString(output.Status),
     StatusDetails: __expectString(output.StatusDetails),
@@ -22168,10 +22185,12 @@ const deserializeAws_json1_1MaintenanceWindowExecutionTaskIdentity = (
 ): MaintenanceWindowExecutionTaskIdentity => {
   return {
     EndTime:
-      output.EndTime !== undefined && output.EndTime !== null ? new Date(Math.round(output.EndTime * 1000)) : undefined,
+      output.EndTime !== undefined && output.EndTime !== null
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.EndTime)))
+        : undefined,
     StartTime:
       output.StartTime !== undefined && output.StartTime !== null
-        ? new Date(Math.round(output.StartTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.StartTime)))
         : undefined,
     Status: __expectString(output.Status),
     StatusDetails: __expectString(output.StatusDetails),
@@ -22213,14 +22232,16 @@ const deserializeAws_json1_1MaintenanceWindowExecutionTaskInvocationIdentity = (
 ): MaintenanceWindowExecutionTaskInvocationIdentity => {
   return {
     EndTime:
-      output.EndTime !== undefined && output.EndTime !== null ? new Date(Math.round(output.EndTime * 1000)) : undefined,
+      output.EndTime !== undefined && output.EndTime !== null
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.EndTime)))
+        : undefined,
     ExecutionId: __expectString(output.ExecutionId),
     InvocationId: __expectString(output.InvocationId),
     OwnerInformation: __expectString(output.OwnerInformation),
     Parameters: __expectString(output.Parameters),
     StartTime:
       output.StartTime !== undefined && output.StartTime !== null
-        ? new Date(Math.round(output.StartTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.StartTime)))
         : undefined,
     Status: __expectString(output.Status),
     StatusDetails: __expectString(output.StatusDetails),
@@ -22665,23 +22686,23 @@ const deserializeAws_json1_1OpsItem = (output: any, context: __SerdeContext): Op
   return {
     ActualEndTime:
       output.ActualEndTime !== undefined && output.ActualEndTime !== null
-        ? new Date(Math.round(output.ActualEndTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.ActualEndTime)))
         : undefined,
     ActualStartTime:
       output.ActualStartTime !== undefined && output.ActualStartTime !== null
-        ? new Date(Math.round(output.ActualStartTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.ActualStartTime)))
         : undefined,
     Category: __expectString(output.Category),
     CreatedBy: __expectString(output.CreatedBy),
     CreatedTime:
       output.CreatedTime !== undefined && output.CreatedTime !== null
-        ? new Date(Math.round(output.CreatedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreatedTime)))
         : undefined,
     Description: __expectString(output.Description),
     LastModifiedBy: __expectString(output.LastModifiedBy),
     LastModifiedTime:
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
-        ? new Date(Math.round(output.LastModifiedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastModifiedTime)))
         : undefined,
     Notifications:
       output.Notifications !== undefined && output.Notifications !== null
@@ -22695,11 +22716,11 @@ const deserializeAws_json1_1OpsItem = (output: any, context: __SerdeContext): Op
     OpsItemType: __expectString(output.OpsItemType),
     PlannedEndTime:
       output.PlannedEndTime !== undefined && output.PlannedEndTime !== null
-        ? new Date(Math.round(output.PlannedEndTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.PlannedEndTime)))
         : undefined,
     PlannedStartTime:
       output.PlannedStartTime !== undefined && output.PlannedStartTime !== null
-        ? new Date(Math.round(output.PlannedStartTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.PlannedStartTime)))
         : undefined,
     Priority: __expectInt32(output.Priority),
     RelatedOpsItems:
@@ -22750,7 +22771,7 @@ const deserializeAws_json1_1OpsItemEventSummary = (output: any, context: __Serde
         : undefined,
     CreatedTime:
       output.CreatedTime !== undefined && output.CreatedTime !== null
-        ? new Date(Math.round(output.CreatedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreatedTime)))
         : undefined,
     Detail: __expectString(output.Detail),
     DetailType: __expectString(output.DetailType),
@@ -22893,7 +22914,7 @@ const deserializeAws_json1_1OpsItemRelatedItemSummary = (
         : undefined,
     CreatedTime:
       output.CreatedTime !== undefined && output.CreatedTime !== null
-        ? new Date(Math.round(output.CreatedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreatedTime)))
         : undefined,
     LastModifiedBy:
       output.LastModifiedBy !== undefined && output.LastModifiedBy !== null
@@ -22901,7 +22922,7 @@ const deserializeAws_json1_1OpsItemRelatedItemSummary = (
         : undefined,
     LastModifiedTime:
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
-        ? new Date(Math.round(output.LastModifiedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastModifiedTime)))
         : undefined,
     OpsItemId: __expectString(output.OpsItemId),
     ResourceType: __expectString(output.ResourceType),
@@ -22924,22 +22945,22 @@ const deserializeAws_json1_1OpsItemSummary = (output: any, context: __SerdeConte
   return {
     ActualEndTime:
       output.ActualEndTime !== undefined && output.ActualEndTime !== null
-        ? new Date(Math.round(output.ActualEndTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.ActualEndTime)))
         : undefined,
     ActualStartTime:
       output.ActualStartTime !== undefined && output.ActualStartTime !== null
-        ? new Date(Math.round(output.ActualStartTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.ActualStartTime)))
         : undefined,
     Category: __expectString(output.Category),
     CreatedBy: __expectString(output.CreatedBy),
     CreatedTime:
       output.CreatedTime !== undefined && output.CreatedTime !== null
-        ? new Date(Math.round(output.CreatedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreatedTime)))
         : undefined,
     LastModifiedBy: __expectString(output.LastModifiedBy),
     LastModifiedTime:
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
-        ? new Date(Math.round(output.LastModifiedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastModifiedTime)))
         : undefined,
     OperationalData:
       output.OperationalData !== undefined && output.OperationalData !== null
@@ -22949,11 +22970,11 @@ const deserializeAws_json1_1OpsItemSummary = (output: any, context: __SerdeConte
     OpsItemType: __expectString(output.OpsItemType),
     PlannedEndTime:
       output.PlannedEndTime !== undefined && output.PlannedEndTime !== null
-        ? new Date(Math.round(output.PlannedEndTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.PlannedEndTime)))
         : undefined,
     PlannedStartTime:
       output.PlannedStartTime !== undefined && output.PlannedStartTime !== null
-        ? new Date(Math.round(output.PlannedStartTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.PlannedStartTime)))
         : undefined,
     Priority: __expectInt32(output.Priority),
     Severity: __expectString(output.Severity),
@@ -22967,11 +22988,11 @@ const deserializeAws_json1_1OpsMetadata = (output: any, context: __SerdeContext)
   return {
     CreationDate:
       output.CreationDate !== undefined && output.CreationDate !== null
-        ? new Date(Math.round(output.CreationDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationDate)))
         : undefined,
     LastModifiedDate:
       output.LastModifiedDate !== undefined && output.LastModifiedDate !== null
-        ? new Date(Math.round(output.LastModifiedDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastModifiedDate)))
         : undefined,
     LastModifiedUser: __expectString(output.LastModifiedUser),
     OpsMetadataArn: __expectString(output.OpsMetadataArn),
@@ -23057,7 +23078,7 @@ const deserializeAws_json1_1Parameter = (output: any, context: __SerdeContext): 
     DataType: __expectString(output.DataType),
     LastModifiedDate:
       output.LastModifiedDate !== undefined && output.LastModifiedDate !== null
-        ? new Date(Math.round(output.LastModifiedDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastModifiedDate)))
         : undefined,
     Name: __expectString(output.Name),
     Selector: __expectString(output.Selector),
@@ -23086,7 +23107,7 @@ const deserializeAws_json1_1ParameterHistory = (output: any, context: __SerdeCon
         : undefined,
     LastModifiedDate:
       output.LastModifiedDate !== undefined && output.LastModifiedDate !== null
-        ? new Date(Math.round(output.LastModifiedDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastModifiedDate)))
         : undefined,
     LastModifiedUser: __expectString(output.LastModifiedUser),
     Name: __expectString(output.Name),
@@ -23165,7 +23186,7 @@ const deserializeAws_json1_1ParameterMetadata = (output: any, context: __SerdeCo
     KeyId: __expectString(output.KeyId),
     LastModifiedDate:
       output.LastModifiedDate !== undefined && output.LastModifiedDate !== null
-        ? new Date(Math.round(output.LastModifiedDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastModifiedDate)))
         : undefined,
     LastModifiedUser: __expectString(output.LastModifiedUser),
     Name: __expectString(output.Name),
@@ -23298,7 +23319,7 @@ const deserializeAws_json1_1Patch = (output: any, context: __SerdeContext): Patc
     Release: __expectString(output.Release),
     ReleaseDate:
       output.ReleaseDate !== undefined && output.ReleaseDate !== null
-        ? new Date(Math.round(output.ReleaseDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.ReleaseDate)))
         : undefined,
     Repository: __expectString(output.Repository),
     Severity: __expectString(output.Severity),
@@ -23360,7 +23381,7 @@ const deserializeAws_json1_1PatchComplianceData = (output: any, context: __Serde
     Classification: __expectString(output.Classification),
     InstalledTime:
       output.InstalledTime !== undefined && output.InstalledTime !== null
-        ? new Date(Math.round(output.InstalledTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.InstalledTime)))
         : undefined,
     KBId: __expectString(output.KBId),
     Severity: __expectString(output.Severity),
@@ -23588,7 +23609,7 @@ const deserializeAws_json1_1PatchStatus = (output: any, context: __SerdeContext)
   return {
     ApprovalDate:
       output.ApprovalDate !== undefined && output.ApprovalDate !== null
-        ? new Date(Math.round(output.ApprovalDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.ApprovalDate)))
         : undefined,
     ComplianceLevel: __expectString(output.ComplianceLevel),
     DeploymentStatus: __expectString(output.DeploymentStatus),
@@ -23841,12 +23862,12 @@ const deserializeAws_json1_1ResourceDataSyncItem = (output: any, context: __Serd
     LastStatus: __expectString(output.LastStatus),
     LastSuccessfulSyncTime:
       output.LastSuccessfulSyncTime !== undefined && output.LastSuccessfulSyncTime !== null
-        ? new Date(Math.round(output.LastSuccessfulSyncTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastSuccessfulSyncTime)))
         : undefined,
     LastSyncStatusMessage: __expectString(output.LastSyncStatusMessage),
     LastSyncTime:
       output.LastSyncTime !== undefined && output.LastSyncTime !== null
-        ? new Date(Math.round(output.LastSyncTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastSyncTime)))
         : undefined,
     S3Destination:
       output.S3Destination !== undefined && output.S3Destination !== null
@@ -23854,11 +23875,11 @@ const deserializeAws_json1_1ResourceDataSyncItem = (output: any, context: __Serd
         : undefined,
     SyncCreatedTime:
       output.SyncCreatedTime !== undefined && output.SyncCreatedTime !== null
-        ? new Date(Math.round(output.SyncCreatedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.SyncCreatedTime)))
         : undefined,
     SyncLastModifiedTime:
       output.SyncLastModifiedTime !== undefined && output.SyncLastModifiedTime !== null
-        ? new Date(Math.round(output.SyncLastModifiedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.SyncLastModifiedTime)))
         : undefined,
     SyncName: __expectString(output.SyncName),
     SyncSource:
@@ -23992,7 +24013,7 @@ const deserializeAws_json1_1ReviewInformation = (output: any, context: __SerdeCo
   return {
     ReviewedTime:
       output.ReviewedTime !== undefined && output.ReviewedTime !== null
-        ? new Date(Math.round(output.ReviewedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.ReviewedTime)))
         : undefined,
     Reviewer: __expectString(output.Reviewer),
     Status: __expectString(output.Status),
@@ -24103,7 +24124,7 @@ const deserializeAws_json1_1ServiceSetting = (output: any, context: __SerdeConte
     ARN: __expectString(output.ARN),
     LastModifiedDate:
       output.LastModifiedDate !== undefined && output.LastModifiedDate !== null
-        ? new Date(Math.round(output.LastModifiedDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastModifiedDate)))
         : undefined,
     LastModifiedUser: __expectString(output.LastModifiedUser),
     SettingId: __expectString(output.SettingId),
@@ -24123,7 +24144,9 @@ const deserializeAws_json1_1Session = (output: any, context: __SerdeContext): Se
     Details: __expectString(output.Details),
     DocumentName: __expectString(output.DocumentName),
     EndDate:
-      output.EndDate !== undefined && output.EndDate !== null ? new Date(Math.round(output.EndDate * 1000)) : undefined,
+      output.EndDate !== undefined && output.EndDate !== null
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.EndDate)))
+        : undefined,
     OutputUrl:
       output.OutputUrl !== undefined && output.OutputUrl !== null
         ? deserializeAws_json1_1SessionManagerOutputUrl(output.OutputUrl, context)
@@ -24132,7 +24155,7 @@ const deserializeAws_json1_1Session = (output: any, context: __SerdeContext): Se
     SessionId: __expectString(output.SessionId),
     StartDate:
       output.StartDate !== undefined && output.StartDate !== null
-        ? new Date(Math.round(output.StartDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.StartDate)))
         : undefined,
     Status: __expectString(output.Status),
     Target: __expectString(output.Target),
@@ -24213,11 +24236,11 @@ const deserializeAws_json1_1StepExecution = (output: any, context: __SerdeContex
     Action: __expectString(output.Action),
     ExecutionEndTime:
       output.ExecutionEndTime !== undefined && output.ExecutionEndTime !== null
-        ? new Date(Math.round(output.ExecutionEndTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.ExecutionEndTime)))
         : undefined,
     ExecutionStartTime:
       output.ExecutionStartTime !== undefined && output.ExecutionStartTime !== null
-        ? new Date(Math.round(output.ExecutionStartTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.ExecutionStartTime)))
         : undefined,
     FailureDetails:
       output.FailureDetails !== undefined && output.FailureDetails !== null
@@ -24691,7 +24714,7 @@ const deserializeAws_json1_1UpdatePatchBaselineResult = (
     BaselineId: __expectString(output.BaselineId),
     CreatedDate:
       output.CreatedDate !== undefined && output.CreatedDate !== null
-        ? new Date(Math.round(output.CreatedDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreatedDate)))
         : undefined,
     Description: __expectString(output.Description),
     GlobalFilters:
@@ -24700,7 +24723,7 @@ const deserializeAws_json1_1UpdatePatchBaselineResult = (
         : undefined,
     ModifiedDate:
       output.ModifiedDate !== undefined && output.ModifiedDate !== null
-        ? new Date(Math.round(output.ModifiedDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.ModifiedDate)))
         : undefined,
     Name: __expectString(output.Name),
     OperatingSystem: __expectString(output.OperatingSystem),

--- a/clients/client-sso-admin/protocols/Aws_json1_1.ts
+++ b/clients/client-sso-admin/protocols/Aws_json1_1.ts
@@ -195,7 +195,12 @@ import {
   ValidationException,
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
-import { expectString as __expectString } from "@aws-sdk/smithy-client";
+import {
+  expectNonNull as __expectNonNull,
+  expectNumber as __expectNumber,
+  expectString as __expectString,
+  parseEpochTimestamp as __parseEpochTimestamp,
+} from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
   HeaderBag as __HeaderBag,
@@ -4091,7 +4096,7 @@ const deserializeAws_json1_1AccountAssignmentOperationStatus = (
   return {
     CreatedDate:
       output.CreatedDate !== undefined && output.CreatedDate !== null
-        ? new Date(Math.round(output.CreatedDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreatedDate)))
         : undefined,
     FailureReason: __expectString(output.FailureReason),
     PermissionSetArn: __expectString(output.PermissionSetArn),
@@ -4125,7 +4130,7 @@ const deserializeAws_json1_1AccountAssignmentOperationStatusMetadata = (
   return {
     CreatedDate:
       output.CreatedDate !== undefined && output.CreatedDate !== null
-        ? new Date(Math.round(output.CreatedDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreatedDate)))
         : undefined,
     RequestId: __expectString(output.RequestId),
     Status: __expectString(output.Status),
@@ -4493,7 +4498,7 @@ const deserializeAws_json1_1PermissionSet = (output: any, context: __SerdeContex
   return {
     CreatedDate:
       output.CreatedDate !== undefined && output.CreatedDate !== null
-        ? new Date(Math.round(output.CreatedDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreatedDate)))
         : undefined,
     Description: __expectString(output.Description),
     Name: __expectString(output.Name),
@@ -4522,7 +4527,7 @@ const deserializeAws_json1_1PermissionSetProvisioningStatus = (
     AccountId: __expectString(output.AccountId),
     CreatedDate:
       output.CreatedDate !== undefined && output.CreatedDate !== null
-        ? new Date(Math.round(output.CreatedDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreatedDate)))
         : undefined,
     FailureReason: __expectString(output.FailureReason),
     PermissionSetArn: __expectString(output.PermissionSetArn),
@@ -4552,7 +4557,7 @@ const deserializeAws_json1_1PermissionSetProvisioningStatusMetadata = (
   return {
     CreatedDate:
       output.CreatedDate !== undefined && output.CreatedDate !== null
-        ? new Date(Math.round(output.CreatedDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreatedDate)))
         : undefined,
     RequestId: __expectString(output.RequestId),
     Status: __expectString(output.Status),

--- a/clients/client-storage-gateway/protocols/Aws_json1_1.ts
+++ b/clients/client-storage-gateway/protocols/Aws_json1_1.ts
@@ -455,8 +455,11 @@ import {
   expectBoolean as __expectBoolean,
   expectInt32 as __expectInt32,
   expectLong as __expectLong,
+  expectNonNull as __expectNonNull,
+  expectNumber as __expectNumber,
   expectString as __expectString,
   limitedParseDouble as __limitedParseDouble,
+  parseEpochTimestamp as __parseEpochTimestamp,
 } from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
@@ -8669,7 +8672,7 @@ const deserializeAws_json1_1CachediSCSIVolume = (output: any, context: __SerdeCo
   return {
     CreatedDate:
       output.CreatedDate !== undefined && output.CreatedDate !== null
-        ? new Date(Math.round(output.CreatedDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreatedDate)))
         : undefined,
     KMSKey: __expectString(output.KMSKey),
     SourceSnapshotId: __expectString(output.SourceSnapshotId),
@@ -8908,7 +8911,7 @@ const deserializeAws_json1_1DescribeAvailabilityMonitorTestOutput = (
     GatewayARN: __expectString(output.GatewayARN),
     StartTime:
       output.StartTime !== undefined && output.StartTime !== null
-        ? new Date(Math.round(output.StartTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.StartTime)))
         : undefined,
     Status: __expectString(output.Status),
   } as any;
@@ -9855,7 +9858,7 @@ const deserializeAws_json1_1StorediSCSIVolume = (output: any, context: __SerdeCo
   return {
     CreatedDate:
       output.CreatedDate !== undefined && output.CreatedDate !== null
-        ? new Date(Math.round(output.CreatedDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreatedDate)))
         : undefined,
     KMSKey: __expectString(output.KMSKey),
     PreservedExistingData: __expectBoolean(output.PreservedExistingData),
@@ -9925,19 +9928,19 @@ const deserializeAws_json1_1Tape = (output: any, context: __SerdeContext): Tape 
     KMSKey: __expectString(output.KMSKey),
     PoolEntryDate:
       output.PoolEntryDate !== undefined && output.PoolEntryDate !== null
-        ? new Date(Math.round(output.PoolEntryDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.PoolEntryDate)))
         : undefined,
     PoolId: __expectString(output.PoolId),
     Progress: __limitedParseDouble(output.Progress),
     RetentionStartDate:
       output.RetentionStartDate !== undefined && output.RetentionStartDate !== null
-        ? new Date(Math.round(output.RetentionStartDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.RetentionStartDate)))
         : undefined,
     TapeARN: __expectString(output.TapeARN),
     TapeBarcode: __expectString(output.TapeBarcode),
     TapeCreatedDate:
       output.TapeCreatedDate !== undefined && output.TapeCreatedDate !== null
-        ? new Date(Math.round(output.TapeCreatedDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.TapeCreatedDate)))
         : undefined,
     TapeSizeInBytes: __expectLong(output.TapeSizeInBytes),
     TapeStatus: __expectString(output.TapeStatus),
@@ -9951,24 +9954,24 @@ const deserializeAws_json1_1TapeArchive = (output: any, context: __SerdeContext)
   return {
     CompletionTime:
       output.CompletionTime !== undefined && output.CompletionTime !== null
-        ? new Date(Math.round(output.CompletionTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CompletionTime)))
         : undefined,
     KMSKey: __expectString(output.KMSKey),
     PoolEntryDate:
       output.PoolEntryDate !== undefined && output.PoolEntryDate !== null
-        ? new Date(Math.round(output.PoolEntryDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.PoolEntryDate)))
         : undefined,
     PoolId: __expectString(output.PoolId),
     RetentionStartDate:
       output.RetentionStartDate !== undefined && output.RetentionStartDate !== null
-        ? new Date(Math.round(output.RetentionStartDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.RetentionStartDate)))
         : undefined,
     RetrievedTo: __expectString(output.RetrievedTo),
     TapeARN: __expectString(output.TapeARN),
     TapeBarcode: __expectString(output.TapeBarcode),
     TapeCreatedDate:
       output.TapeCreatedDate !== undefined && output.TapeCreatedDate !== null
-        ? new Date(Math.round(output.TapeCreatedDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.TapeCreatedDate)))
         : undefined,
     TapeSizeInBytes: __expectLong(output.TapeSizeInBytes),
     TapeStatus: __expectString(output.TapeStatus),
@@ -10004,12 +10007,12 @@ const deserializeAws_json1_1TapeInfo = (output: any, context: __SerdeContext): T
     GatewayARN: __expectString(output.GatewayARN),
     PoolEntryDate:
       output.PoolEntryDate !== undefined && output.PoolEntryDate !== null
-        ? new Date(Math.round(output.PoolEntryDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.PoolEntryDate)))
         : undefined,
     PoolId: __expectString(output.PoolId),
     RetentionStartDate:
       output.RetentionStartDate !== undefined && output.RetentionStartDate !== null
-        ? new Date(Math.round(output.RetentionStartDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.RetentionStartDate)))
         : undefined,
     TapeARN: __expectString(output.TapeARN),
     TapeBarcode: __expectString(output.TapeBarcode),
@@ -10034,7 +10037,7 @@ const deserializeAws_json1_1TapeRecoveryPointInfo = (output: any, context: __Ser
     TapeARN: __expectString(output.TapeARN),
     TapeRecoveryPointTime:
       output.TapeRecoveryPointTime !== undefined && output.TapeRecoveryPointTime !== null
-        ? new Date(Math.round(output.TapeRecoveryPointTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.TapeRecoveryPointTime)))
         : undefined,
     TapeSizeInBytes: __expectLong(output.TapeSizeInBytes),
     TapeStatus: __expectString(output.TapeStatus),

--- a/clients/client-sts/protocols/Aws_query.ts
+++ b/clients/client-sts/protocols/Aws_query.ts
@@ -45,9 +45,11 @@ import {
 } from "../models/models_0";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import {
+  expectNonNull as __expectNonNull,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   getValueFromTextNode as __getValueFromTextNode,
+  parseRfc3339DateTime as __parseRfc3339DateTime,
   strictParseInt32 as __strictParseInt32,
 } from "@aws-sdk/smithy-client";
 import {
@@ -1234,7 +1236,7 @@ const deserializeAws_queryCredentials = (output: any, context: __SerdeContext): 
     contents.SessionToken = __expectString(output["SessionToken"]);
   }
   if (output["Expiration"] !== undefined) {
-    contents.Expiration = new Date(output["Expiration"]);
+    contents.Expiration = __expectNonNull(__parseRfc3339DateTime(output["Expiration"]));
   }
   return contents;
 };

--- a/clients/client-swf/protocols/Aws_json1_0.ts
+++ b/clients/client-swf/protocols/Aws_json1_0.ts
@@ -277,7 +277,10 @@ import {
   expectBoolean as __expectBoolean,
   expectInt32 as __expectInt32,
   expectLong as __expectLong,
+  expectNonNull as __expectNonNull,
+  expectNumber as __expectNumber,
   expectString as __expectString,
+  parseEpochTimestamp as __parseEpochTimestamp,
 } from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
@@ -4403,11 +4406,11 @@ const deserializeAws_json1_0ActivityTypeInfo = (output: any, context: __SerdeCon
         : undefined,
     creationDate:
       output.creationDate !== undefined && output.creationDate !== null
-        ? new Date(Math.round(output.creationDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.creationDate)))
         : undefined,
     deprecationDate:
       output.deprecationDate !== undefined && output.deprecationDate !== null
-        ? new Date(Math.round(output.deprecationDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.deprecationDate)))
         : undefined,
     description: __expectString(output.description),
     status: __expectString(output.status),
@@ -4912,7 +4915,7 @@ const deserializeAws_json1_0HistoryEvent = (output: any, context: __SerdeContext
     eventId: __expectLong(output.eventId),
     eventTimestamp:
       output.eventTimestamp !== undefined && output.eventTimestamp !== null
-        ? new Date(Math.round(output.eventTimestamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.eventTimestamp)))
         : undefined,
     eventType: __expectString(output.eventType),
     externalWorkflowExecutionCancelRequestedEventAttributes:
@@ -5652,7 +5655,7 @@ const deserializeAws_json1_0WorkflowExecutionDetail = (
         : undefined,
     latestActivityTaskTimestamp:
       output.latestActivityTaskTimestamp !== undefined && output.latestActivityTaskTimestamp !== null
-        ? new Date(Math.round(output.latestActivityTaskTimestamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.latestActivityTaskTimestamp)))
         : undefined,
     latestExecutionContext: __expectString(output.latestExecutionContext),
     openCounts:
@@ -5679,7 +5682,7 @@ const deserializeAws_json1_0WorkflowExecutionInfo = (output: any, context: __Ser
     closeStatus: __expectString(output.closeStatus),
     closeTimestamp:
       output.closeTimestamp !== undefined && output.closeTimestamp !== null
-        ? new Date(Math.round(output.closeTimestamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.closeTimestamp)))
         : undefined,
     execution:
       output.execution !== undefined && output.execution !== null
@@ -5692,7 +5695,7 @@ const deserializeAws_json1_0WorkflowExecutionInfo = (output: any, context: __Ser
         : undefined,
     startTimestamp:
       output.startTimestamp !== undefined && output.startTimestamp !== null
-        ? new Date(Math.round(output.startTimestamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.startTimestamp)))
         : undefined,
     tagList:
       output.tagList !== undefined && output.tagList !== null
@@ -5852,11 +5855,11 @@ const deserializeAws_json1_0WorkflowTypeInfo = (output: any, context: __SerdeCon
   return {
     creationDate:
       output.creationDate !== undefined && output.creationDate !== null
-        ? new Date(Math.round(output.creationDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.creationDate)))
         : undefined,
     deprecationDate:
       output.deprecationDate !== undefined && output.deprecationDate !== null
-        ? new Date(Math.round(output.deprecationDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.deprecationDate)))
         : undefined,
     description: __expectString(output.description),
     status: __expectString(output.status),

--- a/clients/client-synthetics/protocols/Aws_restJson1.ts
+++ b/clients/client-synthetics/protocols/Aws_restJson1.ts
@@ -51,9 +51,11 @@ import {
   expectInt32 as __expectInt32,
   expectLong as __expectLong,
   expectNonNull as __expectNonNull,
+  expectNumber as __expectNumber,
   expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
+  parseEpochTimestamp as __parseEpochTimestamp,
 } from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
@@ -1753,10 +1755,12 @@ const deserializeAws_restJson1CanaryRunTimeline = (output: any, context: __Serde
   return {
     Completed:
       output.Completed !== undefined && output.Completed !== null
-        ? new Date(Math.round(output.Completed * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.Completed)))
         : undefined,
     Started:
-      output.Started !== undefined && output.Started !== null ? new Date(Math.round(output.Started * 1000)) : undefined,
+      output.Started !== undefined && output.Started !== null
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.Started)))
+        : undefined,
   } as any;
 };
 
@@ -1778,18 +1782,20 @@ const deserializeAws_restJson1CanaryStatus = (output: any, context: __SerdeConte
 const deserializeAws_restJson1CanaryTimeline = (output: any, context: __SerdeContext): CanaryTimeline => {
   return {
     Created:
-      output.Created !== undefined && output.Created !== null ? new Date(Math.round(output.Created * 1000)) : undefined,
+      output.Created !== undefined && output.Created !== null
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.Created)))
+        : undefined,
     LastModified:
       output.LastModified !== undefined && output.LastModified !== null
-        ? new Date(Math.round(output.LastModified * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastModified)))
         : undefined,
     LastStarted:
       output.LastStarted !== undefined && output.LastStarted !== null
-        ? new Date(Math.round(output.LastStarted * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastStarted)))
         : undefined,
     LastStopped:
       output.LastStopped !== undefined && output.LastStopped !== null
-        ? new Date(Math.round(output.LastStopped * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastStopped)))
         : undefined,
   } as any;
 };
@@ -1798,12 +1804,12 @@ const deserializeAws_restJson1RuntimeVersion = (output: any, context: __SerdeCon
   return {
     DeprecationDate:
       output.DeprecationDate !== undefined && output.DeprecationDate !== null
-        ? new Date(Math.round(output.DeprecationDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.DeprecationDate)))
         : undefined,
     Description: __expectString(output.Description),
     ReleaseDate:
       output.ReleaseDate !== undefined && output.ReleaseDate !== null
-        ? new Date(Math.round(output.ReleaseDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.ReleaseDate)))
         : undefined,
     VersionName: __expectString(output.VersionName),
   } as any;

--- a/clients/client-timestream-write/protocols/Aws_json1_0.ts
+++ b/clients/client-timestream-write/protocols/Aws_json1_0.ts
@@ -66,7 +66,10 @@ import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@a
 import {
   expectInt32 as __expectInt32,
   expectLong as __expectLong,
+  expectNonNull as __expectNonNull,
+  expectNumber as __expectNumber,
   expectString as __expectString,
+  parseEpochTimestamp as __parseEpochTimestamp,
 } from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
@@ -2029,13 +2032,13 @@ const deserializeAws_json1_0Database = (output: any, context: __SerdeContext): D
     Arn: __expectString(output.Arn),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     DatabaseName: __expectString(output.DatabaseName),
     KmsKeyId: __expectString(output.KmsKeyId),
     LastUpdatedTime:
       output.LastUpdatedTime !== undefined && output.LastUpdatedTime !== null
-        ? new Date(Math.round(output.LastUpdatedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastUpdatedTime)))
         : undefined,
     TableCount: __expectLong(output.TableCount),
   } as any;
@@ -2215,12 +2218,12 @@ const deserializeAws_json1_0Table = (output: any, context: __SerdeContext): Tabl
     Arn: __expectString(output.Arn),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     DatabaseName: __expectString(output.DatabaseName),
     LastUpdatedTime:
       output.LastUpdatedTime !== undefined && output.LastUpdatedTime !== null
-        ? new Date(Math.round(output.LastUpdatedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastUpdatedTime)))
         : undefined,
     RetentionProperties:
       output.RetentionProperties !== undefined && output.RetentionProperties !== null

--- a/clients/client-transcribe/protocols/Aws_json1_1.ts
+++ b/clients/client-transcribe/protocols/Aws_json1_1.ts
@@ -245,8 +245,11 @@ import {
   expectBoolean as __expectBoolean,
   expectInt32 as __expectInt32,
   expectLong as __expectLong,
+  expectNonNull as __expectNonNull,
+  expectNumber as __expectNumber,
   expectString as __expectString,
   limitedParseFloat32 as __limitedParseFloat32,
+  parseEpochTimestamp as __parseEpochTimestamp,
 } from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
@@ -4635,11 +4638,11 @@ const deserializeAws_json1_1CallAnalyticsJob = (output: any, context: __SerdeCon
         : undefined,
     CompletionTime:
       output.CompletionTime !== undefined && output.CompletionTime !== null
-        ? new Date(Math.round(output.CompletionTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CompletionTime)))
         : undefined,
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     DataAccessRoleArn: __expectString(output.DataAccessRoleArn),
     FailureReason: __expectString(output.FailureReason),
@@ -4657,7 +4660,7 @@ const deserializeAws_json1_1CallAnalyticsJob = (output: any, context: __SerdeCon
         : undefined,
     StartTime:
       output.StartTime !== undefined && output.StartTime !== null
-        ? new Date(Math.round(output.StartTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.StartTime)))
         : undefined,
     Transcript:
       output.Transcript !== undefined && output.Transcript !== null
@@ -4709,17 +4712,17 @@ const deserializeAws_json1_1CallAnalyticsJobSummary = (
     CallAnalyticsJobStatus: __expectString(output.CallAnalyticsJobStatus),
     CompletionTime:
       output.CompletionTime !== undefined && output.CompletionTime !== null
-        ? new Date(Math.round(output.CompletionTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CompletionTime)))
         : undefined,
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     FailureReason: __expectString(output.FailureReason),
     LanguageCode: __expectString(output.LanguageCode),
     StartTime:
       output.StartTime !== undefined && output.StartTime !== null
-        ? new Date(Math.round(output.StartTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.StartTime)))
         : undefined,
   } as any;
 };
@@ -4729,11 +4732,11 @@ const deserializeAws_json1_1CategoryProperties = (output: any, context: __SerdeC
     CategoryName: __expectString(output.CategoryName),
     CreateTime:
       output.CreateTime !== undefined && output.CreateTime !== null
-        ? new Date(Math.round(output.CreateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreateTime)))
         : undefined,
     LastUpdateTime:
       output.LastUpdateTime !== undefined && output.LastUpdateTime !== null
-        ? new Date(Math.round(output.LastUpdateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastUpdateTime)))
         : undefined,
     Rules:
       output.Rules !== undefined && output.Rules !== null
@@ -4821,7 +4824,7 @@ const deserializeAws_json1_1CreateMedicalVocabularyResponse = (
     LanguageCode: __expectString(output.LanguageCode),
     LastModifiedTime:
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
-        ? new Date(Math.round(output.LastModifiedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastModifiedTime)))
         : undefined,
     VocabularyName: __expectString(output.VocabularyName),
     VocabularyState: __expectString(output.VocabularyState),
@@ -4836,7 +4839,7 @@ const deserializeAws_json1_1CreateVocabularyFilterResponse = (
     LanguageCode: __expectString(output.LanguageCode),
     LastModifiedTime:
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
-        ? new Date(Math.round(output.LastModifiedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastModifiedTime)))
         : undefined,
     VocabularyFilterName: __expectString(output.VocabularyFilterName),
   } as any;
@@ -4851,7 +4854,7 @@ const deserializeAws_json1_1CreateVocabularyResponse = (
     LanguageCode: __expectString(output.LanguageCode),
     LastModifiedTime:
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
-        ? new Date(Math.round(output.LastModifiedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastModifiedTime)))
         : undefined,
     VocabularyName: __expectString(output.VocabularyName),
     VocabularyState: __expectString(output.VocabularyState),
@@ -4930,7 +4933,7 @@ const deserializeAws_json1_1GetMedicalVocabularyResponse = (
     LanguageCode: __expectString(output.LanguageCode),
     LastModifiedTime:
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
-        ? new Date(Math.round(output.LastModifiedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastModifiedTime)))
         : undefined,
     VocabularyName: __expectString(output.VocabularyName),
     VocabularyState: __expectString(output.VocabularyState),
@@ -4958,7 +4961,7 @@ const deserializeAws_json1_1GetVocabularyFilterResponse = (
     LanguageCode: __expectString(output.LanguageCode),
     LastModifiedTime:
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
-        ? new Date(Math.round(output.LastModifiedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastModifiedTime)))
         : undefined,
     VocabularyFilterName: __expectString(output.VocabularyFilterName),
   } as any;
@@ -4971,7 +4974,7 @@ const deserializeAws_json1_1GetVocabularyResponse = (output: any, context: __Ser
     LanguageCode: __expectString(output.LanguageCode),
     LastModifiedTime:
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
-        ? new Date(Math.round(output.LastModifiedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastModifiedTime)))
         : undefined,
     VocabularyName: __expectString(output.VocabularyName),
     VocabularyState: __expectString(output.VocabularyState),
@@ -5023,7 +5026,7 @@ const deserializeAws_json1_1LanguageModel = (output: any, context: __SerdeContex
     BaseModelName: __expectString(output.BaseModelName),
     CreateTime:
       output.CreateTime !== undefined && output.CreateTime !== null
-        ? new Date(Math.round(output.CreateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreateTime)))
         : undefined,
     FailureReason: __expectString(output.FailureReason),
     InputDataConfig:
@@ -5033,7 +5036,7 @@ const deserializeAws_json1_1LanguageModel = (output: any, context: __SerdeContex
     LanguageCode: __expectString(output.LanguageCode),
     LastModifiedTime:
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
-        ? new Date(Math.round(output.LastModifiedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastModifiedTime)))
         : undefined,
     ModelName: __expectString(output.ModelName),
     ModelStatus: __expectString(output.ModelStatus),
@@ -5200,12 +5203,12 @@ const deserializeAws_json1_1MedicalTranscriptionJob = (
   return {
     CompletionTime:
       output.CompletionTime !== undefined && output.CompletionTime !== null
-        ? new Date(Math.round(output.CompletionTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CompletionTime)))
         : undefined,
     ContentIdentificationType: __expectString(output.ContentIdentificationType),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     FailureReason: __expectString(output.FailureReason),
     LanguageCode: __expectString(output.LanguageCode),
@@ -5223,7 +5226,7 @@ const deserializeAws_json1_1MedicalTranscriptionJob = (
     Specialty: __expectString(output.Specialty),
     StartTime:
       output.StartTime !== undefined && output.StartTime !== null
-        ? new Date(Math.round(output.StartTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.StartTime)))
         : undefined,
     Tags:
       output.Tags !== undefined && output.Tags !== null
@@ -5259,12 +5262,12 @@ const deserializeAws_json1_1MedicalTranscriptionJobSummary = (
   return {
     CompletionTime:
       output.CompletionTime !== undefined && output.CompletionTime !== null
-        ? new Date(Math.round(output.CompletionTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CompletionTime)))
         : undefined,
     ContentIdentificationType: __expectString(output.ContentIdentificationType),
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     FailureReason: __expectString(output.FailureReason),
     LanguageCode: __expectString(output.LanguageCode),
@@ -5273,7 +5276,7 @@ const deserializeAws_json1_1MedicalTranscriptionJobSummary = (
     Specialty: __expectString(output.Specialty),
     StartTime:
       output.StartTime !== undefined && output.StartTime !== null
-        ? new Date(Math.round(output.StartTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.StartTime)))
         : undefined,
     TranscriptionJobStatus: __expectString(output.TranscriptionJobStatus),
     Type: __expectString(output.Type),
@@ -5522,7 +5525,7 @@ const deserializeAws_json1_1TranscriptionJob = (output: any, context: __SerdeCon
   return {
     CompletionTime:
       output.CompletionTime !== undefined && output.CompletionTime !== null
-        ? new Date(Math.round(output.CompletionTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CompletionTime)))
         : undefined,
     ContentRedaction:
       output.ContentRedaction !== undefined && output.ContentRedaction !== null
@@ -5530,7 +5533,7 @@ const deserializeAws_json1_1TranscriptionJob = (output: any, context: __SerdeCon
         : undefined,
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     FailureReason: __expectString(output.FailureReason),
     IdentifiedLanguageScore: __limitedParseFloat32(output.IdentifiedLanguageScore),
@@ -5560,7 +5563,7 @@ const deserializeAws_json1_1TranscriptionJob = (output: any, context: __SerdeCon
         : undefined,
     StartTime:
       output.StartTime !== undefined && output.StartTime !== null
-        ? new Date(Math.round(output.StartTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.StartTime)))
         : undefined,
     Tags:
       output.Tags !== undefined && output.Tags !== null
@@ -5596,7 +5599,7 @@ const deserializeAws_json1_1TranscriptionJobSummary = (
   return {
     CompletionTime:
       output.CompletionTime !== undefined && output.CompletionTime !== null
-        ? new Date(Math.round(output.CompletionTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CompletionTime)))
         : undefined,
     ContentRedaction:
       output.ContentRedaction !== undefined && output.ContentRedaction !== null
@@ -5604,7 +5607,7 @@ const deserializeAws_json1_1TranscriptionJobSummary = (
         : undefined,
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     FailureReason: __expectString(output.FailureReason),
     IdentifiedLanguageScore: __limitedParseFloat32(output.IdentifiedLanguageScore),
@@ -5617,7 +5620,7 @@ const deserializeAws_json1_1TranscriptionJobSummary = (
     OutputLocationType: __expectString(output.OutputLocationType),
     StartTime:
       output.StartTime !== undefined && output.StartTime !== null
-        ? new Date(Math.round(output.StartTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.StartTime)))
         : undefined,
     TranscriptionJobName: __expectString(output.TranscriptionJobName),
     TranscriptionJobStatus: __expectString(output.TranscriptionJobStatus),
@@ -5648,7 +5651,7 @@ const deserializeAws_json1_1UpdateMedicalVocabularyResponse = (
     LanguageCode: __expectString(output.LanguageCode),
     LastModifiedTime:
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
-        ? new Date(Math.round(output.LastModifiedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastModifiedTime)))
         : undefined,
     VocabularyName: __expectString(output.VocabularyName),
     VocabularyState: __expectString(output.VocabularyState),
@@ -5663,7 +5666,7 @@ const deserializeAws_json1_1UpdateVocabularyFilterResponse = (
     LanguageCode: __expectString(output.LanguageCode),
     LastModifiedTime:
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
-        ? new Date(Math.round(output.LastModifiedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastModifiedTime)))
         : undefined,
     VocabularyFilterName: __expectString(output.VocabularyFilterName),
   } as any;
@@ -5677,7 +5680,7 @@ const deserializeAws_json1_1UpdateVocabularyResponse = (
     LanguageCode: __expectString(output.LanguageCode),
     LastModifiedTime:
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
-        ? new Date(Math.round(output.LastModifiedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastModifiedTime)))
         : undefined,
     VocabularyName: __expectString(output.VocabularyName),
     VocabularyState: __expectString(output.VocabularyState),
@@ -5700,7 +5703,7 @@ const deserializeAws_json1_1VocabularyFilterInfo = (output: any, context: __Serd
     LanguageCode: __expectString(output.LanguageCode),
     LastModifiedTime:
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
-        ? new Date(Math.round(output.LastModifiedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastModifiedTime)))
         : undefined,
     VocabularyFilterName: __expectString(output.VocabularyFilterName),
   } as any;
@@ -5722,7 +5725,7 @@ const deserializeAws_json1_1VocabularyInfo = (output: any, context: __SerdeConte
     LanguageCode: __expectString(output.LanguageCode),
     LastModifiedTime:
       output.LastModifiedTime !== undefined && output.LastModifiedTime !== null
-        ? new Date(Math.round(output.LastModifiedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastModifiedTime)))
         : undefined,
     VocabularyName: __expectString(output.VocabularyName),
     VocabularyState: __expectString(output.VocabularyState),

--- a/clients/client-transfer/protocols/Aws_json1_1.ts
+++ b/clients/client-transfer/protocols/Aws_json1_1.ts
@@ -154,7 +154,10 @@ import {
   expectBoolean as __expectBoolean,
   expectInt32 as __expectInt32,
   expectLong as __expectLong,
+  expectNonNull as __expectNonNull,
+  expectNumber as __expectNumber,
   expectString as __expectString,
+  parseEpochTimestamp as __parseEpochTimestamp,
 } from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
@@ -4837,7 +4840,7 @@ const deserializeAws_json1_1SshPublicKey = (output: any, context: __SerdeContext
   return {
     DateImported:
       output.DateImported !== undefined && output.DateImported !== null
-        ? new Date(Math.round(output.DateImported * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.DateImported)))
         : undefined,
     SshPublicKeyBody: __expectString(output.SshPublicKeyBody),
     SshPublicKeyId: __expectString(output.SshPublicKeyId),

--- a/clients/client-translate/protocols/Aws_json1_1.ts
+++ b/clients/client-translate/protocols/Aws_json1_1.ts
@@ -84,7 +84,10 @@ import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@a
 import {
   expectInt32 as __expectInt32,
   expectLong as __expectLong,
+  expectNonNull as __expectNonNull,
+  expectNumber as __expectNumber,
   expectString as __expectString,
+  parseEpochTimestamp as __parseEpochTimestamp,
 } from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
@@ -2139,7 +2142,7 @@ const deserializeAws_json1_1ParallelDataProperties = (output: any, context: __Se
     Arn: __expectString(output.Arn),
     CreatedAt:
       output.CreatedAt !== undefined && output.CreatedAt !== null
-        ? new Date(Math.round(output.CreatedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreatedAt)))
         : undefined,
     Description: __expectString(output.Description),
     EncryptionKey:
@@ -2151,11 +2154,11 @@ const deserializeAws_json1_1ParallelDataProperties = (output: any, context: __Se
     ImportedRecordCount: __expectLong(output.ImportedRecordCount),
     LastUpdatedAt:
       output.LastUpdatedAt !== undefined && output.LastUpdatedAt !== null
-        ? new Date(Math.round(output.LastUpdatedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastUpdatedAt)))
         : undefined,
     LatestUpdateAttemptAt:
       output.LatestUpdateAttemptAt !== undefined && output.LatestUpdateAttemptAt !== null
-        ? new Date(Math.round(output.LatestUpdateAttemptAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LatestUpdateAttemptAt)))
         : undefined,
     LatestUpdateAttemptStatus: __expectString(output.LatestUpdateAttemptStatus),
     Message: __expectString(output.Message),
@@ -2270,7 +2273,7 @@ const deserializeAws_json1_1TerminologyProperties = (output: any, context: __Ser
     Arn: __expectString(output.Arn),
     CreatedAt:
       output.CreatedAt !== undefined && output.CreatedAt !== null
-        ? new Date(Math.round(output.CreatedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreatedAt)))
         : undefined,
     Description: __expectString(output.Description),
     EncryptionKey:
@@ -2279,7 +2282,7 @@ const deserializeAws_json1_1TerminologyProperties = (output: any, context: __Ser
         : undefined,
     LastUpdatedAt:
       output.LastUpdatedAt !== undefined && output.LastUpdatedAt !== null
-        ? new Date(Math.round(output.LastUpdatedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastUpdatedAt)))
         : undefined,
     Name: __expectString(output.Name),
     SizeBytes: __expectInt32(output.SizeBytes),
@@ -2333,7 +2336,9 @@ const deserializeAws_json1_1TextTranslationJobProperties = (
   return {
     DataAccessRoleArn: __expectString(output.DataAccessRoleArn),
     EndTime:
-      output.EndTime !== undefined && output.EndTime !== null ? new Date(Math.round(output.EndTime * 1000)) : undefined,
+      output.EndTime !== undefined && output.EndTime !== null
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.EndTime)))
+        : undefined,
     InputDataConfig:
       output.InputDataConfig !== undefined && output.InputDataConfig !== null
         ? deserializeAws_json1_1InputDataConfig(output.InputDataConfig, context)
@@ -2357,7 +2362,7 @@ const deserializeAws_json1_1TextTranslationJobProperties = (
     SourceLanguageCode: __expectString(output.SourceLanguageCode),
     SubmittedTime:
       output.SubmittedTime !== undefined && output.SubmittedTime !== null
-        ? new Date(Math.round(output.SubmittedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.SubmittedTime)))
         : undefined,
     TargetLanguageCodes:
       output.TargetLanguageCodes !== undefined && output.TargetLanguageCodes !== null
@@ -2423,7 +2428,7 @@ const deserializeAws_json1_1UpdateParallelDataResponse = (
   return {
     LatestUpdateAttemptAt:
       output.LatestUpdateAttemptAt !== undefined && output.LatestUpdateAttemptAt !== null
-        ? new Date(Math.round(output.LatestUpdateAttemptAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LatestUpdateAttemptAt)))
         : undefined,
     LatestUpdateAttemptStatus: __expectString(output.LatestUpdateAttemptStatus),
     Name: __expectString(output.Name),

--- a/clients/client-waf-regional/protocols/Aws_json1_1.ts
+++ b/clients/client-waf-regional/protocols/Aws_json1_1.ts
@@ -428,7 +428,10 @@ import {
   expectBoolean as __expectBoolean,
   expectInt32 as __expectInt32,
   expectLong as __expectLong,
+  expectNonNull as __expectNonNull,
+  expectNumber as __expectNumber,
   expectString as __expectString,
+  parseEpochTimestamp as __parseEpochTimestamp,
 } from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
@@ -11069,7 +11072,7 @@ const deserializeAws_json1_1SampledHTTPRequest = (output: any, context: __SerdeC
     RuleWithinRuleGroup: __expectString(output.RuleWithinRuleGroup),
     Timestamp:
       output.Timestamp !== undefined && output.Timestamp !== null
-        ? new Date(Math.round(output.Timestamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.Timestamp)))
         : undefined,
     Weight: __expectLong(output.Weight),
   } as any;
@@ -11263,10 +11266,12 @@ const deserializeAws_json1_1TagResourceResponse = (output: any, context: __Serde
 const deserializeAws_json1_1TimeWindow = (output: any, context: __SerdeContext): TimeWindow => {
   return {
     EndTime:
-      output.EndTime !== undefined && output.EndTime !== null ? new Date(Math.round(output.EndTime * 1000)) : undefined,
+      output.EndTime !== undefined && output.EndTime !== null
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.EndTime)))
+        : undefined,
     StartTime:
       output.StartTime !== undefined && output.StartTime !== null
-        ? new Date(Math.round(output.StartTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.StartTime)))
         : undefined,
   } as any;
 };

--- a/clients/client-waf/protocols/Aws_json1_1.ts
+++ b/clients/client-waf/protocols/Aws_json1_1.ts
@@ -409,7 +409,10 @@ import {
   expectBoolean as __expectBoolean,
   expectInt32 as __expectInt32,
   expectLong as __expectLong,
+  expectNonNull as __expectNonNull,
+  expectNumber as __expectNumber,
   expectString as __expectString,
+  parseEpochTimestamp as __parseEpochTimestamp,
 } from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
@@ -10571,7 +10574,7 @@ const deserializeAws_json1_1SampledHTTPRequest = (output: any, context: __SerdeC
     RuleWithinRuleGroup: __expectString(output.RuleWithinRuleGroup),
     Timestamp:
       output.Timestamp !== undefined && output.Timestamp !== null
-        ? new Date(Math.round(output.Timestamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.Timestamp)))
         : undefined,
     Weight: __expectLong(output.Weight),
   } as any;
@@ -10765,10 +10768,12 @@ const deserializeAws_json1_1TagResourceResponse = (output: any, context: __Serde
 const deserializeAws_json1_1TimeWindow = (output: any, context: __SerdeContext): TimeWindow => {
   return {
     EndTime:
-      output.EndTime !== undefined && output.EndTime !== null ? new Date(Math.round(output.EndTime * 1000)) : undefined,
+      output.EndTime !== undefined && output.EndTime !== null
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.EndTime)))
+        : undefined,
     StartTime:
       output.StartTime !== undefined && output.StartTime !== null
-        ? new Date(Math.round(output.StartTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.StartTime)))
         : undefined,
   } as any;
 };

--- a/clients/client-wafv2/protocols/Aws_json1_1.ts
+++ b/clients/client-wafv2/protocols/Aws_json1_1.ts
@@ -299,7 +299,10 @@ import {
   expectBoolean as __expectBoolean,
   expectInt32 as __expectInt32,
   expectLong as __expectLong,
+  expectNonNull as __expectNonNull,
+  expectNumber as __expectNumber,
   expectString as __expectString,
+  parseEpochTimestamp as __parseEpochTimestamp,
 } from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
@@ -7462,7 +7465,7 @@ const deserializeAws_json1_1ManagedRuleGroupVersion = (
   return {
     LastUpdateTimestamp:
       output.LastUpdateTimestamp !== undefined && output.LastUpdateTimestamp !== null
-        ? new Date(Math.round(output.LastUpdateTimestamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastUpdateTimestamp)))
         : undefined,
     Name: __expectString(output.Name),
   } as any;
@@ -7528,16 +7531,16 @@ const deserializeAws_json1_1ManagedRuleSetVersion = (output: any, context: __Ser
     Capacity: __expectLong(output.Capacity),
     ExpiryTimestamp:
       output.ExpiryTimestamp !== undefined && output.ExpiryTimestamp !== null
-        ? new Date(Math.round(output.ExpiryTimestamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.ExpiryTimestamp)))
         : undefined,
     ForecastedLifetime: __expectInt32(output.ForecastedLifetime),
     LastUpdateTimestamp:
       output.LastUpdateTimestamp !== undefined && output.LastUpdateTimestamp !== null
-        ? new Date(Math.round(output.LastUpdateTimestamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastUpdateTimestamp)))
         : undefined,
     PublishTimestamp:
       output.PublishTimestamp !== undefined && output.PublishTimestamp !== null
-        ? new Date(Math.round(output.PublishTimestamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.PublishTimestamp)))
         : undefined,
   } as any;
 };
@@ -7909,7 +7912,7 @@ const deserializeAws_json1_1SampledHTTPRequest = (output: any, context: __SerdeC
     RuleNameWithinRuleGroup: __expectString(output.RuleNameWithinRuleGroup),
     Timestamp:
       output.Timestamp !== undefined && output.Timestamp !== null
-        ? new Date(Math.round(output.Timestamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.Timestamp)))
         : undefined,
     Weight: __expectLong(output.Weight),
   } as any;
@@ -8094,10 +8097,12 @@ const deserializeAws_json1_1TextTransformations = (output: any, context: __Serde
 const deserializeAws_json1_1TimeWindow = (output: any, context: __SerdeContext): TimeWindow => {
   return {
     EndTime:
-      output.EndTime !== undefined && output.EndTime !== null ? new Date(Math.round(output.EndTime * 1000)) : undefined,
+      output.EndTime !== undefined && output.EndTime !== null
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.EndTime)))
+        : undefined,
     StartTime:
       output.StartTime !== undefined && output.StartTime !== null
-        ? new Date(Math.round(output.StartTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.StartTime)))
         : undefined,
   } as any;
 };
@@ -8120,7 +8125,7 @@ const deserializeAws_json1_1UpdateManagedRuleSetVersionExpiryDateResponse = (
     ExpiringVersion: __expectString(output.ExpiringVersion),
     ExpiryTimestamp:
       output.ExpiryTimestamp !== undefined && output.ExpiryTimestamp !== null
-        ? new Date(Math.round(output.ExpiryTimestamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.ExpiryTimestamp)))
         : undefined,
     NextLockToken: __expectString(output.NextLockToken),
   } as any;

--- a/clients/client-wellarchitected/protocols/Aws_restJson1.ts
+++ b/clients/client-wellarchitected/protocols/Aws_restJson1.ts
@@ -97,9 +97,11 @@ import {
   expectBoolean as __expectBoolean,
   expectInt32 as __expectInt32,
   expectNonNull as __expectNonNull,
+  expectNumber as __expectNumber,
   expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
+  parseEpochTimestamp as __parseEpochTimestamp,
 } from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
@@ -4584,7 +4586,7 @@ const deserializeAws_restJson1LensReview = (output: any, context: __SerdeContext
         : undefined,
     UpdatedAt:
       output.UpdatedAt !== undefined && output.UpdatedAt !== null
-        ? new Date(Math.round(output.UpdatedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.UpdatedAt)))
         : undefined,
   } as any;
 };
@@ -4619,7 +4621,7 @@ const deserializeAws_restJson1LensReviewSummary = (output: any, context: __Serde
         : undefined,
     UpdatedAt:
       output.UpdatedAt !== undefined && output.UpdatedAt !== null
-        ? new Date(Math.round(output.UpdatedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.UpdatedAt)))
         : undefined,
   } as any;
 };
@@ -4660,7 +4662,7 @@ const deserializeAws_restJson1Milestone = (output: any, context: __SerdeContext)
     MilestoneNumber: __expectInt32(output.MilestoneNumber),
     RecordedAt:
       output.RecordedAt !== undefined && output.RecordedAt !== null
-        ? new Date(Math.round(output.RecordedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.RecordedAt)))
         : undefined,
     Workload:
       output.Workload !== undefined && output.Workload !== null
@@ -4686,7 +4688,7 @@ const deserializeAws_restJson1MilestoneSummary = (output: any, context: __SerdeC
     MilestoneNumber: __expectInt32(output.MilestoneNumber),
     RecordedAt:
       output.RecordedAt !== undefined && output.RecordedAt !== null
-        ? new Date(Math.round(output.RecordedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.RecordedAt)))
         : undefined,
     WorkloadSummary:
       output.WorkloadSummary !== undefined && output.WorkloadSummary !== null
@@ -4917,7 +4919,7 @@ const deserializeAws_restJson1Workload = (output: any, context: __SerdeContext):
     ReviewOwner: __expectString(output.ReviewOwner),
     ReviewRestrictionDate:
       output.ReviewRestrictionDate !== undefined && output.ReviewRestrictionDate !== null
-        ? new Date(Math.round(output.ReviewRestrictionDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.ReviewRestrictionDate)))
         : undefined,
     RiskCounts:
       output.RiskCounts !== undefined && output.RiskCounts !== null
@@ -4930,7 +4932,7 @@ const deserializeAws_restJson1Workload = (output: any, context: __SerdeContext):
         : undefined,
     UpdatedAt:
       output.UpdatedAt !== undefined && output.UpdatedAt !== null
-        ? new Date(Math.round(output.UpdatedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.UpdatedAt)))
         : undefined,
     WorkloadArn: __expectString(output.WorkloadArn),
     WorkloadId: __expectString(output.WorkloadId),
@@ -5053,7 +5055,7 @@ const deserializeAws_restJson1WorkloadSummary = (output: any, context: __SerdeCo
         : undefined,
     UpdatedAt:
       output.UpdatedAt !== undefined && output.UpdatedAt !== null
-        ? new Date(Math.round(output.UpdatedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.UpdatedAt)))
         : undefined,
     WorkloadArn: __expectString(output.WorkloadArn),
     WorkloadId: __expectString(output.WorkloadId),

--- a/clients/client-workdocs/protocols/Aws_restJson1.ts
+++ b/clients/client-workdocs/protocols/Aws_restJson1.ts
@@ -143,9 +143,11 @@ import {
   expectBoolean as __expectBoolean,
   expectLong as __expectLong,
   expectNonNull as __expectNonNull,
+  expectNumber as __expectNumber,
   expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
+  parseEpochTimestamp as __parseEpochTimestamp,
 } from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
@@ -6105,7 +6107,7 @@ const deserializeAws_restJson1Activity = (output: any, context: __SerdeContext):
         : undefined,
     TimeStamp:
       output.TimeStamp !== undefined && output.TimeStamp !== null
-        ? new Date(Math.round(output.TimeStamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.TimeStamp)))
         : undefined,
     Type: __expectString(output.Type),
   } as any;
@@ -6120,7 +6122,7 @@ const deserializeAws_restJson1Comment = (output: any, context: __SerdeContext): 
         : undefined,
     CreatedTimestamp:
       output.CreatedTimestamp !== undefined && output.CreatedTimestamp !== null
-        ? new Date(Math.round(output.CreatedTimestamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreatedTimestamp)))
         : undefined,
     ParentId: __expectString(output.ParentId),
     RecipientId: __expectString(output.RecipientId),
@@ -6152,7 +6154,7 @@ const deserializeAws_restJson1CommentMetadata = (output: any, context: __SerdeCo
         : undefined,
     CreatedTimestamp:
       output.CreatedTimestamp !== undefined && output.CreatedTimestamp !== null
-        ? new Date(Math.round(output.CreatedTimestamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreatedTimestamp)))
         : undefined,
     RecipientId: __expectString(output.RecipientId),
   } as any;
@@ -6174,7 +6176,7 @@ const deserializeAws_restJson1DocumentMetadata = (output: any, context: __SerdeC
   return {
     CreatedTimestamp:
       output.CreatedTimestamp !== undefined && output.CreatedTimestamp !== null
-        ? new Date(Math.round(output.CreatedTimestamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreatedTimestamp)))
         : undefined,
     CreatorId: __expectString(output.CreatorId),
     Id: __expectString(output.Id),
@@ -6188,7 +6190,7 @@ const deserializeAws_restJson1DocumentMetadata = (output: any, context: __SerdeC
         : undefined,
     ModifiedTimestamp:
       output.ModifiedTimestamp !== undefined && output.ModifiedTimestamp !== null
-        ? new Date(Math.round(output.ModifiedTimestamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.ModifiedTimestamp)))
         : undefined,
     ParentFolderId: __expectString(output.ParentFolderId),
     ResourceState: __expectString(output.ResourceState),
@@ -6249,22 +6251,22 @@ const deserializeAws_restJson1DocumentVersionMetadata = (
   return {
     ContentCreatedTimestamp:
       output.ContentCreatedTimestamp !== undefined && output.ContentCreatedTimestamp !== null
-        ? new Date(Math.round(output.ContentCreatedTimestamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.ContentCreatedTimestamp)))
         : undefined,
     ContentModifiedTimestamp:
       output.ContentModifiedTimestamp !== undefined && output.ContentModifiedTimestamp !== null
-        ? new Date(Math.round(output.ContentModifiedTimestamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.ContentModifiedTimestamp)))
         : undefined,
     ContentType: __expectString(output.ContentType),
     CreatedTimestamp:
       output.CreatedTimestamp !== undefined && output.CreatedTimestamp !== null
-        ? new Date(Math.round(output.CreatedTimestamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreatedTimestamp)))
         : undefined,
     CreatorId: __expectString(output.CreatorId),
     Id: __expectString(output.Id),
     ModifiedTimestamp:
       output.ModifiedTimestamp !== undefined && output.ModifiedTimestamp !== null
-        ? new Date(Math.round(output.ModifiedTimestamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.ModifiedTimestamp)))
         : undefined,
     Name: __expectString(output.Name),
     Signature: __expectString(output.Signature),
@@ -6310,7 +6312,7 @@ const deserializeAws_restJson1FolderMetadata = (output: any, context: __SerdeCon
   return {
     CreatedTimestamp:
       output.CreatedTimestamp !== undefined && output.CreatedTimestamp !== null
-        ? new Date(Math.round(output.CreatedTimestamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreatedTimestamp)))
         : undefined,
     CreatorId: __expectString(output.CreatorId),
     Id: __expectString(output.Id),
@@ -6321,7 +6323,7 @@ const deserializeAws_restJson1FolderMetadata = (output: any, context: __SerdeCon
     LatestVersionSize: __expectLong(output.LatestVersionSize),
     ModifiedTimestamp:
       output.ModifiedTimestamp !== undefined && output.ModifiedTimestamp !== null
-        ? new Date(Math.round(output.ModifiedTimestamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.ModifiedTimestamp)))
         : undefined,
     Name: __expectString(output.Name),
     ParentFolderId: __expectString(output.ParentFolderId),
@@ -6554,7 +6556,7 @@ const deserializeAws_restJson1User = (output: any, context: __SerdeContext): Use
   return {
     CreatedTimestamp:
       output.CreatedTimestamp !== undefined && output.CreatedTimestamp !== null
-        ? new Date(Math.round(output.CreatedTimestamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreatedTimestamp)))
         : undefined,
     EmailAddress: __expectString(output.EmailAddress),
     GivenName: __expectString(output.GivenName),
@@ -6562,7 +6564,7 @@ const deserializeAws_restJson1User = (output: any, context: __SerdeContext): Use
     Locale: __expectString(output.Locale),
     ModifiedTimestamp:
       output.ModifiedTimestamp !== undefined && output.ModifiedTimestamp !== null
-        ? new Date(Math.round(output.ModifiedTimestamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.ModifiedTimestamp)))
         : undefined,
     OrganizationId: __expectString(output.OrganizationId),
     RecycleBinFolderId: __expectString(output.RecycleBinFolderId),

--- a/clients/client-worklink/protocols/Aws_restJson1.ts
+++ b/clients/client-worklink/protocols/Aws_restJson1.ts
@@ -108,9 +108,11 @@ import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@a
 import {
   expectBoolean as __expectBoolean,
   expectNonNull as __expectNonNull,
+  expectNumber as __expectNumber,
   expectObject as __expectObject,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
+  parseEpochTimestamp as __parseEpochTimestamp,
 } from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
@@ -1664,10 +1666,10 @@ export const deserializeAws_restJson1DescribeDeviceCommand = async (
   };
   const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.FirstAccessedTime !== undefined && data.FirstAccessedTime !== null) {
-    contents.FirstAccessedTime = new Date(Math.round(data.FirstAccessedTime * 1000));
+    contents.FirstAccessedTime = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.FirstAccessedTime)));
   }
   if (data.LastAccessedTime !== undefined && data.LastAccessedTime !== null) {
-    contents.LastAccessedTime = new Date(Math.round(data.LastAccessedTime * 1000));
+    contents.LastAccessedTime = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.LastAccessedTime)));
   }
   if (data.Manufacturer !== undefined && data.Manufacturer !== null) {
     contents.Manufacturer = __expectString(data.Manufacturer);
@@ -1869,7 +1871,7 @@ export const deserializeAws_restJson1DescribeDomainCommand = async (
     contents.AcmCertificateArn = __expectString(data.AcmCertificateArn);
   }
   if (data.CreatedTime !== undefined && data.CreatedTime !== null) {
-    contents.CreatedTime = new Date(Math.round(data.CreatedTime * 1000));
+    contents.CreatedTime = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.CreatedTime)));
   }
   if (data.DisplayName !== undefined && data.DisplayName !== null) {
     contents.DisplayName = __expectString(data.DisplayName);
@@ -1975,7 +1977,7 @@ export const deserializeAws_restJson1DescribeFleetMetadataCommand = async (
     contents.CompanyCode = __expectString(data.CompanyCode);
   }
   if (data.CreatedTime !== undefined && data.CreatedTime !== null) {
-    contents.CreatedTime = new Date(Math.round(data.CreatedTime * 1000));
+    contents.CreatedTime = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.CreatedTime)));
   }
   if (data.DisplayName !== undefined && data.DisplayName !== null) {
     contents.DisplayName = __expectString(data.DisplayName);
@@ -1987,7 +1989,7 @@ export const deserializeAws_restJson1DescribeFleetMetadataCommand = async (
     contents.FleetStatus = __expectString(data.FleetStatus);
   }
   if (data.LastUpdatedTime !== undefined && data.LastUpdatedTime !== null) {
-    contents.LastUpdatedTime = new Date(Math.round(data.LastUpdatedTime * 1000));
+    contents.LastUpdatedTime = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.LastUpdatedTime)));
   }
   if (data.OptimizeForEndUserLocation !== undefined && data.OptimizeForEndUserLocation !== null) {
     contents.OptimizeForEndUserLocation = __expectBoolean(data.OptimizeForEndUserLocation);
@@ -2180,7 +2182,7 @@ export const deserializeAws_restJson1DescribeWebsiteCertificateAuthorityCommand 
     contents.Certificate = __expectString(data.Certificate);
   }
   if (data.CreatedTime !== undefined && data.CreatedTime !== null) {
-    contents.CreatedTime = new Date(Math.round(data.CreatedTime * 1000));
+    contents.CreatedTime = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.CreatedTime)));
   }
   if (data.DisplayName !== undefined && data.DisplayName !== null) {
     contents.DisplayName = __expectString(data.DisplayName);
@@ -4021,7 +4023,7 @@ const deserializeAws_restJson1DomainSummary = (output: any, context: __SerdeCont
   return {
     CreatedTime:
       output.CreatedTime !== undefined && output.CreatedTime !== null
-        ? new Date(Math.round(output.CreatedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreatedTime)))
         : undefined,
     DisplayName: __expectString(output.DisplayName),
     DomainName: __expectString(output.DomainName),
@@ -4045,7 +4047,7 @@ const deserializeAws_restJson1FleetSummary = (output: any, context: __SerdeConte
     CompanyCode: __expectString(output.CompanyCode),
     CreatedTime:
       output.CreatedTime !== undefined && output.CreatedTime !== null
-        ? new Date(Math.round(output.CreatedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreatedTime)))
         : undefined,
     DisplayName: __expectString(output.DisplayName),
     FleetArn: __expectString(output.FleetArn),
@@ -4053,7 +4055,7 @@ const deserializeAws_restJson1FleetSummary = (output: any, context: __SerdeConte
     FleetStatus: __expectString(output.FleetStatus),
     LastUpdatedTime:
       output.LastUpdatedTime !== undefined && output.LastUpdatedTime !== null
-        ? new Date(Math.round(output.LastUpdatedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastUpdatedTime)))
         : undefined,
     Tags:
       output.Tags !== undefined && output.Tags !== null
@@ -4130,7 +4132,7 @@ const deserializeAws_restJson1WebsiteAuthorizationProviderSummary = (
     AuthorizationProviderType: __expectString(output.AuthorizationProviderType),
     CreatedTime:
       output.CreatedTime !== undefined && output.CreatedTime !== null
-        ? new Date(Math.round(output.CreatedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreatedTime)))
         : undefined,
     DomainName: __expectString(output.DomainName),
   } as any;
@@ -4140,7 +4142,7 @@ const deserializeAws_restJson1WebsiteCaSummary = (output: any, context: __SerdeC
   return {
     CreatedTime:
       output.CreatedTime !== undefined && output.CreatedTime !== null
-        ? new Date(Math.round(output.CreatedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreatedTime)))
         : undefined,
     DisplayName: __expectString(output.DisplayName),
     WebsiteCaId: __expectString(output.WebsiteCaId),

--- a/clients/client-workmail/protocols/Aws_json1_1.ts
+++ b/clients/client-workmail/protocols/Aws_json1_1.ts
@@ -283,8 +283,11 @@ import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@a
 import {
   expectBoolean as __expectBoolean,
   expectInt32 as __expectInt32,
+  expectNonNull as __expectNonNull,
+  expectNumber as __expectNumber,
   expectString as __expectString,
   limitedParseDouble as __limitedParseDouble,
+  parseEpochTimestamp as __parseEpochTimestamp,
 } from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
@@ -6716,11 +6719,11 @@ const deserializeAws_json1_1AccessControlRule = (output: any, context: __SerdeCo
         : undefined,
     DateCreated:
       output.DateCreated !== undefined && output.DateCreated !== null
-        ? new Date(Math.round(output.DateCreated * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.DateCreated)))
         : undefined,
     DateModified:
       output.DateModified !== undefined && output.DateModified !== null
-        ? new Date(Math.round(output.DateModified * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.DateModified)))
         : undefined,
     Description: __expectString(output.Description),
     Effect: __expectString(output.Effect),
@@ -6933,12 +6936,12 @@ const deserializeAws_json1_1DescribeGroupResponse = (output: any, context: __Ser
   return {
     DisabledDate:
       output.DisabledDate !== undefined && output.DisabledDate !== null
-        ? new Date(Math.round(output.DisabledDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.DisabledDate)))
         : undefined,
     Email: __expectString(output.Email),
     EnabledDate:
       output.EnabledDate !== undefined && output.EnabledDate !== null
-        ? new Date(Math.round(output.EnabledDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.EnabledDate)))
         : undefined,
     GroupId: __expectString(output.GroupId),
     Name: __expectString(output.Name),
@@ -6953,7 +6956,9 @@ const deserializeAws_json1_1DescribeMailboxExportJobResponse = (
   return {
     Description: __expectString(output.Description),
     EndTime:
-      output.EndTime !== undefined && output.EndTime !== null ? new Date(Math.round(output.EndTime * 1000)) : undefined,
+      output.EndTime !== undefined && output.EndTime !== null
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.EndTime)))
+        : undefined,
     EntityId: __expectString(output.EntityId),
     ErrorInfo: __expectString(output.ErrorInfo),
     EstimatedProgress: __expectInt32(output.EstimatedProgress),
@@ -6964,7 +6969,7 @@ const deserializeAws_json1_1DescribeMailboxExportJobResponse = (
     S3Prefix: __expectString(output.S3Prefix),
     StartTime:
       output.StartTime !== undefined && output.StartTime !== null
-        ? new Date(Math.round(output.StartTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.StartTime)))
         : undefined,
     State: __expectString(output.State),
   } as any;
@@ -6979,7 +6984,7 @@ const deserializeAws_json1_1DescribeOrganizationResponse = (
     Alias: __expectString(output.Alias),
     CompletedDate:
       output.CompletedDate !== undefined && output.CompletedDate !== null
-        ? new Date(Math.round(output.CompletedDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CompletedDate)))
         : undefined,
     DefaultMailDomain: __expectString(output.DefaultMailDomain),
     DirectoryId: __expectString(output.DirectoryId),
@@ -7001,12 +7006,12 @@ const deserializeAws_json1_1DescribeResourceResponse = (
         : undefined,
     DisabledDate:
       output.DisabledDate !== undefined && output.DisabledDate !== null
-        ? new Date(Math.round(output.DisabledDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.DisabledDate)))
         : undefined,
     Email: __expectString(output.Email),
     EnabledDate:
       output.EnabledDate !== undefined && output.EnabledDate !== null
-        ? new Date(Math.round(output.EnabledDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.EnabledDate)))
         : undefined,
     Name: __expectString(output.Name),
     ResourceId: __expectString(output.ResourceId),
@@ -7019,13 +7024,13 @@ const deserializeAws_json1_1DescribeUserResponse = (output: any, context: __Serd
   return {
     DisabledDate:
       output.DisabledDate !== undefined && output.DisabledDate !== null
-        ? new Date(Math.round(output.DisabledDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.DisabledDate)))
         : undefined,
     DisplayName: __expectString(output.DisplayName),
     Email: __expectString(output.Email),
     EnabledDate:
       output.EnabledDate !== undefined && output.EnabledDate !== null
-        ? new Date(Math.round(output.EnabledDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.EnabledDate)))
         : undefined,
     Name: __expectString(output.Name),
     State: __expectString(output.State),
@@ -7226,12 +7231,12 @@ const deserializeAws_json1_1Group = (output: any, context: __SerdeContext): Grou
   return {
     DisabledDate:
       output.DisabledDate !== undefined && output.DisabledDate !== null
-        ? new Date(Math.round(output.DisabledDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.DisabledDate)))
         : undefined,
     Email: __expectString(output.Email),
     EnabledDate:
       output.EnabledDate !== undefined && output.EnabledDate !== null
-        ? new Date(Math.round(output.EnabledDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.EnabledDate)))
         : undefined,
     Id: __expectString(output.Id),
     Name: __expectString(output.Name),
@@ -7448,7 +7453,9 @@ const deserializeAws_json1_1MailboxExportJob = (output: any, context: __SerdeCon
   return {
     Description: __expectString(output.Description),
     EndTime:
-      output.EndTime !== undefined && output.EndTime !== null ? new Date(Math.round(output.EndTime * 1000)) : undefined,
+      output.EndTime !== undefined && output.EndTime !== null
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.EndTime)))
+        : undefined,
     EntityId: __expectString(output.EntityId),
     EstimatedProgress: __expectInt32(output.EstimatedProgress),
     JobId: __expectString(output.JobId),
@@ -7456,7 +7463,7 @@ const deserializeAws_json1_1MailboxExportJob = (output: any, context: __SerdeCon
     S3Path: __expectString(output.S3Path),
     StartTime:
       output.StartTime !== undefined && output.StartTime !== null
-        ? new Date(Math.round(output.StartTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.StartTime)))
         : undefined,
     State: __expectString(output.State),
   } as any;
@@ -7484,11 +7491,11 @@ const deserializeAws_json1_1Member = (output: any, context: __SerdeContext): Mem
   return {
     DisabledDate:
       output.DisabledDate !== undefined && output.DisabledDate !== null
-        ? new Date(Math.round(output.DisabledDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.DisabledDate)))
         : undefined,
     EnabledDate:
       output.EnabledDate !== undefined && output.EnabledDate !== null
-        ? new Date(Math.round(output.EnabledDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.EnabledDate)))
         : undefined,
     Id: __expectString(output.Id),
     Name: __expectString(output.Name),
@@ -7536,11 +7543,11 @@ const deserializeAws_json1_1MobileDeviceAccessRule = (output: any, context: __Se
   return {
     DateCreated:
       output.DateCreated !== undefined && output.DateCreated !== null
-        ? new Date(Math.round(output.DateCreated * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.DateCreated)))
         : undefined,
     DateModified:
       output.DateModified !== undefined && output.DateModified !== null
-        ? new Date(Math.round(output.DateModified * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.DateModified)))
         : undefined,
     Description: __expectString(output.Description),
     DeviceModels:
@@ -7718,12 +7725,12 @@ const deserializeAws_json1_1Resource = (output: any, context: __SerdeContext): R
   return {
     DisabledDate:
       output.DisabledDate !== undefined && output.DisabledDate !== null
-        ? new Date(Math.round(output.DisabledDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.DisabledDate)))
         : undefined,
     Email: __expectString(output.Email),
     EnabledDate:
       output.EnabledDate !== undefined && output.EnabledDate !== null
-        ? new Date(Math.round(output.EnabledDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.EnabledDate)))
         : undefined,
     Id: __expectString(output.Id),
     Name: __expectString(output.Name),
@@ -7842,13 +7849,13 @@ const deserializeAws_json1_1User = (output: any, context: __SerdeContext): User 
   return {
     DisabledDate:
       output.DisabledDate !== undefined && output.DisabledDate !== null
-        ? new Date(Math.round(output.DisabledDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.DisabledDate)))
         : undefined,
     DisplayName: __expectString(output.DisplayName),
     Email: __expectString(output.Email),
     EnabledDate:
       output.EnabledDate !== undefined && output.EnabledDate !== null
-        ? new Date(Math.round(output.EnabledDate * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.EnabledDate)))
         : undefined,
     Id: __expectString(output.Id),
     Name: __expectString(output.Name),

--- a/clients/client-workspaces/protocols/Aws_json1_1.ts
+++ b/clients/client-workspaces/protocols/Aws_json1_1.ts
@@ -311,7 +311,10 @@ import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@a
 import {
   expectBoolean as __expectBoolean,
   expectInt32 as __expectInt32,
+  expectNonNull as __expectNonNull,
+  expectNumber as __expectNumber,
   expectString as __expectString,
+  parseEpochTimestamp as __parseEpochTimestamp,
 } from "@aws-sdk/smithy-client";
 import {
   Endpoint as __Endpoint,
@@ -6106,7 +6109,7 @@ const deserializeAws_json1_1AccountModification = (output: any, context: __Serde
     ModificationState: __expectString(output.ModificationState),
     StartTime:
       output.StartTime !== undefined && output.StartTime !== null
-        ? new Date(Math.round(output.StartTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.StartTime)))
         : undefined,
   } as any;
 };
@@ -6985,7 +6988,7 @@ const deserializeAws_json1_1Snapshot = (output: any, context: __SerdeContext): S
   return {
     SnapshotTime:
       output.SnapshotTime !== undefined && output.SnapshotTime !== null
-        ? new Date(Math.round(output.SnapshotTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.SnapshotTime)))
         : undefined,
   } as any;
 };
@@ -7163,13 +7166,13 @@ const deserializeAws_json1_1WorkspaceBundle = (output: any, context: __SerdeCont
         : undefined,
     CreationTime:
       output.CreationTime !== undefined && output.CreationTime !== null
-        ? new Date(Math.round(output.CreationTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreationTime)))
         : undefined,
     Description: __expectString(output.Description),
     ImageId: __expectString(output.ImageId),
     LastUpdatedTime:
       output.LastUpdatedTime !== undefined && output.LastUpdatedTime !== null
-        ? new Date(Math.round(output.LastUpdatedTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastUpdatedTime)))
         : undefined,
     Name: __expectString(output.Name),
     Owner: __expectString(output.Owner),
@@ -7192,11 +7195,11 @@ const deserializeAws_json1_1WorkspaceConnectionStatus = (
     ConnectionState: __expectString(output.ConnectionState),
     ConnectionStateCheckTimestamp:
       output.ConnectionStateCheckTimestamp !== undefined && output.ConnectionStateCheckTimestamp !== null
-        ? new Date(Math.round(output.ConnectionStateCheckTimestamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.ConnectionStateCheckTimestamp)))
         : undefined,
     LastKnownUserConnectionTimestamp:
       output.LastKnownUserConnectionTimestamp !== undefined && output.LastKnownUserConnectionTimestamp !== null
-        ? new Date(Math.round(output.LastKnownUserConnectionTimestamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastKnownUserConnectionTimestamp)))
         : undefined,
     WorkspaceId: __expectString(output.WorkspaceId),
   } as any;
@@ -7258,7 +7261,9 @@ const deserializeAws_json1_1WorkspaceDirectory = (output: any, context: __SerdeC
 const deserializeAws_json1_1WorkspaceImage = (output: any, context: __SerdeContext): WorkspaceImage => {
   return {
     Created:
-      output.Created !== undefined && output.Created !== null ? new Date(Math.round(output.Created * 1000)) : undefined,
+      output.Created !== undefined && output.Created !== null
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.Created)))
+        : undefined,
     Description: __expectString(output.Description),
     ErrorCode: __expectString(output.ErrorCode),
     ErrorMessage: __expectString(output.ErrorMessage),

--- a/clients/client-xray/protocols/Aws_restJson1.ts
+++ b/clients/client-xray/protocols/Aws_restJson1.ts
@@ -118,9 +118,11 @@ import {
   expectInt32 as __expectInt32,
   expectLong as __expectLong,
   expectNonNull as __expectNonNull,
+  expectNumber as __expectNumber,
   expectObject as __expectObject,
   expectString as __expectString,
   limitedParseDouble as __limitedParseDouble,
+  parseEpochTimestamp as __parseEpochTimestamp,
   serializeFloat as __serializeFloat,
 } from "@aws-sdk/smithy-client";
 import {
@@ -1542,7 +1544,7 @@ export const deserializeAws_restJson1GetInsightImpactGraphCommand = async (
   };
   const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.EndTime !== undefined && data.EndTime !== null) {
-    contents.EndTime = new Date(Math.round(data.EndTime * 1000));
+    contents.EndTime = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.EndTime)));
   }
   if (data.InsightId !== undefined && data.InsightId !== null) {
     contents.InsightId = __expectString(data.InsightId);
@@ -1551,16 +1553,16 @@ export const deserializeAws_restJson1GetInsightImpactGraphCommand = async (
     contents.NextToken = __expectString(data.NextToken);
   }
   if (data.ServiceGraphEndTime !== undefined && data.ServiceGraphEndTime !== null) {
-    contents.ServiceGraphEndTime = new Date(Math.round(data.ServiceGraphEndTime * 1000));
+    contents.ServiceGraphEndTime = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.ServiceGraphEndTime)));
   }
   if (data.ServiceGraphStartTime !== undefined && data.ServiceGraphStartTime !== null) {
-    contents.ServiceGraphStartTime = new Date(Math.round(data.ServiceGraphStartTime * 1000));
+    contents.ServiceGraphStartTime = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.ServiceGraphStartTime)));
   }
   if (data.Services !== undefined && data.Services !== null) {
     contents.Services = deserializeAws_restJson1InsightImpactGraphServiceList(data.Services, context);
   }
   if (data.StartTime !== undefined && data.StartTime !== null) {
-    contents.StartTime = new Date(Math.round(data.StartTime * 1000));
+    contents.StartTime = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.StartTime)));
   }
   return Promise.resolve(contents);
 };
@@ -1829,7 +1831,7 @@ export const deserializeAws_restJson1GetSamplingTargetsCommand = async (
   };
   const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.LastRuleModification !== undefined && data.LastRuleModification !== null) {
-    contents.LastRuleModification = new Date(Math.round(data.LastRuleModification * 1000));
+    contents.LastRuleModification = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.LastRuleModification)));
   }
   if (data.SamplingTargetDocuments !== undefined && data.SamplingTargetDocuments !== null) {
     contents.SamplingTargetDocuments = deserializeAws_restJson1SamplingTargetDocumentList(
@@ -1911,7 +1913,7 @@ export const deserializeAws_restJson1GetServiceGraphCommand = async (
     contents.ContainsOldGroupVersions = __expectBoolean(data.ContainsOldGroupVersions);
   }
   if (data.EndTime !== undefined && data.EndTime !== null) {
-    contents.EndTime = new Date(Math.round(data.EndTime * 1000));
+    contents.EndTime = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.EndTime)));
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
@@ -1920,7 +1922,7 @@ export const deserializeAws_restJson1GetServiceGraphCommand = async (
     contents.Services = deserializeAws_restJson1ServiceList(data.Services, context);
   }
   if (data.StartTime !== undefined && data.StartTime !== null) {
-    contents.StartTime = new Date(Math.round(data.StartTime * 1000));
+    contents.StartTime = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.StartTime)));
   }
   return Promise.resolve(contents);
 };
@@ -2127,7 +2129,7 @@ export const deserializeAws_restJson1GetTraceSummariesCommand = async (
   };
   const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ApproximateTime !== undefined && data.ApproximateTime !== null) {
-    contents.ApproximateTime = new Date(Math.round(data.ApproximateTime * 1000));
+    contents.ApproximateTime = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.ApproximateTime)));
   }
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
@@ -3123,7 +3125,9 @@ const deserializeAws_restJson1Edge = (output: any, context: __SerdeContext): Edg
         ? deserializeAws_restJson1AliasList(output.Aliases, context)
         : undefined,
     EndTime:
-      output.EndTime !== undefined && output.EndTime !== null ? new Date(Math.round(output.EndTime * 1000)) : undefined,
+      output.EndTime !== undefined && output.EndTime !== null
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.EndTime)))
+        : undefined,
     ReferenceId: __expectInt32(output.ReferenceId),
     ResponseTimeHistogram:
       output.ResponseTimeHistogram !== undefined && output.ResponseTimeHistogram !== null
@@ -3131,7 +3135,7 @@ const deserializeAws_restJson1Edge = (output: any, context: __SerdeContext): Edg
         : undefined,
     StartTime:
       output.StartTime !== undefined && output.StartTime !== null
-        ? new Date(Math.round(output.StartTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.StartTime)))
         : undefined,
     SummaryStatistics:
       output.SummaryStatistics !== undefined && output.SummaryStatistics !== null
@@ -3425,7 +3429,9 @@ const deserializeAws_restJson1Insight = (output: any, context: __SerdeContext): 
         ? deserializeAws_restJson1RequestImpactStatistics(output.ClientRequestImpactStatistics, context)
         : undefined,
     EndTime:
-      output.EndTime !== undefined && output.EndTime !== null ? new Date(Math.round(output.EndTime * 1000)) : undefined,
+      output.EndTime !== undefined && output.EndTime !== null
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.EndTime)))
+        : undefined,
     GroupARN: __expectString(output.GroupARN),
     GroupName: __expectString(output.GroupName),
     InsightId: __expectString(output.InsightId),
@@ -3440,7 +3446,7 @@ const deserializeAws_restJson1Insight = (output: any, context: __SerdeContext): 
         : undefined,
     StartTime:
       output.StartTime !== undefined && output.StartTime !== null
-        ? new Date(Math.round(output.StartTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.StartTime)))
         : undefined,
     State: __expectString(output.State),
     Summary: __expectString(output.Summary),
@@ -3473,7 +3479,7 @@ const deserializeAws_restJson1InsightEvent = (output: any, context: __SerdeConte
         : undefined,
     EventTime:
       output.EventTime !== undefined && output.EventTime !== null
-        ? new Date(Math.round(output.EventTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.EventTime)))
         : undefined,
     RootCauseServiceRequestImpactStatistics:
       output.RootCauseServiceRequestImpactStatistics !== undefined &&
@@ -3574,13 +3580,15 @@ const deserializeAws_restJson1InsightSummary = (output: any, context: __SerdeCon
         ? deserializeAws_restJson1RequestImpactStatistics(output.ClientRequestImpactStatistics, context)
         : undefined,
     EndTime:
-      output.EndTime !== undefined && output.EndTime !== null ? new Date(Math.round(output.EndTime * 1000)) : undefined,
+      output.EndTime !== undefined && output.EndTime !== null
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.EndTime)))
+        : undefined,
     GroupARN: __expectString(output.GroupARN),
     GroupName: __expectString(output.GroupName),
     InsightId: __expectString(output.InsightId),
     LastUpdateTime:
       output.LastUpdateTime !== undefined && output.LastUpdateTime !== null
-        ? new Date(Math.round(output.LastUpdateTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.LastUpdateTime)))
         : undefined,
     RootCauseServiceId:
       output.RootCauseServiceId !== undefined && output.RootCauseServiceId !== null
@@ -3593,7 +3601,7 @@ const deserializeAws_restJson1InsightSummary = (output: any, context: __SerdeCon
         : undefined,
     StartTime:
       output.StartTime !== undefined && output.StartTime !== null
-        ? new Date(Math.round(output.StartTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.StartTime)))
         : undefined,
     State: __expectString(output.State),
     Summary: __expectString(output.Summary),
@@ -3764,11 +3772,11 @@ const deserializeAws_restJson1SamplingRuleRecord = (output: any, context: __Serd
   return {
     CreatedAt:
       output.CreatedAt !== undefined && output.CreatedAt !== null
-        ? new Date(Math.round(output.CreatedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.CreatedAt)))
         : undefined,
     ModifiedAt:
       output.ModifiedAt !== undefined && output.ModifiedAt !== null
-        ? new Date(Math.round(output.ModifiedAt * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.ModifiedAt)))
         : undefined,
     SamplingRule:
       output.SamplingRule !== undefined && output.SamplingRule !== null
@@ -3799,7 +3807,7 @@ const deserializeAws_restJson1SamplingStatisticSummary = (
     SampledCount: __expectInt32(output.SampledCount),
     Timestamp:
       output.Timestamp !== undefined && output.Timestamp !== null
-        ? new Date(Math.round(output.Timestamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.Timestamp)))
         : undefined,
   } as any;
 };
@@ -3828,7 +3836,7 @@ const deserializeAws_restJson1SamplingTargetDocument = (
     ReservoirQuota: __expectInt32(output.ReservoirQuota),
     ReservoirQuotaTTL:
       output.ReservoirQuotaTTL !== undefined && output.ReservoirQuotaTTL !== null
-        ? new Date(Math.round(output.ReservoirQuotaTTL * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.ReservoirQuotaTTL)))
         : undefined,
     RuleName: __expectString(output.RuleName),
   } as any;
@@ -3878,7 +3886,9 @@ const deserializeAws_restJson1Service = (output: any, context: __SerdeContext): 
         ? deserializeAws_restJson1EdgeList(output.Edges, context)
         : undefined,
     EndTime:
-      output.EndTime !== undefined && output.EndTime !== null ? new Date(Math.round(output.EndTime * 1000)) : undefined,
+      output.EndTime !== undefined && output.EndTime !== null
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.EndTime)))
+        : undefined,
     Name: __expectString(output.Name),
     Names:
       output.Names !== undefined && output.Names !== null
@@ -3892,7 +3902,7 @@ const deserializeAws_restJson1Service = (output: any, context: __SerdeContext): 
     Root: __expectBoolean(output.Root),
     StartTime:
       output.StartTime !== undefined && output.StartTime !== null
-        ? new Date(Math.round(output.StartTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.StartTime)))
         : undefined,
     State: __expectString(output.State),
     SummaryStatistics:
@@ -4005,7 +4015,7 @@ const deserializeAws_restJson1TimeSeriesServiceStatistics = (
         : undefined,
     Timestamp:
       output.Timestamp !== undefined && output.Timestamp !== null
-        ? new Date(Math.round(output.Timestamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.Timestamp)))
         : undefined,
   } as any;
 };
@@ -4121,7 +4131,7 @@ const deserializeAws_restJson1TraceSummary = (output: any, context: __SerdeConte
     IsPartial: __expectBoolean(output.IsPartial),
     MatchedEventTime:
       output.MatchedEventTime !== undefined && output.MatchedEventTime !== null
-        ? new Date(Math.round(output.MatchedEventTime * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.MatchedEventTime)))
         : undefined,
     ResourceARNs:
       output.ResourceARNs !== undefined && output.ResourceARNs !== null

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsProtocolUtils.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsProtocolUtils.java
@@ -322,11 +322,6 @@ final class AwsProtocolUtils {
             return true;
         }
 
-        // TODO: handle timestamps
-        if (testCase.hasTag("timestamp")) {
-            return true;
-        }
-
         //TODO: request serialization does not verify that the request is an object
         if (testCase.hasTag("technically_valid_json_body")) {
             return true;
@@ -350,6 +345,11 @@ final class AwsProtocolUtils {
         //TODO: Buffer.from isn't decoding base64 strictly.
         if (testCase.getId().equals("RestJsonBodyMalformedBlobInvalidBase64_case1")
             || testCase.getId().equals("RestJsonBodyMalformedBlobInvalidBase64_case2")) {
+            return true;
+        }
+
+        //TODO: Fixed after Smithy 1.11.0
+        if (testCase.getId().equals("RestJsonPathTimestampDefaultRejectsDifferent8601Formats_case14")) {
             return true;
         }
 

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsRestXml.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsRestXml.java
@@ -355,4 +355,9 @@ final class AwsRestXml extends HttpBindingProtocolGenerator {
     public void generateProtocolTests(GenerationContext context) {
         AwsProtocolUtils.generateProtocolTests(this, context);
     }
+
+    @Override
+    protected boolean requiresNumericEpochSecondsInPayload() {
+        return false;
+    }
 }

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/JsonMemberDeserVisitor.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/JsonMemberDeserVisitor.java
@@ -18,6 +18,7 @@ package software.amazon.smithy.aws.typescript.codegen;
 import software.amazon.smithy.codegen.core.CodegenException;
 import software.amazon.smithy.model.shapes.BigDecimalShape;
 import software.amazon.smithy.model.shapes.BigIntegerShape;
+import software.amazon.smithy.model.shapes.MemberShape;
 import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.traits.TimestampFormatTrait.Format;
 import software.amazon.smithy.typescript.codegen.integration.DocumentMemberDeserVisitor;
@@ -31,11 +32,33 @@ import software.amazon.smithy.utils.SmithyInternalApi;
 @SmithyInternalApi
 final class JsonMemberDeserVisitor extends DocumentMemberDeserVisitor {
 
+    private final MemberShape memberShape;
+
     /**
      * @inheritDoc
      */
-    JsonMemberDeserVisitor(GenerationContext context, String dataSource, Format defaultTimestampFormat) {
+    JsonMemberDeserVisitor(GenerationContext context,
+                           MemberShape memberShape,
+                           String dataSource,
+                           Format defaultTimestampFormat) {
         super(context, dataSource, defaultTimestampFormat);
+        this.memberShape = memberShape;
+    }
+
+    JsonMemberDeserVisitor(GenerationContext context,
+                           String dataSource,
+                           Format defaultTimestampFormat) {
+        this(context, null, dataSource, defaultTimestampFormat);
+    }
+
+    @Override
+    protected MemberShape getMemberShape() {
+        return memberShape;
+    }
+
+    @Override
+    protected boolean requiresNumericEpochSecondsInPayload() {
+        return true;
     }
 
     @Override

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/RestJsonProtocolGenerator.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/RestJsonProtocolGenerator.java
@@ -287,7 +287,7 @@ abstract class RestJsonProtocolGenerator extends HttpBindingProtocolGenerator {
             writer.openBlock("if (data.$L !== undefined && data.$L !== null) {", "}", locationName, locationName,
                     () -> {
                 writer.write("contents.$L = $L;", memberName,
-                        target.accept(getMemberDeserVisitor(context, "data." + locationName)));
+                        target.accept(getMemberDeserVisitor(context, binding.getMember(), "data." + locationName)));
             });
         }
     }
@@ -338,12 +338,19 @@ abstract class RestJsonProtocolGenerator extends HttpBindingProtocolGenerator {
         }
     }
 
-    private DocumentMemberDeserVisitor getMemberDeserVisitor(GenerationContext context, String dataSource) {
-        return new JsonMemberDeserVisitor(context, dataSource, getDocumentTimestampFormat());
+    private DocumentMemberDeserVisitor getMemberDeserVisitor(GenerationContext context,
+                                                             MemberShape memberShape,
+                                                             String dataSource) {
+        return new JsonMemberDeserVisitor(context, memberShape, dataSource, getDocumentTimestampFormat());
     }
 
     @Override
     public void generateProtocolTests(GenerationContext context) {
         AwsProtocolUtils.generateProtocolTests(this, context);
+    }
+
+    @Override
+    protected boolean requiresNumericEpochSecondsInPayload() {
+        return true;
     }
 }

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/XmlMemberDeserVisitor.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/XmlMemberDeserVisitor.java
@@ -24,6 +24,7 @@ import software.amazon.smithy.model.shapes.DoubleShape;
 import software.amazon.smithy.model.shapes.FloatShape;
 import software.amazon.smithy.model.shapes.IntegerShape;
 import software.amazon.smithy.model.shapes.LongShape;
+import software.amazon.smithy.model.shapes.MemberShape;
 import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.shapes.ShortShape;
 import software.amazon.smithy.model.traits.TimestampFormatTrait.Format;
@@ -47,8 +48,23 @@ import software.amazon.smithy.utils.SmithyInternalApi;
 @SmithyInternalApi
 final class XmlMemberDeserVisitor extends DocumentMemberDeserVisitor {
 
+    private final MemberShape memberShape;
+
     XmlMemberDeserVisitor(GenerationContext context, String dataSource, Format defaultTimestampFormat) {
+        this(context, null, dataSource, defaultTimestampFormat);
+    }
+
+    XmlMemberDeserVisitor(GenerationContext context,
+                          MemberShape memberShape,
+                          String dataSource,
+                          Format defaultTimestampFormat) {
         super(context, dataSource, defaultTimestampFormat);
+        this.memberShape = memberShape;
+    }
+
+    @Override
+    protected MemberShape getMemberShape() {
+        return memberShape;
     }
 
     @Override

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/XmlShapeDeserVisitor.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/XmlShapeDeserVisitor.java
@@ -59,8 +59,8 @@ final class XmlShapeDeserVisitor extends DocumentShapeDeserVisitor {
         super(context);
     }
 
-    private DocumentMemberDeserVisitor getMemberVisitor(String dataSource) {
-        return new XmlMemberDeserVisitor(getContext(), dataSource, Format.DATE_TIME);
+    private DocumentMemberDeserVisitor getMemberVisitor(MemberShape memberShape, String dataSource) {
+        return new XmlMemberDeserVisitor(getContext(), memberShape, dataSource, Format.DATE_TIME);
     }
 
     @Override
@@ -80,7 +80,7 @@ final class XmlShapeDeserVisitor extends DocumentShapeDeserVisitor {
             writer.write("if (entry === null) { return null as any; }");
 
             String dataSource = getUnnamedTargetWrapper(context, target, "entry");
-            writer.write("return $L$L;", target.accept(getMemberVisitor(dataSource)),
+            writer.write("return $L$L;", target.accept(getMemberVisitor(shape.getMember(), dataSource)),
                     usesExpect(target) ? " as any" : "");
         });
     }
@@ -136,7 +136,9 @@ final class XmlShapeDeserVisitor extends DocumentShapeDeserVisitor {
             writer.openBlock("return {", "};", () -> {
                 writer.write("...acc,");
                 // Dispatch to the output value provider for any additional handling.
-                writer.write("[pair[$S]]: $L$L", keyLocation, target.accept(getMemberVisitor(dataSource)),
+                writer.write("[pair[$S]]: $L$L",
+                        keyLocation,
+                        target.accept(getMemberVisitor(shape.getValue(), dataSource)),
                         usesExpect(target) ? " as any" : "");
             });
         });
@@ -234,7 +236,7 @@ final class XmlShapeDeserVisitor extends DocumentShapeDeserVisitor {
                 .collect(Collectors.joining(" && "));
         writer.openBlock("if ($L) {", "}", validationStatement, () -> {
             String dataSource = getNamedTargetWrapper(context, target, source);
-            statementBodyGenerator.accept(dataSource, getMemberVisitor(dataSource));
+            statementBodyGenerator.accept(dataSource, getMemberVisitor(memberShape, dataSource));
         });
     }
 

--- a/protocol_tests/aws-ec2/protocols/Aws_ec2.ts
+++ b/protocol_tests/aws-ec2/protocols/Aws_ec2.ts
@@ -70,11 +70,15 @@ import {
   isValidHostname as __isValidHostname,
 } from "@aws-sdk/protocol-http";
 import {
+  expectNonNull as __expectNonNull,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   getArrayIfSingleItem as __getArrayIfSingleItem,
   getValueFromTextNode as __getValueFromTextNode,
   parseBoolean as __parseBoolean,
+  parseEpochTimestamp as __parseEpochTimestamp,
+  parseRfc3339DateTime as __parseRfc3339DateTime,
+  parseRfc7231DateTime as __parseRfc7231DateTime,
   serializeFloat as __serializeFloat,
   strictParseByte as __strictParseByte,
   strictParseFloat as __strictParseFloat,
@@ -2011,16 +2015,16 @@ const deserializeAws_ec2XmlTimestampsOutput = (output: any, context: __SerdeCont
     httpDate: undefined,
   };
   if (output["normal"] !== undefined) {
-    contents.normal = new Date(output["normal"]);
+    contents.normal = __expectNonNull(__parseRfc3339DateTime(output["normal"]));
   }
   if (output["dateTime"] !== undefined) {
-    contents.dateTime = new Date(output["dateTime"]);
+    contents.dateTime = __expectNonNull(__parseRfc3339DateTime(output["dateTime"]));
   }
   if (output["epochSeconds"] !== undefined) {
-    contents.epochSeconds = new Date(output["epochSeconds"]);
+    contents.epochSeconds = __expectNonNull(__parseEpochTimestamp(output["epochSeconds"]));
   }
   if (output["httpDate"] !== undefined) {
-    contents.httpDate = new Date(output["httpDate"]);
+    contents.httpDate = __expectNonNull(__parseRfc7231DateTime(output["httpDate"]));
   }
   return contents;
 };
@@ -2121,7 +2125,7 @@ const deserializeAws_ec2TimestampList = (output: any, context: __SerdeContext): 
       if (entry === null) {
         return null as any;
       }
-      return new Date(entry);
+      return __expectNonNull(__parseRfc3339DateTime(entry));
     });
 };
 

--- a/protocol_tests/aws-json-10/protocols/Aws_json1_0.ts
+++ b/protocol_tests/aws-json-10/protocols/Aws_json1_0.ts
@@ -37,9 +37,12 @@ import {
 import {
   expectBoolean as __expectBoolean,
   expectInt32 as __expectInt32,
+  expectNonNull as __expectNonNull,
+  expectNumber as __expectNumber,
   expectString as __expectString,
   limitedParseDouble as __limitedParseDouble,
   limitedParseFloat32 as __limitedParseFloat32,
+  parseEpochTimestamp as __parseEpochTimestamp,
   serializeFloat as __serializeFloat,
 } from "@aws-sdk/smithy-client";
 import {
@@ -751,7 +754,7 @@ const deserializeAws_json1_0MyUnion = (output: any, context: __SerdeContext): My
   }
   if (output.timestampValue !== undefined && output.timestampValue !== null) {
     return {
-      timestampValue: new Date(Math.round(output.timestampValue * 1000)),
+      timestampValue: __expectNonNull(__parseEpochTimestamp(__expectNumber(output.timestampValue))),
     };
   }
   return { $unknown: Object.entries(output)[0] };

--- a/protocol_tests/aws-json/protocols/Aws_json1_1.ts
+++ b/protocol_tests/aws-json/protocols/Aws_json1_1.ts
@@ -57,9 +57,14 @@ import {
   expectBoolean as __expectBoolean,
   expectInt32 as __expectInt32,
   expectLong as __expectLong,
+  expectNonNull as __expectNonNull,
+  expectNumber as __expectNumber,
   expectString as __expectString,
   limitedParseDouble as __limitedParseDouble,
   limitedParseFloat32 as __limitedParseFloat32,
+  parseEpochTimestamp as __parseEpochTimestamp,
+  parseRfc3339DateTime as __parseRfc3339DateTime,
+  parseRfc7231DateTime as __parseRfc7231DateTime,
   serializeFloat as __serializeFloat,
 } from "@aws-sdk/smithy-client";
 import {
@@ -1316,12 +1321,12 @@ const deserializeAws_json1_1KitchenSink = (output: any, context: __SerdeContext)
     Float: __limitedParseFloat32(output.Float),
     HttpdateTimestamp:
       output.HttpdateTimestamp !== undefined && output.HttpdateTimestamp !== null
-        ? new Date(Math.round(output.HttpdateTimestamp * 1000))
+        ? __expectNonNull(__parseRfc7231DateTime(output.HttpdateTimestamp))
         : undefined,
     Integer: __expectInt32(output.Integer),
     Iso8601Timestamp:
       output.Iso8601Timestamp !== undefined && output.Iso8601Timestamp !== null
-        ? new Date(Math.round(output.Iso8601Timestamp * 1000))
+        ? __expectNonNull(__parseRfc3339DateTime(output.Iso8601Timestamp))
         : undefined,
     JsonValue:
       output.JsonValue !== undefined && output.JsonValue !== null ? new __LazyJsonString(output.JsonValue) : undefined,
@@ -1381,11 +1386,11 @@ const deserializeAws_json1_1KitchenSink = (output: any, context: __SerdeContext)
         : undefined,
     Timestamp:
       output.Timestamp !== undefined && output.Timestamp !== null
-        ? new Date(Math.round(output.Timestamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.Timestamp)))
         : undefined,
     UnixTimestamp:
       output.UnixTimestamp !== undefined && output.UnixTimestamp !== null
-        ? new Date(Math.round(output.UnixTimestamp * 1000))
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.UnixTimestamp)))
         : undefined,
   } as any;
 };
@@ -1555,7 +1560,7 @@ const deserializeAws_json1_1MyUnion = (output: any, context: __SerdeContext): My
   }
   if (output.timestampValue !== undefined && output.timestampValue !== null) {
     return {
-      timestampValue: new Date(Math.round(output.timestampValue * 1000)),
+      timestampValue: __expectNonNull(__parseEpochTimestamp(__expectNumber(output.timestampValue))),
     };
   }
   return { $unknown: Object.entries(output)[0] };

--- a/protocol_tests/aws-query/protocols/Aws_query.ts
+++ b/protocol_tests/aws-query/protocols/Aws_query.ts
@@ -92,11 +92,15 @@ import {
   isValidHostname as __isValidHostname,
 } from "@aws-sdk/protocol-http";
 import {
+  expectNonNull as __expectNonNull,
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   getArrayIfSingleItem as __getArrayIfSingleItem,
   getValueFromTextNode as __getValueFromTextNode,
   parseBoolean as __parseBoolean,
+  parseEpochTimestamp as __parseEpochTimestamp,
+  parseRfc3339DateTime as __parseRfc3339DateTime,
+  parseRfc7231DateTime as __parseRfc7231DateTime,
   serializeFloat as __serializeFloat,
   strictParseByte as __strictParseByte,
   strictParseFloat as __strictParseFloat,
@@ -2831,16 +2835,16 @@ const deserializeAws_queryXmlTimestampsOutput = (output: any, context: __SerdeCo
     httpDate: undefined,
   };
   if (output["normal"] !== undefined) {
-    contents.normal = new Date(output["normal"]);
+    contents.normal = __expectNonNull(__parseRfc3339DateTime(output["normal"]));
   }
   if (output["dateTime"] !== undefined) {
-    contents.dateTime = new Date(output["dateTime"]);
+    contents.dateTime = __expectNonNull(__parseRfc3339DateTime(output["dateTime"]));
   }
   if (output["epochSeconds"] !== undefined) {
-    contents.epochSeconds = new Date(output["epochSeconds"]);
+    contents.epochSeconds = __expectNonNull(__parseEpochTimestamp(output["epochSeconds"]));
   }
   if (output["httpDate"] !== undefined) {
-    contents.httpDate = new Date(output["httpDate"]);
+    contents.httpDate = __expectNonNull(__parseRfc7231DateTime(output["httpDate"]));
   }
   return contents;
 };
@@ -2951,7 +2955,7 @@ const deserializeAws_queryTimestampList = (output: any, context: __SerdeContext)
       if (entry === null) {
         return null as any;
       }
-      return new Date(entry);
+      return __expectNonNull(__parseRfc3339DateTime(entry));
     });
 };
 

--- a/protocol_tests/aws-restjson/protocols/Aws_restJson1.ts
+++ b/protocol_tests/aws-restjson/protocols/Aws_restJson1.ts
@@ -149,6 +149,7 @@ import {
   expectInt32 as __expectInt32,
   expectLong as __expectLong,
   expectNonNull as __expectNonNull,
+  expectNumber as __expectNumber,
   expectObject as __expectObject,
   expectShort as __expectShort,
   expectString as __expectString,
@@ -156,6 +157,9 @@ import {
   limitedParseDouble as __limitedParseDouble,
   limitedParseFloat32 as __limitedParseFloat32,
   parseBoolean as __parseBoolean,
+  parseEpochTimestamp as __parseEpochTimestamp,
+  parseRfc3339DateTime as __parseRfc3339DateTime,
+  parseRfc7231DateTime as __parseRfc7231DateTime,
   serializeFloat as __serializeFloat,
   splitEvery as __splitEvery,
   strictParseByte as __strictParseByte,
@@ -2858,7 +2862,7 @@ export const deserializeAws_restJson1InputAndOutputWithHeadersCommand = async (
   }
   if (output.headers["x-timestamplist"] !== undefined) {
     contents.headerTimestampList = __splitEvery(output.headers["x-timestamplist"] || "", ",", 2).map(
-      (_entry) => new Date(_entry.trim()) as any
+      (_entry) => __expectNonNull(__parseRfc7231DateTime(_entry.trim())) as any
     );
   }
   if (output.headers["x-enum"] !== undefined) {
@@ -3192,16 +3196,16 @@ export const deserializeAws_restJson1JsonTimestampsCommand = async (
   };
   const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.dateTime !== undefined && data.dateTime !== null) {
-    contents.dateTime = new Date(Math.round(data.dateTime * 1000));
+    contents.dateTime = __expectNonNull(__parseRfc3339DateTime(data.dateTime));
   }
   if (data.epochSeconds !== undefined && data.epochSeconds !== null) {
-    contents.epochSeconds = new Date(Math.round(data.epochSeconds * 1000));
+    contents.epochSeconds = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.epochSeconds)));
   }
   if (data.httpDate !== undefined && data.httpDate !== null) {
-    contents.httpDate = new Date(Math.round(data.httpDate * 1000));
+    contents.httpDate = __expectNonNull(__parseRfc7231DateTime(data.httpDate));
   }
   if (data.normal !== undefined && data.normal !== null) {
-    contents.normal = new Date(Math.round(data.normal * 1000));
+    contents.normal = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.normal)));
   }
   return Promise.resolve(contents);
 };
@@ -3992,25 +3996,25 @@ export const deserializeAws_restJson1TimestampFormatHeadersCommand = async (
     targetHttpDate: undefined,
   };
   if (output.headers["x-memberepochseconds"] !== undefined) {
-    contents.memberEpochSeconds = new Date(Math.round(parseInt(output.headers["x-memberepochseconds"], 10) * 1000));
+    contents.memberEpochSeconds = __expectNonNull(__parseEpochTimestamp(output.headers["x-memberepochseconds"]));
   }
   if (output.headers["x-memberhttpdate"] !== undefined) {
-    contents.memberHttpDate = new Date(output.headers["x-memberhttpdate"]);
+    contents.memberHttpDate = __expectNonNull(__parseRfc7231DateTime(output.headers["x-memberhttpdate"]));
   }
   if (output.headers["x-memberdatetime"] !== undefined) {
-    contents.memberDateTime = new Date(output.headers["x-memberdatetime"]);
+    contents.memberDateTime = __expectNonNull(__parseRfc3339DateTime(output.headers["x-memberdatetime"]));
   }
   if (output.headers["x-defaultformat"] !== undefined) {
-    contents.defaultFormat = new Date(output.headers["x-defaultformat"]);
+    contents.defaultFormat = __expectNonNull(__parseRfc7231DateTime(output.headers["x-defaultformat"]));
   }
   if (output.headers["x-targetepochseconds"] !== undefined) {
-    contents.targetEpochSeconds = new Date(Math.round(parseInt(output.headers["x-targetepochseconds"], 10) * 1000));
+    contents.targetEpochSeconds = __expectNonNull(__parseEpochTimestamp(output.headers["x-targetepochseconds"]));
   }
   if (output.headers["x-targethttpdate"] !== undefined) {
-    contents.targetHttpDate = new Date(output.headers["x-targethttpdate"]);
+    contents.targetHttpDate = __expectNonNull(__parseRfc7231DateTime(output.headers["x-targethttpdate"]));
   }
   if (output.headers["x-targetdatetime"] !== undefined) {
-    contents.targetDateTime = new Date(output.headers["x-targetdatetime"]);
+    contents.targetDateTime = __expectNonNull(__parseRfc3339DateTime(output.headers["x-targetdatetime"]));
   }
   await collectBody(output.body, context);
   return Promise.resolve(contents);
@@ -4548,7 +4552,7 @@ const deserializeAws_restJson1MyUnion = (output: any, context: __SerdeContext): 
   }
   if (output.timestampValue !== undefined && output.timestampValue !== null) {
     return {
-      timestampValue: new Date(Math.round(output.timestampValue * 1000)),
+      timestampValue: __expectNonNull(__parseEpochTimestamp(__expectNumber(output.timestampValue))),
     };
   }
   return { $unknown: Object.entries(output)[0] };
@@ -4800,7 +4804,7 @@ const deserializeAws_restJson1TimestampList = (output: any, context: __SerdeCont
       if (entry === null) {
         return null as any;
       }
-      return new Date(Math.round(entry * 1000));
+      return __expectNonNull(__parseEpochTimestamp(__expectNumber(entry)));
     });
 };
 

--- a/protocol_tests/aws-restxml/protocols/Aws_restXml.ts
+++ b/protocol_tests/aws-restxml/protocols/Aws_restXml.ts
@@ -167,6 +167,9 @@ import {
   getArrayIfSingleItem as __getArrayIfSingleItem,
   getValueFromTextNode as __getValueFromTextNode,
   parseBoolean as __parseBoolean,
+  parseEpochTimestamp as __parseEpochTimestamp,
+  parseRfc3339DateTime as __parseRfc3339DateTime,
+  parseRfc7231DateTime as __parseRfc7231DateTime,
   splitEvery as __splitEvery,
   strictParseByte as __strictParseByte,
   strictParseDouble as __strictParseDouble,
@@ -3497,7 +3500,7 @@ export const deserializeAws_restXmlInputAndOutputWithHeadersCommand = async (
   }
   if (output.headers["x-timestamplist"] !== undefined) {
     contents.headerTimestampList = __splitEvery(output.headers["x-timestamplist"] || "", ",", 2).map(
-      (_entry) => new Date(_entry.trim()) as any
+      (_entry) => __expectNonNull(__parseRfc7231DateTime(_entry.trim())) as any
     );
   }
   if (output.headers["x-enum"] !== undefined) {
@@ -4112,25 +4115,25 @@ export const deserializeAws_restXmlTimestampFormatHeadersCommand = async (
     targetHttpDate: undefined,
   };
   if (output.headers["x-memberepochseconds"] !== undefined) {
-    contents.memberEpochSeconds = new Date(Math.round(parseInt(output.headers["x-memberepochseconds"], 10) * 1000));
+    contents.memberEpochSeconds = __expectNonNull(__parseEpochTimestamp(output.headers["x-memberepochseconds"]));
   }
   if (output.headers["x-memberhttpdate"] !== undefined) {
-    contents.memberHttpDate = new Date(output.headers["x-memberhttpdate"]);
+    contents.memberHttpDate = __expectNonNull(__parseRfc7231DateTime(output.headers["x-memberhttpdate"]));
   }
   if (output.headers["x-memberdatetime"] !== undefined) {
-    contents.memberDateTime = new Date(output.headers["x-memberdatetime"]);
+    contents.memberDateTime = __expectNonNull(__parseRfc3339DateTime(output.headers["x-memberdatetime"]));
   }
   if (output.headers["x-defaultformat"] !== undefined) {
-    contents.defaultFormat = new Date(output.headers["x-defaultformat"]);
+    contents.defaultFormat = __expectNonNull(__parseRfc7231DateTime(output.headers["x-defaultformat"]));
   }
   if (output.headers["x-targetepochseconds"] !== undefined) {
-    contents.targetEpochSeconds = new Date(Math.round(parseInt(output.headers["x-targetepochseconds"], 10) * 1000));
+    contents.targetEpochSeconds = __expectNonNull(__parseEpochTimestamp(output.headers["x-targetepochseconds"]));
   }
   if (output.headers["x-targethttpdate"] !== undefined) {
-    contents.targetHttpDate = new Date(output.headers["x-targethttpdate"]);
+    contents.targetHttpDate = __expectNonNull(__parseRfc7231DateTime(output.headers["x-targethttpdate"]));
   }
   if (output.headers["x-targetdatetime"] !== undefined) {
-    contents.targetDateTime = new Date(output.headers["x-targetdatetime"]);
+    contents.targetDateTime = __expectNonNull(__parseRfc3339DateTime(output.headers["x-targetdatetime"]));
   }
   await collectBody(output.body, context);
   return Promise.resolve(contents);
@@ -5063,16 +5066,16 @@ export const deserializeAws_restXmlXmlTimestampsCommand = async (
   };
   const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["dateTime"] !== undefined) {
-    contents.dateTime = new Date(data["dateTime"]);
+    contents.dateTime = __expectNonNull(__parseRfc3339DateTime(data["dateTime"]));
   }
   if (data["epochSeconds"] !== undefined) {
-    contents.epochSeconds = new Date(data["epochSeconds"]);
+    contents.epochSeconds = __expectNonNull(__parseEpochTimestamp(data["epochSeconds"]));
   }
   if (data["httpDate"] !== undefined) {
-    contents.httpDate = new Date(data["httpDate"]);
+    contents.httpDate = __expectNonNull(__parseRfc7231DateTime(data["httpDate"]));
   }
   if (data["normal"] !== undefined) {
-    contents.normal = new Date(data["normal"]);
+    contents.normal = __expectNonNull(__parseRfc3339DateTime(data["normal"]));
   }
   return Promise.resolve(contents);
 };
@@ -6147,7 +6150,7 @@ const deserializeAws_restXmlTimestampList = (output: any, context: __SerdeContex
       if (entry === null) {
         return null as any;
       }
-      return new Date(entry);
+      return __expectNonNull(__parseRfc3339DateTime(entry));
     });
 };
 


### PR DESCRIPTION
### Description
Regenerate clients and protocol tests with strict date parsing enabled.

### Testing
Ran the protocol tests locally.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
