### PR TITLE
feat(codegen): assert sets have no duplicates

### DIFF
--- a/clients/client-app-mesh/protocols/Aws_restJson1.ts
+++ b/clients/client-app-mesh/protocols/Aws_restJson1.ts
@@ -8488,13 +8488,20 @@ const deserializeAws_restJson1PortMapping = (output: any, context: __SerdeContex
 };
 
 const deserializeAws_restJson1PortSet = (output: any, context: __SerdeContext): number[] => {
+  const uniqueValues = new Set<any>();
   return (output || [])
     .filter((e: any) => e != null)
     .map((entry: any) => {
       if (entry === null) {
         return null as any;
       }
-      return __expectInt32(entry) as any;
+      const parsedEntry = __expectInt32(entry) as any;
+      if (uniqueValues.has(parsedEntry)) {
+        throw new TypeError('All elements of the set "com.amazonaws.appmesh#PortSet" must be unique.');
+      } else {
+        uniqueValues.add(parsedEntry);
+        return parsedEntry;
+      }
     });
 };
 

--- a/clients/client-codeguruprofiler/protocols/Aws_restJson1.ts
+++ b/clients/client-codeguruprofiler/protocols/Aws_restJson1.ts
@@ -3132,24 +3132,38 @@ const deserializeAws_restJson1Channel = (output: any, context: __SerdeContext): 
 };
 
 const deserializeAws_restJson1Channels = (output: any, context: __SerdeContext): Channel[] => {
+  const uniqueValues = new Set<any>();
   return (output || [])
     .filter((e: any) => e != null)
     .map((entry: any) => {
       if (entry === null) {
         return null as any;
       }
-      return deserializeAws_restJson1Channel(entry, context);
+      const parsedEntry = deserializeAws_restJson1Channel(entry, context);
+      if (uniqueValues.has(parsedEntry)) {
+        throw new TypeError('All elements of the set "com.amazonaws.codeguruprofiler#Channels" must be unique.');
+      } else {
+        uniqueValues.add(parsedEntry);
+        return parsedEntry;
+      }
     });
 };
 
 const deserializeAws_restJson1EventPublishers = (output: any, context: __SerdeContext): (EventPublisher | string)[] => {
+  const uniqueValues = new Set<any>();
   return (output || [])
     .filter((e: any) => e != null)
     .map((entry: any) => {
       if (entry === null) {
         return null as any;
       }
-      return __expectString(entry) as any;
+      const parsedEntry = __expectString(entry) as any;
+      if (uniqueValues.has(parsedEntry)) {
+        throw new TypeError('All elements of the set "com.amazonaws.codeguruprofiler#EventPublishers" must be unique.');
+      } else {
+        uniqueValues.add(parsedEntry);
+        return parsedEntry;
+      }
     });
 };
 

--- a/clients/client-ssm-incidents/protocols/Aws_restJson1.ts
+++ b/clients/client-ssm-incidents/protocols/Aws_restJson1.ts
@@ -3993,24 +3993,42 @@ const deserializeAws_restJson1AutomationExecutionSet = (
   output: any,
   context: __SerdeContext
 ): AutomationExecution[] => {
+  const uniqueValues = new Set<any>();
   return (output || [])
     .filter((e: any) => e != null)
     .map((entry: any) => {
       if (entry === null) {
         return null as any;
       }
-      return deserializeAws_restJson1AutomationExecution(entry, context);
+      const parsedEntry = deserializeAws_restJson1AutomationExecution(entry, context);
+      if (uniqueValues.has(parsedEntry)) {
+        throw new TypeError(
+          'All elements of the set "com.amazonaws.ssmincidents#AutomationExecutionSet" must be unique.'
+        );
+      } else {
+        uniqueValues.add(parsedEntry);
+        return parsedEntry;
+      }
     });
 };
 
 const deserializeAws_restJson1ChatbotSnsConfigurationSet = (output: any, context: __SerdeContext): string[] => {
+  const uniqueValues = new Set<any>();
   return (output || [])
     .filter((e: any) => e != null)
     .map((entry: any) => {
       if (entry === null) {
         return null as any;
       }
-      return __expectString(entry) as any;
+      const parsedEntry = __expectString(entry) as any;
+      if (uniqueValues.has(parsedEntry)) {
+        throw new TypeError(
+          'All elements of the set "com.amazonaws.ssmincidents#ChatbotSnsConfigurationSet" must be unique.'
+        );
+      } else {
+        uniqueValues.add(parsedEntry);
+        return parsedEntry;
+      }
     });
 };
 
@@ -4033,13 +4051,20 @@ const deserializeAws_restJson1EmptyChatChannel = (output: any, context: __SerdeC
 };
 
 const deserializeAws_restJson1EngagementSet = (output: any, context: __SerdeContext): string[] => {
+  const uniqueValues = new Set<any>();
   return (output || [])
     .filter((e: any) => e != null)
     .map((entry: any) => {
       if (entry === null) {
         return null as any;
       }
-      return __expectString(entry) as any;
+      const parsedEntry = __expectString(entry) as any;
+      if (uniqueValues.has(parsedEntry)) {
+        throw new TypeError('All elements of the set "com.amazonaws.ssmincidents#EngagementSet" must be unique.');
+      } else {
+        uniqueValues.add(parsedEntry);
+        return parsedEntry;
+      }
     });
 };
 
@@ -4204,13 +4229,22 @@ const deserializeAws_restJson1NotificationTargetSet = (
   output: any,
   context: __SerdeContext
 ): NotificationTargetItem[] => {
+  const uniqueValues = new Set<any>();
   return (output || [])
     .filter((e: any) => e != null)
     .map((entry: any) => {
       if (entry === null) {
         return null as any;
       }
-      return deserializeAws_restJson1NotificationTargetItem(entry, context);
+      const parsedEntry = deserializeAws_restJson1NotificationTargetItem(entry, context);
+      if (uniqueValues.has(parsedEntry)) {
+        throw new TypeError(
+          'All elements of the set "com.amazonaws.ssmincidents#NotificationTargetSet" must be unique.'
+        );
+      } else {
+        uniqueValues.add(parsedEntry);
+        return parsedEntry;
+      }
     });
 };
 

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsProtocolUtils.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsProtocolUtils.java
@@ -330,10 +330,6 @@ final class AwsProtocolUtils {
         if (testCase.getId().startsWith("RestJsonMalformedUnion")) {
             return true;
         }
-        //TODO: we don't do any set validation
-        if (testCase.getId().startsWith("RestJsonMalformedSet")) {
-            return true;
-        }
         //TODO: we don't do any list validation
         if (testCase.getId().startsWith("RestJsonBodyMalformedList")) {
             return true;

--- a/protocol_tests/aws-json/protocols/Aws_json1_1.ts
+++ b/protocol_tests/aws-json/protocols/Aws_json1_1.ts
@@ -1653,13 +1653,20 @@ const deserializeAws_json1_1FooEnumMap = (
 };
 
 const deserializeAws_json1_1FooEnumSet = (output: any, context: __SerdeContext): (FooEnum | string)[] => {
+  const uniqueValues = new Set<any>();
   return (output || [])
     .filter((e: any) => e != null)
     .map((entry: any) => {
       if (entry === null) {
         return null as any;
       }
-      return __expectString(entry) as any;
+      const parsedEntry = __expectString(entry) as any;
+      if (uniqueValues.has(parsedEntry)) {
+        throw new TypeError('All elements of the set "aws.protocoltests.shared#FooEnumSet" must be unique.');
+      } else {
+        uniqueValues.add(parsedEntry);
+        return parsedEntry;
+      }
     });
 };
 

--- a/protocol_tests/aws-restjson/protocols/Aws_restJson1.ts
+++ b/protocol_tests/aws-restjson/protocols/Aws_restJson1.ts
@@ -4704,13 +4704,20 @@ const deserializeAws_restJson1FooEnumMap = (
 };
 
 const deserializeAws_restJson1FooEnumSet = (output: any, context: __SerdeContext): (FooEnum | string)[] => {
+  const uniqueValues = new Set<any>();
   return (output || [])
     .filter((e: any) => e != null)
     .map((entry: any) => {
       if (entry === null) {
         return null as any;
       }
-      return __expectString(entry) as any;
+      const parsedEntry = __expectString(entry) as any;
+      if (uniqueValues.has(parsedEntry)) {
+        throw new TypeError('All elements of the set "aws.protocoltests.shared#FooEnumSet" must be unique.');
+      } else {
+        uniqueValues.add(parsedEntry);
+        return parsedEntry;
+      }
     });
 };
 
@@ -4787,13 +4794,20 @@ const deserializeAws_restJson1StringMap = (output: any, context: __SerdeContext)
 };
 
 const deserializeAws_restJson1StringSet = (output: any, context: __SerdeContext): string[] => {
+  const uniqueValues = new Set<any>();
   return (output || [])
     .filter((e: any) => e != null)
     .map((entry: any) => {
       if (entry === null) {
         return null as any;
       }
-      return __expectString(entry) as any;
+      const parsedEntry = __expectString(entry) as any;
+      if (uniqueValues.has(parsedEntry)) {
+        throw new TypeError('All elements of the set "aws.protocoltests.shared#StringSet" must be unique.');
+      } else {
+        uniqueValues.add(parsedEntry);
+        return parsedEntry;
+      }
     });
 };
 


### PR DESCRIPTION
### Issue

n/a

### Description

This asserts that sets do not contain duplicate entries.

### Testing

The tests on `main` of smithy were generated and ran.

### Additional context

n/a

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
