### PR TITLE
fix(lib-dynamodb): add util-dynamodb to dependencies

### DIFF
--- a/lib/lib-dynamodb/package.json
+++ b/lib/lib-dynamodb/package.json
@@ -21,19 +21,18 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
+    "@aws-sdk/util-dynamodb": "3.30.0",
     "tslib": "^2.3.0"
   },
   "peerDependencies": {
     "@aws-sdk/client-dynamodb": "^3.0.0",
     "@aws-sdk/smithy-client": "^3.0.0",
-    "@aws-sdk/types": "^3.0.0",
-    "@aws-sdk/util-dynamodb": "^3.0.0"
+    "@aws-sdk/types": "^3.0.0"
   },
   "devDependencies": {
     "@aws-sdk/client-dynamodb": "3.30.0",
     "@aws-sdk/smithy-client": "3.30.0",
     "@aws-sdk/types": "3.29.0",
-    "@aws-sdk/util-dynamodb": "3.30.0",
     "@types/jest": "^26.0.4",
     "@types/node": "^14.11.2",
     "jest": "^26.4.2",


### PR DESCRIPTION
### Issue
Resolves: #2758
Follow up: #2516 

### Description
Move `@aws-sdk/util-dynamodb` to `@aws-sdk/lib-dynamobd`'s production dependency.

### Testing
* Unit test; 
* Local publish, install and validate:
```typescript
import { DynamoDBClient } from "@aws-sdk/client-dynamodb"; // ES6 import
import { DynamoDBDocumentClient, PutCommand } from "@aws-sdk/lib-dynamodb"; // ES6 import

// Bare-bones DynamoDB Client
const client = new DynamoDBClient({});
const ddbDocClient = DynamoDBDocumentClient.from(client);

(async (): Promise<void> => {
  await ddbDocClient.send(
    new PutCommand({
      TableName: "table",
      Item: {
        id: "1",
        content: "content from DynamoDBDocumentClient",
      },
    })
  );
})();
```

### Additional context
Add any other context about the PR here.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
