### PR TITLE
feat(codegen): reject null in non-sparse collections

### DIFF
--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsProtocolUtils.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsProtocolUtils.java
@@ -330,10 +330,6 @@ final class AwsProtocolUtils {
         if (testCase.getId().startsWith("RestJsonMalformedUnion")) {
             return true;
         }
-        //TODO: we don't do any list validation
-        if (testCase.getId().startsWith("RestJsonBodyMalformedList")) {
-            return true;
-        }
         //TODO: we don't validate map values
         if (testCase.getId().equals("RestJsonBodyMalformedMapNullValue")) {
             return true;


### PR DESCRIPTION
### Issue

n/a

### Description

This updates list parsing for SSDKs to throw an error whenever a
null value shows up in a list or set that isn't meant to be sparse.

Clients remain tolerant of these nulls to preserve compatibility with
services that are not so strict.

### Testing

Tests from `main` on smithy were run.

### Additional context

n/a

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
