### PR TITLE
Strict union regeneration

### DIFF
--- a/clients/client-accessanalyzer/protocols/Aws_restJson1.ts
+++ b/clients/client-accessanalyzer/protocols/Aws_restJson1.ts
@@ -116,6 +116,7 @@ import {
   expectNonNull as __expectNonNull,
   expectObject as __expectObject,
   expectString as __expectString,
+  expectUnion as __expectUnion,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   parseRfc3339DateTime as __parseRfc3339DateTime,
   strictParseInt32 as __strictParseInt32,
@@ -4336,7 +4337,7 @@ const deserializeAws_restJson1ConfigurationsMap = (
     }
     return {
       ...acc,
-      [key]: deserializeAws_restJson1Configuration(value, context),
+      [key]: deserializeAws_restJson1Configuration(__expectUnion(value), context),
     };
   }, {});
 };
@@ -4730,7 +4731,7 @@ const deserializeAws_restJson1PathElementList = (output: any, context: __SerdeCo
       if (entry === null) {
         return null as any;
       }
-      return deserializeAws_restJson1PathElement(entry, context);
+      return deserializeAws_restJson1PathElement(__expectUnion(entry), context);
     });
 };
 
@@ -4800,7 +4801,7 @@ const deserializeAws_restJson1S3AccessPointConfiguration = (
     accessPointPolicy: __expectString(output.accessPointPolicy),
     networkOrigin:
       output.networkOrigin !== undefined && output.networkOrigin !== null
-        ? deserializeAws_restJson1NetworkOriginConfiguration(output.networkOrigin, context)
+        ? deserializeAws_restJson1NetworkOriginConfiguration(__expectUnion(output.networkOrigin), context)
         : undefined,
     publicAccessBlock:
       output.publicAccessBlock !== undefined && output.publicAccessBlock !== null
@@ -4834,7 +4835,7 @@ const deserializeAws_restJson1S3BucketAclGrantConfiguration = (
   return {
     grantee:
       output.grantee !== undefined && output.grantee !== null
-        ? deserializeAws_restJson1AclGrantee(output.grantee, context)
+        ? deserializeAws_restJson1AclGrantee(__expectUnion(output.grantee), context)
         : undefined,
     permission: __expectString(output.permission),
   } as any;

--- a/clients/client-app-mesh/protocols/Aws_restJson1.ts
+++ b/clients/client-app-mesh/protocols/Aws_restJson1.ts
@@ -248,6 +248,7 @@ import {
   expectNumber as __expectNumber,
   expectObject as __expectObject,
   expectString as __expectString,
+  expectUnion as __expectUnion,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   parseEpochTimestamp as __parseEpochTimestamp,
 } from "@aws-sdk/smithy-client";
@@ -1894,7 +1895,7 @@ export const deserializeAws_restJson1CreateGatewayRouteCommand = async (
     $metadata: deserializeMetadata(output),
     gatewayRoute: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.gatewayRoute = deserializeAws_restJson1GatewayRouteData(data, context);
   return Promise.resolve(contents);
 };
@@ -2003,7 +2004,7 @@ export const deserializeAws_restJson1CreateMeshCommand = async (
     $metadata: deserializeMetadata(output),
     mesh: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.mesh = deserializeAws_restJson1MeshData(data, context);
   return Promise.resolve(contents);
 };
@@ -2112,7 +2113,7 @@ export const deserializeAws_restJson1CreateRouteCommand = async (
     $metadata: deserializeMetadata(output),
     route: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.route = deserializeAws_restJson1RouteData(data, context);
   return Promise.resolve(contents);
 };
@@ -2221,7 +2222,7 @@ export const deserializeAws_restJson1CreateVirtualGatewayCommand = async (
     $metadata: deserializeMetadata(output),
     virtualGateway: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.virtualGateway = deserializeAws_restJson1VirtualGatewayData(data, context);
   return Promise.resolve(contents);
 };
@@ -2330,7 +2331,7 @@ export const deserializeAws_restJson1CreateVirtualNodeCommand = async (
     $metadata: deserializeMetadata(output),
     virtualNode: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.virtualNode = deserializeAws_restJson1VirtualNodeData(data, context);
   return Promise.resolve(contents);
 };
@@ -2439,7 +2440,7 @@ export const deserializeAws_restJson1CreateVirtualRouterCommand = async (
     $metadata: deserializeMetadata(output),
     virtualRouter: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.virtualRouter = deserializeAws_restJson1VirtualRouterData(data, context);
   return Promise.resolve(contents);
 };
@@ -2548,7 +2549,7 @@ export const deserializeAws_restJson1CreateVirtualServiceCommand = async (
     $metadata: deserializeMetadata(output),
     virtualService: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.virtualService = deserializeAws_restJson1VirtualServiceData(data, context);
   return Promise.resolve(contents);
 };
@@ -2657,7 +2658,7 @@ export const deserializeAws_restJson1DeleteGatewayRouteCommand = async (
     $metadata: deserializeMetadata(output),
     gatewayRoute: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.gatewayRoute = deserializeAws_restJson1GatewayRouteData(data, context);
   return Promise.resolve(contents);
 };
@@ -2758,7 +2759,7 @@ export const deserializeAws_restJson1DeleteMeshCommand = async (
     $metadata: deserializeMetadata(output),
     mesh: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.mesh = deserializeAws_restJson1MeshData(data, context);
   return Promise.resolve(contents);
 };
@@ -2859,7 +2860,7 @@ export const deserializeAws_restJson1DeleteRouteCommand = async (
     $metadata: deserializeMetadata(output),
     route: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.route = deserializeAws_restJson1RouteData(data, context);
   return Promise.resolve(contents);
 };
@@ -2960,7 +2961,7 @@ export const deserializeAws_restJson1DeleteVirtualGatewayCommand = async (
     $metadata: deserializeMetadata(output),
     virtualGateway: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.virtualGateway = deserializeAws_restJson1VirtualGatewayData(data, context);
   return Promise.resolve(contents);
 };
@@ -3061,7 +3062,7 @@ export const deserializeAws_restJson1DeleteVirtualNodeCommand = async (
     $metadata: deserializeMetadata(output),
     virtualNode: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.virtualNode = deserializeAws_restJson1VirtualNodeData(data, context);
   return Promise.resolve(contents);
 };
@@ -3162,7 +3163,7 @@ export const deserializeAws_restJson1DeleteVirtualRouterCommand = async (
     $metadata: deserializeMetadata(output),
     virtualRouter: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.virtualRouter = deserializeAws_restJson1VirtualRouterData(data, context);
   return Promise.resolve(contents);
 };
@@ -3263,7 +3264,7 @@ export const deserializeAws_restJson1DeleteVirtualServiceCommand = async (
     $metadata: deserializeMetadata(output),
     virtualService: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.virtualService = deserializeAws_restJson1VirtualServiceData(data, context);
   return Promise.resolve(contents);
 };
@@ -3364,7 +3365,7 @@ export const deserializeAws_restJson1DescribeGatewayRouteCommand = async (
     $metadata: deserializeMetadata(output),
     gatewayRoute: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.gatewayRoute = deserializeAws_restJson1GatewayRouteData(data, context);
   return Promise.resolve(contents);
 };
@@ -3457,7 +3458,7 @@ export const deserializeAws_restJson1DescribeMeshCommand = async (
     $metadata: deserializeMetadata(output),
     mesh: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.mesh = deserializeAws_restJson1MeshData(data, context);
   return Promise.resolve(contents);
 };
@@ -3550,7 +3551,7 @@ export const deserializeAws_restJson1DescribeRouteCommand = async (
     $metadata: deserializeMetadata(output),
     route: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.route = deserializeAws_restJson1RouteData(data, context);
   return Promise.resolve(contents);
 };
@@ -3643,7 +3644,7 @@ export const deserializeAws_restJson1DescribeVirtualGatewayCommand = async (
     $metadata: deserializeMetadata(output),
     virtualGateway: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.virtualGateway = deserializeAws_restJson1VirtualGatewayData(data, context);
   return Promise.resolve(contents);
 };
@@ -3736,7 +3737,7 @@ export const deserializeAws_restJson1DescribeVirtualNodeCommand = async (
     $metadata: deserializeMetadata(output),
     virtualNode: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.virtualNode = deserializeAws_restJson1VirtualNodeData(data, context);
   return Promise.resolve(contents);
 };
@@ -3829,7 +3830,7 @@ export const deserializeAws_restJson1DescribeVirtualRouterCommand = async (
     $metadata: deserializeMetadata(output),
     virtualRouter: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.virtualRouter = deserializeAws_restJson1VirtualRouterData(data, context);
   return Promise.resolve(contents);
 };
@@ -3922,7 +3923,7 @@ export const deserializeAws_restJson1DescribeVirtualServiceCommand = async (
     $metadata: deserializeMetadata(output),
     virtualService: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.virtualService = deserializeAws_restJson1VirtualServiceData(data, context);
   return Promise.resolve(contents);
 };
@@ -4997,7 +4998,7 @@ export const deserializeAws_restJson1UpdateGatewayRouteCommand = async (
     $metadata: deserializeMetadata(output),
     gatewayRoute: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.gatewayRoute = deserializeAws_restJson1GatewayRouteData(data, context);
   return Promise.resolve(contents);
 };
@@ -5106,7 +5107,7 @@ export const deserializeAws_restJson1UpdateMeshCommand = async (
     $metadata: deserializeMetadata(output),
     mesh: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.mesh = deserializeAws_restJson1MeshData(data, context);
   return Promise.resolve(contents);
 };
@@ -5207,7 +5208,7 @@ export const deserializeAws_restJson1UpdateRouteCommand = async (
     $metadata: deserializeMetadata(output),
     route: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.route = deserializeAws_restJson1RouteData(data, context);
   return Promise.resolve(contents);
 };
@@ -5316,7 +5317,7 @@ export const deserializeAws_restJson1UpdateVirtualGatewayCommand = async (
     $metadata: deserializeMetadata(output),
     virtualGateway: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.virtualGateway = deserializeAws_restJson1VirtualGatewayData(data, context);
   return Promise.resolve(contents);
 };
@@ -5425,7 +5426,7 @@ export const deserializeAws_restJson1UpdateVirtualNodeCommand = async (
     $metadata: deserializeMetadata(output),
     virtualNode: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.virtualNode = deserializeAws_restJson1VirtualNodeData(data, context);
   return Promise.resolve(contents);
 };
@@ -5534,7 +5535,7 @@ export const deserializeAws_restJson1UpdateVirtualRouterCommand = async (
     $metadata: deserializeMetadata(output),
     virtualRouter: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.virtualRouter = deserializeAws_restJson1VirtualRouterData(data, context);
   return Promise.resolve(contents);
 };
@@ -5643,7 +5644,7 @@ export const deserializeAws_restJson1UpdateVirtualServiceCommand = async (
     $metadata: deserializeMetadata(output),
     virtualService: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.virtualService = deserializeAws_restJson1VirtualServiceData(data, context);
   return Promise.resolve(contents);
 };
@@ -7495,7 +7496,7 @@ const deserializeAws_restJson1Backends = (output: any, context: __SerdeContext):
       if (entry === null) {
         return null as any;
       }
-      return deserializeAws_restJson1Backend(entry, context);
+      return deserializeAws_restJson1Backend(__expectUnion(entry), context);
     });
 };
 
@@ -7523,7 +7524,7 @@ const deserializeAws_restJson1ClientPolicyTls = (output: any, context: __SerdeCo
   return {
     certificate:
       output.certificate !== undefined && output.certificate !== null
-        ? deserializeAws_restJson1ClientTlsCertificate(output.certificate, context)
+        ? deserializeAws_restJson1ClientTlsCertificate(__expectUnion(output.certificate), context)
         : undefined,
     enforce: __expectBoolean(output.enforce),
     ports:
@@ -7740,7 +7741,7 @@ const deserializeAws_restJson1GrpcGatewayRouteMetadata = (
     invert: __expectBoolean(output.invert),
     match:
       output.match !== undefined && output.match !== null
-        ? deserializeAws_restJson1GrpcMetadataMatchMethod(output.match, context)
+        ? deserializeAws_restJson1GrpcMetadataMatchMethod(__expectUnion(output.match), context)
         : undefined,
     name: __expectString(output.name),
   } as any;
@@ -7878,7 +7879,7 @@ const deserializeAws_restJson1GrpcRouteMetadata = (output: any, context: __Serde
     invert: __expectBoolean(output.invert),
     match:
       output.match !== undefined && output.match !== null
-        ? deserializeAws_restJson1GrpcRouteMetadataMatchMethod(output.match, context)
+        ? deserializeAws_restJson1GrpcRouteMetadataMatchMethod(__expectUnion(output.match), context)
         : undefined,
     name: __expectString(output.name),
   } as any;
@@ -8002,7 +8003,7 @@ const deserializeAws_restJson1HttpGatewayRouteHeader = (
     invert: __expectBoolean(output.invert),
     match:
       output.match !== undefined && output.match !== null
-        ? deserializeAws_restJson1HeaderMatchMethod(output.match, context)
+        ? deserializeAws_restJson1HeaderMatchMethod(__expectUnion(output.match), context)
         : undefined,
     name: __expectString(output.name),
   } as any;
@@ -8176,7 +8177,7 @@ const deserializeAws_restJson1HttpRouteHeader = (output: any, context: __SerdeCo
     invert: __expectBoolean(output.invert),
     match:
       output.match !== undefined && output.match !== null
-        ? deserializeAws_restJson1HeaderMatchMethod(output.match, context)
+        ? deserializeAws_restJson1HeaderMatchMethod(__expectUnion(output.match), context)
         : undefined,
     name: __expectString(output.name),
   } as any;
@@ -8230,7 +8231,7 @@ const deserializeAws_restJson1Listener = (output: any, context: __SerdeContext):
   return {
     connectionPool:
       output.connectionPool !== undefined && output.connectionPool !== null
-        ? deserializeAws_restJson1VirtualNodeConnectionPool(output.connectionPool, context)
+        ? deserializeAws_restJson1VirtualNodeConnectionPool(__expectUnion(output.connectionPool), context)
         : undefined,
     healthCheck:
       output.healthCheck !== undefined && output.healthCheck !== null
@@ -8246,7 +8247,7 @@ const deserializeAws_restJson1Listener = (output: any, context: __SerdeContext):
         : undefined,
     timeout:
       output.timeout !== undefined && output.timeout !== null
-        ? deserializeAws_restJson1ListenerTimeout(output.timeout, context)
+        ? deserializeAws_restJson1ListenerTimeout(__expectUnion(output.timeout), context)
         : undefined,
     tls:
       output.tls !== undefined && output.tls !== null
@@ -8294,7 +8295,7 @@ const deserializeAws_restJson1ListenerTls = (output: any, context: __SerdeContex
   return {
     certificate:
       output.certificate !== undefined && output.certificate !== null
-        ? deserializeAws_restJson1ListenerTlsCertificate(output.certificate, context)
+        ? deserializeAws_restJson1ListenerTlsCertificate(__expectUnion(output.certificate), context)
         : undefined,
     mode: __expectString(output.mode),
     validation:
@@ -8365,7 +8366,7 @@ const deserializeAws_restJson1ListenerTlsValidationContext = (
         : undefined,
     trust:
       output.trust !== undefined && output.trust !== null
-        ? deserializeAws_restJson1ListenerTlsValidationContextTrust(output.trust, context)
+        ? deserializeAws_restJson1ListenerTlsValidationContextTrust(__expectUnion(output.trust), context)
         : undefined,
   } as any;
 };
@@ -8391,7 +8392,7 @@ const deserializeAws_restJson1Logging = (output: any, context: __SerdeContext): 
   return {
     accessLog:
       output.accessLog !== undefined && output.accessLog !== null
-        ? deserializeAws_restJson1AccessLog(output.accessLog, context)
+        ? deserializeAws_restJson1AccessLog(__expectUnion(output.accessLog), context)
         : undefined,
   } as any;
 };
@@ -8728,7 +8729,7 @@ const deserializeAws_restJson1TlsValidationContext = (output: any, context: __Se
         : undefined,
     trust:
       output.trust !== undefined && output.trust !== null
-        ? deserializeAws_restJson1TlsValidationContextTrust(output.trust, context)
+        ? deserializeAws_restJson1TlsValidationContextTrust(__expectUnion(output.trust), context)
         : undefined,
   } as any;
 };
@@ -8842,7 +8843,7 @@ const deserializeAws_restJson1VirtualGatewayClientPolicyTls = (
   return {
     certificate:
       output.certificate !== undefined && output.certificate !== null
-        ? deserializeAws_restJson1VirtualGatewayClientTlsCertificate(output.certificate, context)
+        ? deserializeAws_restJson1VirtualGatewayClientTlsCertificate(__expectUnion(output.certificate), context)
         : undefined,
     enforce: __expectBoolean(output.enforce),
     ports:
@@ -8984,7 +8985,7 @@ const deserializeAws_restJson1VirtualGatewayListener = (
   return {
     connectionPool:
       output.connectionPool !== undefined && output.connectionPool !== null
-        ? deserializeAws_restJson1VirtualGatewayConnectionPool(output.connectionPool, context)
+        ? deserializeAws_restJson1VirtualGatewayConnectionPool(__expectUnion(output.connectionPool), context)
         : undefined,
     healthCheck:
       output.healthCheck !== undefined && output.healthCheck !== null
@@ -9022,7 +9023,7 @@ const deserializeAws_restJson1VirtualGatewayListenerTls = (
   return {
     certificate:
       output.certificate !== undefined && output.certificate !== null
-        ? deserializeAws_restJson1VirtualGatewayListenerTlsCertificate(output.certificate, context)
+        ? deserializeAws_restJson1VirtualGatewayListenerTlsCertificate(__expectUnion(output.certificate), context)
         : undefined,
     mode: __expectString(output.mode),
     validation:
@@ -9093,7 +9094,7 @@ const deserializeAws_restJson1VirtualGatewayListenerTlsValidationContext = (
         : undefined,
     trust:
       output.trust !== undefined && output.trust !== null
-        ? deserializeAws_restJson1VirtualGatewayListenerTlsValidationContextTrust(output.trust, context)
+        ? deserializeAws_restJson1VirtualGatewayListenerTlsValidationContextTrust(__expectUnion(output.trust), context)
         : undefined,
   } as any;
 };
@@ -9119,7 +9120,7 @@ const deserializeAws_restJson1VirtualGatewayLogging = (output: any, context: __S
   return {
     accessLog:
       output.accessLog !== undefined && output.accessLog !== null
-        ? deserializeAws_restJson1VirtualGatewayAccessLog(output.accessLog, context)
+        ? deserializeAws_restJson1VirtualGatewayAccessLog(__expectUnion(output.accessLog), context)
         : undefined,
   } as any;
 };
@@ -9187,7 +9188,7 @@ const deserializeAws_restJson1VirtualGatewayTlsValidationContext = (
         : undefined,
     trust:
       output.trust !== undefined && output.trust !== null
-        ? deserializeAws_restJson1VirtualGatewayTlsValidationContextTrust(output.trust, context)
+        ? deserializeAws_restJson1VirtualGatewayTlsValidationContextTrust(__expectUnion(output.trust), context)
         : undefined,
   } as any;
 };
@@ -9377,7 +9378,7 @@ const deserializeAws_restJson1VirtualNodeSpec = (output: any, context: __SerdeCo
         : undefined,
     serviceDiscovery:
       output.serviceDiscovery !== undefined && output.serviceDiscovery !== null
-        ? deserializeAws_restJson1ServiceDiscovery(output.serviceDiscovery, context)
+        ? deserializeAws_restJson1ServiceDiscovery(__expectUnion(output.serviceDiscovery), context)
         : undefined,
   } as any;
 };
@@ -9573,7 +9574,7 @@ const deserializeAws_restJson1VirtualServiceSpec = (output: any, context: __Serd
   return {
     provider:
       output.provider !== undefined && output.provider !== null
-        ? deserializeAws_restJson1VirtualServiceProvider(output.provider, context)
+        ? deserializeAws_restJson1VirtualServiceProvider(__expectUnion(output.provider), context)
         : undefined,
   } as any;
 };

--- a/clients/client-clouddirectory/protocols/Aws_restJson1.ts
+++ b/clients/client-clouddirectory/protocols/Aws_restJson1.ts
@@ -282,6 +282,7 @@ import {
   expectNumber as __expectNumber,
   expectObject as __expectObject,
   expectString as __expectString,
+  expectUnion as __expectUnion,
   parseEpochTimestamp as __parseEpochTimestamp,
 } from "@aws-sdk/smithy-client";
 import {
@@ -11841,7 +11842,7 @@ const deserializeAws_restJson1AttributeKeyAndValue = (output: any, context: __Se
         : undefined,
     Value:
       output.Value !== undefined && output.Value !== null
-        ? deserializeAws_restJson1TypedAttributeValue(output.Value, context)
+        ? deserializeAws_restJson1TypedAttributeValue(__expectUnion(output.Value), context)
         : undefined,
   } as any;
 };
@@ -11865,7 +11866,7 @@ const deserializeAws_restJson1AttributeNameAndValue = (output: any, context: __S
     AttributeName: __expectString(output.AttributeName),
     Value:
       output.Value !== undefined && output.Value !== null
-        ? deserializeAws_restJson1TypedAttributeValue(output.Value, context)
+        ? deserializeAws_restJson1TypedAttributeValue(__expectUnion(output.Value), context)
         : undefined,
   } as any;
 };
@@ -12435,7 +12436,7 @@ const deserializeAws_restJson1FacetAttributeDefinition = (
   return {
     DefaultValue:
       output.DefaultValue !== undefined && output.DefaultValue !== null
-        ? deserializeAws_restJson1TypedAttributeValue(output.DefaultValue, context)
+        ? deserializeAws_restJson1TypedAttributeValue(__expectUnion(output.DefaultValue), context)
         : undefined,
     IsImmutable: __expectBoolean(output.IsImmutable),
     Rules:
@@ -12737,7 +12738,7 @@ const deserializeAws_restJson1TypedLinkAttributeDefinition = (
   return {
     DefaultValue:
       output.DefaultValue !== undefined && output.DefaultValue !== null
-        ? deserializeAws_restJson1TypedAttributeValue(output.DefaultValue, context)
+        ? deserializeAws_restJson1TypedAttributeValue(__expectUnion(output.DefaultValue), context)
         : undefined,
     IsImmutable: __expectBoolean(output.IsImmutable),
     Name: __expectString(output.Name),

--- a/clients/client-cloudfront/protocols/Aws_restXml.ts
+++ b/clients/client-cloudfront/protocols/Aws_restXml.ts
@@ -3436,7 +3436,7 @@ export const deserializeAws_restXmlCreateCachePolicyCommand = async (
   if (output.headers["etag"] !== undefined) {
     contents.ETag = output.headers["etag"];
   }
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.CachePolicy = deserializeAws_restXmlCachePolicy(data, context);
   return Promise.resolve(contents);
 };
@@ -3553,7 +3553,7 @@ export const deserializeAws_restXmlCreateCloudFrontOriginAccessIdentityCommand =
   if (output.headers["etag"] !== undefined) {
     contents.ETag = output.headers["etag"];
   }
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.CloudFrontOriginAccessIdentity = deserializeAws_restXmlCloudFrontOriginAccessIdentity(data, context);
   return Promise.resolve(contents);
 };
@@ -3646,7 +3646,7 @@ export const deserializeAws_restXmlCreateDistributionCommand = async (
   if (output.headers["etag"] !== undefined) {
     contents.ETag = output.headers["etag"];
   }
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.Distribution = deserializeAws_restXmlDistribution(data, context);
   return Promise.resolve(contents);
 };
@@ -4164,7 +4164,7 @@ export const deserializeAws_restXmlCreateDistributionWithTagsCommand = async (
   if (output.headers["etag"] !== undefined) {
     contents.ETag = output.headers["etag"];
   }
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.Distribution = deserializeAws_restXmlDistribution(data, context);
   return Promise.resolve(contents);
 };
@@ -4690,7 +4690,7 @@ export const deserializeAws_restXmlCreateFieldLevelEncryptionConfigCommand = asy
   if (output.headers["etag"] !== undefined) {
     contents.ETag = output.headers["etag"];
   }
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.FieldLevelEncryption = deserializeAws_restXmlFieldLevelEncryption(data, context);
   return Promise.resolve(contents);
 };
@@ -4807,7 +4807,7 @@ export const deserializeAws_restXmlCreateFieldLevelEncryptionProfileCommand = as
   if (output.headers["etag"] !== undefined) {
     contents.ETag = output.headers["etag"];
   }
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.FieldLevelEncryptionProfile = deserializeAws_restXmlFieldLevelEncryptionProfile(data, context);
   return Promise.resolve(contents);
 };
@@ -4924,7 +4924,7 @@ export const deserializeAws_restXmlCreateFunctionCommand = async (
   if (output.headers["etag"] !== undefined) {
     contents.ETag = output.headers["etag"];
   }
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.FunctionSummary = deserializeAws_restXmlFunctionSummary(data, context);
   return Promise.resolve(contents);
 };
@@ -5013,7 +5013,7 @@ export const deserializeAws_restXmlCreateInvalidationCommand = async (
   if (output.headers["location"] !== undefined) {
     contents.Location = output.headers["location"];
   }
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.Invalidation = deserializeAws_restXmlInvalidation(data, context);
   return Promise.resolve(contents);
 };
@@ -5122,7 +5122,7 @@ export const deserializeAws_restXmlCreateKeyGroupCommand = async (
   if (output.headers["etag"] !== undefined) {
     contents.ETag = output.headers["etag"];
   }
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.KeyGroup = deserializeAws_restXmlKeyGroup(data, context);
   return Promise.resolve(contents);
 };
@@ -5199,7 +5199,7 @@ export const deserializeAws_restXmlCreateMonitoringSubscriptionCommand = async (
     $metadata: deserializeMetadata(output),
     MonitoringSubscription: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.MonitoringSubscription = deserializeAws_restXmlMonitoringSubscription(data, context);
   return Promise.resolve(contents);
 };
@@ -5276,7 +5276,7 @@ export const deserializeAws_restXmlCreateOriginRequestPolicyCommand = async (
   if (output.headers["etag"] !== undefined) {
     contents.ETag = output.headers["etag"];
   }
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.OriginRequestPolicy = deserializeAws_restXmlOriginRequestPolicy(data, context);
   return Promise.resolve(contents);
 };
@@ -5393,7 +5393,7 @@ export const deserializeAws_restXmlCreatePublicKeyCommand = async (
   if (output.headers["etag"] !== undefined) {
     contents.ETag = output.headers["etag"];
   }
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.PublicKey = deserializeAws_restXmlPublicKey(data, context);
   return Promise.resolve(contents);
 };
@@ -5549,7 +5549,7 @@ export const deserializeAws_restXmlCreateStreamingDistributionCommand = async (
   if (output.headers["etag"] !== undefined) {
     contents.ETag = output.headers["etag"];
   }
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.StreamingDistribution = deserializeAws_restXmlStreamingDistribution(data, context);
   return Promise.resolve(contents);
 };
@@ -5698,7 +5698,7 @@ export const deserializeAws_restXmlCreateStreamingDistributionWithTagsCommand = 
   if (output.headers["etag"] !== undefined) {
     contents.ETag = output.headers["etag"];
   }
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.StreamingDistribution = deserializeAws_restXmlStreamingDistribution(data, context);
   return Promise.resolve(contents);
 };
@@ -6831,7 +6831,7 @@ export const deserializeAws_restXmlDescribeFunctionCommand = async (
   if (output.headers["etag"] !== undefined) {
     contents.ETag = output.headers["etag"];
   }
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.FunctionSummary = deserializeAws_restXmlFunctionSummary(data, context);
   return Promise.resolve(contents);
 };
@@ -6896,7 +6896,7 @@ export const deserializeAws_restXmlGetCachePolicyCommand = async (
   if (output.headers["etag"] !== undefined) {
     contents.ETag = output.headers["etag"];
   }
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.CachePolicy = deserializeAws_restXmlCachePolicy(data, context);
   return Promise.resolve(contents);
 };
@@ -6961,7 +6961,7 @@ export const deserializeAws_restXmlGetCachePolicyConfigCommand = async (
   if (output.headers["etag"] !== undefined) {
     contents.ETag = output.headers["etag"];
   }
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.CachePolicyConfig = deserializeAws_restXmlCachePolicyConfig(data, context);
   return Promise.resolve(contents);
 };
@@ -7026,7 +7026,7 @@ export const deserializeAws_restXmlGetCloudFrontOriginAccessIdentityCommand = as
   if (output.headers["etag"] !== undefined) {
     contents.ETag = output.headers["etag"];
   }
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.CloudFrontOriginAccessIdentity = deserializeAws_restXmlCloudFrontOriginAccessIdentity(data, context);
   return Promise.resolve(contents);
 };
@@ -7091,7 +7091,7 @@ export const deserializeAws_restXmlGetCloudFrontOriginAccessIdentityConfigComman
   if (output.headers["etag"] !== undefined) {
     contents.ETag = output.headers["etag"];
   }
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.CloudFrontOriginAccessIdentityConfig = deserializeAws_restXmlCloudFrontOriginAccessIdentityConfig(
     data,
     context
@@ -7159,7 +7159,7 @@ export const deserializeAws_restXmlGetDistributionCommand = async (
   if (output.headers["etag"] !== undefined) {
     contents.ETag = output.headers["etag"];
   }
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.Distribution = deserializeAws_restXmlDistribution(data, context);
   return Promise.resolve(contents);
 };
@@ -7224,7 +7224,7 @@ export const deserializeAws_restXmlGetDistributionConfigCommand = async (
   if (output.headers["etag"] !== undefined) {
     contents.ETag = output.headers["etag"];
   }
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.DistributionConfig = deserializeAws_restXmlDistributionConfig(data, context);
   return Promise.resolve(contents);
 };
@@ -7289,7 +7289,7 @@ export const deserializeAws_restXmlGetFieldLevelEncryptionCommand = async (
   if (output.headers["etag"] !== undefined) {
     contents.ETag = output.headers["etag"];
   }
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.FieldLevelEncryption = deserializeAws_restXmlFieldLevelEncryption(data, context);
   return Promise.resolve(contents);
 };
@@ -7354,7 +7354,7 @@ export const deserializeAws_restXmlGetFieldLevelEncryptionConfigCommand = async 
   if (output.headers["etag"] !== undefined) {
     contents.ETag = output.headers["etag"];
   }
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.FieldLevelEncryptionConfig = deserializeAws_restXmlFieldLevelEncryptionConfig(data, context);
   return Promise.resolve(contents);
 };
@@ -7419,7 +7419,7 @@ export const deserializeAws_restXmlGetFieldLevelEncryptionProfileCommand = async
   if (output.headers["etag"] !== undefined) {
     contents.ETag = output.headers["etag"];
   }
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.FieldLevelEncryptionProfile = deserializeAws_restXmlFieldLevelEncryptionProfile(data, context);
   return Promise.resolve(contents);
 };
@@ -7484,7 +7484,7 @@ export const deserializeAws_restXmlGetFieldLevelEncryptionProfileConfigCommand =
   if (output.headers["etag"] !== undefined) {
     contents.ETag = output.headers["etag"];
   }
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.FieldLevelEncryptionProfileConfig = deserializeAws_restXmlFieldLevelEncryptionProfileConfig(data, context);
   return Promise.resolve(contents);
 };
@@ -7614,7 +7614,7 @@ export const deserializeAws_restXmlGetInvalidationCommand = async (
     $metadata: deserializeMetadata(output),
     Invalidation: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.Invalidation = deserializeAws_restXmlInvalidation(data, context);
   return Promise.resolve(contents);
 };
@@ -7687,7 +7687,7 @@ export const deserializeAws_restXmlGetKeyGroupCommand = async (
   if (output.headers["etag"] !== undefined) {
     contents.ETag = output.headers["etag"];
   }
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.KeyGroup = deserializeAws_restXmlKeyGroup(data, context);
   return Promise.resolve(contents);
 };
@@ -7744,7 +7744,7 @@ export const deserializeAws_restXmlGetKeyGroupConfigCommand = async (
   if (output.headers["etag"] !== undefined) {
     contents.ETag = output.headers["etag"];
   }
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.KeyGroupConfig = deserializeAws_restXmlKeyGroupConfig(data, context);
   return Promise.resolve(contents);
 };
@@ -7797,7 +7797,7 @@ export const deserializeAws_restXmlGetMonitoringSubscriptionCommand = async (
     $metadata: deserializeMetadata(output),
     MonitoringSubscription: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.MonitoringSubscription = deserializeAws_restXmlMonitoringSubscription(data, context);
   return Promise.resolve(contents);
 };
@@ -7870,7 +7870,7 @@ export const deserializeAws_restXmlGetOriginRequestPolicyCommand = async (
   if (output.headers["etag"] !== undefined) {
     contents.ETag = output.headers["etag"];
   }
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.OriginRequestPolicy = deserializeAws_restXmlOriginRequestPolicy(data, context);
   return Promise.resolve(contents);
 };
@@ -7935,7 +7935,7 @@ export const deserializeAws_restXmlGetOriginRequestPolicyConfigCommand = async (
   if (output.headers["etag"] !== undefined) {
     contents.ETag = output.headers["etag"];
   }
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.OriginRequestPolicyConfig = deserializeAws_restXmlOriginRequestPolicyConfig(data, context);
   return Promise.resolve(contents);
 };
@@ -8000,7 +8000,7 @@ export const deserializeAws_restXmlGetPublicKeyCommand = async (
   if (output.headers["etag"] !== undefined) {
     contents.ETag = output.headers["etag"];
   }
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.PublicKey = deserializeAws_restXmlPublicKey(data, context);
   return Promise.resolve(contents);
 };
@@ -8065,7 +8065,7 @@ export const deserializeAws_restXmlGetPublicKeyConfigCommand = async (
   if (output.headers["etag"] !== undefined) {
     contents.ETag = output.headers["etag"];
   }
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.PublicKeyConfig = deserializeAws_restXmlPublicKeyConfig(data, context);
   return Promise.resolve(contents);
 };
@@ -8201,7 +8201,7 @@ export const deserializeAws_restXmlGetStreamingDistributionCommand = async (
   if (output.headers["etag"] !== undefined) {
     contents.ETag = output.headers["etag"];
   }
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.StreamingDistribution = deserializeAws_restXmlStreamingDistribution(data, context);
   return Promise.resolve(contents);
 };
@@ -8266,7 +8266,7 @@ export const deserializeAws_restXmlGetStreamingDistributionConfigCommand = async
   if (output.headers["etag"] !== undefined) {
     contents.ETag = output.headers["etag"];
   }
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.StreamingDistributionConfig = deserializeAws_restXmlStreamingDistributionConfig(data, context);
   return Promise.resolve(contents);
 };
@@ -8327,7 +8327,7 @@ export const deserializeAws_restXmlListCachePoliciesCommand = async (
     $metadata: deserializeMetadata(output),
     CachePolicyList: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.CachePolicyList = deserializeAws_restXmlCachePolicyList(data, context);
   return Promise.resolve(contents);
 };
@@ -8396,7 +8396,7 @@ export const deserializeAws_restXmlListCloudFrontOriginAccessIdentitiesCommand =
     $metadata: deserializeMetadata(output),
     CloudFrontOriginAccessIdentityList: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.CloudFrontOriginAccessIdentityList = deserializeAws_restXmlCloudFrontOriginAccessIdentityList(data, context);
   return Promise.resolve(contents);
 };
@@ -8449,7 +8449,7 @@ export const deserializeAws_restXmlListConflictingAliasesCommand = async (
     $metadata: deserializeMetadata(output),
     ConflictingAliasesList: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.ConflictingAliasesList = deserializeAws_restXmlConflictingAliasesList(data, context);
   return Promise.resolve(contents);
 };
@@ -8510,7 +8510,7 @@ export const deserializeAws_restXmlListDistributionsCommand = async (
     $metadata: deserializeMetadata(output),
     DistributionList: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.DistributionList = deserializeAws_restXmlDistributionList(data, context);
   return Promise.resolve(contents);
 };
@@ -8563,7 +8563,7 @@ export const deserializeAws_restXmlListDistributionsByCachePolicyIdCommand = asy
     $metadata: deserializeMetadata(output),
     DistributionIdList: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.DistributionIdList = deserializeAws_restXmlDistributionIdList(data, context);
   return Promise.resolve(contents);
 };
@@ -8632,7 +8632,7 @@ export const deserializeAws_restXmlListDistributionsByKeyGroupCommand = async (
     $metadata: deserializeMetadata(output),
     DistributionIdList: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.DistributionIdList = deserializeAws_restXmlDistributionIdList(data, context);
   return Promise.resolve(contents);
 };
@@ -8693,7 +8693,7 @@ export const deserializeAws_restXmlListDistributionsByOriginRequestPolicyIdComma
     $metadata: deserializeMetadata(output),
     DistributionIdList: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.DistributionIdList = deserializeAws_restXmlDistributionIdList(data, context);
   return Promise.resolve(contents);
 };
@@ -8762,7 +8762,7 @@ export const deserializeAws_restXmlListDistributionsByRealtimeLogConfigCommand =
     $metadata: deserializeMetadata(output),
     DistributionList: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.DistributionList = deserializeAws_restXmlDistributionList(data, context);
   return Promise.resolve(contents);
 };
@@ -8815,7 +8815,7 @@ export const deserializeAws_restXmlListDistributionsByWebACLIdCommand = async (
     $metadata: deserializeMetadata(output),
     DistributionList: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.DistributionList = deserializeAws_restXmlDistributionList(data, context);
   return Promise.resolve(contents);
 };
@@ -8876,7 +8876,7 @@ export const deserializeAws_restXmlListFieldLevelEncryptionConfigsCommand = asyn
     $metadata: deserializeMetadata(output),
     FieldLevelEncryptionList: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.FieldLevelEncryptionList = deserializeAws_restXmlFieldLevelEncryptionList(data, context);
   return Promise.resolve(contents);
 };
@@ -8929,7 +8929,7 @@ export const deserializeAws_restXmlListFieldLevelEncryptionProfilesCommand = asy
     $metadata: deserializeMetadata(output),
     FieldLevelEncryptionProfileList: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.FieldLevelEncryptionProfileList = deserializeAws_restXmlFieldLevelEncryptionProfileList(data, context);
   return Promise.resolve(contents);
 };
@@ -8982,7 +8982,7 @@ export const deserializeAws_restXmlListFunctionsCommand = async (
     $metadata: deserializeMetadata(output),
     FunctionList: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.FunctionList = deserializeAws_restXmlFunctionList(data, context);
   return Promise.resolve(contents);
 };
@@ -9043,7 +9043,7 @@ export const deserializeAws_restXmlListInvalidationsCommand = async (
     $metadata: deserializeMetadata(output),
     InvalidationList: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.InvalidationList = deserializeAws_restXmlInvalidationList(data, context);
   return Promise.resolve(contents);
 };
@@ -9112,7 +9112,7 @@ export const deserializeAws_restXmlListKeyGroupsCommand = async (
     $metadata: deserializeMetadata(output),
     KeyGroupList: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.KeyGroupList = deserializeAws_restXmlKeyGroupList(data, context);
   return Promise.resolve(contents);
 };
@@ -9165,7 +9165,7 @@ export const deserializeAws_restXmlListOriginRequestPoliciesCommand = async (
     $metadata: deserializeMetadata(output),
     OriginRequestPolicyList: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.OriginRequestPolicyList = deserializeAws_restXmlOriginRequestPolicyList(data, context);
   return Promise.resolve(contents);
 };
@@ -9234,7 +9234,7 @@ export const deserializeAws_restXmlListPublicKeysCommand = async (
     $metadata: deserializeMetadata(output),
     PublicKeyList: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.PublicKeyList = deserializeAws_restXmlPublicKeyList(data, context);
   return Promise.resolve(contents);
 };
@@ -9287,7 +9287,7 @@ export const deserializeAws_restXmlListRealtimeLogConfigsCommand = async (
     $metadata: deserializeMetadata(output),
     RealtimeLogConfigs: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.RealtimeLogConfigs = deserializeAws_restXmlRealtimeLogConfigs(data, context);
   return Promise.resolve(contents);
 };
@@ -9356,7 +9356,7 @@ export const deserializeAws_restXmlListStreamingDistributionsCommand = async (
     $metadata: deserializeMetadata(output),
     StreamingDistributionList: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.StreamingDistributionList = deserializeAws_restXmlStreamingDistributionList(data, context);
   return Promise.resolve(contents);
 };
@@ -9409,7 +9409,7 @@ export const deserializeAws_restXmlListTagsForResourceCommand = async (
     $metadata: deserializeMetadata(output),
     Tags: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.Tags = deserializeAws_restXmlTags(data, context);
   return Promise.resolve(contents);
 };
@@ -9486,7 +9486,7 @@ export const deserializeAws_restXmlPublishFunctionCommand = async (
     $metadata: deserializeMetadata(output),
     FunctionSummary: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.FunctionSummary = deserializeAws_restXmlFunctionSummary(data, context);
   return Promise.resolve(contents);
 };
@@ -9646,7 +9646,7 @@ export const deserializeAws_restXmlTestFunctionCommand = async (
     $metadata: deserializeMetadata(output),
     TestResult: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.TestResult = deserializeAws_restXmlTestResult(data, context);
   return Promise.resolve(contents);
 };
@@ -9810,7 +9810,7 @@ export const deserializeAws_restXmlUpdateCachePolicyCommand = async (
   if (output.headers["etag"] !== undefined) {
     contents.ETag = output.headers["etag"];
   }
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.CachePolicy = deserializeAws_restXmlCachePolicy(data, context);
   return Promise.resolve(contents);
 };
@@ -9947,7 +9947,7 @@ export const deserializeAws_restXmlUpdateCloudFrontOriginAccessIdentityCommand =
   if (output.headers["etag"] !== undefined) {
     contents.ETag = output.headers["etag"];
   }
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.CloudFrontOriginAccessIdentity = deserializeAws_restXmlCloudFrontOriginAccessIdentity(data, context);
   return Promise.resolve(contents);
 };
@@ -10060,7 +10060,7 @@ export const deserializeAws_restXmlUpdateDistributionCommand = async (
   if (output.headers["etag"] !== undefined) {
     contents.ETag = output.headers["etag"];
   }
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.Distribution = deserializeAws_restXmlDistribution(data, context);
   return Promise.resolve(contents);
 };
@@ -10574,7 +10574,7 @@ export const deserializeAws_restXmlUpdateFieldLevelEncryptionConfigCommand = asy
   if (output.headers["etag"] !== undefined) {
     contents.ETag = output.headers["etag"];
   }
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.FieldLevelEncryption = deserializeAws_restXmlFieldLevelEncryption(data, context);
   return Promise.resolve(contents);
 };
@@ -10711,7 +10711,7 @@ export const deserializeAws_restXmlUpdateFieldLevelEncryptionProfileCommand = as
   if (output.headers["etag"] !== undefined) {
     contents.ETag = output.headers["etag"];
   }
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.FieldLevelEncryptionProfile = deserializeAws_restXmlFieldLevelEncryptionProfile(data, context);
   return Promise.resolve(contents);
 };
@@ -10856,7 +10856,7 @@ export const deserializeAws_restXmlUpdateFunctionCommand = async (
   if (output.headers["ettag"] !== undefined) {
     contents.ETag = output.headers["ettag"];
   }
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.FunctionSummary = deserializeAws_restXmlFunctionSummary(data, context);
   return Promise.resolve(contents);
 };
@@ -10953,7 +10953,7 @@ export const deserializeAws_restXmlUpdateKeyGroupCommand = async (
   if (output.headers["etag"] !== undefined) {
     contents.ETag = output.headers["etag"];
   }
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.KeyGroup = deserializeAws_restXmlKeyGroup(data, context);
   return Promise.resolve(contents);
 };
@@ -11050,7 +11050,7 @@ export const deserializeAws_restXmlUpdateOriginRequestPolicyCommand = async (
   if (output.headers["etag"] !== undefined) {
     contents.ETag = output.headers["etag"];
   }
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.OriginRequestPolicy = deserializeAws_restXmlOriginRequestPolicy(data, context);
   return Promise.resolve(contents);
 };
@@ -11187,7 +11187,7 @@ export const deserializeAws_restXmlUpdatePublicKeyCommand = async (
   if (output.headers["etag"] !== undefined) {
     contents.ETag = output.headers["etag"];
   }
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.PublicKey = deserializeAws_restXmlPublicKey(data, context);
   return Promise.resolve(contents);
 };
@@ -11363,7 +11363,7 @@ export const deserializeAws_restXmlUpdateStreamingDistributionCommand = async (
   if (output.headers["etag"] !== undefined) {
     contents.ETag = output.headers["etag"];
   }
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.StreamingDistribution = deserializeAws_restXmlStreamingDistribution(data, context);
   return Promise.resolve(contents);
 };

--- a/clients/client-codeguruprofiler/protocols/Aws_restJson1.ts
+++ b/clients/client-codeguruprofiler/protocols/Aws_restJson1.ts
@@ -1140,7 +1140,7 @@ export const deserializeAws_restJson1ConfigureAgentCommand = async (
     $metadata: deserializeMetadata(output),
     configuration: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.configuration = deserializeAws_restJson1AgentConfiguration(data, context);
   return Promise.resolve(contents);
 };
@@ -1217,7 +1217,7 @@ export const deserializeAws_restJson1CreateProfilingGroupCommand = async (
     $metadata: deserializeMetadata(output),
     profilingGroup: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.profilingGroup = deserializeAws_restJson1ProfilingGroupDescription(data, context);
   return Promise.resolve(contents);
 };
@@ -1385,7 +1385,7 @@ export const deserializeAws_restJson1DescribeProfilingGroupCommand = async (
     $metadata: deserializeMetadata(output),
     profilingGroup: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.profilingGroup = deserializeAws_restJson1ProfilingGroupDescription(data, context);
   return Promise.resolve(contents);
 };
@@ -2733,7 +2733,7 @@ export const deserializeAws_restJson1UpdateProfilingGroupCommand = async (
     $metadata: deserializeMetadata(output),
     profilingGroup: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.profilingGroup = deserializeAws_restJson1ProfilingGroupDescription(data, context);
   return Promise.resolve(contents);
 };

--- a/clients/client-dynamodb-streams/protocols/Aws_json1_0.ts
+++ b/clients/client-dynamodb-streams/protocols/Aws_json1_0.ts
@@ -33,6 +33,7 @@ import {
   expectNonNull as __expectNonNull,
   expectNumber as __expectNumber,
   expectString as __expectString,
+  expectUnion as __expectUnion,
   parseEpochTimestamp as __parseEpochTimestamp,
 } from "@aws-sdk/smithy-client";
 import {
@@ -497,7 +498,7 @@ const deserializeAws_json1_0AttributeMap = (
     }
     return {
       ...acc,
-      [key]: deserializeAws_json1_0AttributeValue(value, context),
+      [key]: deserializeAws_json1_0AttributeValue(__expectUnion(value), context),
     };
   }, {});
 };
@@ -637,7 +638,7 @@ const deserializeAws_json1_0ListAttributeValue = (output: any, context: __SerdeC
       if (entry === null) {
         return null as any;
       }
-      return deserializeAws_json1_0AttributeValue(entry, context);
+      return deserializeAws_json1_0AttributeValue(__expectUnion(entry), context);
     });
 };
 
@@ -661,7 +662,7 @@ const deserializeAws_json1_0MapAttributeValue = (
     }
     return {
       ...acc,
-      [key]: deserializeAws_json1_0AttributeValue(value, context),
+      [key]: deserializeAws_json1_0AttributeValue(__expectUnion(value), context),
     };
   }, {});
 };

--- a/clients/client-dynamodb/protocols/Aws_json1_0.ts
+++ b/clients/client-dynamodb/protocols/Aws_json1_0.ts
@@ -329,6 +329,7 @@ import {
   expectNonNull as __expectNonNull,
   expectNumber as __expectNumber,
   expectString as __expectString,
+  expectUnion as __expectUnion,
   limitedParseDouble as __limitedParseDouble,
   parseEpochTimestamp as __parseEpochTimestamp,
   serializeFloat as __serializeFloat,
@@ -7601,7 +7602,7 @@ const deserializeAws_json1_0AttributeMap = (
     }
     return {
       ...acc,
-      [key]: deserializeAws_json1_0AttributeValue(value, context),
+      [key]: deserializeAws_json1_0AttributeValue(__expectUnion(value), context),
     };
   }, {});
 };
@@ -8635,7 +8636,7 @@ const deserializeAws_json1_0ItemCollectionKeyAttributeMap = (
     }
     return {
       ...acc,
-      [key]: deserializeAws_json1_0AttributeValue(value, context),
+      [key]: deserializeAws_json1_0AttributeValue(__expectUnion(value), context),
     };
   }, {});
 };
@@ -8743,7 +8744,7 @@ const deserializeAws_json1_0Key = (output: any, context: __SerdeContext): { [key
     }
     return {
       ...acc,
-      [key]: deserializeAws_json1_0AttributeValue(value, context),
+      [key]: deserializeAws_json1_0AttributeValue(__expectUnion(value), context),
     };
   }, {});
 };
@@ -8845,7 +8846,7 @@ const deserializeAws_json1_0ListAttributeValue = (output: any, context: __SerdeC
       if (entry === null) {
         return null as any;
       }
-      return deserializeAws_json1_0AttributeValue(entry, context);
+      return deserializeAws_json1_0AttributeValue(__expectUnion(entry), context);
     });
 };
 
@@ -8990,7 +8991,7 @@ const deserializeAws_json1_0MapAttributeValue = (
     }
     return {
       ...acc,
-      [key]: deserializeAws_json1_0AttributeValue(value, context),
+      [key]: deserializeAws_json1_0AttributeValue(__expectUnion(value), context),
     };
   }, {});
 };
@@ -9118,7 +9119,7 @@ const deserializeAws_json1_0PutItemInputAttributeMap = (
     }
     return {
       ...acc,
-      [key]: deserializeAws_json1_0AttributeValue(value, context),
+      [key]: deserializeAws_json1_0AttributeValue(__expectUnion(value), context),
     };
   }, {});
 };

--- a/clients/client-emr-containers/protocols/Aws_restJson1.ts
+++ b/clients/client-emr-containers/protocols/Aws_restJson1.ts
@@ -64,6 +64,7 @@ import {
   expectNumber as __expectNumber,
   expectObject as __expectObject,
   expectString as __expectString,
+  expectUnion as __expectUnion,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   parseEpochTimestamp as __parseEpochTimestamp,
 } from "@aws-sdk/smithy-client";
@@ -1964,7 +1965,7 @@ const deserializeAws_restJson1ContainerProvider = (output: any, context: __Serde
     id: __expectString(output.id),
     info:
       output.info !== undefined && output.info !== null
-        ? deserializeAws_restJson1ContainerInfo(output.info, context)
+        ? deserializeAws_restJson1ContainerInfo(__expectUnion(output.info), context)
         : undefined,
     type: __expectString(output.type),
   } as any;

--- a/clients/client-glacier/protocols/Aws_restJson1.ts
+++ b/clients/client-glacier/protocols/Aws_restJson1.ts
@@ -2755,7 +2755,7 @@ export const deserializeAws_restJson1GetVaultAccessPolicyCommand = async (
     $metadata: deserializeMetadata(output),
     policy: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.policy = deserializeAws_restJson1VaultAccessPolicy(data, context);
   return Promise.resolve(contents);
 };
@@ -2923,7 +2923,7 @@ export const deserializeAws_restJson1GetVaultNotificationsCommand = async (
     $metadata: deserializeMetadata(output),
     vaultNotificationConfig: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.vaultNotificationConfig = deserializeAws_restJson1VaultNotificationConfig(data, context);
   return Promise.resolve(contents);
 };

--- a/clients/client-groundstation/protocols/Aws_restJson1.ts
+++ b/clients/client-groundstation/protocols/Aws_restJson1.ts
@@ -97,6 +97,7 @@ import {
   expectNumber as __expectNumber,
   expectObject as __expectObject,
   expectString as __expectString,
+  expectUnion as __expectUnion,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   limitedParseDouble as __limitedParseDouble,
   parseEpochTimestamp as __parseEpochTimestamp,
@@ -1559,7 +1560,7 @@ export const deserializeAws_restJson1GetConfigCommand = async (
     contents.configArn = __expectString(data.configArn);
   }
   if (data.configData !== undefined && data.configData !== null) {
-    contents.configData = deserializeAws_restJson1ConfigTypeData(data.configData, context);
+    contents.configData = deserializeAws_restJson1ConfigTypeData(__expectUnion(data.configData), context);
   }
   if (data.configId !== undefined && data.configId !== null) {
     contents.configId = __expectString(data.configId);
@@ -3507,7 +3508,7 @@ const deserializeAws_restJson1Destination = (output: any, context: __SerdeContex
   return {
     configDetails:
       output.configDetails !== undefined && output.configDetails !== null
-        ? deserializeAws_restJson1ConfigDetails(output.configDetails, context)
+        ? deserializeAws_restJson1ConfigDetails(__expectUnion(output.configDetails), context)
         : undefined,
     configId: __expectString(output.configId),
     configType: __expectString(output.configType),
@@ -3694,7 +3695,7 @@ const deserializeAws_restJson1Source = (output: any, context: __SerdeContext): S
   return {
     configDetails:
       output.configDetails !== undefined && output.configDetails !== null
-        ? deserializeAws_restJson1ConfigDetails(output.configDetails, context)
+        ? deserializeAws_restJson1ConfigDetails(__expectUnion(output.configDetails), context)
         : undefined,
     configId: __expectString(output.configId),
     configType: __expectString(output.configType),

--- a/clients/client-healthlake/protocols/Aws_json1_0.ts
+++ b/clients/client-healthlake/protocols/Aws_json1_0.ts
@@ -79,6 +79,7 @@ import {
   expectNonNull as __expectNonNull,
   expectNumber as __expectNumber,
   expectString as __expectString,
+  expectUnion as __expectUnion,
   parseEpochTimestamp as __parseEpochTimestamp,
 } from "@aws-sdk/smithy-client";
 import {
@@ -1728,7 +1729,7 @@ const deserializeAws_json1_0ExportJobProperties = (output: any, context: __Serde
     Message: __expectString(output.Message),
     OutputDataConfig:
       output.OutputDataConfig !== undefined && output.OutputDataConfig !== null
-        ? deserializeAws_json1_0OutputDataConfig(output.OutputDataConfig, context)
+        ? deserializeAws_json1_0OutputDataConfig(__expectUnion(output.OutputDataConfig), context)
         : undefined,
     SubmitTime:
       output.SubmitTime !== undefined && output.SubmitTime !== null
@@ -1758,13 +1759,13 @@ const deserializeAws_json1_0ImportJobProperties = (output: any, context: __Serde
         : undefined,
     InputDataConfig:
       output.InputDataConfig !== undefined && output.InputDataConfig !== null
-        ? deserializeAws_json1_0InputDataConfig(output.InputDataConfig, context)
+        ? deserializeAws_json1_0InputDataConfig(__expectUnion(output.InputDataConfig), context)
         : undefined,
     JobId: __expectString(output.JobId),
     JobName: __expectString(output.JobName),
     JobOutputDataConfig:
       output.JobOutputDataConfig !== undefined && output.JobOutputDataConfig !== null
-        ? deserializeAws_json1_0OutputDataConfig(output.JobOutputDataConfig, context)
+        ? deserializeAws_json1_0OutputDataConfig(__expectUnion(output.JobOutputDataConfig), context)
         : undefined,
     JobStatus: __expectString(output.JobStatus),
     Message: __expectString(output.Message),

--- a/clients/client-iot/protocols/Aws_restJson1.ts
+++ b/clients/client-iot/protocols/Aws_restJson1.ts
@@ -868,6 +868,7 @@ import {
   expectNumber as __expectNumber,
   expectObject as __expectObject,
   expectString as __expectString,
+  expectUnion as __expectUnion,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   limitedParseDouble as __limitedParseDouble,
   parseEpochTimestamp as __parseEpochTimestamp,
@@ -32585,7 +32586,7 @@ const deserializeAws_restJson1AssetPropertyValue = (output: any, context: __Serd
         : undefined,
     value:
       output.value !== undefined && output.value !== null
-        ? deserializeAws_restJson1AssetPropertyVariant(output.value, context)
+        ? deserializeAws_restJson1AssetPropertyVariant(__expectUnion(output.value), context)
         : undefined,
   } as any;
 };

--- a/clients/client-iotanalytics/protocols/Aws_restJson1.ts
+++ b/clients/client-iotanalytics/protocols/Aws_restJson1.ts
@@ -152,6 +152,7 @@ import {
   expectNumber as __expectNumber,
   expectObject as __expectObject,
   expectString as __expectString,
+  expectUnion as __expectUnion,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   limitedParseDouble as __limitedParseDouble,
   parseEpochTimestamp as __parseEpochTimestamp,
@@ -5659,7 +5660,7 @@ const deserializeAws_restJson1Datastore = (output: any, context: __SerdeContext)
     status: __expectString(output.status),
     storage:
       output.storage !== undefined && output.storage !== null
-        ? deserializeAws_restJson1DatastoreStorage(output.storage, context)
+        ? deserializeAws_restJson1DatastoreStorage(__expectUnion(output.storage), context)
         : undefined,
   } as any;
 };

--- a/clients/client-kendra/protocols/Aws_json1_1.ts
+++ b/clients/client-kendra/protocols/Aws_json1_1.ts
@@ -290,6 +290,7 @@ import {
   expectNonNull as __expectNonNull,
   expectNumber as __expectNumber,
   expectString as __expectString,
+  expectUnion as __expectUnion,
   limitedParseFloat32 as __limitedParseFloat32,
   parseEpochTimestamp as __parseEpochTimestamp,
   serializeFloat as __serializeFloat,
@@ -8133,7 +8134,7 @@ const deserializeAws_json1_1DocumentAttribute = (output: any, context: __SerdeCo
     Key: __expectString(output.Key),
     Value:
       output.Value !== undefined && output.Value !== null
-        ? deserializeAws_json1_1DocumentAttributeValue(output.Value, context)
+        ? deserializeAws_json1_1DocumentAttributeValue(__expectUnion(output.Value), context)
         : undefined,
   } as any;
 };
@@ -8188,7 +8189,7 @@ const deserializeAws_json1_1DocumentAttributeValueCountPair = (
     Count: __expectInt32(output.Count),
     DocumentAttributeValue:
       output.DocumentAttributeValue !== undefined && output.DocumentAttributeValue !== null
-        ? deserializeAws_json1_1DocumentAttributeValue(output.DocumentAttributeValue, context)
+        ? deserializeAws_json1_1DocumentAttributeValue(__expectUnion(output.DocumentAttributeValue), context)
         : undefined,
   } as any;
 };

--- a/clients/client-kinesis/protocols/Aws_json1_1.ts
+++ b/clients/client-kinesis/protocols/Aws_json1_1.ts
@@ -148,6 +148,7 @@ import {
   expectNonNull as __expectNonNull,
   expectNumber as __expectNumber,
   expectString as __expectString,
+  expectUnion as __expectUnion,
   parseEpochTimestamp as __parseEpochTimestamp,
 } from "@aws-sdk/smithy-client";
 import {
@@ -3895,7 +3896,7 @@ const deserializeAws_json1_1SubscribeToShardOutput = (output: any, context: __Se
   return {
     EventStream:
       output.EventStream !== undefined && output.EventStream !== null
-        ? deserializeAws_json1_1SubscribeToShardEventStream(output.EventStream, context)
+        ? deserializeAws_json1_1SubscribeToShardEventStream(__expectUnion(output.EventStream), context)
         : undefined,
   } as any;
 };

--- a/clients/client-marketplace-entitlement-service/protocols/Aws_json1_1.ts
+++ b/clients/client-marketplace-entitlement-service/protocols/Aws_json1_1.ts
@@ -16,6 +16,7 @@ import {
   expectNonNull as __expectNonNull,
   expectNumber as __expectNumber,
   expectString as __expectString,
+  expectUnion as __expectUnion,
   limitedParseDouble as __limitedParseDouble,
   parseEpochTimestamp as __parseEpochTimestamp,
 } from "@aws-sdk/smithy-client";
@@ -206,7 +207,7 @@ const deserializeAws_json1_1Entitlement = (output: any, context: __SerdeContext)
     ProductCode: __expectString(output.ProductCode),
     Value:
       output.Value !== undefined && output.Value !== null
-        ? deserializeAws_json1_1EntitlementValue(output.Value, context)
+        ? deserializeAws_json1_1EntitlementValue(__expectUnion(output.Value), context)
         : undefined,
   } as any;
 };

--- a/clients/client-pinpoint/protocols/Aws_restJson1.ts
+++ b/clients/client-pinpoint/protocols/Aws_restJson1.ts
@@ -4531,7 +4531,7 @@ export const deserializeAws_restJson1CreateAppCommand = async (
     $metadata: deserializeMetadata(output),
     ApplicationResponse: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.ApplicationResponse = deserializeAws_restJson1ApplicationResponse(data, context);
   return Promise.resolve(contents);
 };
@@ -4632,7 +4632,7 @@ export const deserializeAws_restJson1CreateCampaignCommand = async (
     $metadata: deserializeMetadata(output),
     CampaignResponse: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.CampaignResponse = deserializeAws_restJson1CampaignResponse(data, context);
   return Promise.resolve(contents);
 };
@@ -4733,7 +4733,7 @@ export const deserializeAws_restJson1CreateEmailTemplateCommand = async (
     $metadata: deserializeMetadata(output),
     CreateTemplateMessageBody: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.CreateTemplateMessageBody = deserializeAws_restJson1CreateTemplateMessageBody(data, context);
   return Promise.resolve(contents);
 };
@@ -4818,7 +4818,7 @@ export const deserializeAws_restJson1CreateExportJobCommand = async (
     $metadata: deserializeMetadata(output),
     ExportJobResponse: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.ExportJobResponse = deserializeAws_restJson1ExportJobResponse(data, context);
   return Promise.resolve(contents);
 };
@@ -4919,7 +4919,7 @@ export const deserializeAws_restJson1CreateImportJobCommand = async (
     $metadata: deserializeMetadata(output),
     ImportJobResponse: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.ImportJobResponse = deserializeAws_restJson1ImportJobResponse(data, context);
   return Promise.resolve(contents);
 };
@@ -5020,7 +5020,7 @@ export const deserializeAws_restJson1CreateJourneyCommand = async (
     $metadata: deserializeMetadata(output),
     JourneyResponse: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.JourneyResponse = deserializeAws_restJson1JourneyResponse(data, context);
   return Promise.resolve(contents);
 };
@@ -5121,7 +5121,7 @@ export const deserializeAws_restJson1CreatePushTemplateCommand = async (
     $metadata: deserializeMetadata(output),
     CreateTemplateMessageBody: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.CreateTemplateMessageBody = deserializeAws_restJson1CreateTemplateMessageBody(data, context);
   return Promise.resolve(contents);
 };
@@ -5206,7 +5206,7 @@ export const deserializeAws_restJson1CreateRecommenderConfigurationCommand = asy
     $metadata: deserializeMetadata(output),
     RecommenderConfigurationResponse: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.RecommenderConfigurationResponse = deserializeAws_restJson1RecommenderConfigurationResponse(data, context);
   return Promise.resolve(contents);
 };
@@ -5307,7 +5307,7 @@ export const deserializeAws_restJson1CreateSegmentCommand = async (
     $metadata: deserializeMetadata(output),
     SegmentResponse: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.SegmentResponse = deserializeAws_restJson1SegmentResponse(data, context);
   return Promise.resolve(contents);
 };
@@ -5408,7 +5408,7 @@ export const deserializeAws_restJson1CreateSmsTemplateCommand = async (
     $metadata: deserializeMetadata(output),
     CreateTemplateMessageBody: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.CreateTemplateMessageBody = deserializeAws_restJson1CreateTemplateMessageBody(data, context);
   return Promise.resolve(contents);
 };
@@ -5493,7 +5493,7 @@ export const deserializeAws_restJson1CreateVoiceTemplateCommand = async (
     $metadata: deserializeMetadata(output),
     CreateTemplateMessageBody: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.CreateTemplateMessageBody = deserializeAws_restJson1CreateTemplateMessageBody(data, context);
   return Promise.resolve(contents);
 };
@@ -5578,7 +5578,7 @@ export const deserializeAws_restJson1DeleteAdmChannelCommand = async (
     $metadata: deserializeMetadata(output),
     ADMChannelResponse: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.ADMChannelResponse = deserializeAws_restJson1ADMChannelResponse(data, context);
   return Promise.resolve(contents);
 };
@@ -5679,7 +5679,7 @@ export const deserializeAws_restJson1DeleteApnsChannelCommand = async (
     $metadata: deserializeMetadata(output),
     APNSChannelResponse: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.APNSChannelResponse = deserializeAws_restJson1APNSChannelResponse(data, context);
   return Promise.resolve(contents);
 };
@@ -5780,7 +5780,7 @@ export const deserializeAws_restJson1DeleteApnsSandboxChannelCommand = async (
     $metadata: deserializeMetadata(output),
     APNSSandboxChannelResponse: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.APNSSandboxChannelResponse = deserializeAws_restJson1APNSSandboxChannelResponse(data, context);
   return Promise.resolve(contents);
 };
@@ -5881,7 +5881,7 @@ export const deserializeAws_restJson1DeleteApnsVoipChannelCommand = async (
     $metadata: deserializeMetadata(output),
     APNSVoipChannelResponse: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.APNSVoipChannelResponse = deserializeAws_restJson1APNSVoipChannelResponse(data, context);
   return Promise.resolve(contents);
 };
@@ -5982,7 +5982,7 @@ export const deserializeAws_restJson1DeleteApnsVoipSandboxChannelCommand = async
     $metadata: deserializeMetadata(output),
     APNSVoipSandboxChannelResponse: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.APNSVoipSandboxChannelResponse = deserializeAws_restJson1APNSVoipSandboxChannelResponse(data, context);
   return Promise.resolve(contents);
 };
@@ -6083,7 +6083,7 @@ export const deserializeAws_restJson1DeleteAppCommand = async (
     $metadata: deserializeMetadata(output),
     ApplicationResponse: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.ApplicationResponse = deserializeAws_restJson1ApplicationResponse(data, context);
   return Promise.resolve(contents);
 };
@@ -6184,7 +6184,7 @@ export const deserializeAws_restJson1DeleteBaiduChannelCommand = async (
     $metadata: deserializeMetadata(output),
     BaiduChannelResponse: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.BaiduChannelResponse = deserializeAws_restJson1BaiduChannelResponse(data, context);
   return Promise.resolve(contents);
 };
@@ -6285,7 +6285,7 @@ export const deserializeAws_restJson1DeleteCampaignCommand = async (
     $metadata: deserializeMetadata(output),
     CampaignResponse: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.CampaignResponse = deserializeAws_restJson1CampaignResponse(data, context);
   return Promise.resolve(contents);
 };
@@ -6386,7 +6386,7 @@ export const deserializeAws_restJson1DeleteEmailChannelCommand = async (
     $metadata: deserializeMetadata(output),
     EmailChannelResponse: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.EmailChannelResponse = deserializeAws_restJson1EmailChannelResponse(data, context);
   return Promise.resolve(contents);
 };
@@ -6487,7 +6487,7 @@ export const deserializeAws_restJson1DeleteEmailTemplateCommand = async (
     $metadata: deserializeMetadata(output),
     MessageBody: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.MessageBody = deserializeAws_restJson1MessageBody(data, context);
   return Promise.resolve(contents);
 };
@@ -6588,7 +6588,7 @@ export const deserializeAws_restJson1DeleteEndpointCommand = async (
     $metadata: deserializeMetadata(output),
     EndpointResponse: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.EndpointResponse = deserializeAws_restJson1EndpointResponse(data, context);
   return Promise.resolve(contents);
 };
@@ -6689,7 +6689,7 @@ export const deserializeAws_restJson1DeleteEventStreamCommand = async (
     $metadata: deserializeMetadata(output),
     EventStream: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.EventStream = deserializeAws_restJson1EventStream(data, context);
   return Promise.resolve(contents);
 };
@@ -6790,7 +6790,7 @@ export const deserializeAws_restJson1DeleteGcmChannelCommand = async (
     $metadata: deserializeMetadata(output),
     GCMChannelResponse: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.GCMChannelResponse = deserializeAws_restJson1GCMChannelResponse(data, context);
   return Promise.resolve(contents);
 };
@@ -6891,7 +6891,7 @@ export const deserializeAws_restJson1DeleteJourneyCommand = async (
     $metadata: deserializeMetadata(output),
     JourneyResponse: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.JourneyResponse = deserializeAws_restJson1JourneyResponse(data, context);
   return Promise.resolve(contents);
 };
@@ -6992,7 +6992,7 @@ export const deserializeAws_restJson1DeletePushTemplateCommand = async (
     $metadata: deserializeMetadata(output),
     MessageBody: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.MessageBody = deserializeAws_restJson1MessageBody(data, context);
   return Promise.resolve(contents);
 };
@@ -7093,7 +7093,7 @@ export const deserializeAws_restJson1DeleteRecommenderConfigurationCommand = asy
     $metadata: deserializeMetadata(output),
     RecommenderConfigurationResponse: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.RecommenderConfigurationResponse = deserializeAws_restJson1RecommenderConfigurationResponse(data, context);
   return Promise.resolve(contents);
 };
@@ -7194,7 +7194,7 @@ export const deserializeAws_restJson1DeleteSegmentCommand = async (
     $metadata: deserializeMetadata(output),
     SegmentResponse: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.SegmentResponse = deserializeAws_restJson1SegmentResponse(data, context);
   return Promise.resolve(contents);
 };
@@ -7295,7 +7295,7 @@ export const deserializeAws_restJson1DeleteSmsChannelCommand = async (
     $metadata: deserializeMetadata(output),
     SMSChannelResponse: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.SMSChannelResponse = deserializeAws_restJson1SMSChannelResponse(data, context);
   return Promise.resolve(contents);
 };
@@ -7396,7 +7396,7 @@ export const deserializeAws_restJson1DeleteSmsTemplateCommand = async (
     $metadata: deserializeMetadata(output),
     MessageBody: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.MessageBody = deserializeAws_restJson1MessageBody(data, context);
   return Promise.resolve(contents);
 };
@@ -7497,7 +7497,7 @@ export const deserializeAws_restJson1DeleteUserEndpointsCommand = async (
     $metadata: deserializeMetadata(output),
     EndpointsResponse: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.EndpointsResponse = deserializeAws_restJson1EndpointsResponse(data, context);
   return Promise.resolve(contents);
 };
@@ -7598,7 +7598,7 @@ export const deserializeAws_restJson1DeleteVoiceChannelCommand = async (
     $metadata: deserializeMetadata(output),
     VoiceChannelResponse: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.VoiceChannelResponse = deserializeAws_restJson1VoiceChannelResponse(data, context);
   return Promise.resolve(contents);
 };
@@ -7699,7 +7699,7 @@ export const deserializeAws_restJson1DeleteVoiceTemplateCommand = async (
     $metadata: deserializeMetadata(output),
     MessageBody: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.MessageBody = deserializeAws_restJson1MessageBody(data, context);
   return Promise.resolve(contents);
 };
@@ -7800,7 +7800,7 @@ export const deserializeAws_restJson1GetAdmChannelCommand = async (
     $metadata: deserializeMetadata(output),
     ADMChannelResponse: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.ADMChannelResponse = deserializeAws_restJson1ADMChannelResponse(data, context);
   return Promise.resolve(contents);
 };
@@ -7901,7 +7901,7 @@ export const deserializeAws_restJson1GetApnsChannelCommand = async (
     $metadata: deserializeMetadata(output),
     APNSChannelResponse: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.APNSChannelResponse = deserializeAws_restJson1APNSChannelResponse(data, context);
   return Promise.resolve(contents);
 };
@@ -8002,7 +8002,7 @@ export const deserializeAws_restJson1GetApnsSandboxChannelCommand = async (
     $metadata: deserializeMetadata(output),
     APNSSandboxChannelResponse: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.APNSSandboxChannelResponse = deserializeAws_restJson1APNSSandboxChannelResponse(data, context);
   return Promise.resolve(contents);
 };
@@ -8103,7 +8103,7 @@ export const deserializeAws_restJson1GetApnsVoipChannelCommand = async (
     $metadata: deserializeMetadata(output),
     APNSVoipChannelResponse: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.APNSVoipChannelResponse = deserializeAws_restJson1APNSVoipChannelResponse(data, context);
   return Promise.resolve(contents);
 };
@@ -8204,7 +8204,7 @@ export const deserializeAws_restJson1GetApnsVoipSandboxChannelCommand = async (
     $metadata: deserializeMetadata(output),
     APNSVoipSandboxChannelResponse: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.APNSVoipSandboxChannelResponse = deserializeAws_restJson1APNSVoipSandboxChannelResponse(data, context);
   return Promise.resolve(contents);
 };
@@ -8305,7 +8305,7 @@ export const deserializeAws_restJson1GetAppCommand = async (
     $metadata: deserializeMetadata(output),
     ApplicationResponse: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.ApplicationResponse = deserializeAws_restJson1ApplicationResponse(data, context);
   return Promise.resolve(contents);
 };
@@ -8406,7 +8406,7 @@ export const deserializeAws_restJson1GetApplicationDateRangeKpiCommand = async (
     $metadata: deserializeMetadata(output),
     ApplicationDateRangeKpiResponse: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.ApplicationDateRangeKpiResponse = deserializeAws_restJson1ApplicationDateRangeKpiResponse(data, context);
   return Promise.resolve(contents);
 };
@@ -8507,7 +8507,7 @@ export const deserializeAws_restJson1GetApplicationSettingsCommand = async (
     $metadata: deserializeMetadata(output),
     ApplicationSettingsResource: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.ApplicationSettingsResource = deserializeAws_restJson1ApplicationSettingsResource(data, context);
   return Promise.resolve(contents);
 };
@@ -8608,7 +8608,7 @@ export const deserializeAws_restJson1GetAppsCommand = async (
     $metadata: deserializeMetadata(output),
     ApplicationsResponse: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.ApplicationsResponse = deserializeAws_restJson1ApplicationsResponse(data, context);
   return Promise.resolve(contents);
 };
@@ -8709,7 +8709,7 @@ export const deserializeAws_restJson1GetBaiduChannelCommand = async (
     $metadata: deserializeMetadata(output),
     BaiduChannelResponse: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.BaiduChannelResponse = deserializeAws_restJson1BaiduChannelResponse(data, context);
   return Promise.resolve(contents);
 };
@@ -8810,7 +8810,7 @@ export const deserializeAws_restJson1GetCampaignCommand = async (
     $metadata: deserializeMetadata(output),
     CampaignResponse: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.CampaignResponse = deserializeAws_restJson1CampaignResponse(data, context);
   return Promise.resolve(contents);
 };
@@ -8911,7 +8911,7 @@ export const deserializeAws_restJson1GetCampaignActivitiesCommand = async (
     $metadata: deserializeMetadata(output),
     ActivitiesResponse: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.ActivitiesResponse = deserializeAws_restJson1ActivitiesResponse(data, context);
   return Promise.resolve(contents);
 };
@@ -9012,7 +9012,7 @@ export const deserializeAws_restJson1GetCampaignDateRangeKpiCommand = async (
     $metadata: deserializeMetadata(output),
     CampaignDateRangeKpiResponse: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.CampaignDateRangeKpiResponse = deserializeAws_restJson1CampaignDateRangeKpiResponse(data, context);
   return Promise.resolve(contents);
 };
@@ -9113,7 +9113,7 @@ export const deserializeAws_restJson1GetCampaignsCommand = async (
     $metadata: deserializeMetadata(output),
     CampaignsResponse: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.CampaignsResponse = deserializeAws_restJson1CampaignsResponse(data, context);
   return Promise.resolve(contents);
 };
@@ -9214,7 +9214,7 @@ export const deserializeAws_restJson1GetCampaignVersionCommand = async (
     $metadata: deserializeMetadata(output),
     CampaignResponse: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.CampaignResponse = deserializeAws_restJson1CampaignResponse(data, context);
   return Promise.resolve(contents);
 };
@@ -9315,7 +9315,7 @@ export const deserializeAws_restJson1GetCampaignVersionsCommand = async (
     $metadata: deserializeMetadata(output),
     CampaignsResponse: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.CampaignsResponse = deserializeAws_restJson1CampaignsResponse(data, context);
   return Promise.resolve(contents);
 };
@@ -9416,7 +9416,7 @@ export const deserializeAws_restJson1GetChannelsCommand = async (
     $metadata: deserializeMetadata(output),
     ChannelsResponse: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.ChannelsResponse = deserializeAws_restJson1ChannelsResponse(data, context);
   return Promise.resolve(contents);
 };
@@ -9517,7 +9517,7 @@ export const deserializeAws_restJson1GetEmailChannelCommand = async (
     $metadata: deserializeMetadata(output),
     EmailChannelResponse: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.EmailChannelResponse = deserializeAws_restJson1EmailChannelResponse(data, context);
   return Promise.resolve(contents);
 };
@@ -9618,7 +9618,7 @@ export const deserializeAws_restJson1GetEmailTemplateCommand = async (
     $metadata: deserializeMetadata(output),
     EmailTemplateResponse: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.EmailTemplateResponse = deserializeAws_restJson1EmailTemplateResponse(data, context);
   return Promise.resolve(contents);
 };
@@ -9719,7 +9719,7 @@ export const deserializeAws_restJson1GetEndpointCommand = async (
     $metadata: deserializeMetadata(output),
     EndpointResponse: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.EndpointResponse = deserializeAws_restJson1EndpointResponse(data, context);
   return Promise.resolve(contents);
 };
@@ -9820,7 +9820,7 @@ export const deserializeAws_restJson1GetEventStreamCommand = async (
     $metadata: deserializeMetadata(output),
     EventStream: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.EventStream = deserializeAws_restJson1EventStream(data, context);
   return Promise.resolve(contents);
 };
@@ -9921,7 +9921,7 @@ export const deserializeAws_restJson1GetExportJobCommand = async (
     $metadata: deserializeMetadata(output),
     ExportJobResponse: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.ExportJobResponse = deserializeAws_restJson1ExportJobResponse(data, context);
   return Promise.resolve(contents);
 };
@@ -10022,7 +10022,7 @@ export const deserializeAws_restJson1GetExportJobsCommand = async (
     $metadata: deserializeMetadata(output),
     ExportJobsResponse: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.ExportJobsResponse = deserializeAws_restJson1ExportJobsResponse(data, context);
   return Promise.resolve(contents);
 };
@@ -10123,7 +10123,7 @@ export const deserializeAws_restJson1GetGcmChannelCommand = async (
     $metadata: deserializeMetadata(output),
     GCMChannelResponse: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.GCMChannelResponse = deserializeAws_restJson1GCMChannelResponse(data, context);
   return Promise.resolve(contents);
 };
@@ -10224,7 +10224,7 @@ export const deserializeAws_restJson1GetImportJobCommand = async (
     $metadata: deserializeMetadata(output),
     ImportJobResponse: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.ImportJobResponse = deserializeAws_restJson1ImportJobResponse(data, context);
   return Promise.resolve(contents);
 };
@@ -10325,7 +10325,7 @@ export const deserializeAws_restJson1GetImportJobsCommand = async (
     $metadata: deserializeMetadata(output),
     ImportJobsResponse: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.ImportJobsResponse = deserializeAws_restJson1ImportJobsResponse(data, context);
   return Promise.resolve(contents);
 };
@@ -10426,7 +10426,7 @@ export const deserializeAws_restJson1GetJourneyCommand = async (
     $metadata: deserializeMetadata(output),
     JourneyResponse: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.JourneyResponse = deserializeAws_restJson1JourneyResponse(data, context);
   return Promise.resolve(contents);
 };
@@ -10527,7 +10527,7 @@ export const deserializeAws_restJson1GetJourneyDateRangeKpiCommand = async (
     $metadata: deserializeMetadata(output),
     JourneyDateRangeKpiResponse: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.JourneyDateRangeKpiResponse = deserializeAws_restJson1JourneyDateRangeKpiResponse(data, context);
   return Promise.resolve(contents);
 };
@@ -10628,7 +10628,7 @@ export const deserializeAws_restJson1GetJourneyExecutionActivityMetricsCommand =
     $metadata: deserializeMetadata(output),
     JourneyExecutionActivityMetricsResponse: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.JourneyExecutionActivityMetricsResponse = deserializeAws_restJson1JourneyExecutionActivityMetricsResponse(
     data,
     context
@@ -10732,7 +10732,7 @@ export const deserializeAws_restJson1GetJourneyExecutionMetricsCommand = async (
     $metadata: deserializeMetadata(output),
     JourneyExecutionMetricsResponse: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.JourneyExecutionMetricsResponse = deserializeAws_restJson1JourneyExecutionMetricsResponse(data, context);
   return Promise.resolve(contents);
 };
@@ -10833,7 +10833,7 @@ export const deserializeAws_restJson1GetPushTemplateCommand = async (
     $metadata: deserializeMetadata(output),
     PushNotificationTemplateResponse: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.PushNotificationTemplateResponse = deserializeAws_restJson1PushNotificationTemplateResponse(data, context);
   return Promise.resolve(contents);
 };
@@ -10934,7 +10934,7 @@ export const deserializeAws_restJson1GetRecommenderConfigurationCommand = async 
     $metadata: deserializeMetadata(output),
     RecommenderConfigurationResponse: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.RecommenderConfigurationResponse = deserializeAws_restJson1RecommenderConfigurationResponse(data, context);
   return Promise.resolve(contents);
 };
@@ -11035,7 +11035,7 @@ export const deserializeAws_restJson1GetRecommenderConfigurationsCommand = async
     $metadata: deserializeMetadata(output),
     ListRecommenderConfigurationsResponse: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.ListRecommenderConfigurationsResponse = deserializeAws_restJson1ListRecommenderConfigurationsResponse(
     data,
     context
@@ -11139,7 +11139,7 @@ export const deserializeAws_restJson1GetSegmentCommand = async (
     $metadata: deserializeMetadata(output),
     SegmentResponse: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.SegmentResponse = deserializeAws_restJson1SegmentResponse(data, context);
   return Promise.resolve(contents);
 };
@@ -11240,7 +11240,7 @@ export const deserializeAws_restJson1GetSegmentExportJobsCommand = async (
     $metadata: deserializeMetadata(output),
     ExportJobsResponse: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.ExportJobsResponse = deserializeAws_restJson1ExportJobsResponse(data, context);
   return Promise.resolve(contents);
 };
@@ -11341,7 +11341,7 @@ export const deserializeAws_restJson1GetSegmentImportJobsCommand = async (
     $metadata: deserializeMetadata(output),
     ImportJobsResponse: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.ImportJobsResponse = deserializeAws_restJson1ImportJobsResponse(data, context);
   return Promise.resolve(contents);
 };
@@ -11442,7 +11442,7 @@ export const deserializeAws_restJson1GetSegmentsCommand = async (
     $metadata: deserializeMetadata(output),
     SegmentsResponse: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.SegmentsResponse = deserializeAws_restJson1SegmentsResponse(data, context);
   return Promise.resolve(contents);
 };
@@ -11543,7 +11543,7 @@ export const deserializeAws_restJson1GetSegmentVersionCommand = async (
     $metadata: deserializeMetadata(output),
     SegmentResponse: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.SegmentResponse = deserializeAws_restJson1SegmentResponse(data, context);
   return Promise.resolve(contents);
 };
@@ -11644,7 +11644,7 @@ export const deserializeAws_restJson1GetSegmentVersionsCommand = async (
     $metadata: deserializeMetadata(output),
     SegmentsResponse: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.SegmentsResponse = deserializeAws_restJson1SegmentsResponse(data, context);
   return Promise.resolve(contents);
 };
@@ -11745,7 +11745,7 @@ export const deserializeAws_restJson1GetSmsChannelCommand = async (
     $metadata: deserializeMetadata(output),
     SMSChannelResponse: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.SMSChannelResponse = deserializeAws_restJson1SMSChannelResponse(data, context);
   return Promise.resolve(contents);
 };
@@ -11846,7 +11846,7 @@ export const deserializeAws_restJson1GetSmsTemplateCommand = async (
     $metadata: deserializeMetadata(output),
     SMSTemplateResponse: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.SMSTemplateResponse = deserializeAws_restJson1SMSTemplateResponse(data, context);
   return Promise.resolve(contents);
 };
@@ -11947,7 +11947,7 @@ export const deserializeAws_restJson1GetUserEndpointsCommand = async (
     $metadata: deserializeMetadata(output),
     EndpointsResponse: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.EndpointsResponse = deserializeAws_restJson1EndpointsResponse(data, context);
   return Promise.resolve(contents);
 };
@@ -12048,7 +12048,7 @@ export const deserializeAws_restJson1GetVoiceChannelCommand = async (
     $metadata: deserializeMetadata(output),
     VoiceChannelResponse: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.VoiceChannelResponse = deserializeAws_restJson1VoiceChannelResponse(data, context);
   return Promise.resolve(contents);
 };
@@ -12149,7 +12149,7 @@ export const deserializeAws_restJson1GetVoiceTemplateCommand = async (
     $metadata: deserializeMetadata(output),
     VoiceTemplateResponse: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.VoiceTemplateResponse = deserializeAws_restJson1VoiceTemplateResponse(data, context);
   return Promise.resolve(contents);
 };
@@ -12250,7 +12250,7 @@ export const deserializeAws_restJson1ListJourneysCommand = async (
     $metadata: deserializeMetadata(output),
     JourneysResponse: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.JourneysResponse = deserializeAws_restJson1JourneysResponse(data, context);
   return Promise.resolve(contents);
 };
@@ -12351,7 +12351,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     $metadata: deserializeMetadata(output),
     TagsModel: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.TagsModel = deserializeAws_restJson1TagsModel(data, context);
   return Promise.resolve(contents);
 };
@@ -12396,7 +12396,7 @@ export const deserializeAws_restJson1ListTemplatesCommand = async (
     $metadata: deserializeMetadata(output),
     TemplatesResponse: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.TemplatesResponse = deserializeAws_restJson1TemplatesResponse(data, context);
   return Promise.resolve(contents);
 };
@@ -12481,7 +12481,7 @@ export const deserializeAws_restJson1ListTemplateVersionsCommand = async (
     $metadata: deserializeMetadata(output),
     TemplateVersionsResponse: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.TemplateVersionsResponse = deserializeAws_restJson1TemplateVersionsResponse(data, context);
   return Promise.resolve(contents);
 };
@@ -12582,7 +12582,7 @@ export const deserializeAws_restJson1PhoneNumberValidateCommand = async (
     $metadata: deserializeMetadata(output),
     NumberValidateResponse: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.NumberValidateResponse = deserializeAws_restJson1NumberValidateResponse(data, context);
   return Promise.resolve(contents);
 };
@@ -12683,7 +12683,7 @@ export const deserializeAws_restJson1PutEventsCommand = async (
     $metadata: deserializeMetadata(output),
     EventsResponse: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.EventsResponse = deserializeAws_restJson1EventsResponse(data, context);
   return Promise.resolve(contents);
 };
@@ -12784,7 +12784,7 @@ export const deserializeAws_restJson1PutEventStreamCommand = async (
     $metadata: deserializeMetadata(output),
     EventStream: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.EventStream = deserializeAws_restJson1EventStream(data, context);
   return Promise.resolve(contents);
 };
@@ -12885,7 +12885,7 @@ export const deserializeAws_restJson1RemoveAttributesCommand = async (
     $metadata: deserializeMetadata(output),
     AttributesResource: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.AttributesResource = deserializeAws_restJson1AttributesResource(data, context);
   return Promise.resolve(contents);
 };
@@ -12986,7 +12986,7 @@ export const deserializeAws_restJson1SendMessagesCommand = async (
     $metadata: deserializeMetadata(output),
     MessageResponse: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.MessageResponse = deserializeAws_restJson1MessageResponse(data, context);
   return Promise.resolve(contents);
 };
@@ -13087,7 +13087,7 @@ export const deserializeAws_restJson1SendUsersMessagesCommand = async (
     $metadata: deserializeMetadata(output),
     SendUsersMessageResponse: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.SendUsersMessageResponse = deserializeAws_restJson1SendUsersMessageResponse(data, context);
   return Promise.resolve(contents);
 };
@@ -13274,7 +13274,7 @@ export const deserializeAws_restJson1UpdateAdmChannelCommand = async (
     $metadata: deserializeMetadata(output),
     ADMChannelResponse: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.ADMChannelResponse = deserializeAws_restJson1ADMChannelResponse(data, context);
   return Promise.resolve(contents);
 };
@@ -13375,7 +13375,7 @@ export const deserializeAws_restJson1UpdateApnsChannelCommand = async (
     $metadata: deserializeMetadata(output),
     APNSChannelResponse: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.APNSChannelResponse = deserializeAws_restJson1APNSChannelResponse(data, context);
   return Promise.resolve(contents);
 };
@@ -13476,7 +13476,7 @@ export const deserializeAws_restJson1UpdateApnsSandboxChannelCommand = async (
     $metadata: deserializeMetadata(output),
     APNSSandboxChannelResponse: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.APNSSandboxChannelResponse = deserializeAws_restJson1APNSSandboxChannelResponse(data, context);
   return Promise.resolve(contents);
 };
@@ -13577,7 +13577,7 @@ export const deserializeAws_restJson1UpdateApnsVoipChannelCommand = async (
     $metadata: deserializeMetadata(output),
     APNSVoipChannelResponse: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.APNSVoipChannelResponse = deserializeAws_restJson1APNSVoipChannelResponse(data, context);
   return Promise.resolve(contents);
 };
@@ -13678,7 +13678,7 @@ export const deserializeAws_restJson1UpdateApnsVoipSandboxChannelCommand = async
     $metadata: deserializeMetadata(output),
     APNSVoipSandboxChannelResponse: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.APNSVoipSandboxChannelResponse = deserializeAws_restJson1APNSVoipSandboxChannelResponse(data, context);
   return Promise.resolve(contents);
 };
@@ -13779,7 +13779,7 @@ export const deserializeAws_restJson1UpdateApplicationSettingsCommand = async (
     $metadata: deserializeMetadata(output),
     ApplicationSettingsResource: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.ApplicationSettingsResource = deserializeAws_restJson1ApplicationSettingsResource(data, context);
   return Promise.resolve(contents);
 };
@@ -13880,7 +13880,7 @@ export const deserializeAws_restJson1UpdateBaiduChannelCommand = async (
     $metadata: deserializeMetadata(output),
     BaiduChannelResponse: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.BaiduChannelResponse = deserializeAws_restJson1BaiduChannelResponse(data, context);
   return Promise.resolve(contents);
 };
@@ -13981,7 +13981,7 @@ export const deserializeAws_restJson1UpdateCampaignCommand = async (
     $metadata: deserializeMetadata(output),
     CampaignResponse: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.CampaignResponse = deserializeAws_restJson1CampaignResponse(data, context);
   return Promise.resolve(contents);
 };
@@ -14082,7 +14082,7 @@ export const deserializeAws_restJson1UpdateEmailChannelCommand = async (
     $metadata: deserializeMetadata(output),
     EmailChannelResponse: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.EmailChannelResponse = deserializeAws_restJson1EmailChannelResponse(data, context);
   return Promise.resolve(contents);
 };
@@ -14183,7 +14183,7 @@ export const deserializeAws_restJson1UpdateEmailTemplateCommand = async (
     $metadata: deserializeMetadata(output),
     MessageBody: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.MessageBody = deserializeAws_restJson1MessageBody(data, context);
   return Promise.resolve(contents);
 };
@@ -14284,7 +14284,7 @@ export const deserializeAws_restJson1UpdateEndpointCommand = async (
     $metadata: deserializeMetadata(output),
     MessageBody: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.MessageBody = deserializeAws_restJson1MessageBody(data, context);
   return Promise.resolve(contents);
 };
@@ -14385,7 +14385,7 @@ export const deserializeAws_restJson1UpdateEndpointsBatchCommand = async (
     $metadata: deserializeMetadata(output),
     MessageBody: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.MessageBody = deserializeAws_restJson1MessageBody(data, context);
   return Promise.resolve(contents);
 };
@@ -14486,7 +14486,7 @@ export const deserializeAws_restJson1UpdateGcmChannelCommand = async (
     $metadata: deserializeMetadata(output),
     GCMChannelResponse: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.GCMChannelResponse = deserializeAws_restJson1GCMChannelResponse(data, context);
   return Promise.resolve(contents);
 };
@@ -14587,7 +14587,7 @@ export const deserializeAws_restJson1UpdateJourneyCommand = async (
     $metadata: deserializeMetadata(output),
     JourneyResponse: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.JourneyResponse = deserializeAws_restJson1JourneyResponse(data, context);
   return Promise.resolve(contents);
 };
@@ -14696,7 +14696,7 @@ export const deserializeAws_restJson1UpdateJourneyStateCommand = async (
     $metadata: deserializeMetadata(output),
     JourneyResponse: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.JourneyResponse = deserializeAws_restJson1JourneyResponse(data, context);
   return Promise.resolve(contents);
 };
@@ -14797,7 +14797,7 @@ export const deserializeAws_restJson1UpdatePushTemplateCommand = async (
     $metadata: deserializeMetadata(output),
     MessageBody: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.MessageBody = deserializeAws_restJson1MessageBody(data, context);
   return Promise.resolve(contents);
 };
@@ -14898,7 +14898,7 @@ export const deserializeAws_restJson1UpdateRecommenderConfigurationCommand = asy
     $metadata: deserializeMetadata(output),
     RecommenderConfigurationResponse: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.RecommenderConfigurationResponse = deserializeAws_restJson1RecommenderConfigurationResponse(data, context);
   return Promise.resolve(contents);
 };
@@ -14999,7 +14999,7 @@ export const deserializeAws_restJson1UpdateSegmentCommand = async (
     $metadata: deserializeMetadata(output),
     SegmentResponse: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.SegmentResponse = deserializeAws_restJson1SegmentResponse(data, context);
   return Promise.resolve(contents);
 };
@@ -15100,7 +15100,7 @@ export const deserializeAws_restJson1UpdateSmsChannelCommand = async (
     $metadata: deserializeMetadata(output),
     SMSChannelResponse: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.SMSChannelResponse = deserializeAws_restJson1SMSChannelResponse(data, context);
   return Promise.resolve(contents);
 };
@@ -15201,7 +15201,7 @@ export const deserializeAws_restJson1UpdateSmsTemplateCommand = async (
     $metadata: deserializeMetadata(output),
     MessageBody: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.MessageBody = deserializeAws_restJson1MessageBody(data, context);
   return Promise.resolve(contents);
 };
@@ -15302,7 +15302,7 @@ export const deserializeAws_restJson1UpdateTemplateActiveVersionCommand = async 
     $metadata: deserializeMetadata(output),
     MessageBody: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.MessageBody = deserializeAws_restJson1MessageBody(data, context);
   return Promise.resolve(contents);
 };
@@ -15403,7 +15403,7 @@ export const deserializeAws_restJson1UpdateVoiceChannelCommand = async (
     $metadata: deserializeMetadata(output),
     VoiceChannelResponse: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.VoiceChannelResponse = deserializeAws_restJson1VoiceChannelResponse(data, context);
   return Promise.resolve(contents);
 };
@@ -15504,7 +15504,7 @@ export const deserializeAws_restJson1UpdateVoiceTemplateCommand = async (
     $metadata: deserializeMetadata(output),
     MessageBody: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.MessageBody = deserializeAws_restJson1MessageBody(data, context);
   return Promise.resolve(contents);
 };

--- a/clients/client-quicksight/protocols/Aws_restJson1.ts
+++ b/clients/client-quicksight/protocols/Aws_restJson1.ts
@@ -419,6 +419,7 @@ import {
   expectNumber as __expectNumber,
   expectObject as __expectObject,
   expectString as __expectString,
+  expectUnion as __expectUnion,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   parseEpochTimestamp as __parseEpochTimestamp,
   serializeFloat as __serializeFloat,
@@ -20848,7 +20849,7 @@ const deserializeAws_restJson1DataSource = (output: any, context: __SerdeContext
     DataSourceId: __expectString(output.DataSourceId),
     DataSourceParameters:
       output.DataSourceParameters !== undefined && output.DataSourceParameters !== null
-        ? deserializeAws_restJson1DataSourceParameters(output.DataSourceParameters, context)
+        ? deserializeAws_restJson1DataSourceParameters(__expectUnion(output.DataSourceParameters), context)
         : undefined,
     ErrorInfo:
       output.ErrorInfo !== undefined && output.ErrorInfo !== null
@@ -21013,7 +21014,7 @@ const deserializeAws_restJson1DataSourceParametersList = (
       if (entry === null) {
         return null as any;
       }
-      return deserializeAws_restJson1DataSourceParameters(entry, context);
+      return deserializeAws_restJson1DataSourceParameters(__expectUnion(entry), context);
     });
 };
 
@@ -21510,7 +21511,7 @@ const deserializeAws_restJson1PhysicalTableMap = (
     }
     return {
       ...acc,
-      [key]: deserializeAws_restJson1PhysicalTable(value, context),
+      [key]: deserializeAws_restJson1PhysicalTable(__expectUnion(value), context),
     };
   }, {});
 };
@@ -22171,7 +22172,7 @@ const deserializeAws_restJson1TransformOperationList = (output: any, context: __
       if (entry === null) {
         return null as any;
       }
-      return deserializeAws_restJson1TransformOperation(entry, context);
+      return deserializeAws_restJson1TransformOperation(__expectUnion(entry), context);
     });
 };
 

--- a/clients/client-rds-data/protocols/Aws_restJson1.ts
+++ b/clients/client-rds-data/protocols/Aws_restJson1.ts
@@ -38,6 +38,7 @@ import {
   expectNonNull as __expectNonNull,
   expectObject as __expectObject,
   expectString as __expectString,
+  expectUnion as __expectUnion,
   limitedParseDouble as __limitedParseDouble,
   limitedParseFloat32 as __limitedParseFloat32,
   serializeFloat as __serializeFloat,
@@ -995,7 +996,7 @@ const deserializeAws_restJson1ArrayOfArray = (output: any, context: __SerdeConte
       if (entry === null) {
         return null as any;
       }
-      return deserializeAws_restJson1ArrayValue(entry, context);
+      return deserializeAws_restJson1ArrayValue(__expectUnion(entry), context);
     });
 };
 
@@ -1035,7 +1036,7 @@ const deserializeAws_restJson1ArrayValueList = (output: any, context: __SerdeCon
       if (entry === null) {
         return null as any;
       }
-      return deserializeAws_restJson1Value(entry, context);
+      return deserializeAws_restJson1Value(__expectUnion(entry), context);
     });
 };
 
@@ -1083,7 +1084,7 @@ const deserializeAws_restJson1DoubleArray = (output: any, context: __SerdeContex
 const deserializeAws_restJson1Field = (output: any, context: __SerdeContext): Field => {
   if (output.arrayValue !== undefined && output.arrayValue !== null) {
     return {
-      arrayValue: deserializeAws_restJson1ArrayValue(output.arrayValue, context),
+      arrayValue: deserializeAws_restJson1ArrayValue(__expectUnion(output.arrayValue), context),
     };
   }
   if (output.blobValue !== undefined && output.blobValue !== null) {
@@ -1116,7 +1117,7 @@ const deserializeAws_restJson1FieldList = (output: any, context: __SerdeContext)
       if (entry === null) {
         return null as any;
       }
-      return deserializeAws_restJson1Field(entry, context);
+      return deserializeAws_restJson1Field(__expectUnion(entry), context);
     });
 };
 
@@ -1192,7 +1193,7 @@ const deserializeAws_restJson1Row = (output: any, context: __SerdeContext): Valu
       if (entry === null) {
         return null as any;
       }
-      return deserializeAws_restJson1Value(entry, context);
+      return deserializeAws_restJson1Value(__expectUnion(entry), context);
     });
 };
 

--- a/clients/client-redshift-data/protocols/Aws_json1_1.ts
+++ b/clients/client-redshift-data/protocols/Aws_json1_1.ts
@@ -53,6 +53,7 @@ import {
   expectNonNull as __expectNonNull,
   expectNumber as __expectNumber,
   expectString as __expectString,
+  expectUnion as __expectUnion,
   limitedParseDouble as __limitedParseDouble,
   parseEpochTimestamp as __parseEpochTimestamp,
 } from "@aws-sdk/smithy-client";
@@ -1299,7 +1300,7 @@ const deserializeAws_json1_1FieldList = (output: any, context: __SerdeContext): 
       if (entry === null) {
         return null as any;
       }
-      return deserializeAws_json1_1Field(entry, context);
+      return deserializeAws_json1_1Field(__expectUnion(entry), context);
     });
 };
 

--- a/clients/client-s3-control/protocols/Aws_restXml.ts
+++ b/clients/client-s3-control/protocols/Aws_restXml.ts
@@ -271,6 +271,7 @@ import {
   expectNonNull as __expectNonNull,
   expectObject as __expectObject,
   expectString as __expectString,
+  expectUnion as __expectUnion,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   getArrayIfSingleItem as __getArrayIfSingleItem,
   getValueFromTextNode as __getValueFromTextNode,
@@ -4701,7 +4702,7 @@ export const deserializeAws_restXmlGetPublicAccessBlockCommand = async (
     $metadata: deserializeMetadata(output),
     PublicAccessBlockConfiguration: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.PublicAccessBlockConfiguration = deserializeAws_restXmlPublicAccessBlockConfiguration(data, context);
   return Promise.resolve(contents);
 };
@@ -4754,7 +4755,7 @@ export const deserializeAws_restXmlGetStorageLensConfigurationCommand = async (
     $metadata: deserializeMetadata(output),
     StorageLensConfiguration: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.StorageLensConfiguration = deserializeAws_restXmlStorageLensConfiguration(data, context);
   return Promise.resolve(contents);
 };
@@ -8568,7 +8569,7 @@ const deserializeAws_restXmlObjectLambdaTransformationConfiguration = (
   }
   if (output["ContentTransformation"] !== undefined) {
     contents.ContentTransformation = deserializeAws_restXmlObjectLambdaContentTransformation(
-      output["ContentTransformation"],
+      __expectUnion(output["ContentTransformation"]),
       context
     );
   }

--- a/clients/client-s3/protocols/Aws_restXml.ts
+++ b/clients/client-s3/protocols/Aws_restXml.ts
@@ -395,6 +395,7 @@ import {
   expectNonNull as __expectNonNull,
   expectObject as __expectObject,
   expectString as __expectString,
+  expectUnion as __expectUnion,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   getArrayIfSingleItem as __getArrayIfSingleItem,
   getValueFromTextNode as __getValueFromTextNode,
@@ -5117,7 +5118,7 @@ export const deserializeAws_restXmlCopyObjectCommand = async (
   if (output.headers["x-amz-request-charged"] !== undefined) {
     contents.RequestCharged = output.headers["x-amz-request-charged"];
   }
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.CopyObjectResult = deserializeAws_restXmlCopyObjectResult(data, context);
   return Promise.resolve(contents);
 };
@@ -6190,7 +6191,7 @@ export const deserializeAws_restXmlGetBucketAnalyticsConfigurationCommand = asyn
     $metadata: deserializeMetadata(output),
     AnalyticsConfiguration: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.AnalyticsConfiguration = deserializeAws_restXmlAnalyticsConfiguration(data, context);
   return Promise.resolve(contents);
 };
@@ -6285,7 +6286,7 @@ export const deserializeAws_restXmlGetBucketEncryptionCommand = async (
     $metadata: deserializeMetadata(output),
     ServerSideEncryptionConfiguration: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.ServerSideEncryptionConfiguration = deserializeAws_restXmlServerSideEncryptionConfiguration(data, context);
   return Promise.resolve(contents);
 };
@@ -6330,7 +6331,7 @@ export const deserializeAws_restXmlGetBucketIntelligentTieringConfigurationComma
     $metadata: deserializeMetadata(output),
     IntelligentTieringConfiguration: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.IntelligentTieringConfiguration = deserializeAws_restXmlIntelligentTieringConfiguration(data, context);
   return Promise.resolve(contents);
 };
@@ -6375,7 +6376,7 @@ export const deserializeAws_restXmlGetBucketInventoryConfigurationCommand = asyn
     $metadata: deserializeMetadata(output),
     InventoryConfiguration: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.InventoryConfiguration = deserializeAws_restXmlInventoryConfiguration(data, context);
   return Promise.resolve(contents);
 };
@@ -6564,7 +6565,7 @@ export const deserializeAws_restXmlGetBucketMetricsConfigurationCommand = async 
     $metadata: deserializeMetadata(output),
     MetricsConfiguration: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.MetricsConfiguration = deserializeAws_restXmlMetricsConfiguration(data, context);
   return Promise.resolve(contents);
 };
@@ -6682,7 +6683,7 @@ export const deserializeAws_restXmlGetBucketOwnershipControlsCommand = async (
     $metadata: deserializeMetadata(output),
     OwnershipControls: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.OwnershipControls = deserializeAws_restXmlOwnershipControls(data, context);
   return Promise.resolve(contents);
 };
@@ -6772,7 +6773,7 @@ export const deserializeAws_restXmlGetBucketPolicyStatusCommand = async (
     $metadata: deserializeMetadata(output),
     PolicyStatus: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.PolicyStatus = deserializeAws_restXmlPolicyStatus(data, context);
   return Promise.resolve(contents);
 };
@@ -6817,7 +6818,7 @@ export const deserializeAws_restXmlGetBucketReplicationCommand = async (
     $metadata: deserializeMetadata(output),
     ReplicationConfiguration: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.ReplicationConfiguration = deserializeAws_restXmlReplicationConfiguration(data, context);
   return Promise.resolve(contents);
 };
@@ -7336,7 +7337,7 @@ export const deserializeAws_restXmlGetObjectLegalHoldCommand = async (
     $metadata: deserializeMetadata(output),
     LegalHold: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.LegalHold = deserializeAws_restXmlObjectLockLegalHold(data, context);
   return Promise.resolve(contents);
 };
@@ -7381,7 +7382,7 @@ export const deserializeAws_restXmlGetObjectLockConfigurationCommand = async (
     $metadata: deserializeMetadata(output),
     ObjectLockConfiguration: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.ObjectLockConfiguration = deserializeAws_restXmlObjectLockConfiguration(data, context);
   return Promise.resolve(contents);
 };
@@ -7426,7 +7427,7 @@ export const deserializeAws_restXmlGetObjectRetentionCommand = async (
     $metadata: deserializeMetadata(output),
     Retention: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.Retention = deserializeAws_restXmlObjectLockRetention(data, context);
   return Promise.resolve(contents);
 };
@@ -7574,7 +7575,7 @@ export const deserializeAws_restXmlGetPublicAccessBlockCommand = async (
     $metadata: deserializeMetadata(output),
     PublicAccessBlockConfiguration: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.PublicAccessBlockConfiguration = deserializeAws_restXmlPublicAccessBlockConfiguration(data, context);
   return Promise.resolve(contents);
 };
@@ -10039,7 +10040,7 @@ export const deserializeAws_restXmlUploadPartCopyCommand = async (
   if (output.headers["x-amz-request-charged"] !== undefined) {
     contents.RequestCharged = output.headers["x-amz-request-charged"];
   }
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.CopyPartResult = deserializeAws_restXmlCopyPartResult(data, context);
   return Promise.resolve(contents);
 };
@@ -12623,7 +12624,7 @@ const deserializeAws_restXmlAnalyticsConfiguration = (output: any, context: __Se
     contents.Id = __expectString(output["Id"]);
   }
   if (output["Filter"] !== undefined) {
-    contents.Filter = deserializeAws_restXmlAnalyticsFilter(output["Filter"], context);
+    contents.Filter = deserializeAws_restXmlAnalyticsFilter(__expectUnion(output["Filter"]), context);
   }
   if (output["StorageClassAnalysis"] !== undefined) {
     contents.StorageClassAnalysis = deserializeAws_restXmlStorageClassAnalysis(output["StorageClassAnalysis"], context);
@@ -13509,7 +13510,7 @@ const deserializeAws_restXmlLifecycleRule = (output: any, context: __SerdeContex
     contents.Prefix = __expectString(output["Prefix"]);
   }
   if (output["Filter"] !== undefined) {
-    contents.Filter = deserializeAws_restXmlLifecycleRuleFilter(output["Filter"], context);
+    contents.Filter = deserializeAws_restXmlLifecycleRuleFilter(__expectUnion(output["Filter"]), context);
   }
   if (output["Status"] !== undefined) {
     contents.Status = __expectString(output["Status"]);
@@ -13658,7 +13659,7 @@ const deserializeAws_restXmlMetricsConfiguration = (output: any, context: __Serd
     contents.Id = __expectString(output["Id"]);
   }
   if (output["Filter"] !== undefined) {
-    contents.Filter = deserializeAws_restXmlMetricsFilter(output["Filter"], context);
+    contents.Filter = deserializeAws_restXmlMetricsFilter(__expectUnion(output["Filter"]), context);
   }
   return contents;
 };
@@ -14220,7 +14221,7 @@ const deserializeAws_restXmlReplicationRule = (output: any, context: __SerdeCont
     contents.Prefix = __expectString(output["Prefix"]);
   }
   if (output["Filter"] !== undefined) {
-    contents.Filter = deserializeAws_restXmlReplicationRuleFilter(output["Filter"], context);
+    contents.Filter = deserializeAws_restXmlReplicationRuleFilter(__expectUnion(output["Filter"]), context);
   }
   if (output["Status"] !== undefined) {
     contents.Status = __expectString(output["Status"]);

--- a/clients/client-sagemaker/protocols/Aws_json1_1.ts
+++ b/clients/client-sagemaker/protocols/Aws_json1_1.ts
@@ -1362,6 +1362,7 @@ import {
   expectNonNull as __expectNonNull,
   expectNumber as __expectNumber,
   expectString as __expectString,
+  expectUnion as __expectUnion,
   limitedParseDouble as __limitedParseDouble,
   limitedParseFloat32 as __limitedParseFloat32,
   parseEpochTimestamp as __parseEpochTimestamp,
@@ -33195,7 +33196,7 @@ const deserializeAws_json1_1TrialComponentParameters = (
       }
       return {
         ...acc,
-        [key]: deserializeAws_json1_1TrialComponentParameterValue(value, context),
+        [key]: deserializeAws_json1_1TrialComponentParameterValue(__expectUnion(value), context),
       };
     },
     {}

--- a/clients/client-ssm-incidents/protocols/Aws_restJson1.ts
+++ b/clients/client-ssm-incidents/protocols/Aws_restJson1.ts
@@ -114,6 +114,7 @@ import {
   expectNumber as __expectNumber,
   expectObject as __expectObject,
   expectString as __expectString,
+  expectUnion as __expectUnion,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   parseEpochTimestamp as __parseEpochTimestamp,
 } from "@aws-sdk/smithy-client";
@@ -1922,7 +1923,7 @@ export const deserializeAws_restJson1GetResponsePlanCommand = async (
     contents.arn = __expectString(data.arn);
   }
   if (data.chatChannel !== undefined && data.chatChannel !== null) {
-    contents.chatChannel = deserializeAws_restJson1ChatChannel(data.chatChannel, context);
+    contents.chatChannel = deserializeAws_restJson1ChatChannel(__expectUnion(data.chatChannel), context);
   }
   if (data.displayName !== undefined && data.displayName !== null) {
     contents.displayName = __expectString(data.displayName);
@@ -3978,7 +3979,7 @@ const deserializeAws_restJson1ActionsList = (output: any, context: __SerdeContex
       if (entry === null) {
         return null as any;
       }
-      return deserializeAws_restJson1Action(entry, context);
+      return deserializeAws_restJson1Action(__expectUnion(entry), context);
     });
 };
 
@@ -4000,7 +4001,7 @@ const deserializeAws_restJson1AutomationExecutionSet = (
       if (entry === null) {
         return null as any;
       }
-      const parsedEntry = deserializeAws_restJson1AutomationExecution(entry, context);
+      const parsedEntry = deserializeAws_restJson1AutomationExecution(__expectUnion(entry), context);
       if (uniqueValues.has(parsedEntry)) {
         throw new TypeError(
           'All elements of the set "com.amazonaws.ssmincidents#AutomationExecutionSet" must be unique.'
@@ -4104,7 +4105,7 @@ const deserializeAws_restJson1IncidentRecord = (output: any, context: __SerdeCon
         : undefined,
     chatChannel:
       output.chatChannel !== undefined && output.chatChannel !== null
-        ? deserializeAws_restJson1ChatChannel(output.chatChannel, context)
+        ? deserializeAws_restJson1ChatChannel(__expectUnion(output.chatChannel), context)
         : undefined,
     creationTime:
       output.creationTime !== undefined && output.creationTime !== null
@@ -4197,7 +4198,7 @@ const deserializeAws_restJson1ItemIdentifier = (output: any, context: __SerdeCon
     type: __expectString(output.type),
     value:
       output.value !== undefined && output.value !== null
-        ? deserializeAws_restJson1ItemValue(output.value, context)
+        ? deserializeAws_restJson1ItemValue(__expectUnion(output.value), context)
         : undefined,
   } as any;
 };
@@ -4236,7 +4237,7 @@ const deserializeAws_restJson1NotificationTargetSet = (
       if (entry === null) {
         return null as any;
       }
-      const parsedEntry = deserializeAws_restJson1NotificationTargetItem(entry, context);
+      const parsedEntry = deserializeAws_restJson1NotificationTargetItem(__expectUnion(entry), context);
       if (uniqueValues.has(parsedEntry)) {
         throw new TypeError(
           'All elements of the set "com.amazonaws.ssmincidents#NotificationTargetSet" must be unique.'

--- a/clients/client-transcribe/protocols/Aws_json1_1.ts
+++ b/clients/client-transcribe/protocols/Aws_json1_1.ts
@@ -248,6 +248,7 @@ import {
   expectNonNull as __expectNonNull,
   expectNumber as __expectNumber,
   expectString as __expectString,
+  expectUnion as __expectUnion,
   limitedParseFloat32 as __limitedParseFloat32,
   parseEpochTimestamp as __parseEpochTimestamp,
 } from "@aws-sdk/smithy-client";
@@ -5375,7 +5376,7 @@ const deserializeAws_json1_1RuleList = (output: any, context: __SerdeContext): R
       if (entry === null) {
         return null as any;
       }
-      return deserializeAws_json1_1Rule(entry, context);
+      return deserializeAws_json1_1Rule(__expectUnion(entry), context);
     });
 };
 

--- a/clients/client-xray/protocols/Aws_restJson1.ts
+++ b/clients/client-xray/protocols/Aws_restJson1.ts
@@ -121,6 +121,7 @@ import {
   expectNumber as __expectNumber,
   expectObject as __expectObject,
   expectString as __expectString,
+  expectUnion as __expectUnion,
   limitedParseDouble as __limitedParseDouble,
   parseEpochTimestamp as __parseEpochTimestamp,
   serializeFloat as __serializeFloat,
@@ -4259,7 +4260,7 @@ const deserializeAws_restJson1ValueWithServiceIds = (output: any, context: __Ser
   return {
     AnnotationValue:
       output.AnnotationValue !== undefined && output.AnnotationValue !== null
-        ? deserializeAws_restJson1AnnotationValue(output.AnnotationValue, context)
+        ? deserializeAws_restJson1AnnotationValue(__expectUnion(output.AnnotationValue), context)
         : undefined,
     ServiceIds:
       output.ServiceIds !== undefined && output.ServiceIds !== null

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsProtocolUtils.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsProtocolUtils.java
@@ -322,14 +322,6 @@ final class AwsProtocolUtils {
             return true;
         }
 
-        //TODO: request serialization does not verify that the request is an object
-        if (testCase.hasTag("technically_valid_json_body")) {
-            return true;
-        }
-        //TODO: we don't do any union validation
-        if (testCase.getId().startsWith("RestJsonMalformedUnion")) {
-            return true;
-        }
         //TODO: we don't validate map values
         if (testCase.getId().equals("RestJsonBodyMalformedMapNullValue")) {
             return true;

--- a/protocol_tests/aws-json-10/protocols/Aws_json1_0.ts
+++ b/protocol_tests/aws-json-10/protocols/Aws_json1_0.ts
@@ -40,6 +40,7 @@ import {
   expectNonNull as __expectNonNull,
   expectNumber as __expectNumber,
   expectString as __expectString,
+  expectUnion as __expectUnion,
   limitedParseDouble as __limitedParseDouble,
   limitedParseFloat32 as __limitedParseFloat32,
   parseEpochTimestamp as __parseEpochTimestamp,
@@ -778,7 +779,7 @@ const deserializeAws_json1_0UnionInputOutput = (output: any, context: __SerdeCon
   return {
     contents:
       output.contents !== undefined && output.contents !== null
-        ? deserializeAws_json1_0MyUnion(output.contents, context)
+        ? deserializeAws_json1_0MyUnion(__expectUnion(output.contents), context)
         : undefined,
   } as any;
 };

--- a/protocol_tests/aws-json/protocols/Aws_json1_1.ts
+++ b/protocol_tests/aws-json/protocols/Aws_json1_1.ts
@@ -60,6 +60,7 @@ import {
   expectNonNull as __expectNonNull,
   expectNumber as __expectNumber,
   expectString as __expectString,
+  expectUnion as __expectUnion,
   limitedParseDouble as __limitedParseDouble,
   limitedParseFloat32 as __limitedParseFloat32,
   parseEpochTimestamp as __parseEpochTimestamp,
@@ -1621,7 +1622,7 @@ const deserializeAws_json1_1UnionInputOutput = (output: any, context: __SerdeCon
   return {
     contents:
       output.contents !== undefined && output.contents !== null
-        ? deserializeAws_json1_1MyUnion(output.contents, context)
+        ? deserializeAws_json1_1MyUnion(__expectUnion(output.contents), context)
         : undefined,
   } as any;
 };

--- a/protocol_tests/aws-restjson/protocols/Aws_restJson1.ts
+++ b/protocol_tests/aws-restjson/protocols/Aws_restJson1.ts
@@ -153,6 +153,7 @@ import {
   expectObject as __expectObject,
   expectShort as __expectShort,
   expectString as __expectString,
+  expectUnion as __expectUnion,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   limitedParseDouble as __limitedParseDouble,
   limitedParseFloat32 as __limitedParseFloat32,
@@ -2338,7 +2339,7 @@ export const deserializeAws_restJson1HttpPayloadWithStructureCommand = async (
     $metadata: deserializeMetadata(output),
     nested: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.nested = deserializeAws_restJson1NestedPayload(data, context);
   return Promise.resolve(contents);
 };
@@ -3252,7 +3253,7 @@ export const deserializeAws_restJson1JsonUnionsCommand = async (
   };
   const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.contents !== undefined && data.contents !== null) {
-    contents.contents = deserializeAws_restJson1MyUnion(data.contents, context);
+    contents.contents = deserializeAws_restJson1MyUnion(__expectUnion(data.contents), context);
   }
   return Promise.resolve(contents);
 };

--- a/protocol_tests/aws-restxml/protocols/Aws_restXml.ts
+++ b/protocol_tests/aws-restxml/protocols/Aws_restXml.ts
@@ -163,6 +163,7 @@ import {
   expectNonNull as __expectNonNull,
   expectObject as __expectObject,
   expectString as __expectString,
+  expectUnion as __expectUnion,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   getArrayIfSingleItem as __getArrayIfSingleItem,
   getValueFromTextNode as __getValueFromTextNode,
@@ -2893,7 +2894,7 @@ export const deserializeAws_restXmlHttpPayloadWithMemberXmlNameCommand = async (
     $metadata: deserializeMetadata(output),
     nested: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.nested = deserializeAws_restXmlPayloadWithXmlName(data, context);
   return Promise.resolve(contents);
 };
@@ -2938,7 +2939,7 @@ export const deserializeAws_restXmlHttpPayloadWithStructureCommand = async (
     $metadata: deserializeMetadata(output),
     nested: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.nested = deserializeAws_restXmlNestedPayload(data, context);
   return Promise.resolve(contents);
 };
@@ -2983,7 +2984,7 @@ export const deserializeAws_restXmlHttpPayloadWithXmlNameCommand = async (
     $metadata: deserializeMetadata(output),
     nested: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.nested = deserializeAws_restXmlPayloadWithXmlName(data, context);
   return Promise.resolve(contents);
 };
@@ -3028,7 +3029,7 @@ export const deserializeAws_restXmlHttpPayloadWithXmlNamespaceCommand = async (
     $metadata: deserializeMetadata(output),
     nested: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.nested = deserializeAws_restXmlPayloadWithXmlNamespace(data, context);
   return Promise.resolve(contents);
 };
@@ -3073,7 +3074,7 @@ export const deserializeAws_restXmlHttpPayloadWithXmlNamespaceAndPrefixCommand =
     $metadata: deserializeMetadata(output),
     nested: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.nested = deserializeAws_restXmlPayloadWithXmlNamespaceAndPrefix(data, context);
   return Promise.resolve(contents);
 };
@@ -4230,7 +4231,7 @@ export const deserializeAws_restXmlXmlAttributesOnPayloadCommand = async (
     $metadata: deserializeMetadata(output),
     payload: undefined,
   };
-  const data: object | undefined = __expectObject(await parseBody(output.body, context));
+  const data: { [key: string]: any } | undefined = __expectObject(await parseBody(output.body, context));
   contents.payload = deserializeAws_restXmlXmlAttributesInputOutput(data, context);
   return Promise.resolve(contents);
 };
@@ -5122,7 +5123,7 @@ export const deserializeAws_restXmlXmlUnionsCommand = async (
   };
   const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["unionValue"] !== undefined) {
-    contents.unionValue = deserializeAws_restXmlXmlUnionShape(data["unionValue"], context);
+    contents.unionValue = deserializeAws_restXmlXmlUnionShape(__expectUnion(data["unionValue"]), context);
   }
   return Promise.resolve(contents);
 };
@@ -6030,7 +6031,7 @@ const deserializeAws_restXmlXmlUnionShape = (output: any, context: __SerdeContex
   }
   if (output["unionValue"] !== undefined) {
     return {
-      unionValue: deserializeAws_restXmlXmlUnionShape(output["unionValue"], context),
+      unionValue: deserializeAws_restXmlXmlUnionShape(__expectUnion(output["unionValue"]), context),
     };
   }
   if (output["structValue"] !== undefined) {


### PR DESCRIPTION
### Description
Regenerates clients and protocol tests, and re-enables server protocol tests, based on changes in https://github.com/awslabs/smithy-typescript/pull/414

### Testing
Ran both protocol and server protocol tests locally.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
