### PR TITLE
fix(s3-request-presigner): inject hostname with custom port

### DIFF
--- a/packages/s3-request-presigner/src/presigner.spec.ts
+++ b/packages/s3-request-presigner/src/presigner.spec.ts
@@ -108,11 +108,12 @@ describe("s3 presigner", () => {
     expect(signedHeaders).toContain("x-amz-server-side-encryption-customer-algorithm");
   });
 
-  it("should inject host header if not supplied", async () => {
+  it("should inject host header with port if not supplied", async () => {
     const signer = new S3RequestPresigner(s3ResolvedConfig);
-    const signed = await signer.presign(minimalRequest);
+    const port = 12345;
+    const signed = await signer.presign({ ...minimalRequest, headers: {}, port });
     expect(signed.headers).toMatchObject({
-      host: minimalRequest.hostname,
+      host: `${minimalRequest.hostname}:${port}`,
     });
   });
 });

--- a/packages/s3-request-presigner/src/presigner.ts
+++ b/packages/s3-request-presigner/src/presigner.ts
@@ -45,6 +45,9 @@ export class S3RequestPresigner implements RequestPresigner {
     requestToSign.headers[SHA256_HEADER] = UNSIGNED_PAYLOAD;
     if (!requestToSign.headers["host"]) {
       requestToSign.headers.host = requestToSign.hostname;
+      if (requestToSign.port) {
+        requestToSign.headers.host = `${requestToSign.headers.host}:${requestToSign.port}`;
+      }
     }
     return this.signer.presign(requestToSign, {
       expiresIn: 900,


### PR DESCRIPTION
### Issue
Resolves: #2726

### Description
When presigning requests, the presigner will put the request's hostanme into the `host` header. However, when presigning a request with custom port (not `443`, `80`), the port is missed from the `host` header. Thus the signature will mismatch. This change fixes the issue.

### Testing
Unit test

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
