### PR TITLE
fix(client-s3): remove int validation of object size type

### DIFF
--- a/clients/client-s3/protocols/Aws_restXml.ts
+++ b/clients/client-s3/protocols/Aws_restXml.ts
@@ -13814,7 +13814,7 @@ const deserializeAws_restXml_Object = (output: any, context: __SerdeContext): _O
     contents.ETag = __expectString(output["ETag"]);
   }
   if (output["Size"] !== undefined) {
-    contents.Size = __strictParseInt32(output["Size"]) as number;
+    contents.Size = __strictParseLong(output["Size"]) as number;
   }
   if (output["StorageClass"] !== undefined) {
     contents.StorageClass = __expectString(output["StorageClass"]);
@@ -13902,7 +13902,7 @@ const deserializeAws_restXmlObjectVersion = (output: any, context: __SerdeContex
     contents.ETag = __expectString(output["ETag"]);
   }
   if (output["Size"] !== undefined) {
-    contents.Size = __strictParseInt32(output["Size"]) as number;
+    contents.Size = __strictParseLong(output["Size"]) as number;
   }
   if (output["StorageClass"] !== undefined) {
     contents.StorageClass = __expectString(output["StorageClass"]);
@@ -14004,7 +14004,7 @@ const deserializeAws_restXmlPart = (output: any, context: __SerdeContext): Part 
     contents.ETag = __expectString(output["ETag"]);
   }
   if (output["Size"] !== undefined) {
-    contents.Size = __strictParseInt32(output["Size"]) as number;
+    contents.Size = __strictParseLong(output["Size"]) as number;
   }
   return contents;
 };

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddS3ObjectSizeMemberShapeType.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddS3ObjectSizeMemberShapeType.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.aws.typescript.codegen;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.logging.Logger;
+import software.amazon.smithy.build.PluginContext;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.shapes.LongShape;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.typescript.codegen.TypeScriptSettings;
+import software.amazon.smithy.typescript.codegen.integration.TypeScriptIntegration;
+import software.amazon.smithy.utils.MapUtils;
+import software.amazon.smithy.utils.OptionalUtils;
+import software.amazon.smithy.utils.SetUtils;
+import software.amazon.smithy.utils.SmithyInternalApi;
+
+/**
+ * Transform the S3 object size member from an integer to a long.
+ */
+@SmithyInternalApi
+public final class AddS3ObjectSizeMemberShapeType implements TypeScriptIntegration {
+    private static final Logger LOGGER = Logger.getLogger(AddS3ObjectSizeMemberShapeType.class.getName());
+
+    private static final Map<ShapeId, Set<ShapeId>> SERVICE_TO_SHAPE_MAP = MapUtils.of(
+        ShapeId.from("com.amazonaws.s3#AmazonS3"), SetUtils.of(
+                ShapeId.from("com.amazonaws.s3#Size")
+        )
+    );
+
+    @Override
+    public byte getOrder() {
+        // This integration should happen before other integrations that rely on the presence of this trait
+        return -60;
+    }
+
+    @Override
+    public Model preprocessModel(PluginContext context, TypeScriptSettings settings) {
+        Model model = context.getModel();
+        ShapeId serviceId = settings.getService();
+        if (!SERVICE_TO_SHAPE_MAP.containsKey(serviceId)) {
+            return model;
+        }
+
+        Set<ShapeId> shapeIds = SERVICE_TO_SHAPE_MAP.get(serviceId);
+
+        Model.Builder builder = model.toBuilder();
+        for (ShapeId shapeId : shapeIds) {
+            OptionalUtils.ifPresentOrElse(
+                model.getShape(shapeId),
+                (shape) -> {
+                    if (shape.isLongShape()) {
+                        LOGGER.warning("shape is already modeled as an LONG does not require backfill");
+                        return;
+                    }
+
+                    builder.addShape(LongShape.builder()
+                            .id(shape.getId())
+                            .addTraits(shape.getAllTraits().values())
+                            .build());
+                },
+                () -> LOGGER.warning("shape " + shapeId + " not found in " + serviceId + " model")
+            );
+        }
+
+        return builder.build();
+    }
+}

--- a/codegen/smithy-aws-typescript-codegen/src/main/resources/META-INF/services/software.amazon.smithy.typescript.codegen.integration.TypeScriptIntegration
+++ b/codegen/smithy-aws-typescript-codegen/src/main/resources/META-INF/services/software.amazon.smithy.typescript.codegen.integration.TypeScriptIntegration
@@ -10,6 +10,7 @@ software.amazon.smithy.aws.typescript.codegen.AddSqsDependency
 software.amazon.smithy.aws.typescript.codegen.AddBodyChecksumGeneratorDependency
 software.amazon.smithy.aws.typescript.codegen.AddS3Config
 software.amazon.smithy.aws.typescript.codegen.AddS3ControlDependency
+software.amazon.smithy.aws.typescript.codegen.AddS3ObjectSizeMemberShapeType
 software.amazon.smithy.aws.typescript.codegen.AddEventStreamHandlingDependency
 software.amazon.smithy.aws.typescript.codegen.AddHttp2Dependency
 software.amazon.smithy.aws.typescript.codegen.AddTranscribeStreamingDependency


### PR DESCRIPTION
### Issue
Resolves: #2751 
Reference: https://github.com/aws/aws-sdk-go-v2/pull/767

### Description
Add customization to S3 model to change `Size` shape from integer to long. This will unblock the object size longer than the integer range.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
