### PR TITLE
fix(base64): validate base64 strings

### DIFF
--- a/packages/util-base64-browser/src/index.spec.ts
+++ b/packages/util-base64-browser/src/index.spec.ts
@@ -35,4 +35,10 @@ describe("fromBase64", () => {
   it("should convert double padded base64 strings to Uint8Arrays", () => {
     expect(fromBase64(b64DoublePadded)).toEqual(doublePadded);
   });
+
+  describe("should reject invalid base64 strings", () => {
+    it.each(["Rg", "Rg=", "[][]", "-_=="])("rejects '%s'", (value) => {
+      expect(() => fromBase64(value)).toThrowError();
+    });
+  });
 });

--- a/packages/util-base64-browser/src/index.ts
+++ b/packages/util-base64-browser/src/index.ts
@@ -52,6 +52,11 @@ export function fromBase64(input: string): Uint8Array {
     let bitLength = 0;
     for (let j = i, limit = i + 3; j <= limit; j++) {
       if (input[j] !== "=") {
+        // If we don't check for this, we'll end up using undefined in a bitwise
+        // operation, in which it will be treated as 0.
+        if (!(input[j] in alphabetByEncoding)) {
+          throw new TypeError(`Invalid character ${input[j]} in base64 string.`);
+        }
         bits |= alphabetByEncoding[input[j]] << ((limit - j) * bitsPerLetter);
         bitLength += bitsPerLetter;
       } else {

--- a/packages/util-base64-node/src/index.spec.ts
+++ b/packages/util-base64-node/src/index.spec.ts
@@ -43,4 +43,10 @@ describe("fromBase64", () => {
   it("should throw when given a number", () => {
     expect(() => fromBase64(0xdeadbeefface as any)).toThrow();
   });
+
+  describe("should reject invalid base64 strings", () => {
+    it.each(["Rg", "Rg=", "[][]", "-_=="])("rejects '%s'", (value) => {
+      expect(() => fromBase64(value)).toThrowError();
+    });
+  });
 });

--- a/packages/util-base64-node/src/index.ts
+++ b/packages/util-base64-node/src/index.ts
@@ -1,5 +1,7 @@
 import { fromArrayBuffer, fromString } from "@aws-sdk/util-buffer-from";
 
+const BASE64_REGEX = /^[A-Za-z0-9+/]*={0,2}$/;
+
 /**
  * Converts a base-64 encoded string to a Uint8Array of bytes using Node.JS's
  * `buffer` module.
@@ -7,6 +9,20 @@ import { fromArrayBuffer, fromString } from "@aws-sdk/util-buffer-from";
  * @param input The base-64 encoded string
  */
 export function fromBase64(input: string): Uint8Array {
+  // Node's buffer module allows padding to be omitted, but we want to enforce
+  // it. So here we ensure that the input represents a number of bits divisible
+  // by 8. Each character represents 6 bits, so after reducing the fraction we
+  // end up mulitplying by 3/4 and checking for a remainder.
+  if ((input.length * 3) % 4 !== 0) {
+    throw new TypeError(`Incorrect padding on base64 string.`);
+  }
+
+  // Node will just ingore invalid characters, so we need to make sure they're
+  // properly rejected.
+  if (!BASE64_REGEX.exec(input)) {
+    throw new TypeError(`Invalid base64 string.`);
+  }
+
   const buffer = fromString(input, "base64");
 
   return new Uint8Array(buffer.buffer, buffer.byteOffset, buffer.byteLength);


### PR DESCRIPTION
### Issue

n/a

### Description

This updates the node and browser base64 parsers to validate the input string before parsing.

Node previously would just ignore invalid characters and treat padding as optional. The browser implementation required padding, but had a bug where invalid characters were treated as 0.

### Testing

Additional unit tests were added.

### Additional context

n/a

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
