### PR TITLE
fix: provide ES module wrapper using conditional exports

### DIFF
--- a/clients/client-accessanalyzer/package.json
+++ b/clients/client-accessanalyzer/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-accessanalyzer/package.json
+++ b/clients/client-accessanalyzer/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-acm-pca/package.json
+++ b/clients/client-acm-pca/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-acm-pca/package.json
+++ b/clients/client-acm-pca/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-acm/package.json
+++ b/clients/client-acm/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-acm/package.json
+++ b/clients/client-acm/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-alexa-for-business/package.json
+++ b/clients/client-alexa-for-business/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-alexa-for-business/package.json
+++ b/clients/client-alexa-for-business/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-amp/package.json
+++ b/clients/client-amp/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-amp/package.json
+++ b/clients/client-amp/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-amplify/package.json
+++ b/clients/client-amplify/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-amplify/package.json
+++ b/clients/client-amplify/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-amplifybackend/package.json
+++ b/clients/client-amplifybackend/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-amplifybackend/package.json
+++ b/clients/client-amplifybackend/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-api-gateway/package.json
+++ b/clients/client-api-gateway/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-api-gateway/package.json
+++ b/clients/client-api-gateway/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-apigatewaymanagementapi/package.json
+++ b/clients/client-apigatewaymanagementapi/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-apigatewaymanagementapi/package.json
+++ b/clients/client-apigatewaymanagementapi/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-apigatewayv2/package.json
+++ b/clients/client-apigatewayv2/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-apigatewayv2/package.json
+++ b/clients/client-apigatewayv2/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-app-mesh/package.json
+++ b/clients/client-app-mesh/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-app-mesh/package.json
+++ b/clients/client-app-mesh/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-appconfig/package.json
+++ b/clients/client-appconfig/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-appconfig/package.json
+++ b/clients/client-appconfig/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-appflow/package.json
+++ b/clients/client-appflow/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-appflow/package.json
+++ b/clients/client-appflow/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-appintegrations/package.json
+++ b/clients/client-appintegrations/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-appintegrations/package.json
+++ b/clients/client-appintegrations/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-application-auto-scaling/package.json
+++ b/clients/client-application-auto-scaling/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-application-auto-scaling/package.json
+++ b/clients/client-application-auto-scaling/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-application-discovery-service/package.json
+++ b/clients/client-application-discovery-service/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-application-discovery-service/package.json
+++ b/clients/client-application-discovery-service/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-application-insights/package.json
+++ b/clients/client-application-insights/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-application-insights/package.json
+++ b/clients/client-application-insights/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-applicationcostprofiler/package.json
+++ b/clients/client-applicationcostprofiler/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-applicationcostprofiler/package.json
+++ b/clients/client-applicationcostprofiler/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-apprunner/package.json
+++ b/clients/client-apprunner/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-apprunner/package.json
+++ b/clients/client-apprunner/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-appstream/package.json
+++ b/clients/client-appstream/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-appstream/package.json
+++ b/clients/client-appstream/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-appsync/package.json
+++ b/clients/client-appsync/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-appsync/package.json
+++ b/clients/client-appsync/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-athena/package.json
+++ b/clients/client-athena/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-athena/package.json
+++ b/clients/client-athena/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-auditmanager/package.json
+++ b/clients/client-auditmanager/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-auditmanager/package.json
+++ b/clients/client-auditmanager/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-auto-scaling-plans/package.json
+++ b/clients/client-auto-scaling-plans/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-auto-scaling-plans/package.json
+++ b/clients/client-auto-scaling-plans/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-auto-scaling/package.json
+++ b/clients/client-auto-scaling/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-auto-scaling/package.json
+++ b/clients/client-auto-scaling/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-backup/package.json
+++ b/clients/client-backup/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-backup/package.json
+++ b/clients/client-backup/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-batch/package.json
+++ b/clients/client-batch/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-batch/package.json
+++ b/clients/client-batch/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-braket/package.json
+++ b/clients/client-braket/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-braket/package.json
+++ b/clients/client-braket/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-budgets/package.json
+++ b/clients/client-budgets/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-budgets/package.json
+++ b/clients/client-budgets/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-chime-sdk-identity/package.json
+++ b/clients/client-chime-sdk-identity/package.json
@@ -15,6 +15,10 @@
     "build": "yarn build:cjs && yarn build:es"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-chime-sdk-identity/package.json
+++ b/clients/client-chime-sdk-identity/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-chime-sdk-messaging/package.json
+++ b/clients/client-chime-sdk-messaging/package.json
@@ -15,6 +15,10 @@
     "build": "yarn build:cjs && yarn build:es"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-chime-sdk-messaging/package.json
+++ b/clients/client-chime-sdk-messaging/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-chime/package.json
+++ b/clients/client-chime/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-chime/package.json
+++ b/clients/client-chime/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-cloud9/package.json
+++ b/clients/client-cloud9/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-cloud9/package.json
+++ b/clients/client-cloud9/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-clouddirectory/package.json
+++ b/clients/client-clouddirectory/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-clouddirectory/package.json
+++ b/clients/client-clouddirectory/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-cloudformation/package.json
+++ b/clients/client-cloudformation/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-cloudformation/package.json
+++ b/clients/client-cloudformation/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-cloudfront/package.json
+++ b/clients/client-cloudfront/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-cloudfront/package.json
+++ b/clients/client-cloudfront/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-cloudhsm-v2/package.json
+++ b/clients/client-cloudhsm-v2/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-cloudhsm-v2/package.json
+++ b/clients/client-cloudhsm-v2/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-cloudhsm/package.json
+++ b/clients/client-cloudhsm/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-cloudhsm/package.json
+++ b/clients/client-cloudhsm/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-cloudsearch-domain/package.json
+++ b/clients/client-cloudsearch-domain/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-cloudsearch-domain/package.json
+++ b/clients/client-cloudsearch-domain/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-cloudsearch/package.json
+++ b/clients/client-cloudsearch/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-cloudsearch/package.json
+++ b/clients/client-cloudsearch/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-cloudtrail/package.json
+++ b/clients/client-cloudtrail/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-cloudtrail/package.json
+++ b/clients/client-cloudtrail/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-cloudwatch-events/package.json
+++ b/clients/client-cloudwatch-events/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-cloudwatch-events/package.json
+++ b/clients/client-cloudwatch-events/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-cloudwatch-logs/package.json
+++ b/clients/client-cloudwatch-logs/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-cloudwatch-logs/package.json
+++ b/clients/client-cloudwatch-logs/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-cloudwatch/package.json
+++ b/clients/client-cloudwatch/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-cloudwatch/package.json
+++ b/clients/client-cloudwatch/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-codeartifact/package.json
+++ b/clients/client-codeartifact/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-codeartifact/package.json
+++ b/clients/client-codeartifact/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-codebuild/package.json
+++ b/clients/client-codebuild/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-codebuild/package.json
+++ b/clients/client-codebuild/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-codecommit/package.json
+++ b/clients/client-codecommit/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-codecommit/package.json
+++ b/clients/client-codecommit/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-codedeploy/package.json
+++ b/clients/client-codedeploy/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-codedeploy/package.json
+++ b/clients/client-codedeploy/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-codeguru-reviewer/package.json
+++ b/clients/client-codeguru-reviewer/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-codeguru-reviewer/package.json
+++ b/clients/client-codeguru-reviewer/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-codeguruprofiler/package.json
+++ b/clients/client-codeguruprofiler/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-codeguruprofiler/package.json
+++ b/clients/client-codeguruprofiler/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-codepipeline/package.json
+++ b/clients/client-codepipeline/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-codepipeline/package.json
+++ b/clients/client-codepipeline/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-codestar-connections/package.json
+++ b/clients/client-codestar-connections/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-codestar-connections/package.json
+++ b/clients/client-codestar-connections/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-codestar-notifications/package.json
+++ b/clients/client-codestar-notifications/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-codestar-notifications/package.json
+++ b/clients/client-codestar-notifications/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-codestar/package.json
+++ b/clients/client-codestar/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-codestar/package.json
+++ b/clients/client-codestar/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-cognito-identity-provider/package.json
+++ b/clients/client-cognito-identity-provider/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-cognito-identity-provider/package.json
+++ b/clients/client-cognito-identity-provider/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-cognito-identity/package.json
+++ b/clients/client-cognito-identity/package.json
@@ -17,6 +17,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-cognito-identity/package.json
+++ b/clients/client-cognito-identity/package.json
@@ -21,6 +21,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-cognito-sync/package.json
+++ b/clients/client-cognito-sync/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-cognito-sync/package.json
+++ b/clients/client-cognito-sync/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-comprehend/package.json
+++ b/clients/client-comprehend/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-comprehend/package.json
+++ b/clients/client-comprehend/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-comprehendmedical/package.json
+++ b/clients/client-comprehendmedical/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-comprehendmedical/package.json
+++ b/clients/client-comprehendmedical/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-compute-optimizer/package.json
+++ b/clients/client-compute-optimizer/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-compute-optimizer/package.json
+++ b/clients/client-compute-optimizer/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-config-service/package.json
+++ b/clients/client-config-service/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-config-service/package.json
+++ b/clients/client-config-service/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-connect-contact-lens/package.json
+++ b/clients/client-connect-contact-lens/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-connect-contact-lens/package.json
+++ b/clients/client-connect-contact-lens/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-connect/package.json
+++ b/clients/client-connect/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-connect/package.json
+++ b/clients/client-connect/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-connectparticipant/package.json
+++ b/clients/client-connectparticipant/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-connectparticipant/package.json
+++ b/clients/client-connectparticipant/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-cost-and-usage-report-service/package.json
+++ b/clients/client-cost-and-usage-report-service/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-cost-and-usage-report-service/package.json
+++ b/clients/client-cost-and-usage-report-service/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-cost-explorer/package.json
+++ b/clients/client-cost-explorer/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-cost-explorer/package.json
+++ b/clients/client-cost-explorer/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-customer-profiles/package.json
+++ b/clients/client-customer-profiles/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-customer-profiles/package.json
+++ b/clients/client-customer-profiles/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-data-pipeline/package.json
+++ b/clients/client-data-pipeline/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-data-pipeline/package.json
+++ b/clients/client-data-pipeline/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-database-migration-service/package.json
+++ b/clients/client-database-migration-service/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-database-migration-service/package.json
+++ b/clients/client-database-migration-service/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-databrew/package.json
+++ b/clients/client-databrew/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-databrew/package.json
+++ b/clients/client-databrew/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-dataexchange/package.json
+++ b/clients/client-dataexchange/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-dataexchange/package.json
+++ b/clients/client-dataexchange/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-datasync/package.json
+++ b/clients/client-datasync/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-datasync/package.json
+++ b/clients/client-datasync/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-dax/package.json
+++ b/clients/client-dax/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-dax/package.json
+++ b/clients/client-dax/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-detective/package.json
+++ b/clients/client-detective/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-detective/package.json
+++ b/clients/client-detective/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-device-farm/package.json
+++ b/clients/client-device-farm/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-device-farm/package.json
+++ b/clients/client-device-farm/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-devops-guru/package.json
+++ b/clients/client-devops-guru/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-devops-guru/package.json
+++ b/clients/client-devops-guru/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-direct-connect/package.json
+++ b/clients/client-direct-connect/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-direct-connect/package.json
+++ b/clients/client-direct-connect/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-directory-service/package.json
+++ b/clients/client-directory-service/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-directory-service/package.json
+++ b/clients/client-directory-service/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-dlm/package.json
+++ b/clients/client-dlm/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-dlm/package.json
+++ b/clients/client-dlm/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-docdb/package.json
+++ b/clients/client-docdb/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-docdb/package.json
+++ b/clients/client-docdb/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-dynamodb-streams/package.json
+++ b/clients/client-dynamodb-streams/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-dynamodb-streams/package.json
+++ b/clients/client-dynamodb-streams/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-dynamodb/package.json
+++ b/clients/client-dynamodb/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-dynamodb/package.json
+++ b/clients/client-dynamodb/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-ebs/package.json
+++ b/clients/client-ebs/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-ebs/package.json
+++ b/clients/client-ebs/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-ec2-instance-connect/package.json
+++ b/clients/client-ec2-instance-connect/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-ec2-instance-connect/package.json
+++ b/clients/client-ec2-instance-connect/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-ec2/package.json
+++ b/clients/client-ec2/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-ec2/package.json
+++ b/clients/client-ec2/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-ecr-public/package.json
+++ b/clients/client-ecr-public/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-ecr-public/package.json
+++ b/clients/client-ecr-public/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-ecr/package.json
+++ b/clients/client-ecr/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-ecr/package.json
+++ b/clients/client-ecr/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-ecs/package.json
+++ b/clients/client-ecs/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-ecs/package.json
+++ b/clients/client-ecs/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-efs/package.json
+++ b/clients/client-efs/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-efs/package.json
+++ b/clients/client-efs/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-eks/package.json
+++ b/clients/client-eks/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-eks/package.json
+++ b/clients/client-eks/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-elastic-beanstalk/package.json
+++ b/clients/client-elastic-beanstalk/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-elastic-beanstalk/package.json
+++ b/clients/client-elastic-beanstalk/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-elastic-inference/package.json
+++ b/clients/client-elastic-inference/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-elastic-inference/package.json
+++ b/clients/client-elastic-inference/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-elastic-load-balancing-v2/package.json
+++ b/clients/client-elastic-load-balancing-v2/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-elastic-load-balancing-v2/package.json
+++ b/clients/client-elastic-load-balancing-v2/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-elastic-load-balancing/package.json
+++ b/clients/client-elastic-load-balancing/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-elastic-load-balancing/package.json
+++ b/clients/client-elastic-load-balancing/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-elastic-transcoder/package.json
+++ b/clients/client-elastic-transcoder/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-elastic-transcoder/package.json
+++ b/clients/client-elastic-transcoder/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-elasticache/package.json
+++ b/clients/client-elasticache/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-elasticache/package.json
+++ b/clients/client-elasticache/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-elasticsearch-service/package.json
+++ b/clients/client-elasticsearch-service/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-elasticsearch-service/package.json
+++ b/clients/client-elasticsearch-service/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-emr-containers/package.json
+++ b/clients/client-emr-containers/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-emr-containers/package.json
+++ b/clients/client-emr-containers/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-emr/package.json
+++ b/clients/client-emr/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-emr/package.json
+++ b/clients/client-emr/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-eventbridge/package.json
+++ b/clients/client-eventbridge/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-eventbridge/package.json
+++ b/clients/client-eventbridge/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-finspace-data/package.json
+++ b/clients/client-finspace-data/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-finspace-data/package.json
+++ b/clients/client-finspace-data/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-finspace/package.json
+++ b/clients/client-finspace/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-finspace/package.json
+++ b/clients/client-finspace/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-firehose/package.json
+++ b/clients/client-firehose/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-firehose/package.json
+++ b/clients/client-firehose/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-fis/package.json
+++ b/clients/client-fis/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-fis/package.json
+++ b/clients/client-fis/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-fms/package.json
+++ b/clients/client-fms/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-fms/package.json
+++ b/clients/client-fms/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-forecast/package.json
+++ b/clients/client-forecast/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-forecast/package.json
+++ b/clients/client-forecast/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-forecastquery/package.json
+++ b/clients/client-forecastquery/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-forecastquery/package.json
+++ b/clients/client-forecastquery/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-frauddetector/package.json
+++ b/clients/client-frauddetector/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-frauddetector/package.json
+++ b/clients/client-frauddetector/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-fsx/package.json
+++ b/clients/client-fsx/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-fsx/package.json
+++ b/clients/client-fsx/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-gamelift/package.json
+++ b/clients/client-gamelift/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-gamelift/package.json
+++ b/clients/client-gamelift/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-glacier/package.json
+++ b/clients/client-glacier/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-glacier/package.json
+++ b/clients/client-glacier/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-global-accelerator/package.json
+++ b/clients/client-global-accelerator/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-global-accelerator/package.json
+++ b/clients/client-global-accelerator/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-glue/package.json
+++ b/clients/client-glue/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-glue/package.json
+++ b/clients/client-glue/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-greengrass/package.json
+++ b/clients/client-greengrass/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-greengrass/package.json
+++ b/clients/client-greengrass/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-greengrassv2/package.json
+++ b/clients/client-greengrassv2/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-greengrassv2/package.json
+++ b/clients/client-greengrassv2/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-groundstation/package.json
+++ b/clients/client-groundstation/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-groundstation/package.json
+++ b/clients/client-groundstation/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-guardduty/package.json
+++ b/clients/client-guardduty/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-guardduty/package.json
+++ b/clients/client-guardduty/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-health/package.json
+++ b/clients/client-health/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-health/package.json
+++ b/clients/client-health/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-healthlake/package.json
+++ b/clients/client-healthlake/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-healthlake/package.json
+++ b/clients/client-healthlake/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-honeycode/package.json
+++ b/clients/client-honeycode/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-honeycode/package.json
+++ b/clients/client-honeycode/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-iam/package.json
+++ b/clients/client-iam/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-iam/package.json
+++ b/clients/client-iam/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-identitystore/package.json
+++ b/clients/client-identitystore/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-identitystore/package.json
+++ b/clients/client-identitystore/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-imagebuilder/package.json
+++ b/clients/client-imagebuilder/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-imagebuilder/package.json
+++ b/clients/client-imagebuilder/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-inspector/package.json
+++ b/clients/client-inspector/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-inspector/package.json
+++ b/clients/client-inspector/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-iot-1click-devices-service/package.json
+++ b/clients/client-iot-1click-devices-service/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-iot-1click-devices-service/package.json
+++ b/clients/client-iot-1click-devices-service/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-iot-1click-projects/package.json
+++ b/clients/client-iot-1click-projects/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-iot-1click-projects/package.json
+++ b/clients/client-iot-1click-projects/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-iot-data-plane/package.json
+++ b/clients/client-iot-data-plane/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-iot-data-plane/package.json
+++ b/clients/client-iot-data-plane/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-iot-events-data/package.json
+++ b/clients/client-iot-events-data/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-iot-events-data/package.json
+++ b/clients/client-iot-events-data/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-iot-events/package.json
+++ b/clients/client-iot-events/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-iot-events/package.json
+++ b/clients/client-iot-events/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-iot-jobs-data-plane/package.json
+++ b/clients/client-iot-jobs-data-plane/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-iot-jobs-data-plane/package.json
+++ b/clients/client-iot-jobs-data-plane/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-iot-wireless/package.json
+++ b/clients/client-iot-wireless/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-iot-wireless/package.json
+++ b/clients/client-iot-wireless/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-iot/package.json
+++ b/clients/client-iot/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-iot/package.json
+++ b/clients/client-iot/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-iotanalytics/package.json
+++ b/clients/client-iotanalytics/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-iotanalytics/package.json
+++ b/clients/client-iotanalytics/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-iotdeviceadvisor/package.json
+++ b/clients/client-iotdeviceadvisor/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-iotdeviceadvisor/package.json
+++ b/clients/client-iotdeviceadvisor/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-iotfleethub/package.json
+++ b/clients/client-iotfleethub/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-iotfleethub/package.json
+++ b/clients/client-iotfleethub/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-iotsecuretunneling/package.json
+++ b/clients/client-iotsecuretunneling/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-iotsecuretunneling/package.json
+++ b/clients/client-iotsecuretunneling/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-iotsitewise/package.json
+++ b/clients/client-iotsitewise/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-iotsitewise/package.json
+++ b/clients/client-iotsitewise/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-iotthingsgraph/package.json
+++ b/clients/client-iotthingsgraph/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-iotthingsgraph/package.json
+++ b/clients/client-iotthingsgraph/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-ivs/package.json
+++ b/clients/client-ivs/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-ivs/package.json
+++ b/clients/client-ivs/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-kafka/package.json
+++ b/clients/client-kafka/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-kafka/package.json
+++ b/clients/client-kafka/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-kendra/package.json
+++ b/clients/client-kendra/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-kendra/package.json
+++ b/clients/client-kendra/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-kinesis-analytics-v2/package.json
+++ b/clients/client-kinesis-analytics-v2/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-kinesis-analytics-v2/package.json
+++ b/clients/client-kinesis-analytics-v2/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-kinesis-analytics/package.json
+++ b/clients/client-kinesis-analytics/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-kinesis-analytics/package.json
+++ b/clients/client-kinesis-analytics/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-kinesis-video-archived-media/package.json
+++ b/clients/client-kinesis-video-archived-media/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-kinesis-video-archived-media/package.json
+++ b/clients/client-kinesis-video-archived-media/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-kinesis-video-media/package.json
+++ b/clients/client-kinesis-video-media/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-kinesis-video-media/package.json
+++ b/clients/client-kinesis-video-media/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-kinesis-video-signaling/package.json
+++ b/clients/client-kinesis-video-signaling/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-kinesis-video-signaling/package.json
+++ b/clients/client-kinesis-video-signaling/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-kinesis-video/package.json
+++ b/clients/client-kinesis-video/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-kinesis-video/package.json
+++ b/clients/client-kinesis-video/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-kinesis/package.json
+++ b/clients/client-kinesis/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-kinesis/package.json
+++ b/clients/client-kinesis/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-kms/package.json
+++ b/clients/client-kms/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-kms/package.json
+++ b/clients/client-kms/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-lakeformation/package.json
+++ b/clients/client-lakeformation/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-lakeformation/package.json
+++ b/clients/client-lakeformation/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-lambda/package.json
+++ b/clients/client-lambda/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-lambda/package.json
+++ b/clients/client-lambda/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-lex-model-building-service/package.json
+++ b/clients/client-lex-model-building-service/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-lex-model-building-service/package.json
+++ b/clients/client-lex-model-building-service/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-lex-models-v2/package.json
+++ b/clients/client-lex-models-v2/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-lex-models-v2/package.json
+++ b/clients/client-lex-models-v2/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-lex-runtime-service/package.json
+++ b/clients/client-lex-runtime-service/package.json
@@ -20,6 +20,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-lex-runtime-service/package.json
+++ b/clients/client-lex-runtime-service/package.json
@@ -16,6 +16,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-lex-runtime-v2/package.json
+++ b/clients/client-lex-runtime-v2/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-lex-runtime-v2/package.json
+++ b/clients/client-lex-runtime-v2/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-license-manager/package.json
+++ b/clients/client-license-manager/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-license-manager/package.json
+++ b/clients/client-license-manager/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-lightsail/package.json
+++ b/clients/client-lightsail/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-lightsail/package.json
+++ b/clients/client-lightsail/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-location/package.json
+++ b/clients/client-location/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-location/package.json
+++ b/clients/client-location/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-lookoutequipment/package.json
+++ b/clients/client-lookoutequipment/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-lookoutequipment/package.json
+++ b/clients/client-lookoutequipment/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-lookoutmetrics/package.json
+++ b/clients/client-lookoutmetrics/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-lookoutmetrics/package.json
+++ b/clients/client-lookoutmetrics/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-lookoutvision/package.json
+++ b/clients/client-lookoutvision/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-lookoutvision/package.json
+++ b/clients/client-lookoutvision/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-machine-learning/package.json
+++ b/clients/client-machine-learning/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-machine-learning/package.json
+++ b/clients/client-machine-learning/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-macie/package.json
+++ b/clients/client-macie/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-macie/package.json
+++ b/clients/client-macie/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-macie2/package.json
+++ b/clients/client-macie2/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-macie2/package.json
+++ b/clients/client-macie2/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-managedblockchain/package.json
+++ b/clients/client-managedblockchain/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-managedblockchain/package.json
+++ b/clients/client-managedblockchain/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-marketplace-catalog/package.json
+++ b/clients/client-marketplace-catalog/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-marketplace-catalog/package.json
+++ b/clients/client-marketplace-catalog/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-marketplace-commerce-analytics/package.json
+++ b/clients/client-marketplace-commerce-analytics/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-marketplace-commerce-analytics/package.json
+++ b/clients/client-marketplace-commerce-analytics/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-marketplace-entitlement-service/package.json
+++ b/clients/client-marketplace-entitlement-service/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-marketplace-entitlement-service/package.json
+++ b/clients/client-marketplace-entitlement-service/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-marketplace-metering/package.json
+++ b/clients/client-marketplace-metering/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-marketplace-metering/package.json
+++ b/clients/client-marketplace-metering/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-mediaconnect/package.json
+++ b/clients/client-mediaconnect/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-mediaconnect/package.json
+++ b/clients/client-mediaconnect/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-mediaconvert/package.json
+++ b/clients/client-mediaconvert/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-mediaconvert/package.json
+++ b/clients/client-mediaconvert/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-medialive/package.json
+++ b/clients/client-medialive/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-medialive/package.json
+++ b/clients/client-medialive/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-mediapackage-vod/package.json
+++ b/clients/client-mediapackage-vod/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-mediapackage-vod/package.json
+++ b/clients/client-mediapackage-vod/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-mediapackage/package.json
+++ b/clients/client-mediapackage/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-mediapackage/package.json
+++ b/clients/client-mediapackage/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-mediastore-data/package.json
+++ b/clients/client-mediastore-data/package.json
@@ -20,6 +20,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-mediastore-data/package.json
+++ b/clients/client-mediastore-data/package.json
@@ -16,6 +16,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-mediastore/package.json
+++ b/clients/client-mediastore/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-mediastore/package.json
+++ b/clients/client-mediastore/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-mediatailor/package.json
+++ b/clients/client-mediatailor/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-mediatailor/package.json
+++ b/clients/client-mediatailor/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-memorydb/package.json
+++ b/clients/client-memorydb/package.json
@@ -15,6 +15,10 @@
     "build": "yarn build:cjs && yarn build:es"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-memorydb/package.json
+++ b/clients/client-memorydb/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-mgn/package.json
+++ b/clients/client-mgn/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-mgn/package.json
+++ b/clients/client-mgn/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-migration-hub/package.json
+++ b/clients/client-migration-hub/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-migration-hub/package.json
+++ b/clients/client-migration-hub/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-migrationhub-config/package.json
+++ b/clients/client-migrationhub-config/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-migrationhub-config/package.json
+++ b/clients/client-migrationhub-config/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-mobile/package.json
+++ b/clients/client-mobile/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-mobile/package.json
+++ b/clients/client-mobile/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-mq/package.json
+++ b/clients/client-mq/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-mq/package.json
+++ b/clients/client-mq/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-mturk/package.json
+++ b/clients/client-mturk/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-mturk/package.json
+++ b/clients/client-mturk/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-mwaa/package.json
+++ b/clients/client-mwaa/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-mwaa/package.json
+++ b/clients/client-mwaa/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-neptune/package.json
+++ b/clients/client-neptune/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-neptune/package.json
+++ b/clients/client-neptune/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-network-firewall/package.json
+++ b/clients/client-network-firewall/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-network-firewall/package.json
+++ b/clients/client-network-firewall/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-networkmanager/package.json
+++ b/clients/client-networkmanager/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-networkmanager/package.json
+++ b/clients/client-networkmanager/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-nimble/package.json
+++ b/clients/client-nimble/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-nimble/package.json
+++ b/clients/client-nimble/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-opensearch/package.json
+++ b/clients/client-opensearch/package.json
@@ -15,6 +15,10 @@
     "build": "yarn build:cjs && yarn build:es"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-opensearch/package.json
+++ b/clients/client-opensearch/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-opsworks/package.json
+++ b/clients/client-opsworks/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-opsworks/package.json
+++ b/clients/client-opsworks/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-opsworkscm/package.json
+++ b/clients/client-opsworkscm/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-opsworkscm/package.json
+++ b/clients/client-opsworkscm/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-organizations/package.json
+++ b/clients/client-organizations/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-organizations/package.json
+++ b/clients/client-organizations/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-outposts/package.json
+++ b/clients/client-outposts/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-outposts/package.json
+++ b/clients/client-outposts/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-personalize-events/package.json
+++ b/clients/client-personalize-events/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-personalize-events/package.json
+++ b/clients/client-personalize-events/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-personalize-runtime/package.json
+++ b/clients/client-personalize-runtime/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-personalize-runtime/package.json
+++ b/clients/client-personalize-runtime/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-personalize/package.json
+++ b/clients/client-personalize/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-personalize/package.json
+++ b/clients/client-personalize/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-pi/package.json
+++ b/clients/client-pi/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-pi/package.json
+++ b/clients/client-pi/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-pinpoint-email/package.json
+++ b/clients/client-pinpoint-email/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-pinpoint-email/package.json
+++ b/clients/client-pinpoint-email/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-pinpoint-sms-voice/package.json
+++ b/clients/client-pinpoint-sms-voice/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-pinpoint-sms-voice/package.json
+++ b/clients/client-pinpoint-sms-voice/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-pinpoint/package.json
+++ b/clients/client-pinpoint/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-pinpoint/package.json
+++ b/clients/client-pinpoint/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-polly/package.json
+++ b/clients/client-polly/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-polly/package.json
+++ b/clients/client-polly/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-pricing/package.json
+++ b/clients/client-pricing/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-pricing/package.json
+++ b/clients/client-pricing/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-proton/package.json
+++ b/clients/client-proton/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-proton/package.json
+++ b/clients/client-proton/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-qldb-session/package.json
+++ b/clients/client-qldb-session/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-qldb-session/package.json
+++ b/clients/client-qldb-session/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-qldb/package.json
+++ b/clients/client-qldb/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-qldb/package.json
+++ b/clients/client-qldb/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-quicksight/package.json
+++ b/clients/client-quicksight/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-quicksight/package.json
+++ b/clients/client-quicksight/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-ram/package.json
+++ b/clients/client-ram/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-ram/package.json
+++ b/clients/client-ram/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-rds-data/package.json
+++ b/clients/client-rds-data/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-rds-data/package.json
+++ b/clients/client-rds-data/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-rds/package.json
+++ b/clients/client-rds/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-rds/package.json
+++ b/clients/client-rds/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-redshift-data/package.json
+++ b/clients/client-redshift-data/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-redshift-data/package.json
+++ b/clients/client-redshift-data/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-redshift/package.json
+++ b/clients/client-redshift/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-redshift/package.json
+++ b/clients/client-redshift/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-rekognition/package.json
+++ b/clients/client-rekognition/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-rekognition/package.json
+++ b/clients/client-rekognition/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-resource-groups-tagging-api/package.json
+++ b/clients/client-resource-groups-tagging-api/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-resource-groups-tagging-api/package.json
+++ b/clients/client-resource-groups-tagging-api/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-resource-groups/package.json
+++ b/clients/client-resource-groups/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-resource-groups/package.json
+++ b/clients/client-resource-groups/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-robomaker/package.json
+++ b/clients/client-robomaker/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-robomaker/package.json
+++ b/clients/client-robomaker/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-route-53-domains/package.json
+++ b/clients/client-route-53-domains/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-route-53-domains/package.json
+++ b/clients/client-route-53-domains/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-route-53/package.json
+++ b/clients/client-route-53/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-route-53/package.json
+++ b/clients/client-route-53/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-route53-recovery-cluster/package.json
+++ b/clients/client-route53-recovery-cluster/package.json
@@ -15,6 +15,10 @@
     "build": "yarn build:cjs && yarn build:es"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-route53-recovery-cluster/package.json
+++ b/clients/client-route53-recovery-cluster/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-route53-recovery-control-config/package.json
+++ b/clients/client-route53-recovery-control-config/package.json
@@ -15,6 +15,10 @@
     "build": "yarn build:cjs && yarn build:es"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-route53-recovery-control-config/package.json
+++ b/clients/client-route53-recovery-control-config/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-route53-recovery-readiness/package.json
+++ b/clients/client-route53-recovery-readiness/package.json
@@ -15,6 +15,10 @@
     "build": "yarn build:cjs && yarn build:es"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-route53-recovery-readiness/package.json
+++ b/clients/client-route53-recovery-readiness/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-route53resolver/package.json
+++ b/clients/client-route53resolver/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-route53resolver/package.json
+++ b/clients/client-route53resolver/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-s3-control/package.json
+++ b/clients/client-s3-control/package.json
@@ -20,6 +20,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-s3-control/package.json
+++ b/clients/client-s3-control/package.json
@@ -16,6 +16,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-s3/package.json
+++ b/clients/client-s3/package.json
@@ -17,6 +17,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-s3/package.json
+++ b/clients/client-s3/package.json
@@ -21,6 +21,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-s3outposts/package.json
+++ b/clients/client-s3outposts/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-s3outposts/package.json
+++ b/clients/client-s3outposts/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-sagemaker-a2i-runtime/package.json
+++ b/clients/client-sagemaker-a2i-runtime/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-sagemaker-a2i-runtime/package.json
+++ b/clients/client-sagemaker-a2i-runtime/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-sagemaker-edge/package.json
+++ b/clients/client-sagemaker-edge/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-sagemaker-edge/package.json
+++ b/clients/client-sagemaker-edge/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-sagemaker-featurestore-runtime/package.json
+++ b/clients/client-sagemaker-featurestore-runtime/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-sagemaker-featurestore-runtime/package.json
+++ b/clients/client-sagemaker-featurestore-runtime/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-sagemaker-runtime/package.json
+++ b/clients/client-sagemaker-runtime/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-sagemaker-runtime/package.json
+++ b/clients/client-sagemaker-runtime/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-sagemaker/package.json
+++ b/clients/client-sagemaker/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-sagemaker/package.json
+++ b/clients/client-sagemaker/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-savingsplans/package.json
+++ b/clients/client-savingsplans/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-savingsplans/package.json
+++ b/clients/client-savingsplans/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-schemas/package.json
+++ b/clients/client-schemas/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-schemas/package.json
+++ b/clients/client-schemas/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-secrets-manager/package.json
+++ b/clients/client-secrets-manager/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-secrets-manager/package.json
+++ b/clients/client-secrets-manager/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-securityhub/package.json
+++ b/clients/client-securityhub/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-securityhub/package.json
+++ b/clients/client-securityhub/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-serverlessapplicationrepository/package.json
+++ b/clients/client-serverlessapplicationrepository/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-serverlessapplicationrepository/package.json
+++ b/clients/client-serverlessapplicationrepository/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-service-catalog-appregistry/package.json
+++ b/clients/client-service-catalog-appregistry/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-service-catalog-appregistry/package.json
+++ b/clients/client-service-catalog-appregistry/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-service-catalog/package.json
+++ b/clients/client-service-catalog/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-service-catalog/package.json
+++ b/clients/client-service-catalog/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-service-quotas/package.json
+++ b/clients/client-service-quotas/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-service-quotas/package.json
+++ b/clients/client-service-quotas/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-servicediscovery/package.json
+++ b/clients/client-servicediscovery/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-servicediscovery/package.json
+++ b/clients/client-servicediscovery/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-ses/package.json
+++ b/clients/client-ses/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-ses/package.json
+++ b/clients/client-ses/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-sesv2/package.json
+++ b/clients/client-sesv2/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-sesv2/package.json
+++ b/clients/client-sesv2/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-sfn/package.json
+++ b/clients/client-sfn/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-sfn/package.json
+++ b/clients/client-sfn/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-shield/package.json
+++ b/clients/client-shield/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-shield/package.json
+++ b/clients/client-shield/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-signer/package.json
+++ b/clients/client-signer/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-signer/package.json
+++ b/clients/client-signer/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-sms/package.json
+++ b/clients/client-sms/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-sms/package.json
+++ b/clients/client-sms/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-snow-device-management/package.json
+++ b/clients/client-snow-device-management/package.json
@@ -15,6 +15,10 @@
     "build": "yarn build:cjs && yarn build:es"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-snow-device-management/package.json
+++ b/clients/client-snow-device-management/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-snowball/package.json
+++ b/clients/client-snowball/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-snowball/package.json
+++ b/clients/client-snowball/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-sns/package.json
+++ b/clients/client-sns/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-sns/package.json
+++ b/clients/client-sns/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-sqs/package.json
+++ b/clients/client-sqs/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-sqs/package.json
+++ b/clients/client-sqs/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-ssm-contacts/package.json
+++ b/clients/client-ssm-contacts/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-ssm-contacts/package.json
+++ b/clients/client-ssm-contacts/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-ssm-incidents/package.json
+++ b/clients/client-ssm-incidents/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-ssm-incidents/package.json
+++ b/clients/client-ssm-incidents/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-ssm/package.json
+++ b/clients/client-ssm/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-ssm/package.json
+++ b/clients/client-ssm/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-sso-admin/package.json
+++ b/clients/client-sso-admin/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-sso-admin/package.json
+++ b/clients/client-sso-admin/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-sso-oidc/package.json
+++ b/clients/client-sso-oidc/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-sso-oidc/package.json
+++ b/clients/client-sso-oidc/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-sso/package.json
+++ b/clients/client-sso/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-sso/package.json
+++ b/clients/client-sso/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-storage-gateway/package.json
+++ b/clients/client-storage-gateway/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-storage-gateway/package.json
+++ b/clients/client-storage-gateway/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-sts/package.json
+++ b/clients/client-sts/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-sts/package.json
+++ b/clients/client-sts/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-support/package.json
+++ b/clients/client-support/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-support/package.json
+++ b/clients/client-support/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-swf/package.json
+++ b/clients/client-swf/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-swf/package.json
+++ b/clients/client-swf/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-synthetics/package.json
+++ b/clients/client-synthetics/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-synthetics/package.json
+++ b/clients/client-synthetics/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-textract/package.json
+++ b/clients/client-textract/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-textract/package.json
+++ b/clients/client-textract/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-timestream-query/package.json
+++ b/clients/client-timestream-query/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-timestream-query/package.json
+++ b/clients/client-timestream-query/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-timestream-write/package.json
+++ b/clients/client-timestream-write/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-timestream-write/package.json
+++ b/clients/client-timestream-write/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-transcribe-streaming/package.json
+++ b/clients/client-transcribe-streaming/package.json
@@ -22,6 +22,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-transcribe-streaming/package.json
+++ b/clients/client-transcribe-streaming/package.json
@@ -18,6 +18,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-transcribe/package.json
+++ b/clients/client-transcribe/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-transcribe/package.json
+++ b/clients/client-transcribe/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-transfer/package.json
+++ b/clients/client-transfer/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-transfer/package.json
+++ b/clients/client-transfer/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-translate/package.json
+++ b/clients/client-translate/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-translate/package.json
+++ b/clients/client-translate/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-waf-regional/package.json
+++ b/clients/client-waf-regional/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-waf-regional/package.json
+++ b/clients/client-waf-regional/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-waf/package.json
+++ b/clients/client-waf/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-waf/package.json
+++ b/clients/client-waf/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-wafv2/package.json
+++ b/clients/client-wafv2/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-wafv2/package.json
+++ b/clients/client-wafv2/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-wellarchitected/package.json
+++ b/clients/client-wellarchitected/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-wellarchitected/package.json
+++ b/clients/client-wellarchitected/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-workdocs/package.json
+++ b/clients/client-workdocs/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-workdocs/package.json
+++ b/clients/client-workdocs/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-worklink/package.json
+++ b/clients/client-worklink/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-worklink/package.json
+++ b/clients/client-worklink/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-workmail/package.json
+++ b/clients/client-workmail/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-workmail/package.json
+++ b/clients/client-workmail/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-workmailmessageflow/package.json
+++ b/clients/client-workmailmessageflow/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-workmailmessageflow/package.json
+++ b/clients/client-workmailmessageflow/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-workspaces/package.json
+++ b/clients/client-workspaces/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-workspaces/package.json
+++ b/clients/client-workspaces/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-xray/package.json
+++ b/clients/client-xray/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/clients/client-xray/package.json
+++ b/clients/client-xray/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/lib/lib-dynamodb/package.json
+++ b/lib/lib-dynamodb/package.json
@@ -3,6 +3,10 @@
   "version": "3.31.0",
   "description": "The document client simplifies working with items in Amazon DynamoDB by abstracting away the notion of attribute values.",
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "scripts": {

--- a/lib/lib-dynamodb/package.json
+++ b/lib/lib-dynamodb/package.json
@@ -7,6 +7,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "scripts": {

--- a/lib/lib-storage/package.json
+++ b/lib/lib-storage/package.json
@@ -3,6 +3,10 @@
   "version": "3.31.0",
   "description": "Storage higher order operation",
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "scripts": {

--- a/lib/lib-storage/package.json
+++ b/lib/lib-storage/package.json
@@ -7,6 +7,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "scripts": {

--- a/packages/abort-controller/package.json
+++ b/packages/abort-controller/package.json
@@ -3,6 +3,10 @@
   "version": "3.29.0",
   "description": "A simple abort controller library",
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "scripts": {

--- a/packages/abort-controller/package.json
+++ b/packages/abort-controller/package.json
@@ -7,6 +7,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "scripts": {

--- a/packages/body-checksum-browser/package.json
+++ b/packages/body-checksum-browser/package.json
@@ -13,6 +13,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "author": {

--- a/packages/body-checksum-browser/package.json
+++ b/packages/body-checksum-browser/package.json
@@ -9,6 +9,10 @@
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "author": {

--- a/packages/body-checksum-node/package.json
+++ b/packages/body-checksum-node/package.json
@@ -13,6 +13,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "author": {

--- a/packages/body-checksum-node/package.json
+++ b/packages/body-checksum-node/package.json
@@ -9,6 +9,10 @@
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "author": {

--- a/packages/chunked-blob-reader-native/package.json
+++ b/packages/chunked-blob-reader-native/package.json
@@ -13,6 +13,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "author": {

--- a/packages/chunked-blob-reader-native/package.json
+++ b/packages/chunked-blob-reader-native/package.json
@@ -9,6 +9,10 @@
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "author": {

--- a/packages/chunked-blob-reader/package.json
+++ b/packages/chunked-blob-reader/package.json
@@ -13,6 +13,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "author": {

--- a/packages/chunked-blob-reader/package.json
+++ b/packages/chunked-blob-reader/package.json
@@ -9,6 +9,10 @@
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "author": {

--- a/packages/chunked-stream-reader-node/package.json
+++ b/packages/chunked-stream-reader-node/package.json
@@ -13,6 +13,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "author": {

--- a/packages/chunked-stream-reader-node/package.json
+++ b/packages/chunked-stream-reader-node/package.json
@@ -9,6 +9,10 @@
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "author": {

--- a/packages/client-documentation-generator/package.json
+++ b/packages/client-documentation-generator/package.json
@@ -13,6 +13,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "author": {

--- a/packages/client-documentation-generator/package.json
+++ b/packages/client-documentation-generator/package.json
@@ -9,6 +9,10 @@
     "test": "exit 0"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "author": {

--- a/packages/config-resolver/package.json
+++ b/packages/config-resolver/package.json
@@ -13,6 +13,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "author": {

--- a/packages/config-resolver/package.json
+++ b/packages/config-resolver/package.json
@@ -9,6 +9,10 @@
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "author": {

--- a/packages/core-packages-documentation-generator/package.json
+++ b/packages/core-packages-documentation-generator/package.json
@@ -13,6 +13,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "author": {

--- a/packages/core-packages-documentation-generator/package.json
+++ b/packages/core-packages-documentation-generator/package.json
@@ -9,6 +9,10 @@
     "test": "exit 0"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "author": {

--- a/packages/credential-provider-cognito-identity/package.json
+++ b/packages/credential-provider-cognito-identity/package.json
@@ -13,6 +13,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "sideEffects": false,

--- a/packages/credential-provider-cognito-identity/package.json
+++ b/packages/credential-provider-cognito-identity/package.json
@@ -9,6 +9,10 @@
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "sideEffects": false,

--- a/packages/credential-provider-env/package.json
+++ b/packages/credential-provider-env/package.json
@@ -7,6 +7,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "module": "./dist/es/index.js",
   "scripts": {
     "build:cjs": "tsc -p tsconfig.cjs.json",

--- a/packages/credential-provider-env/package.json
+++ b/packages/credential-provider-env/package.json
@@ -3,6 +3,10 @@
   "version": "3.29.0",
   "description": "AWS credential provider that sources credentials from known environment variables",
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "module": "./dist/es/index.js",
   "scripts": {
     "build:cjs": "tsc -p tsconfig.cjs.json",

--- a/packages/credential-provider-imds/package.json
+++ b/packages/credential-provider-imds/package.json
@@ -7,6 +7,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "module": "./dist/es/index.js",
   "scripts": {
     "build:cjs": "tsc -p tsconfig.cjs.json",

--- a/packages/credential-provider-imds/package.json
+++ b/packages/credential-provider-imds/package.json
@@ -3,6 +3,10 @@
   "version": "3.29.0",
   "description": "AWS credential provider that sources credentials from the EC2 instance metadata service and ECS container metadata service",
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "module": "./dist/es/index.js",
   "scripts": {
     "build:cjs": "tsc -p tsconfig.cjs.json",

--- a/packages/credential-provider-ini/package.json
+++ b/packages/credential-provider-ini/package.json
@@ -7,6 +7,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "module": "./dist/es/index.js",
   "scripts": {
     "build:cjs": "tsc -p tsconfig.cjs.json",

--- a/packages/credential-provider-ini/package.json
+++ b/packages/credential-provider-ini/package.json
@@ -3,6 +3,10 @@
   "version": "3.31.0",
   "description": "AWS credential provider that sources credentials from ~/.aws/credentials and ~/.aws/config",
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "module": "./dist/es/index.js",
   "scripts": {
     "build:cjs": "tsc -p tsconfig.cjs.json",

--- a/packages/credential-provider-node/package.json
+++ b/packages/credential-provider-node/package.json
@@ -6,6 +6,10 @@
     "node": ">=10.0.0"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "module": "./dist/es/index.js",
   "scripts": {
     "build:cjs": "tsc -p tsconfig.cjs.json",

--- a/packages/credential-provider-node/package.json
+++ b/packages/credential-provider-node/package.json
@@ -10,6 +10,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "module": "./dist/es/index.js",
   "scripts": {
     "build:cjs": "tsc -p tsconfig.cjs.json",

--- a/packages/credential-provider-process/package.json
+++ b/packages/credential-provider-process/package.json
@@ -7,6 +7,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "module": "./dist/es/index.js",
   "scripts": {
     "build:cjs": "tsc -p tsconfig.cjs.json",

--- a/packages/credential-provider-process/package.json
+++ b/packages/credential-provider-process/package.json
@@ -3,6 +3,10 @@
   "version": "3.29.0",
   "description": "AWS credential provider that sources credential_process from ~/.aws/credentials and ~/.aws/config",
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "module": "./dist/es/index.js",
   "scripts": {
     "build:cjs": "tsc -p tsconfig.cjs.json",

--- a/packages/credential-provider-sso/package.json
+++ b/packages/credential-provider-sso/package.json
@@ -7,6 +7,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "module": "./dist/es/index.js",
   "scripts": {
     "build:cjs": "tsc -p tsconfig.cjs.json",

--- a/packages/credential-provider-sso/package.json
+++ b/packages/credential-provider-sso/package.json
@@ -3,6 +3,10 @@
   "version": "3.31.0",
   "description": "AWS credential provider that exchanges a resolved SSO login token file for temporary AWS credentials",
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "module": "./dist/es/index.js",
   "scripts": {
     "build:cjs": "tsc -p tsconfig.cjs.json",

--- a/packages/credential-provider-web-identity/package.json
+++ b/packages/credential-provider-web-identity/package.json
@@ -3,6 +3,10 @@
   "version": "3.29.0",
   "description": "AWS credential provider that calls STS assumeRole for temporary AWS credentials",
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "module": "./dist/es/index.js",
   "scripts": {
     "build:cjs": "tsc -p tsconfig.cjs.json",

--- a/packages/credential-provider-web-identity/package.json
+++ b/packages/credential-provider-web-identity/package.json
@@ -7,6 +7,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "module": "./dist/es/index.js",
   "scripts": {
     "build:cjs": "tsc -p tsconfig.cjs.json",

--- a/packages/credential-providers/package.json
+++ b/packages/credential-providers/package.json
@@ -7,6 +7,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "module": "./dist/es/index.js",
   "browser": {
     "@aws-sdk/credential-provider-env": false,

--- a/packages/credential-providers/package.json
+++ b/packages/credential-providers/package.json
@@ -3,6 +3,10 @@
   "version": "3.31.0",
   "description": "A collection of credential providers, without requiring service clients like STS, Cognito",
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "module": "./dist/es/index.js",
   "browser": {
     "@aws-sdk/credential-provider-env": false,

--- a/packages/endpoint-cache/package.json
+++ b/packages/endpoint-cache/package.json
@@ -18,6 +18,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "dependencies": {

--- a/packages/endpoint-cache/package.json
+++ b/packages/endpoint-cache/package.json
@@ -14,6 +14,10 @@
   },
   "license": "Apache-2.0",
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "dependencies": {

--- a/packages/eventstream-handler-node/package.json
+++ b/packages/eventstream-handler-node/package.json
@@ -13,6 +13,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "author": {

--- a/packages/eventstream-handler-node/package.json
+++ b/packages/eventstream-handler-node/package.json
@@ -9,6 +9,10 @@
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "author": {

--- a/packages/eventstream-marshaller/package.json
+++ b/packages/eventstream-marshaller/package.json
@@ -13,6 +13,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "author": {

--- a/packages/eventstream-marshaller/package.json
+++ b/packages/eventstream-marshaller/package.json
@@ -9,6 +9,10 @@
     "test": "jest --coverage"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "author": {

--- a/packages/eventstream-serde-browser/package.json
+++ b/packages/eventstream-serde-browser/package.json
@@ -13,6 +13,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "author": {

--- a/packages/eventstream-serde-browser/package.json
+++ b/packages/eventstream-serde-browser/package.json
@@ -9,6 +9,10 @@
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "author": {

--- a/packages/eventstream-serde-config-resolver/package.json
+++ b/packages/eventstream-serde-config-resolver/package.json
@@ -13,6 +13,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "author": {

--- a/packages/eventstream-serde-config-resolver/package.json
+++ b/packages/eventstream-serde-config-resolver/package.json
@@ -9,6 +9,10 @@
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "author": {

--- a/packages/eventstream-serde-node/package.json
+++ b/packages/eventstream-serde-node/package.json
@@ -13,6 +13,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "author": {

--- a/packages/eventstream-serde-node/package.json
+++ b/packages/eventstream-serde-node/package.json
@@ -9,6 +9,10 @@
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "author": {

--- a/packages/eventstream-serde-universal/package.json
+++ b/packages/eventstream-serde-universal/package.json
@@ -13,6 +13,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "author": {

--- a/packages/eventstream-serde-universal/package.json
+++ b/packages/eventstream-serde-universal/package.json
@@ -9,6 +9,10 @@
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "author": {

--- a/packages/fetch-http-handler/package.json
+++ b/packages/fetch-http-handler/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "dependencies": {

--- a/packages/fetch-http-handler/package.json
+++ b/packages/fetch-http-handler/package.json
@@ -15,6 +15,10 @@
   },
   "license": "Apache-2.0",
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "dependencies": {

--- a/packages/hash-blob-browser/package.json
+++ b/packages/hash-blob-browser/package.json
@@ -9,6 +9,10 @@
     "test": "karma start karma.conf.js"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "author": {

--- a/packages/hash-blob-browser/package.json
+++ b/packages/hash-blob-browser/package.json
@@ -13,6 +13,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "author": {

--- a/packages/hash-node/package.json
+++ b/packages/hash-node/package.json
@@ -13,6 +13,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "author": {

--- a/packages/hash-node/package.json
+++ b/packages/hash-node/package.json
@@ -9,6 +9,10 @@
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "author": {

--- a/packages/hash-stream-node/package.json
+++ b/packages/hash-stream-node/package.json
@@ -13,6 +13,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "author": {

--- a/packages/hash-stream-node/package.json
+++ b/packages/hash-stream-node/package.json
@@ -9,6 +9,10 @@
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "author": {

--- a/packages/invalid-dependency/package.json
+++ b/packages/invalid-dependency/package.json
@@ -13,6 +13,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "author": {

--- a/packages/invalid-dependency/package.json
+++ b/packages/invalid-dependency/package.json
@@ -9,6 +9,10 @@
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "author": {

--- a/packages/is-array-buffer/package.json
+++ b/packages/is-array-buffer/package.json
@@ -15,6 +15,10 @@
   },
   "license": "Apache-2.0",
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "module": "./dist/es/index.js",
   "devDependencies": {
     "@types/jest": "^26.0.4",

--- a/packages/is-array-buffer/package.json
+++ b/packages/is-array-buffer/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "module": "./dist/es/index.js",
   "devDependencies": {
     "@types/jest": "^26.0.4",

--- a/packages/karma-credential-loader/package.json
+++ b/packages/karma-credential-loader/package.json
@@ -13,6 +13,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "author": {

--- a/packages/karma-credential-loader/package.json
+++ b/packages/karma-credential-loader/package.json
@@ -9,6 +9,10 @@
     "test": "jest --passWithNoTests"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "author": {

--- a/packages/md5-js/package.json
+++ b/packages/md5-js/package.json
@@ -13,6 +13,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "author": {

--- a/packages/md5-js/package.json
+++ b/packages/md5-js/package.json
@@ -9,6 +9,10 @@
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "author": {

--- a/packages/middleware-apply-body-checksum/package.json
+++ b/packages/middleware-apply-body-checksum/package.json
@@ -13,6 +13,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "author": {

--- a/packages/middleware-apply-body-checksum/package.json
+++ b/packages/middleware-apply-body-checksum/package.json
@@ -9,6 +9,10 @@
     "test": "jest --coverage"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "author": {

--- a/packages/middleware-bucket-endpoint/package.json
+++ b/packages/middleware-bucket-endpoint/package.json
@@ -13,6 +13,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "author": {

--- a/packages/middleware-bucket-endpoint/package.json
+++ b/packages/middleware-bucket-endpoint/package.json
@@ -9,6 +9,10 @@
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "author": {

--- a/packages/middleware-content-length/package.json
+++ b/packages/middleware-content-length/package.json
@@ -13,6 +13,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "author": {

--- a/packages/middleware-content-length/package.json
+++ b/packages/middleware-content-length/package.json
@@ -9,6 +9,10 @@
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "author": {

--- a/packages/middleware-endpoint-discovery/package.json
+++ b/packages/middleware-endpoint-discovery/package.json
@@ -13,6 +13,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "author": {

--- a/packages/middleware-endpoint-discovery/package.json
+++ b/packages/middleware-endpoint-discovery/package.json
@@ -9,6 +9,10 @@
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "author": {

--- a/packages/middleware-eventstream/package.json
+++ b/packages/middleware-eventstream/package.json
@@ -13,6 +13,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "author": {

--- a/packages/middleware-eventstream/package.json
+++ b/packages/middleware-eventstream/package.json
@@ -9,6 +9,10 @@
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "author": {

--- a/packages/middleware-expect-continue/package.json
+++ b/packages/middleware-expect-continue/package.json
@@ -13,6 +13,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "author": {

--- a/packages/middleware-expect-continue/package.json
+++ b/packages/middleware-expect-continue/package.json
@@ -9,6 +9,10 @@
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "author": {

--- a/packages/middleware-header-default/package.json
+++ b/packages/middleware-header-default/package.json
@@ -13,6 +13,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "author": {

--- a/packages/middleware-header-default/package.json
+++ b/packages/middleware-header-default/package.json
@@ -9,6 +9,10 @@
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "author": {

--- a/packages/middleware-host-header/package.json
+++ b/packages/middleware-host-header/package.json
@@ -13,6 +13,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "author": {

--- a/packages/middleware-host-header/package.json
+++ b/packages/middleware-host-header/package.json
@@ -9,6 +9,10 @@
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "author": {

--- a/packages/middleware-location-constraint/package.json
+++ b/packages/middleware-location-constraint/package.json
@@ -13,6 +13,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "author": {

--- a/packages/middleware-location-constraint/package.json
+++ b/packages/middleware-location-constraint/package.json
@@ -9,6 +9,10 @@
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "author": {

--- a/packages/middleware-logger/package.json
+++ b/packages/middleware-logger/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "dependencies": {

--- a/packages/middleware-logger/package.json
+++ b/packages/middleware-logger/package.json
@@ -15,6 +15,10 @@
   },
   "license": "Apache-2.0",
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "dependencies": {

--- a/packages/middleware-retry/package.json
+++ b/packages/middleware-retry/package.json
@@ -13,6 +13,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "author": {

--- a/packages/middleware-retry/package.json
+++ b/packages/middleware-retry/package.json
@@ -9,6 +9,10 @@
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "author": {

--- a/packages/middleware-sdk-api-gateway/package.json
+++ b/packages/middleware-sdk-api-gateway/package.json
@@ -13,6 +13,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "author": {

--- a/packages/middleware-sdk-api-gateway/package.json
+++ b/packages/middleware-sdk-api-gateway/package.json
@@ -9,6 +9,10 @@
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "author": {

--- a/packages/middleware-sdk-ec2/package.json
+++ b/packages/middleware-sdk-ec2/package.json
@@ -13,6 +13,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "author": {

--- a/packages/middleware-sdk-ec2/package.json
+++ b/packages/middleware-sdk-ec2/package.json
@@ -9,6 +9,10 @@
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "author": {

--- a/packages/middleware-sdk-glacier/package.json
+++ b/packages/middleware-sdk-glacier/package.json
@@ -13,6 +13,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "author": {

--- a/packages/middleware-sdk-glacier/package.json
+++ b/packages/middleware-sdk-glacier/package.json
@@ -9,6 +9,10 @@
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "author": {

--- a/packages/middleware-sdk-machinelearning/package.json
+++ b/packages/middleware-sdk-machinelearning/package.json
@@ -13,6 +13,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "author": {

--- a/packages/middleware-sdk-machinelearning/package.json
+++ b/packages/middleware-sdk-machinelearning/package.json
@@ -9,6 +9,10 @@
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "author": {

--- a/packages/middleware-sdk-rds/package.json
+++ b/packages/middleware-sdk-rds/package.json
@@ -13,6 +13,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "author": {

--- a/packages/middleware-sdk-rds/package.json
+++ b/packages/middleware-sdk-rds/package.json
@@ -9,6 +9,10 @@
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "author": {

--- a/packages/middleware-sdk-route53/package.json
+++ b/packages/middleware-sdk-route53/package.json
@@ -13,6 +13,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "author": {

--- a/packages/middleware-sdk-route53/package.json
+++ b/packages/middleware-sdk-route53/package.json
@@ -9,6 +9,10 @@
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "author": {

--- a/packages/middleware-sdk-s3-control/package.json
+++ b/packages/middleware-sdk-s3-control/package.json
@@ -13,6 +13,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "author": {

--- a/packages/middleware-sdk-s3-control/package.json
+++ b/packages/middleware-sdk-s3-control/package.json
@@ -9,6 +9,10 @@
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "author": {

--- a/packages/middleware-sdk-s3/package.json
+++ b/packages/middleware-sdk-s3/package.json
@@ -13,6 +13,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "author": {

--- a/packages/middleware-sdk-s3/package.json
+++ b/packages/middleware-sdk-s3/package.json
@@ -9,6 +9,10 @@
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "author": {

--- a/packages/middleware-sdk-sqs/package.json
+++ b/packages/middleware-sdk-sqs/package.json
@@ -13,6 +13,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "author": {

--- a/packages/middleware-sdk-sqs/package.json
+++ b/packages/middleware-sdk-sqs/package.json
@@ -9,6 +9,10 @@
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "author": {

--- a/packages/middleware-sdk-sts/package.json
+++ b/packages/middleware-sdk-sts/package.json
@@ -13,6 +13,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "author": {

--- a/packages/middleware-sdk-sts/package.json
+++ b/packages/middleware-sdk-sts/package.json
@@ -9,6 +9,10 @@
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "author": {

--- a/packages/middleware-sdk-transcribe-streaming/package.json
+++ b/packages/middleware-sdk-transcribe-streaming/package.json
@@ -6,6 +6,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "scripts": {

--- a/packages/middleware-sdk-transcribe-streaming/package.json
+++ b/packages/middleware-sdk-transcribe-streaming/package.json
@@ -2,6 +2,10 @@
   "name": "@aws-sdk/middleware-sdk-transcribe-streaming",
   "version": "3.30.0",
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "scripts": {

--- a/packages/middleware-serde/package.json
+++ b/packages/middleware-serde/package.json
@@ -13,6 +13,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "author": {

--- a/packages/middleware-serde/package.json
+++ b/packages/middleware-serde/package.json
@@ -9,6 +9,10 @@
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "author": {

--- a/packages/middleware-signing/package.json
+++ b/packages/middleware-signing/package.json
@@ -13,6 +13,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "author": {

--- a/packages/middleware-signing/package.json
+++ b/packages/middleware-signing/package.json
@@ -9,6 +9,10 @@
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "author": {

--- a/packages/middleware-ssec/package.json
+++ b/packages/middleware-ssec/package.json
@@ -13,6 +13,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "author": {

--- a/packages/middleware-ssec/package.json
+++ b/packages/middleware-ssec/package.json
@@ -9,6 +9,10 @@
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "author": {

--- a/packages/middleware-stack/package.json
+++ b/packages/middleware-stack/package.json
@@ -20,6 +20,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "dependencies": {

--- a/packages/middleware-stack/package.json
+++ b/packages/middleware-stack/package.json
@@ -16,6 +16,10 @@
   },
   "license": "Apache-2.0",
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "dependencies": {

--- a/packages/middleware-user-agent/package.json
+++ b/packages/middleware-user-agent/package.json
@@ -13,6 +13,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "author": {

--- a/packages/middleware-user-agent/package.json
+++ b/packages/middleware-user-agent/package.json
@@ -9,6 +9,10 @@
     "test": "jest --passWithNoTests"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "author": {

--- a/packages/node-config-provider/package.json
+++ b/packages/node-config-provider/package.json
@@ -20,6 +20,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "dependencies": {

--- a/packages/node-config-provider/package.json
+++ b/packages/node-config-provider/package.json
@@ -16,6 +16,10 @@
   },
   "license": "Apache-2.0",
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "dependencies": {

--- a/packages/node-http-handler/package.json
+++ b/packages/node-http-handler/package.json
@@ -20,6 +20,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "dependencies": {

--- a/packages/node-http-handler/package.json
+++ b/packages/node-http-handler/package.json
@@ -16,6 +16,10 @@
   },
   "license": "Apache-2.0",
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "dependencies": {

--- a/packages/polly-request-presigner/package.json
+++ b/packages/polly-request-presigner/package.json
@@ -13,6 +13,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "author": {

--- a/packages/polly-request-presigner/package.json
+++ b/packages/polly-request-presigner/package.json
@@ -9,6 +9,10 @@
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "author": {

--- a/packages/property-provider/package.json
+++ b/packages/property-provider/package.json
@@ -13,6 +13,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "author": {

--- a/packages/property-provider/package.json
+++ b/packages/property-provider/package.json
@@ -9,6 +9,10 @@
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "author": {

--- a/packages/protocol-http/package.json
+++ b/packages/protocol-http/package.json
@@ -13,6 +13,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "author": {

--- a/packages/protocol-http/package.json
+++ b/packages/protocol-http/package.json
@@ -9,6 +9,10 @@
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "author": {

--- a/packages/querystring-builder/package.json
+++ b/packages/querystring-builder/package.json
@@ -13,6 +13,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "author": {

--- a/packages/querystring-builder/package.json
+++ b/packages/querystring-builder/package.json
@@ -9,6 +9,10 @@
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "author": {

--- a/packages/querystring-parser/package.json
+++ b/packages/querystring-parser/package.json
@@ -13,6 +13,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "author": {

--- a/packages/querystring-parser/package.json
+++ b/packages/querystring-parser/package.json
@@ -9,6 +9,10 @@
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "author": {

--- a/packages/s3-presigned-post/package.json
+++ b/packages/s3-presigned-post/package.json
@@ -13,6 +13,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "author": {

--- a/packages/s3-presigned-post/package.json
+++ b/packages/s3-presigned-post/package.json
@@ -9,6 +9,10 @@
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "author": {

--- a/packages/s3-request-presigner/package.json
+++ b/packages/s3-request-presigner/package.json
@@ -13,6 +13,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "author": {

--- a/packages/s3-request-presigner/package.json
+++ b/packages/s3-request-presigner/package.json
@@ -9,6 +9,10 @@
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "author": {

--- a/packages/service-error-classification/package.json
+++ b/packages/service-error-classification/package.json
@@ -13,6 +13,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "author": {

--- a/packages/service-error-classification/package.json
+++ b/packages/service-error-classification/package.json
@@ -9,6 +9,10 @@
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "author": {

--- a/packages/sha256-tree-hash/package.json
+++ b/packages/sha256-tree-hash/package.json
@@ -13,6 +13,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "author": {

--- a/packages/sha256-tree-hash/package.json
+++ b/packages/sha256-tree-hash/package.json
@@ -9,6 +9,10 @@
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "author": {

--- a/packages/shared-ini-file-loader/package.json
+++ b/packages/shared-ini-file-loader/package.json
@@ -23,6 +23,10 @@
   },
   "license": "Apache-2.0",
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "engines": {

--- a/packages/shared-ini-file-loader/package.json
+++ b/packages/shared-ini-file-loader/package.json
@@ -27,6 +27,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "engines": {

--- a/packages/signature-v4/package.json
+++ b/packages/signature-v4/package.json
@@ -7,6 +7,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "scripts": {

--- a/packages/signature-v4/package.json
+++ b/packages/signature-v4/package.json
@@ -3,6 +3,10 @@
   "version": "3.30.0",
   "description": "A standalone implementation of the AWS Signature V4 request signing algorithm",
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "scripts": {

--- a/packages/smithy-client/package.json
+++ b/packages/smithy-client/package.json
@@ -13,6 +13,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "author": {

--- a/packages/smithy-client/package.json
+++ b/packages/smithy-client/package.json
@@ -9,6 +9,10 @@
     "test": "jest --passWithNoTests"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "author": {

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -6,6 +6,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "description": "Types for the AWS SDK",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -2,6 +2,10 @@
   "name": "@aws-sdk/types",
   "version": "3.29.0",
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "description": "Types for the AWS SDK",

--- a/packages/url-parser/package.json
+++ b/packages/url-parser/package.json
@@ -13,6 +13,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "author": {

--- a/packages/url-parser/package.json
+++ b/packages/url-parser/package.json
@@ -9,6 +9,10 @@
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "author": {

--- a/packages/util-arn-parser/package.json
+++ b/packages/util-arn-parser/package.json
@@ -7,6 +7,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "module": "./dist/es/index.js",
   "scripts": {
     "build:cjs": "tsc -p tsconfig.cjs.json",

--- a/packages/util-arn-parser/package.json
+++ b/packages/util-arn-parser/package.json
@@ -3,6 +3,10 @@
   "version": "3.29.0",
   "description": "A parser to Amazon Resource Names",
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "module": "./dist/es/index.js",
   "scripts": {
     "build:cjs": "tsc -p tsconfig.cjs.json",

--- a/packages/util-base64-browser/package.json
+++ b/packages/util-base64-browser/package.json
@@ -7,6 +7,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "module": "./dist/es/index.js",
   "scripts": {
     "build:cjs": "tsc -p tsconfig.cjs.json",

--- a/packages/util-base64-browser/package.json
+++ b/packages/util-base64-browser/package.json
@@ -3,6 +3,10 @@
   "version": "3.29.0",
   "description": "A pure JS Base64 <-> UInt8Array converter",
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "module": "./dist/es/index.js",
   "scripts": {
     "build:cjs": "tsc -p tsconfig.cjs.json",

--- a/packages/util-base64-node/package.json
+++ b/packages/util-base64-node/package.json
@@ -7,6 +7,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "module": "./dist/es/index.js",
   "scripts": {
     "build:cjs": "tsc -p tsconfig.cjs.json",

--- a/packages/util-base64-node/package.json
+++ b/packages/util-base64-node/package.json
@@ -3,6 +3,10 @@
   "version": "3.29.0",
   "description": "A Node.JS Base64 <-> UInt8Array converter",
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "module": "./dist/es/index.js",
   "scripts": {
     "build:cjs": "tsc -p tsconfig.cjs.json",

--- a/packages/util-body-length-browser/package.json
+++ b/packages/util-body-length-browser/package.json
@@ -14,6 +14,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "author": {

--- a/packages/util-body-length-browser/package.json
+++ b/packages/util-body-length-browser/package.json
@@ -10,6 +10,10 @@
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "author": {

--- a/packages/util-body-length-node/package.json
+++ b/packages/util-body-length-node/package.json
@@ -16,6 +16,10 @@
     "typescript": "~4.4.2"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "author": {

--- a/packages/util-body-length-node/package.json
+++ b/packages/util-body-length-node/package.json
@@ -20,6 +20,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "author": {

--- a/packages/util-buffer-from/package.json
+++ b/packages/util-buffer-from/package.json
@@ -24,6 +24,10 @@
     "typescript": "~4.4.2"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "engines": {

--- a/packages/util-buffer-from/package.json
+++ b/packages/util-buffer-from/package.json
@@ -28,6 +28,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "engines": {

--- a/packages/util-create-request/package.json
+++ b/packages/util-create-request/package.json
@@ -13,6 +13,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "author": {

--- a/packages/util-create-request/package.json
+++ b/packages/util-create-request/package.json
@@ -9,6 +9,10 @@
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "author": {

--- a/packages/util-credentials/package.json
+++ b/packages/util-credentials/package.json
@@ -7,6 +7,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "module": "./dist/es/index.js",
   "scripts": {
     "build:cjs": "tsc -p tsconfig.cjs.json",

--- a/packages/util-credentials/package.json
+++ b/packages/util-credentials/package.json
@@ -3,6 +3,10 @@
   "version": "3.29.0",
   "description": "Shared utilities for all credential providers.",
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "module": "./dist/es/index.js",
   "scripts": {
     "build:cjs": "tsc -p tsconfig.cjs.json",

--- a/packages/util-dynamodb/package.json
+++ b/packages/util-dynamodb/package.json
@@ -13,6 +13,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "author": {

--- a/packages/util-dynamodb/package.json
+++ b/packages/util-dynamodb/package.json
@@ -9,6 +9,10 @@
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "author": {

--- a/packages/util-format-url/package.json
+++ b/packages/util-format-url/package.json
@@ -13,6 +13,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "author": {

--- a/packages/util-format-url/package.json
+++ b/packages/util-format-url/package.json
@@ -9,6 +9,10 @@
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "author": {

--- a/packages/util-hex-encoding/package.json
+++ b/packages/util-hex-encoding/package.json
@@ -15,6 +15,10 @@
   },
   "license": "Apache-2.0",
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "module": "./dist/es/index.js",
   "dependencies": {
     "tslib": "^2.3.0"

--- a/packages/util-hex-encoding/package.json
+++ b/packages/util-hex-encoding/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "module": "./dist/es/index.js",
   "dependencies": {
     "tslib": "^2.3.0"

--- a/packages/util-locate-window/package.json
+++ b/packages/util-locate-window/package.json
@@ -23,6 +23,10 @@
     "typescript": "~4.4.2"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "engines": {

--- a/packages/util-locate-window/package.json
+++ b/packages/util-locate-window/package.json
@@ -27,6 +27,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "engines": {

--- a/packages/util-uri-escape/package.json
+++ b/packages/util-uri-escape/package.json
@@ -13,6 +13,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "author": {

--- a/packages/util-uri-escape/package.json
+++ b/packages/util-uri-escape/package.json
@@ -9,6 +9,10 @@
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "author": {

--- a/packages/util-user-agent-browser/package.json
+++ b/packages/util-user-agent-browser/package.json
@@ -13,6 +13,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "author": {

--- a/packages/util-user-agent-browser/package.json
+++ b/packages/util-user-agent-browser/package.json
@@ -9,6 +9,10 @@
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "author": {

--- a/packages/util-user-agent-node/package.json
+++ b/packages/util-user-agent-node/package.json
@@ -13,6 +13,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "author": {

--- a/packages/util-user-agent-node/package.json
+++ b/packages/util-user-agent-node/package.json
@@ -9,6 +9,10 @@
     "test": "jest"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "author": {

--- a/packages/util-utf8-browser/package.json
+++ b/packages/util-utf8-browser/package.json
@@ -7,6 +7,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "module": "./dist/es/index.js",
   "scripts": {
     "build:cjs": "tsc -p tsconfig.cjs.json",

--- a/packages/util-utf8-browser/package.json
+++ b/packages/util-utf8-browser/package.json
@@ -3,6 +3,10 @@
   "version": "3.29.0",
   "description": "A browser UTF-8 string <-> UInt8Array converter",
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "module": "./dist/es/index.js",
   "scripts": {
     "build:cjs": "tsc -p tsconfig.cjs.json",

--- a/packages/util-utf8-node/package.json
+++ b/packages/util-utf8-node/package.json
@@ -7,6 +7,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "module": "./dist/es/index.js",
   "scripts": {
     "build:cjs": "tsc -p tsconfig.cjs.json",

--- a/packages/util-utf8-node/package.json
+++ b/packages/util-utf8-node/package.json
@@ -3,6 +3,10 @@
   "version": "3.29.0",
   "description": "A Node.JS UTF-8 string <-> UInt8Array converter",
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "module": "./dist/es/index.js",
   "scripts": {
     "build:cjs": "tsc -p tsconfig.cjs.json",

--- a/packages/util-waiter/package.json
+++ b/packages/util-waiter/package.json
@@ -29,6 +29,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "engines": {

--- a/packages/util-waiter/package.json
+++ b/packages/util-waiter/package.json
@@ -25,6 +25,10 @@
   },
   "license": "Apache-2.0",
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "engines": {

--- a/packages/xml-builder/package.json
+++ b/packages/xml-builder/package.json
@@ -23,6 +23,10 @@
   },
   "license": "Apache-2.0",
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "engines": {

--- a/packages/xml-builder/package.json
+++ b/packages/xml-builder/package.json
@@ -27,6 +27,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "engines": {

--- a/protocol_tests/aws-ec2/package.json
+++ b/protocol_tests/aws-ec2/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/protocol_tests/aws-ec2/package.json
+++ b/protocol_tests/aws-ec2/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/protocol_tests/aws-json-10/package.json
+++ b/protocol_tests/aws-json-10/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/protocol_tests/aws-json-10/package.json
+++ b/protocol_tests/aws-json-10/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/protocol_tests/aws-json/package.json
+++ b/protocol_tests/aws-json/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/protocol_tests/aws-json/package.json
+++ b/protocol_tests/aws-json/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/protocol_tests/aws-query/package.json
+++ b/protocol_tests/aws-query/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/protocol_tests/aws-query/package.json
+++ b/protocol_tests/aws-query/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/protocol_tests/aws-restjson/package.json
+++ b/protocol_tests/aws-restjson/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/protocol_tests/aws-restjson/package.json
+++ b/protocol_tests/aws-restjson/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/protocol_tests/aws-restxml/package.json
+++ b/protocol_tests/aws-restxml/package.json
@@ -15,6 +15,10 @@
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
   },
   "main": "./dist/cjs/index.js",
+  "exports": {
+    "import": "./dist/es/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {

--- a/protocol_tests/aws-restxml/package.json
+++ b/protocol_tests/aws-restxml/package.json
@@ -19,6 +19,7 @@
     "import": "./dist/es/index.js",
     "require": "./dist/cjs/index.js"
   },
+  "type": "module",
   "types": "./dist/types/index.d.ts",
   "module": "./dist/es/index.js",
   "browser": {


### PR DESCRIPTION
### Issue
Attempt to fix: https://github.com/aws/aws-sdk-js-v3/issues/2754

### Description
Add ESModule wrapper using conditional exports, so that `import` in Node.js will use ES module.

### Testing
Linked packages from workspace using the following command:
```console
$ pwd
/home/trivikr/workspace/aws-sdk-js-v3/clients/client-s3

$ npm link                      
...
/local/home/trivikr/.fnm/node-versions/v14.17.4/installation/lib/node_modules/@aws-sdk/client-s3 -> /local/home/trivikr/workspace/aws-sdk-js-v3/clients/client-s3
```

The error is still thrown when `test.mjs` is run after running `npm link @aws-sdk/client-s3`
```console
$ cat test.mjs
import { S3 } from "@aws-sdk/client-s3";
```

### Additional context
API reference: https://nodejs.org/api/packages.html#packages_approach_1_use_an_es_module_wrapper

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
