### PR TITLE
docs(lib-dynamodb): fix syntax errors inside objects

### DIFF
--- a/lib/lib-dynamodb/README.md
+++ b/lib/lib-dynamodb/README.md
@@ -101,16 +101,16 @@ second parameter during creation of document client as follows:
 ```js
 const marshallOptions = {
   // Whether to automatically convert empty strings, blobs, and sets to `null`.
-  convertEmptyValues: false; // false, by default.
+  convertEmptyValues: false, // false, by default.
   // Whether to remove undefined values while marshalling.
-  removeUndefinedValues: false; // false, by default.
+  removeUndefinedValues: false, // false, by default.
   // Whether to convert typeof object to map attribute.
-  convertClassInstanceToMap: false; // false, by default.
+  convertClassInstanceToMap: false, // false, by default.
 };
 
 const unmarshallOptions = {
   // Whether to return numbers as a string instead of converting them to native JavaScript numbers.
-  wrapNumbers: false; // false, by default.
+  wrapNumbers: false, // false, by default.
 };
 
 const translateConfig = { marshallOptions, unmarshallOptions };


### PR DESCRIPTION
### Issue
N/A

### Description
There was a syntax error in the documentation of the `lib-dynamodb` module.

### Testing
Using eslint

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
