### PR TITLE
chore(tsconfig): define workspace specific compilerOptions

### DIFF
--- a/lib/lib-dynamodb/tsconfig.es.json
+++ b/lib/lib-dynamodb/tsconfig.es.json
@@ -1,16 +1,9 @@
 {
   "compilerOptions": {
     "lib": ["es5", "es2015.collection", "dom"],
-    "strict": true,
-    "sourceMap": false,
-    "declaration": true,
     "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/es",
-    "importHelpers": true,
-    "noEmitHelpers": true,
-    "inlineSourceMap": true,
-    "inlineSources": true,
     "baseUrl": "."
   },
   "extends": "../../tsconfig.es.json",

--- a/lib/lib-storage/tsconfig.cjs.json
+++ b/lib/lib-storage/tsconfig.cjs.json
@@ -1,17 +1,9 @@
 {
   "compilerOptions": {
     "lib": ["es5", "es2015.collection", "dom"],
-    "strict": true,
-    "sourceMap": false,
-    "declaration": true,
-    "stripInternal": true,
     "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "importHelpers": true,
-    "noEmitHelpers": true,
-    "inlineSourceMap": true,
-    "inlineSources": true,
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/lib/lib-storage/tsconfig.es.json
+++ b/lib/lib-storage/tsconfig.es.json
@@ -1,17 +1,9 @@
 {
   "compilerOptions": {
     "lib": ["es5", "es2015.collection", "dom"],
-    "strict": true,
-    "sourceMap": false,
-    "declaration": true,
-    "stripInternal": true,
     "declarationDir": "./dist/types",
     "rootDir": "./src",
     "outDir": "./dist/es",
-    "importHelpers": true,
-    "noEmitHelpers": true,
-    "inlineSourceMap": true,
-    "inlineSources": true,
     "baseUrl": "."
   },
   "extends": "../../tsconfig.es.json",


### PR DESCRIPTION
### Issue
Noticed while working on https://github.com/aws/aws-sdk-js-v3/issues/2799

### Description
Define workspace specific compilerOptions in lib-*

### Testing
Verified that following values are present in root `tsconfig.cjs.json`
```
    "strict": true,
    "sourceMap": false,
    "declaration": true,
    "importHelpers": true,
    "noEmitHelpers": true,
    "inlineSourceMap": true,
    "inlineSources": true,
```
We're using default for `stringInternal`

Verified that following values are present in root `tsconfig.es.json`
```
    "strict": true,
    "sourceMap": false,
    "declaration": true,
    "importHelpers": true,
    "noEmitHelpers": true,
    "inlineSourceMap": true,
    "inlineSources": true,
```
---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
