### PR TITLE
fix(middleware-sdk-s3): missing dependency with esbuild

### DIFF
--- a/packages/middleware-sdk-s3/src/S3SignatureV4.ts
+++ b/packages/middleware-sdk-s3/src/S3SignatureV4.ts
@@ -35,7 +35,7 @@ export class S3SignatureV4 implements RequestPresigner, RequestSigner {
     if (options.signingRegion === "*") {
       if (this.signerOptions.runtime !== "node")
         throw new Error("This request requires signing with SigV4Asymmetric algorithm. It's only available in Node.js");
-      return (await this.getSigv4aSigner()).sign(requestToSign, options);
+      return this.getSigv4aSigner().sign(requestToSign, options);
     }
     return this.sigv4Signer.sign(requestToSign, options);
   }
@@ -44,16 +44,17 @@ export class S3SignatureV4 implements RequestPresigner, RequestSigner {
     if (options.signingRegion === "*") {
       if (this.signerOptions.runtime !== "node")
         throw new Error("This request requires signing with SigV4Asymmetric algorithm. It's only available in Node.js");
-      return (await this.getSigv4aSigner()).presign(originalRequest, options);
+      return this.getSigv4aSigner().presign(originalRequest, options);
     }
     return this.sigv4Signer.presign(originalRequest, options);
   }
 
-  private async getSigv4aSigner(): Promise<CrtSignerV4> {
+  private getSigv4aSigner(): CrtSignerV4 {
     if (!this.sigv4aSigner) {
       let CrtSignerV4: new (options: CrtSignerV4Init & SignatureV4CryptoInit) => CrtSignerV4;
       try {
-        CrtSignerV4 = (await import("@aws-sdk/signature-v4-crt")).CrtSignerV4;
+        CrtSignerV4 = require("@aws-sdk/signature-v4-crt").CrtSignerV4;
+        if (typeof CrtSignerV4 !== "function") throw new Error();
       } catch (e) {
         e.message =
           `${e.message}\nPlease check if you have installed "@aws-sdk/signature-v4-crt" package explicitly. \n` +


### PR DESCRIPTION
### Issue
Resolves #2806

### Description
esbuild will try to bundle the optional dependency `@aws-sdk/signature-v4-crt` and will throw if the dependency is not installed. Unlike Webpack, there's no good way to suppress it with magical comments. 

One way to solve this is to wrap the `await import()` with `try...catch`, because esBuild [supresses this error explicitly](https://github.com/evanw/esbuild/commit/6be8e44beba8e765c2b99683608540ce40d6a58f). However, in generated code the import is wrapped by tslib import helper. I didn't remove the import helper because it may break the ES6 class polyfill provided by import helper. Instead, we use the Node.js `require()` here because:
1. Crt package doesn't work for any bundlers now anyway
2. `require()` won't be analyzed by bundler, so `@aws-sdk/signature-v4-crt` is not required

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
