### PR TITLE
feat(clients): remove comments from transpiled JS files

### DIFF
--- a/clients/client-accessanalyzer/package.json
+++ b/clients/client-accessanalyzer/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-accessanalyzer/package.json
+++ b/clients/client-accessanalyzer/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-accessanalyzer/tsconfig.es.json
+++ b/clients/client-accessanalyzer/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-accessanalyzer/tsconfig.json
+++ b/clients/client-accessanalyzer/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-accessanalyzer/tsconfig.types.json
+++ b/clients/client-accessanalyzer/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-acm-pca/package.json
+++ b/clients/client-acm-pca/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-acm-pca/package.json
+++ b/clients/client-acm-pca/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-acm-pca/tsconfig.es.json
+++ b/clients/client-acm-pca/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-acm-pca/tsconfig.json
+++ b/clients/client-acm-pca/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-acm-pca/tsconfig.types.json
+++ b/clients/client-acm-pca/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-acm/package.json
+++ b/clients/client-acm/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-acm/package.json
+++ b/clients/client-acm/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-acm/tsconfig.es.json
+++ b/clients/client-acm/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-acm/tsconfig.json
+++ b/clients/client-acm/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-acm/tsconfig.types.json
+++ b/clients/client-acm/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-alexa-for-business/package.json
+++ b/clients/client-alexa-for-business/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-alexa-for-business/package.json
+++ b/clients/client-alexa-for-business/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-alexa-for-business/tsconfig.es.json
+++ b/clients/client-alexa-for-business/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-alexa-for-business/tsconfig.json
+++ b/clients/client-alexa-for-business/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-alexa-for-business/tsconfig.types.json
+++ b/clients/client-alexa-for-business/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-amp/package.json
+++ b/clients/client-amp/package.json
@@ -11,7 +11,7 @@
     "test": "jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-amp/package.json
+++ b/clients/client-amp/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-amp/tsconfig.es.json
+++ b/clients/client-amp/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-amp/tsconfig.json
+++ b/clients/client-amp/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-amp/tsconfig.types.json
+++ b/clients/client-amp/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-amplify/package.json
+++ b/clients/client-amplify/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-amplify/package.json
+++ b/clients/client-amplify/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-amplify/tsconfig.es.json
+++ b/clients/client-amplify/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-amplify/tsconfig.json
+++ b/clients/client-amplify/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-amplify/tsconfig.types.json
+++ b/clients/client-amplify/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-amplifybackend/package.json
+++ b/clients/client-amplifybackend/package.json
@@ -11,7 +11,7 @@
     "test": "jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-amplifybackend/package.json
+++ b/clients/client-amplifybackend/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-amplifybackend/tsconfig.es.json
+++ b/clients/client-amplifybackend/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-amplifybackend/tsconfig.json
+++ b/clients/client-amplifybackend/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-amplifybackend/tsconfig.types.json
+++ b/clients/client-amplifybackend/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-api-gateway/package.json
+++ b/clients/client-api-gateway/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-api-gateway/package.json
+++ b/clients/client-api-gateway/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-api-gateway/tsconfig.es.json
+++ b/clients/client-api-gateway/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-api-gateway/tsconfig.json
+++ b/clients/client-api-gateway/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-api-gateway/tsconfig.types.json
+++ b/clients/client-api-gateway/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-apigatewaymanagementapi/package.json
+++ b/clients/client-apigatewaymanagementapi/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-apigatewaymanagementapi/package.json
+++ b/clients/client-apigatewaymanagementapi/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-apigatewaymanagementapi/tsconfig.es.json
+++ b/clients/client-apigatewaymanagementapi/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-apigatewaymanagementapi/tsconfig.json
+++ b/clients/client-apigatewaymanagementapi/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-apigatewaymanagementapi/tsconfig.types.json
+++ b/clients/client-apigatewaymanagementapi/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-apigatewayv2/package.json
+++ b/clients/client-apigatewayv2/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-apigatewayv2/package.json
+++ b/clients/client-apigatewayv2/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-apigatewayv2/tsconfig.es.json
+++ b/clients/client-apigatewayv2/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-apigatewayv2/tsconfig.json
+++ b/clients/client-apigatewayv2/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-apigatewayv2/tsconfig.types.json
+++ b/clients/client-apigatewayv2/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-app-mesh/package.json
+++ b/clients/client-app-mesh/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-app-mesh/package.json
+++ b/clients/client-app-mesh/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-app-mesh/tsconfig.es.json
+++ b/clients/client-app-mesh/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-app-mesh/tsconfig.json
+++ b/clients/client-app-mesh/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-app-mesh/tsconfig.types.json
+++ b/clients/client-app-mesh/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-appconfig/package.json
+++ b/clients/client-appconfig/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-appconfig/package.json
+++ b/clients/client-appconfig/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-appconfig/tsconfig.es.json
+++ b/clients/client-appconfig/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-appconfig/tsconfig.json
+++ b/clients/client-appconfig/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-appconfig/tsconfig.types.json
+++ b/clients/client-appconfig/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-appflow/package.json
+++ b/clients/client-appflow/package.json
@@ -11,7 +11,7 @@
     "test": "jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-appflow/package.json
+++ b/clients/client-appflow/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-appflow/tsconfig.es.json
+++ b/clients/client-appflow/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-appflow/tsconfig.json
+++ b/clients/client-appflow/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-appflow/tsconfig.types.json
+++ b/clients/client-appflow/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-appintegrations/package.json
+++ b/clients/client-appintegrations/package.json
@@ -11,7 +11,7 @@
     "test": "jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-appintegrations/package.json
+++ b/clients/client-appintegrations/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-appintegrations/tsconfig.es.json
+++ b/clients/client-appintegrations/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-appintegrations/tsconfig.json
+++ b/clients/client-appintegrations/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-appintegrations/tsconfig.types.json
+++ b/clients/client-appintegrations/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-application-auto-scaling/package.json
+++ b/clients/client-application-auto-scaling/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-application-auto-scaling/package.json
+++ b/clients/client-application-auto-scaling/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-application-auto-scaling/tsconfig.es.json
+++ b/clients/client-application-auto-scaling/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-application-auto-scaling/tsconfig.json
+++ b/clients/client-application-auto-scaling/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-application-auto-scaling/tsconfig.types.json
+++ b/clients/client-application-auto-scaling/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-application-discovery-service/package.json
+++ b/clients/client-application-discovery-service/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-application-discovery-service/package.json
+++ b/clients/client-application-discovery-service/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-application-discovery-service/tsconfig.es.json
+++ b/clients/client-application-discovery-service/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-application-discovery-service/tsconfig.json
+++ b/clients/client-application-discovery-service/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-application-discovery-service/tsconfig.types.json
+++ b/clients/client-application-discovery-service/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-application-insights/package.json
+++ b/clients/client-application-insights/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-application-insights/package.json
+++ b/clients/client-application-insights/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-application-insights/tsconfig.es.json
+++ b/clients/client-application-insights/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-application-insights/tsconfig.json
+++ b/clients/client-application-insights/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-application-insights/tsconfig.types.json
+++ b/clients/client-application-insights/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-applicationcostprofiler/package.json
+++ b/clients/client-applicationcostprofiler/package.json
@@ -11,7 +11,7 @@
     "test": "jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-applicationcostprofiler/package.json
+++ b/clients/client-applicationcostprofiler/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-applicationcostprofiler/tsconfig.es.json
+++ b/clients/client-applicationcostprofiler/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-applicationcostprofiler/tsconfig.json
+++ b/clients/client-applicationcostprofiler/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-applicationcostprofiler/tsconfig.types.json
+++ b/clients/client-applicationcostprofiler/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-apprunner/package.json
+++ b/clients/client-apprunner/package.json
@@ -11,7 +11,7 @@
     "test": "jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-apprunner/package.json
+++ b/clients/client-apprunner/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-apprunner/tsconfig.es.json
+++ b/clients/client-apprunner/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-apprunner/tsconfig.json
+++ b/clients/client-apprunner/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-apprunner/tsconfig.types.json
+++ b/clients/client-apprunner/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-appstream/package.json
+++ b/clients/client-appstream/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-appstream/package.json
+++ b/clients/client-appstream/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-appstream/tsconfig.es.json
+++ b/clients/client-appstream/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-appstream/tsconfig.json
+++ b/clients/client-appstream/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-appstream/tsconfig.types.json
+++ b/clients/client-appstream/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-appsync/package.json
+++ b/clients/client-appsync/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-appsync/package.json
+++ b/clients/client-appsync/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-appsync/tsconfig.es.json
+++ b/clients/client-appsync/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-appsync/tsconfig.json
+++ b/clients/client-appsync/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-appsync/tsconfig.types.json
+++ b/clients/client-appsync/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-athena/package.json
+++ b/clients/client-athena/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-athena/package.json
+++ b/clients/client-athena/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-athena/tsconfig.es.json
+++ b/clients/client-athena/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-athena/tsconfig.json
+++ b/clients/client-athena/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-athena/tsconfig.types.json
+++ b/clients/client-athena/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-auditmanager/package.json
+++ b/clients/client-auditmanager/package.json
@@ -11,7 +11,7 @@
     "test": "jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-auditmanager/package.json
+++ b/clients/client-auditmanager/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-auditmanager/tsconfig.es.json
+++ b/clients/client-auditmanager/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-auditmanager/tsconfig.json
+++ b/clients/client-auditmanager/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-auditmanager/tsconfig.types.json
+++ b/clients/client-auditmanager/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-auto-scaling-plans/package.json
+++ b/clients/client-auto-scaling-plans/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-auto-scaling-plans/package.json
+++ b/clients/client-auto-scaling-plans/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-auto-scaling-plans/tsconfig.es.json
+++ b/clients/client-auto-scaling-plans/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-auto-scaling-plans/tsconfig.json
+++ b/clients/client-auto-scaling-plans/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-auto-scaling-plans/tsconfig.types.json
+++ b/clients/client-auto-scaling-plans/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-auto-scaling/package.json
+++ b/clients/client-auto-scaling/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-auto-scaling/package.json
+++ b/clients/client-auto-scaling/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-auto-scaling/tsconfig.es.json
+++ b/clients/client-auto-scaling/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-auto-scaling/tsconfig.json
+++ b/clients/client-auto-scaling/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-auto-scaling/tsconfig.types.json
+++ b/clients/client-auto-scaling/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-backup/package.json
+++ b/clients/client-backup/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-backup/package.json
+++ b/clients/client-backup/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-backup/tsconfig.es.json
+++ b/clients/client-backup/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-backup/tsconfig.json
+++ b/clients/client-backup/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-backup/tsconfig.types.json
+++ b/clients/client-backup/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-batch/package.json
+++ b/clients/client-batch/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-batch/package.json
+++ b/clients/client-batch/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-batch/tsconfig.es.json
+++ b/clients/client-batch/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-batch/tsconfig.json
+++ b/clients/client-batch/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-batch/tsconfig.types.json
+++ b/clients/client-batch/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-braket/package.json
+++ b/clients/client-braket/package.json
@@ -11,7 +11,7 @@
     "test": "jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-braket/package.json
+++ b/clients/client-braket/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-braket/tsconfig.es.json
+++ b/clients/client-braket/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-braket/tsconfig.json
+++ b/clients/client-braket/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-braket/tsconfig.types.json
+++ b/clients/client-braket/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-budgets/package.json
+++ b/clients/client-budgets/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-budgets/package.json
+++ b/clients/client-budgets/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-budgets/tsconfig.es.json
+++ b/clients/client-budgets/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-budgets/tsconfig.json
+++ b/clients/client-budgets/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-budgets/tsconfig.types.json
+++ b/clients/client-budgets/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-chime-sdk-identity/package.json
+++ b/clients/client-chime-sdk-identity/package.json
@@ -12,7 +12,7 @@
     "test": "jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",

--- a/clients/client-chime-sdk-identity/package.json
+++ b/clients/client-chime-sdk-identity/package.json
@@ -12,7 +12,8 @@
     "test": "jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-chime-sdk-identity/tsconfig.es.json
+++ b/clients/client-chime-sdk-identity/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-chime-sdk-identity/tsconfig.json
+++ b/clients/client-chime-sdk-identity/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-chime-sdk-identity/tsconfig.types.json
+++ b/clients/client-chime-sdk-identity/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-chime-sdk-messaging/package.json
+++ b/clients/client-chime-sdk-messaging/package.json
@@ -12,7 +12,7 @@
     "test": "jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",

--- a/clients/client-chime-sdk-messaging/package.json
+++ b/clients/client-chime-sdk-messaging/package.json
@@ -12,7 +12,8 @@
     "test": "jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-chime-sdk-messaging/tsconfig.es.json
+++ b/clients/client-chime-sdk-messaging/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-chime-sdk-messaging/tsconfig.json
+++ b/clients/client-chime-sdk-messaging/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-chime-sdk-messaging/tsconfig.types.json
+++ b/clients/client-chime-sdk-messaging/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-chime/package.json
+++ b/clients/client-chime/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-chime/package.json
+++ b/clients/client-chime/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-chime/tsconfig.es.json
+++ b/clients/client-chime/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-chime/tsconfig.json
+++ b/clients/client-chime/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-chime/tsconfig.types.json
+++ b/clients/client-chime/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-cloud9/package.json
+++ b/clients/client-cloud9/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-cloud9/package.json
+++ b/clients/client-cloud9/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-cloud9/tsconfig.es.json
+++ b/clients/client-cloud9/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-cloud9/tsconfig.json
+++ b/clients/client-cloud9/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-cloud9/tsconfig.types.json
+++ b/clients/client-cloud9/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-clouddirectory/package.json
+++ b/clients/client-clouddirectory/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-clouddirectory/package.json
+++ b/clients/client-clouddirectory/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-clouddirectory/tsconfig.es.json
+++ b/clients/client-clouddirectory/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-clouddirectory/tsconfig.json
+++ b/clients/client-clouddirectory/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-clouddirectory/tsconfig.types.json
+++ b/clients/client-clouddirectory/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-cloudformation/package.json
+++ b/clients/client-cloudformation/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-cloudformation/package.json
+++ b/clients/client-cloudformation/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-cloudformation/tsconfig.es.json
+++ b/clients/client-cloudformation/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-cloudformation/tsconfig.json
+++ b/clients/client-cloudformation/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-cloudformation/tsconfig.types.json
+++ b/clients/client-cloudformation/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-cloudfront/package.json
+++ b/clients/client-cloudfront/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-cloudfront/package.json
+++ b/clients/client-cloudfront/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-cloudfront/tsconfig.es.json
+++ b/clients/client-cloudfront/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-cloudfront/tsconfig.json
+++ b/clients/client-cloudfront/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-cloudfront/tsconfig.types.json
+++ b/clients/client-cloudfront/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-cloudhsm-v2/package.json
+++ b/clients/client-cloudhsm-v2/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-cloudhsm-v2/package.json
+++ b/clients/client-cloudhsm-v2/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-cloudhsm-v2/tsconfig.es.json
+++ b/clients/client-cloudhsm-v2/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-cloudhsm-v2/tsconfig.json
+++ b/clients/client-cloudhsm-v2/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-cloudhsm-v2/tsconfig.types.json
+++ b/clients/client-cloudhsm-v2/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-cloudhsm/package.json
+++ b/clients/client-cloudhsm/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-cloudhsm/package.json
+++ b/clients/client-cloudhsm/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-cloudhsm/tsconfig.es.json
+++ b/clients/client-cloudhsm/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-cloudhsm/tsconfig.json
+++ b/clients/client-cloudhsm/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-cloudhsm/tsconfig.types.json
+++ b/clients/client-cloudhsm/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-cloudsearch-domain/package.json
+++ b/clients/client-cloudsearch-domain/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-cloudsearch-domain/package.json
+++ b/clients/client-cloudsearch-domain/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-cloudsearch-domain/tsconfig.es.json
+++ b/clients/client-cloudsearch-domain/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-cloudsearch-domain/tsconfig.json
+++ b/clients/client-cloudsearch-domain/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-cloudsearch-domain/tsconfig.types.json
+++ b/clients/client-cloudsearch-domain/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-cloudsearch/package.json
+++ b/clients/client-cloudsearch/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-cloudsearch/package.json
+++ b/clients/client-cloudsearch/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-cloudsearch/tsconfig.es.json
+++ b/clients/client-cloudsearch/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-cloudsearch/tsconfig.json
+++ b/clients/client-cloudsearch/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-cloudsearch/tsconfig.types.json
+++ b/clients/client-cloudsearch/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-cloudtrail/package.json
+++ b/clients/client-cloudtrail/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-cloudtrail/package.json
+++ b/clients/client-cloudtrail/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-cloudtrail/tsconfig.es.json
+++ b/clients/client-cloudtrail/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-cloudtrail/tsconfig.json
+++ b/clients/client-cloudtrail/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-cloudtrail/tsconfig.types.json
+++ b/clients/client-cloudtrail/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-cloudwatch-events/package.json
+++ b/clients/client-cloudwatch-events/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-cloudwatch-events/package.json
+++ b/clients/client-cloudwatch-events/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-cloudwatch-events/tsconfig.es.json
+++ b/clients/client-cloudwatch-events/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-cloudwatch-events/tsconfig.json
+++ b/clients/client-cloudwatch-events/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-cloudwatch-events/tsconfig.types.json
+++ b/clients/client-cloudwatch-events/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-cloudwatch-logs/package.json
+++ b/clients/client-cloudwatch-logs/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-cloudwatch-logs/package.json
+++ b/clients/client-cloudwatch-logs/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-cloudwatch-logs/tsconfig.es.json
+++ b/clients/client-cloudwatch-logs/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-cloudwatch-logs/tsconfig.json
+++ b/clients/client-cloudwatch-logs/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-cloudwatch-logs/tsconfig.types.json
+++ b/clients/client-cloudwatch-logs/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-cloudwatch/package.json
+++ b/clients/client-cloudwatch/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-cloudwatch/package.json
+++ b/clients/client-cloudwatch/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-cloudwatch/tsconfig.es.json
+++ b/clients/client-cloudwatch/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-cloudwatch/tsconfig.json
+++ b/clients/client-cloudwatch/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-cloudwatch/tsconfig.types.json
+++ b/clients/client-cloudwatch/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-codeartifact/package.json
+++ b/clients/client-codeartifact/package.json
@@ -11,7 +11,7 @@
     "test": "jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-codeartifact/package.json
+++ b/clients/client-codeartifact/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-codeartifact/tsconfig.es.json
+++ b/clients/client-codeartifact/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-codeartifact/tsconfig.json
+++ b/clients/client-codeartifact/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-codeartifact/tsconfig.types.json
+++ b/clients/client-codeartifact/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-codebuild/package.json
+++ b/clients/client-codebuild/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-codebuild/package.json
+++ b/clients/client-codebuild/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-codebuild/tsconfig.es.json
+++ b/clients/client-codebuild/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-codebuild/tsconfig.json
+++ b/clients/client-codebuild/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-codebuild/tsconfig.types.json
+++ b/clients/client-codebuild/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-codecommit/package.json
+++ b/clients/client-codecommit/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-codecommit/package.json
+++ b/clients/client-codecommit/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-codecommit/tsconfig.es.json
+++ b/clients/client-codecommit/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-codecommit/tsconfig.json
+++ b/clients/client-codecommit/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-codecommit/tsconfig.types.json
+++ b/clients/client-codecommit/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-codedeploy/package.json
+++ b/clients/client-codedeploy/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-codedeploy/package.json
+++ b/clients/client-codedeploy/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-codedeploy/tsconfig.es.json
+++ b/clients/client-codedeploy/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-codedeploy/tsconfig.json
+++ b/clients/client-codedeploy/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-codedeploy/tsconfig.types.json
+++ b/clients/client-codedeploy/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-codeguru-reviewer/package.json
+++ b/clients/client-codeguru-reviewer/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-codeguru-reviewer/package.json
+++ b/clients/client-codeguru-reviewer/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-codeguru-reviewer/tsconfig.es.json
+++ b/clients/client-codeguru-reviewer/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-codeguru-reviewer/tsconfig.json
+++ b/clients/client-codeguru-reviewer/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-codeguru-reviewer/tsconfig.types.json
+++ b/clients/client-codeguru-reviewer/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-codeguruprofiler/package.json
+++ b/clients/client-codeguruprofiler/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-codeguruprofiler/package.json
+++ b/clients/client-codeguruprofiler/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-codeguruprofiler/tsconfig.es.json
+++ b/clients/client-codeguruprofiler/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-codeguruprofiler/tsconfig.json
+++ b/clients/client-codeguruprofiler/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-codeguruprofiler/tsconfig.types.json
+++ b/clients/client-codeguruprofiler/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-codepipeline/package.json
+++ b/clients/client-codepipeline/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-codepipeline/package.json
+++ b/clients/client-codepipeline/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-codepipeline/tsconfig.es.json
+++ b/clients/client-codepipeline/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-codepipeline/tsconfig.json
+++ b/clients/client-codepipeline/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-codepipeline/tsconfig.types.json
+++ b/clients/client-codepipeline/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-codestar-connections/package.json
+++ b/clients/client-codestar-connections/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-codestar-connections/package.json
+++ b/clients/client-codestar-connections/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-codestar-connections/tsconfig.es.json
+++ b/clients/client-codestar-connections/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-codestar-connections/tsconfig.json
+++ b/clients/client-codestar-connections/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-codestar-connections/tsconfig.types.json
+++ b/clients/client-codestar-connections/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-codestar-notifications/package.json
+++ b/clients/client-codestar-notifications/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-codestar-notifications/package.json
+++ b/clients/client-codestar-notifications/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-codestar-notifications/tsconfig.es.json
+++ b/clients/client-codestar-notifications/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-codestar-notifications/tsconfig.json
+++ b/clients/client-codestar-notifications/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-codestar-notifications/tsconfig.types.json
+++ b/clients/client-codestar-notifications/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-codestar/package.json
+++ b/clients/client-codestar/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-codestar/package.json
+++ b/clients/client-codestar/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-codestar/tsconfig.es.json
+++ b/clients/client-codestar/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-codestar/tsconfig.json
+++ b/clients/client-codestar/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-codestar/tsconfig.types.json
+++ b/clients/client-codestar/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-cognito-identity-provider/package.json
+++ b/clients/client-cognito-identity-provider/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-cognito-identity-provider/package.json
+++ b/clients/client-cognito-identity-provider/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-cognito-identity-provider/tsconfig.es.json
+++ b/clients/client-cognito-identity-provider/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-cognito-identity-provider/tsconfig.json
+++ b/clients/client-cognito-identity-provider/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-cognito-identity-provider/tsconfig.types.json
+++ b/clients/client-cognito-identity-provider/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-cognito-identity/package.json
+++ b/clients/client-cognito-identity/package.json
@@ -14,7 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-cognito-identity/package.json
+++ b/clients/client-cognito-identity/package.json
@@ -13,7 +13,7 @@
     "test": "yarn test:unit",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-cognito-identity/tsconfig.es.json
+++ b/clients/client-cognito-identity/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-cognito-identity/tsconfig.json
+++ b/clients/client-cognito-identity/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
     "outDir": "dist/cjs",
+    "removeComments": true,
     "types": ["mocha", "node"]
   },
   "typedocOptions": {

--- a/clients/client-cognito-identity/tsconfig.types.json
+++ b/clients/client-cognito-identity/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-cognito-sync/package.json
+++ b/clients/client-cognito-sync/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-cognito-sync/package.json
+++ b/clients/client-cognito-sync/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-cognito-sync/tsconfig.es.json
+++ b/clients/client-cognito-sync/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-cognito-sync/tsconfig.json
+++ b/clients/client-cognito-sync/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-cognito-sync/tsconfig.types.json
+++ b/clients/client-cognito-sync/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-comprehend/package.json
+++ b/clients/client-comprehend/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-comprehend/package.json
+++ b/clients/client-comprehend/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-comprehend/tsconfig.es.json
+++ b/clients/client-comprehend/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-comprehend/tsconfig.json
+++ b/clients/client-comprehend/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-comprehend/tsconfig.types.json
+++ b/clients/client-comprehend/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-comprehendmedical/package.json
+++ b/clients/client-comprehendmedical/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-comprehendmedical/package.json
+++ b/clients/client-comprehendmedical/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-comprehendmedical/tsconfig.es.json
+++ b/clients/client-comprehendmedical/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-comprehendmedical/tsconfig.json
+++ b/clients/client-comprehendmedical/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-comprehendmedical/tsconfig.types.json
+++ b/clients/client-comprehendmedical/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-compute-optimizer/package.json
+++ b/clients/client-compute-optimizer/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-compute-optimizer/package.json
+++ b/clients/client-compute-optimizer/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-compute-optimizer/tsconfig.es.json
+++ b/clients/client-compute-optimizer/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-compute-optimizer/tsconfig.json
+++ b/clients/client-compute-optimizer/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-compute-optimizer/tsconfig.types.json
+++ b/clients/client-compute-optimizer/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-config-service/package.json
+++ b/clients/client-config-service/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-config-service/package.json
+++ b/clients/client-config-service/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-config-service/tsconfig.es.json
+++ b/clients/client-config-service/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-config-service/tsconfig.json
+++ b/clients/client-config-service/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-config-service/tsconfig.types.json
+++ b/clients/client-config-service/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-connect-contact-lens/package.json
+++ b/clients/client-connect-contact-lens/package.json
@@ -11,7 +11,7 @@
     "test": "jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-connect-contact-lens/package.json
+++ b/clients/client-connect-contact-lens/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-connect-contact-lens/tsconfig.es.json
+++ b/clients/client-connect-contact-lens/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-connect-contact-lens/tsconfig.json
+++ b/clients/client-connect-contact-lens/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-connect-contact-lens/tsconfig.types.json
+++ b/clients/client-connect-contact-lens/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-connect/package.json
+++ b/clients/client-connect/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-connect/package.json
+++ b/clients/client-connect/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-connect/tsconfig.es.json
+++ b/clients/client-connect/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-connect/tsconfig.json
+++ b/clients/client-connect/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-connect/tsconfig.types.json
+++ b/clients/client-connect/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-connectparticipant/package.json
+++ b/clients/client-connectparticipant/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-connectparticipant/package.json
+++ b/clients/client-connectparticipant/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-connectparticipant/tsconfig.es.json
+++ b/clients/client-connectparticipant/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-connectparticipant/tsconfig.json
+++ b/clients/client-connectparticipant/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-connectparticipant/tsconfig.types.json
+++ b/clients/client-connectparticipant/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-cost-and-usage-report-service/package.json
+++ b/clients/client-cost-and-usage-report-service/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-cost-and-usage-report-service/package.json
+++ b/clients/client-cost-and-usage-report-service/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-cost-and-usage-report-service/tsconfig.es.json
+++ b/clients/client-cost-and-usage-report-service/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-cost-and-usage-report-service/tsconfig.json
+++ b/clients/client-cost-and-usage-report-service/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-cost-and-usage-report-service/tsconfig.types.json
+++ b/clients/client-cost-and-usage-report-service/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-cost-explorer/package.json
+++ b/clients/client-cost-explorer/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-cost-explorer/package.json
+++ b/clients/client-cost-explorer/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-cost-explorer/tsconfig.es.json
+++ b/clients/client-cost-explorer/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-cost-explorer/tsconfig.json
+++ b/clients/client-cost-explorer/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-cost-explorer/tsconfig.types.json
+++ b/clients/client-cost-explorer/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-customer-profiles/package.json
+++ b/clients/client-customer-profiles/package.json
@@ -11,7 +11,7 @@
     "test": "jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-customer-profiles/package.json
+++ b/clients/client-customer-profiles/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-customer-profiles/tsconfig.es.json
+++ b/clients/client-customer-profiles/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-customer-profiles/tsconfig.json
+++ b/clients/client-customer-profiles/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-customer-profiles/tsconfig.types.json
+++ b/clients/client-customer-profiles/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-data-pipeline/package.json
+++ b/clients/client-data-pipeline/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-data-pipeline/package.json
+++ b/clients/client-data-pipeline/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-data-pipeline/tsconfig.es.json
+++ b/clients/client-data-pipeline/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-data-pipeline/tsconfig.json
+++ b/clients/client-data-pipeline/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-data-pipeline/tsconfig.types.json
+++ b/clients/client-data-pipeline/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-database-migration-service/package.json
+++ b/clients/client-database-migration-service/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-database-migration-service/package.json
+++ b/clients/client-database-migration-service/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-database-migration-service/tsconfig.es.json
+++ b/clients/client-database-migration-service/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-database-migration-service/tsconfig.json
+++ b/clients/client-database-migration-service/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-database-migration-service/tsconfig.types.json
+++ b/clients/client-database-migration-service/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-databrew/package.json
+++ b/clients/client-databrew/package.json
@@ -11,7 +11,7 @@
     "test": "jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-databrew/package.json
+++ b/clients/client-databrew/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-databrew/tsconfig.es.json
+++ b/clients/client-databrew/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-databrew/tsconfig.json
+++ b/clients/client-databrew/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-databrew/tsconfig.types.json
+++ b/clients/client-databrew/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-dataexchange/package.json
+++ b/clients/client-dataexchange/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-dataexchange/package.json
+++ b/clients/client-dataexchange/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-dataexchange/tsconfig.es.json
+++ b/clients/client-dataexchange/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-dataexchange/tsconfig.json
+++ b/clients/client-dataexchange/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-dataexchange/tsconfig.types.json
+++ b/clients/client-dataexchange/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-datasync/package.json
+++ b/clients/client-datasync/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-datasync/package.json
+++ b/clients/client-datasync/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-datasync/tsconfig.es.json
+++ b/clients/client-datasync/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-datasync/tsconfig.json
+++ b/clients/client-datasync/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-datasync/tsconfig.types.json
+++ b/clients/client-datasync/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-dax/package.json
+++ b/clients/client-dax/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-dax/package.json
+++ b/clients/client-dax/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-dax/tsconfig.es.json
+++ b/clients/client-dax/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-dax/tsconfig.json
+++ b/clients/client-dax/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-dax/tsconfig.types.json
+++ b/clients/client-dax/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-detective/package.json
+++ b/clients/client-detective/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-detective/package.json
+++ b/clients/client-detective/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-detective/tsconfig.es.json
+++ b/clients/client-detective/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-detective/tsconfig.json
+++ b/clients/client-detective/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-detective/tsconfig.types.json
+++ b/clients/client-detective/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-device-farm/package.json
+++ b/clients/client-device-farm/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-device-farm/package.json
+++ b/clients/client-device-farm/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-device-farm/tsconfig.es.json
+++ b/clients/client-device-farm/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-device-farm/tsconfig.json
+++ b/clients/client-device-farm/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-device-farm/tsconfig.types.json
+++ b/clients/client-device-farm/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-devops-guru/package.json
+++ b/clients/client-devops-guru/package.json
@@ -11,7 +11,7 @@
     "test": "jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-devops-guru/package.json
+++ b/clients/client-devops-guru/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-devops-guru/tsconfig.es.json
+++ b/clients/client-devops-guru/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-devops-guru/tsconfig.json
+++ b/clients/client-devops-guru/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-devops-guru/tsconfig.types.json
+++ b/clients/client-devops-guru/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-direct-connect/package.json
+++ b/clients/client-direct-connect/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-direct-connect/package.json
+++ b/clients/client-direct-connect/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-direct-connect/tsconfig.es.json
+++ b/clients/client-direct-connect/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-direct-connect/tsconfig.json
+++ b/clients/client-direct-connect/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-direct-connect/tsconfig.types.json
+++ b/clients/client-direct-connect/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-directory-service/package.json
+++ b/clients/client-directory-service/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-directory-service/package.json
+++ b/clients/client-directory-service/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-directory-service/tsconfig.es.json
+++ b/clients/client-directory-service/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-directory-service/tsconfig.json
+++ b/clients/client-directory-service/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-directory-service/tsconfig.types.json
+++ b/clients/client-directory-service/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-dlm/package.json
+++ b/clients/client-dlm/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-dlm/package.json
+++ b/clients/client-dlm/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-dlm/tsconfig.es.json
+++ b/clients/client-dlm/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-dlm/tsconfig.json
+++ b/clients/client-dlm/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-dlm/tsconfig.types.json
+++ b/clients/client-dlm/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-docdb/package.json
+++ b/clients/client-docdb/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-docdb/package.json
+++ b/clients/client-docdb/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-docdb/tsconfig.es.json
+++ b/clients/client-docdb/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-docdb/tsconfig.json
+++ b/clients/client-docdb/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-docdb/tsconfig.types.json
+++ b/clients/client-docdb/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-dynamodb-streams/package.json
+++ b/clients/client-dynamodb-streams/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-dynamodb-streams/package.json
+++ b/clients/client-dynamodb-streams/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-dynamodb-streams/tsconfig.es.json
+++ b/clients/client-dynamodb-streams/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-dynamodb-streams/tsconfig.json
+++ b/clients/client-dynamodb-streams/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-dynamodb-streams/tsconfig.types.json
+++ b/clients/client-dynamodb-streams/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-dynamodb/package.json
+++ b/clients/client-dynamodb/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-dynamodb/package.json
+++ b/clients/client-dynamodb/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-dynamodb/tsconfig.es.json
+++ b/clients/client-dynamodb/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-dynamodb/tsconfig.json
+++ b/clients/client-dynamodb/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-dynamodb/tsconfig.types.json
+++ b/clients/client-dynamodb/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-ebs/package.json
+++ b/clients/client-ebs/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-ebs/package.json
+++ b/clients/client-ebs/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-ebs/tsconfig.es.json
+++ b/clients/client-ebs/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-ebs/tsconfig.json
+++ b/clients/client-ebs/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-ebs/tsconfig.types.json
+++ b/clients/client-ebs/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-ec2-instance-connect/package.json
+++ b/clients/client-ec2-instance-connect/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-ec2-instance-connect/package.json
+++ b/clients/client-ec2-instance-connect/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-ec2-instance-connect/tsconfig.es.json
+++ b/clients/client-ec2-instance-connect/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-ec2-instance-connect/tsconfig.json
+++ b/clients/client-ec2-instance-connect/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-ec2-instance-connect/tsconfig.types.json
+++ b/clients/client-ec2-instance-connect/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-ec2/package.json
+++ b/clients/client-ec2/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-ec2/package.json
+++ b/clients/client-ec2/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-ec2/tsconfig.es.json
+++ b/clients/client-ec2/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-ec2/tsconfig.json
+++ b/clients/client-ec2/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-ec2/tsconfig.types.json
+++ b/clients/client-ec2/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-ecr-public/package.json
+++ b/clients/client-ecr-public/package.json
@@ -11,7 +11,7 @@
     "test": "jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-ecr-public/package.json
+++ b/clients/client-ecr-public/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-ecr-public/tsconfig.es.json
+++ b/clients/client-ecr-public/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-ecr-public/tsconfig.json
+++ b/clients/client-ecr-public/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-ecr-public/tsconfig.types.json
+++ b/clients/client-ecr-public/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-ecr/package.json
+++ b/clients/client-ecr/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-ecr/package.json
+++ b/clients/client-ecr/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-ecr/tsconfig.es.json
+++ b/clients/client-ecr/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-ecr/tsconfig.json
+++ b/clients/client-ecr/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-ecr/tsconfig.types.json
+++ b/clients/client-ecr/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-ecs/package.json
+++ b/clients/client-ecs/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-ecs/package.json
+++ b/clients/client-ecs/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-ecs/tsconfig.es.json
+++ b/clients/client-ecs/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-ecs/tsconfig.json
+++ b/clients/client-ecs/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-ecs/tsconfig.types.json
+++ b/clients/client-ecs/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-efs/package.json
+++ b/clients/client-efs/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-efs/package.json
+++ b/clients/client-efs/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-efs/tsconfig.es.json
+++ b/clients/client-efs/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-efs/tsconfig.json
+++ b/clients/client-efs/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-efs/tsconfig.types.json
+++ b/clients/client-efs/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-eks/package.json
+++ b/clients/client-eks/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-eks/package.json
+++ b/clients/client-eks/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-eks/tsconfig.es.json
+++ b/clients/client-eks/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-eks/tsconfig.json
+++ b/clients/client-eks/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-eks/tsconfig.types.json
+++ b/clients/client-eks/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-elastic-beanstalk/package.json
+++ b/clients/client-elastic-beanstalk/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-elastic-beanstalk/package.json
+++ b/clients/client-elastic-beanstalk/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-elastic-beanstalk/tsconfig.es.json
+++ b/clients/client-elastic-beanstalk/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-elastic-beanstalk/tsconfig.json
+++ b/clients/client-elastic-beanstalk/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-elastic-beanstalk/tsconfig.types.json
+++ b/clients/client-elastic-beanstalk/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-elastic-inference/package.json
+++ b/clients/client-elastic-inference/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-elastic-inference/package.json
+++ b/clients/client-elastic-inference/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-elastic-inference/tsconfig.es.json
+++ b/clients/client-elastic-inference/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-elastic-inference/tsconfig.json
+++ b/clients/client-elastic-inference/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-elastic-inference/tsconfig.types.json
+++ b/clients/client-elastic-inference/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-elastic-load-balancing-v2/package.json
+++ b/clients/client-elastic-load-balancing-v2/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-elastic-load-balancing-v2/package.json
+++ b/clients/client-elastic-load-balancing-v2/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-elastic-load-balancing-v2/tsconfig.es.json
+++ b/clients/client-elastic-load-balancing-v2/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-elastic-load-balancing-v2/tsconfig.json
+++ b/clients/client-elastic-load-balancing-v2/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-elastic-load-balancing-v2/tsconfig.types.json
+++ b/clients/client-elastic-load-balancing-v2/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-elastic-load-balancing/package.json
+++ b/clients/client-elastic-load-balancing/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-elastic-load-balancing/package.json
+++ b/clients/client-elastic-load-balancing/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-elastic-load-balancing/tsconfig.es.json
+++ b/clients/client-elastic-load-balancing/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-elastic-load-balancing/tsconfig.json
+++ b/clients/client-elastic-load-balancing/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-elastic-load-balancing/tsconfig.types.json
+++ b/clients/client-elastic-load-balancing/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-elastic-transcoder/package.json
+++ b/clients/client-elastic-transcoder/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-elastic-transcoder/package.json
+++ b/clients/client-elastic-transcoder/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-elastic-transcoder/tsconfig.es.json
+++ b/clients/client-elastic-transcoder/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-elastic-transcoder/tsconfig.json
+++ b/clients/client-elastic-transcoder/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-elastic-transcoder/tsconfig.types.json
+++ b/clients/client-elastic-transcoder/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-elasticache/package.json
+++ b/clients/client-elasticache/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-elasticache/package.json
+++ b/clients/client-elasticache/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-elasticache/tsconfig.es.json
+++ b/clients/client-elasticache/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-elasticache/tsconfig.json
+++ b/clients/client-elasticache/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-elasticache/tsconfig.types.json
+++ b/clients/client-elasticache/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-elasticsearch-service/package.json
+++ b/clients/client-elasticsearch-service/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-elasticsearch-service/package.json
+++ b/clients/client-elasticsearch-service/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-elasticsearch-service/tsconfig.es.json
+++ b/clients/client-elasticsearch-service/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-elasticsearch-service/tsconfig.json
+++ b/clients/client-elasticsearch-service/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-elasticsearch-service/tsconfig.types.json
+++ b/clients/client-elasticsearch-service/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-emr-containers/package.json
+++ b/clients/client-emr-containers/package.json
@@ -11,7 +11,7 @@
     "test": "jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-emr-containers/package.json
+++ b/clients/client-emr-containers/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-emr-containers/tsconfig.es.json
+++ b/clients/client-emr-containers/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-emr-containers/tsconfig.json
+++ b/clients/client-emr-containers/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-emr-containers/tsconfig.types.json
+++ b/clients/client-emr-containers/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-emr/package.json
+++ b/clients/client-emr/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-emr/package.json
+++ b/clients/client-emr/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-emr/tsconfig.es.json
+++ b/clients/client-emr/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-emr/tsconfig.json
+++ b/clients/client-emr/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-emr/tsconfig.types.json
+++ b/clients/client-emr/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-eventbridge/package.json
+++ b/clients/client-eventbridge/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-eventbridge/package.json
+++ b/clients/client-eventbridge/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-eventbridge/tsconfig.es.json
+++ b/clients/client-eventbridge/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-eventbridge/tsconfig.json
+++ b/clients/client-eventbridge/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-eventbridge/tsconfig.types.json
+++ b/clients/client-eventbridge/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-finspace-data/package.json
+++ b/clients/client-finspace-data/package.json
@@ -11,7 +11,7 @@
     "test": "jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-finspace-data/package.json
+++ b/clients/client-finspace-data/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-finspace-data/tsconfig.es.json
+++ b/clients/client-finspace-data/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-finspace-data/tsconfig.json
+++ b/clients/client-finspace-data/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-finspace-data/tsconfig.types.json
+++ b/clients/client-finspace-data/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-finspace/package.json
+++ b/clients/client-finspace/package.json
@@ -11,7 +11,7 @@
     "test": "jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-finspace/package.json
+++ b/clients/client-finspace/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-finspace/tsconfig.es.json
+++ b/clients/client-finspace/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-finspace/tsconfig.json
+++ b/clients/client-finspace/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-finspace/tsconfig.types.json
+++ b/clients/client-finspace/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-firehose/package.json
+++ b/clients/client-firehose/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-firehose/package.json
+++ b/clients/client-firehose/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-firehose/tsconfig.es.json
+++ b/clients/client-firehose/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-firehose/tsconfig.json
+++ b/clients/client-firehose/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-firehose/tsconfig.types.json
+++ b/clients/client-firehose/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-fis/package.json
+++ b/clients/client-fis/package.json
@@ -11,7 +11,7 @@
     "test": "jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-fis/package.json
+++ b/clients/client-fis/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-fis/tsconfig.es.json
+++ b/clients/client-fis/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-fis/tsconfig.json
+++ b/clients/client-fis/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-fis/tsconfig.types.json
+++ b/clients/client-fis/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-fms/package.json
+++ b/clients/client-fms/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-fms/package.json
+++ b/clients/client-fms/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-fms/tsconfig.es.json
+++ b/clients/client-fms/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-fms/tsconfig.json
+++ b/clients/client-fms/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-fms/tsconfig.types.json
+++ b/clients/client-fms/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-forecast/package.json
+++ b/clients/client-forecast/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-forecast/package.json
+++ b/clients/client-forecast/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-forecast/tsconfig.es.json
+++ b/clients/client-forecast/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-forecast/tsconfig.json
+++ b/clients/client-forecast/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-forecast/tsconfig.types.json
+++ b/clients/client-forecast/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-forecastquery/package.json
+++ b/clients/client-forecastquery/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-forecastquery/package.json
+++ b/clients/client-forecastquery/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-forecastquery/tsconfig.es.json
+++ b/clients/client-forecastquery/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-forecastquery/tsconfig.json
+++ b/clients/client-forecastquery/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-forecastquery/tsconfig.types.json
+++ b/clients/client-forecastquery/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-frauddetector/package.json
+++ b/clients/client-frauddetector/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-frauddetector/package.json
+++ b/clients/client-frauddetector/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-frauddetector/tsconfig.es.json
+++ b/clients/client-frauddetector/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-frauddetector/tsconfig.json
+++ b/clients/client-frauddetector/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-frauddetector/tsconfig.types.json
+++ b/clients/client-frauddetector/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-fsx/package.json
+++ b/clients/client-fsx/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-fsx/package.json
+++ b/clients/client-fsx/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-fsx/tsconfig.es.json
+++ b/clients/client-fsx/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-fsx/tsconfig.json
+++ b/clients/client-fsx/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-fsx/tsconfig.types.json
+++ b/clients/client-fsx/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-gamelift/package.json
+++ b/clients/client-gamelift/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-gamelift/package.json
+++ b/clients/client-gamelift/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-gamelift/tsconfig.es.json
+++ b/clients/client-gamelift/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-gamelift/tsconfig.json
+++ b/clients/client-gamelift/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-gamelift/tsconfig.types.json
+++ b/clients/client-gamelift/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-glacier/package.json
+++ b/clients/client-glacier/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-glacier/package.json
+++ b/clients/client-glacier/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-glacier/tsconfig.es.json
+++ b/clients/client-glacier/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-glacier/tsconfig.json
+++ b/clients/client-glacier/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-glacier/tsconfig.types.json
+++ b/clients/client-glacier/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-global-accelerator/package.json
+++ b/clients/client-global-accelerator/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-global-accelerator/package.json
+++ b/clients/client-global-accelerator/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-global-accelerator/tsconfig.es.json
+++ b/clients/client-global-accelerator/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-global-accelerator/tsconfig.json
+++ b/clients/client-global-accelerator/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-global-accelerator/tsconfig.types.json
+++ b/clients/client-global-accelerator/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-glue/package.json
+++ b/clients/client-glue/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-glue/package.json
+++ b/clients/client-glue/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-glue/tsconfig.es.json
+++ b/clients/client-glue/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-glue/tsconfig.json
+++ b/clients/client-glue/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-glue/tsconfig.types.json
+++ b/clients/client-glue/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-greengrass/package.json
+++ b/clients/client-greengrass/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-greengrass/package.json
+++ b/clients/client-greengrass/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-greengrass/tsconfig.es.json
+++ b/clients/client-greengrass/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-greengrass/tsconfig.json
+++ b/clients/client-greengrass/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-greengrass/tsconfig.types.json
+++ b/clients/client-greengrass/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-greengrassv2/package.json
+++ b/clients/client-greengrassv2/package.json
@@ -11,7 +11,7 @@
     "test": "jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-greengrassv2/package.json
+++ b/clients/client-greengrassv2/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-greengrassv2/tsconfig.es.json
+++ b/clients/client-greengrassv2/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-greengrassv2/tsconfig.json
+++ b/clients/client-greengrassv2/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-greengrassv2/tsconfig.types.json
+++ b/clients/client-greengrassv2/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-groundstation/package.json
+++ b/clients/client-groundstation/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-groundstation/package.json
+++ b/clients/client-groundstation/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-groundstation/tsconfig.es.json
+++ b/clients/client-groundstation/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-groundstation/tsconfig.json
+++ b/clients/client-groundstation/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-groundstation/tsconfig.types.json
+++ b/clients/client-groundstation/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-guardduty/package.json
+++ b/clients/client-guardduty/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-guardduty/package.json
+++ b/clients/client-guardduty/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-guardduty/tsconfig.es.json
+++ b/clients/client-guardduty/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-guardduty/tsconfig.json
+++ b/clients/client-guardduty/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-guardduty/tsconfig.types.json
+++ b/clients/client-guardduty/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-health/package.json
+++ b/clients/client-health/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-health/package.json
+++ b/clients/client-health/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-health/tsconfig.es.json
+++ b/clients/client-health/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-health/tsconfig.json
+++ b/clients/client-health/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-health/tsconfig.types.json
+++ b/clients/client-health/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-healthlake/package.json
+++ b/clients/client-healthlake/package.json
@@ -11,7 +11,7 @@
     "test": "jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-healthlake/package.json
+++ b/clients/client-healthlake/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-healthlake/tsconfig.es.json
+++ b/clients/client-healthlake/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-healthlake/tsconfig.json
+++ b/clients/client-healthlake/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-healthlake/tsconfig.types.json
+++ b/clients/client-healthlake/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-honeycode/package.json
+++ b/clients/client-honeycode/package.json
@@ -11,7 +11,7 @@
     "test": "jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-honeycode/package.json
+++ b/clients/client-honeycode/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-honeycode/tsconfig.es.json
+++ b/clients/client-honeycode/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-honeycode/tsconfig.json
+++ b/clients/client-honeycode/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-honeycode/tsconfig.types.json
+++ b/clients/client-honeycode/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-iam/package.json
+++ b/clients/client-iam/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-iam/package.json
+++ b/clients/client-iam/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-iam/tsconfig.es.json
+++ b/clients/client-iam/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-iam/tsconfig.json
+++ b/clients/client-iam/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-iam/tsconfig.types.json
+++ b/clients/client-iam/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-identitystore/package.json
+++ b/clients/client-identitystore/package.json
@@ -11,7 +11,7 @@
     "test": "jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-identitystore/package.json
+++ b/clients/client-identitystore/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-identitystore/tsconfig.es.json
+++ b/clients/client-identitystore/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-identitystore/tsconfig.json
+++ b/clients/client-identitystore/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-identitystore/tsconfig.types.json
+++ b/clients/client-identitystore/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-imagebuilder/package.json
+++ b/clients/client-imagebuilder/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-imagebuilder/package.json
+++ b/clients/client-imagebuilder/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-imagebuilder/tsconfig.es.json
+++ b/clients/client-imagebuilder/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-imagebuilder/tsconfig.json
+++ b/clients/client-imagebuilder/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-imagebuilder/tsconfig.types.json
+++ b/clients/client-imagebuilder/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-inspector/package.json
+++ b/clients/client-inspector/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-inspector/package.json
+++ b/clients/client-inspector/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-inspector/tsconfig.es.json
+++ b/clients/client-inspector/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-inspector/tsconfig.json
+++ b/clients/client-inspector/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-inspector/tsconfig.types.json
+++ b/clients/client-inspector/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-iot-1click-devices-service/package.json
+++ b/clients/client-iot-1click-devices-service/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-iot-1click-devices-service/package.json
+++ b/clients/client-iot-1click-devices-service/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-iot-1click-devices-service/tsconfig.es.json
+++ b/clients/client-iot-1click-devices-service/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-iot-1click-devices-service/tsconfig.json
+++ b/clients/client-iot-1click-devices-service/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-iot-1click-devices-service/tsconfig.types.json
+++ b/clients/client-iot-1click-devices-service/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-iot-1click-projects/package.json
+++ b/clients/client-iot-1click-projects/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-iot-1click-projects/package.json
+++ b/clients/client-iot-1click-projects/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-iot-1click-projects/tsconfig.es.json
+++ b/clients/client-iot-1click-projects/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-iot-1click-projects/tsconfig.json
+++ b/clients/client-iot-1click-projects/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-iot-1click-projects/tsconfig.types.json
+++ b/clients/client-iot-1click-projects/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-iot-data-plane/package.json
+++ b/clients/client-iot-data-plane/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-iot-data-plane/package.json
+++ b/clients/client-iot-data-plane/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-iot-data-plane/tsconfig.es.json
+++ b/clients/client-iot-data-plane/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-iot-data-plane/tsconfig.json
+++ b/clients/client-iot-data-plane/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-iot-data-plane/tsconfig.types.json
+++ b/clients/client-iot-data-plane/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-iot-events-data/package.json
+++ b/clients/client-iot-events-data/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-iot-events-data/package.json
+++ b/clients/client-iot-events-data/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-iot-events-data/tsconfig.es.json
+++ b/clients/client-iot-events-data/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-iot-events-data/tsconfig.json
+++ b/clients/client-iot-events-data/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-iot-events-data/tsconfig.types.json
+++ b/clients/client-iot-events-data/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-iot-events/package.json
+++ b/clients/client-iot-events/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-iot-events/package.json
+++ b/clients/client-iot-events/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-iot-events/tsconfig.es.json
+++ b/clients/client-iot-events/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-iot-events/tsconfig.json
+++ b/clients/client-iot-events/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-iot-events/tsconfig.types.json
+++ b/clients/client-iot-events/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-iot-jobs-data-plane/package.json
+++ b/clients/client-iot-jobs-data-plane/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-iot-jobs-data-plane/package.json
+++ b/clients/client-iot-jobs-data-plane/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-iot-jobs-data-plane/tsconfig.es.json
+++ b/clients/client-iot-jobs-data-plane/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-iot-jobs-data-plane/tsconfig.json
+++ b/clients/client-iot-jobs-data-plane/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-iot-jobs-data-plane/tsconfig.types.json
+++ b/clients/client-iot-jobs-data-plane/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-iot-wireless/package.json
+++ b/clients/client-iot-wireless/package.json
@@ -11,7 +11,7 @@
     "test": "jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-iot-wireless/package.json
+++ b/clients/client-iot-wireless/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-iot-wireless/tsconfig.es.json
+++ b/clients/client-iot-wireless/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-iot-wireless/tsconfig.json
+++ b/clients/client-iot-wireless/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-iot-wireless/tsconfig.types.json
+++ b/clients/client-iot-wireless/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-iot/package.json
+++ b/clients/client-iot/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-iot/package.json
+++ b/clients/client-iot/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-iot/tsconfig.es.json
+++ b/clients/client-iot/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-iot/tsconfig.json
+++ b/clients/client-iot/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-iot/tsconfig.types.json
+++ b/clients/client-iot/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-iotanalytics/package.json
+++ b/clients/client-iotanalytics/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-iotanalytics/package.json
+++ b/clients/client-iotanalytics/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-iotanalytics/tsconfig.es.json
+++ b/clients/client-iotanalytics/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-iotanalytics/tsconfig.json
+++ b/clients/client-iotanalytics/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-iotanalytics/tsconfig.types.json
+++ b/clients/client-iotanalytics/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-iotdeviceadvisor/package.json
+++ b/clients/client-iotdeviceadvisor/package.json
@@ -11,7 +11,7 @@
     "test": "jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-iotdeviceadvisor/package.json
+++ b/clients/client-iotdeviceadvisor/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-iotdeviceadvisor/tsconfig.es.json
+++ b/clients/client-iotdeviceadvisor/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-iotdeviceadvisor/tsconfig.json
+++ b/clients/client-iotdeviceadvisor/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-iotdeviceadvisor/tsconfig.types.json
+++ b/clients/client-iotdeviceadvisor/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-iotfleethub/package.json
+++ b/clients/client-iotfleethub/package.json
@@ -11,7 +11,7 @@
     "test": "jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-iotfleethub/package.json
+++ b/clients/client-iotfleethub/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-iotfleethub/tsconfig.es.json
+++ b/clients/client-iotfleethub/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-iotfleethub/tsconfig.json
+++ b/clients/client-iotfleethub/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-iotfleethub/tsconfig.types.json
+++ b/clients/client-iotfleethub/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-iotsecuretunneling/package.json
+++ b/clients/client-iotsecuretunneling/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-iotsecuretunneling/package.json
+++ b/clients/client-iotsecuretunneling/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-iotsecuretunneling/tsconfig.es.json
+++ b/clients/client-iotsecuretunneling/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-iotsecuretunneling/tsconfig.json
+++ b/clients/client-iotsecuretunneling/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-iotsecuretunneling/tsconfig.types.json
+++ b/clients/client-iotsecuretunneling/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-iotsitewise/package.json
+++ b/clients/client-iotsitewise/package.json
@@ -11,7 +11,7 @@
     "test": "jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-iotsitewise/package.json
+++ b/clients/client-iotsitewise/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-iotsitewise/tsconfig.es.json
+++ b/clients/client-iotsitewise/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-iotsitewise/tsconfig.json
+++ b/clients/client-iotsitewise/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-iotsitewise/tsconfig.types.json
+++ b/clients/client-iotsitewise/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-iotthingsgraph/package.json
+++ b/clients/client-iotthingsgraph/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-iotthingsgraph/package.json
+++ b/clients/client-iotthingsgraph/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-iotthingsgraph/tsconfig.es.json
+++ b/clients/client-iotthingsgraph/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-iotthingsgraph/tsconfig.json
+++ b/clients/client-iotthingsgraph/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-iotthingsgraph/tsconfig.types.json
+++ b/clients/client-iotthingsgraph/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-ivs/package.json
+++ b/clients/client-ivs/package.json
@@ -11,7 +11,7 @@
     "test": "jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-ivs/package.json
+++ b/clients/client-ivs/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-ivs/tsconfig.es.json
+++ b/clients/client-ivs/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-ivs/tsconfig.json
+++ b/clients/client-ivs/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-ivs/tsconfig.types.json
+++ b/clients/client-ivs/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-kafka/package.json
+++ b/clients/client-kafka/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-kafka/package.json
+++ b/clients/client-kafka/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-kafka/tsconfig.es.json
+++ b/clients/client-kafka/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-kafka/tsconfig.json
+++ b/clients/client-kafka/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-kafka/tsconfig.types.json
+++ b/clients/client-kafka/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-kafkaconnect/package.json
+++ b/clients/client-kafkaconnect/package.json
@@ -12,7 +12,7 @@
     "test": "jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",

--- a/clients/client-kafkaconnect/package.json
+++ b/clients/client-kafkaconnect/package.json
@@ -12,7 +12,8 @@
     "test": "jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-kafkaconnect/tsconfig.es.json
+++ b/clients/client-kafkaconnect/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-kafkaconnect/tsconfig.json
+++ b/clients/client-kafkaconnect/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-kafkaconnect/tsconfig.types.json
+++ b/clients/client-kafkaconnect/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-kendra/package.json
+++ b/clients/client-kendra/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-kendra/package.json
+++ b/clients/client-kendra/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-kendra/tsconfig.es.json
+++ b/clients/client-kendra/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-kendra/tsconfig.json
+++ b/clients/client-kendra/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-kendra/tsconfig.types.json
+++ b/clients/client-kendra/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-kinesis-analytics-v2/package.json
+++ b/clients/client-kinesis-analytics-v2/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-kinesis-analytics-v2/package.json
+++ b/clients/client-kinesis-analytics-v2/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-kinesis-analytics-v2/tsconfig.es.json
+++ b/clients/client-kinesis-analytics-v2/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-kinesis-analytics-v2/tsconfig.json
+++ b/clients/client-kinesis-analytics-v2/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-kinesis-analytics-v2/tsconfig.types.json
+++ b/clients/client-kinesis-analytics-v2/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-kinesis-analytics/package.json
+++ b/clients/client-kinesis-analytics/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-kinesis-analytics/package.json
+++ b/clients/client-kinesis-analytics/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-kinesis-analytics/tsconfig.es.json
+++ b/clients/client-kinesis-analytics/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-kinesis-analytics/tsconfig.json
+++ b/clients/client-kinesis-analytics/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-kinesis-analytics/tsconfig.types.json
+++ b/clients/client-kinesis-analytics/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-kinesis-video-archived-media/package.json
+++ b/clients/client-kinesis-video-archived-media/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-kinesis-video-archived-media/package.json
+++ b/clients/client-kinesis-video-archived-media/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-kinesis-video-archived-media/tsconfig.es.json
+++ b/clients/client-kinesis-video-archived-media/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-kinesis-video-archived-media/tsconfig.json
+++ b/clients/client-kinesis-video-archived-media/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-kinesis-video-archived-media/tsconfig.types.json
+++ b/clients/client-kinesis-video-archived-media/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-kinesis-video-media/package.json
+++ b/clients/client-kinesis-video-media/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-kinesis-video-media/package.json
+++ b/clients/client-kinesis-video-media/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-kinesis-video-media/tsconfig.es.json
+++ b/clients/client-kinesis-video-media/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-kinesis-video-media/tsconfig.json
+++ b/clients/client-kinesis-video-media/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-kinesis-video-media/tsconfig.types.json
+++ b/clients/client-kinesis-video-media/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-kinesis-video-signaling/package.json
+++ b/clients/client-kinesis-video-signaling/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-kinesis-video-signaling/package.json
+++ b/clients/client-kinesis-video-signaling/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-kinesis-video-signaling/tsconfig.es.json
+++ b/clients/client-kinesis-video-signaling/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-kinesis-video-signaling/tsconfig.json
+++ b/clients/client-kinesis-video-signaling/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-kinesis-video-signaling/tsconfig.types.json
+++ b/clients/client-kinesis-video-signaling/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-kinesis-video/package.json
+++ b/clients/client-kinesis-video/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-kinesis-video/package.json
+++ b/clients/client-kinesis-video/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-kinesis-video/tsconfig.es.json
+++ b/clients/client-kinesis-video/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-kinesis-video/tsconfig.json
+++ b/clients/client-kinesis-video/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-kinesis-video/tsconfig.types.json
+++ b/clients/client-kinesis-video/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-kinesis/package.json
+++ b/clients/client-kinesis/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-kinesis/package.json
+++ b/clients/client-kinesis/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-kinesis/tsconfig.es.json
+++ b/clients/client-kinesis/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-kinesis/tsconfig.json
+++ b/clients/client-kinesis/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-kinesis/tsconfig.types.json
+++ b/clients/client-kinesis/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-kms/package.json
+++ b/clients/client-kms/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-kms/package.json
+++ b/clients/client-kms/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-kms/tsconfig.es.json
+++ b/clients/client-kms/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-kms/tsconfig.json
+++ b/clients/client-kms/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-kms/tsconfig.types.json
+++ b/clients/client-kms/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-lakeformation/package.json
+++ b/clients/client-lakeformation/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-lakeformation/package.json
+++ b/clients/client-lakeformation/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-lakeformation/tsconfig.es.json
+++ b/clients/client-lakeformation/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-lakeformation/tsconfig.json
+++ b/clients/client-lakeformation/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-lakeformation/tsconfig.types.json
+++ b/clients/client-lakeformation/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-lambda/package.json
+++ b/clients/client-lambda/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-lambda/package.json
+++ b/clients/client-lambda/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-lambda/tsconfig.es.json
+++ b/clients/client-lambda/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-lambda/tsconfig.json
+++ b/clients/client-lambda/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-lambda/tsconfig.types.json
+++ b/clients/client-lambda/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-lex-model-building-service/package.json
+++ b/clients/client-lex-model-building-service/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-lex-model-building-service/package.json
+++ b/clients/client-lex-model-building-service/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-lex-model-building-service/tsconfig.es.json
+++ b/clients/client-lex-model-building-service/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-lex-model-building-service/tsconfig.json
+++ b/clients/client-lex-model-building-service/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-lex-model-building-service/tsconfig.types.json
+++ b/clients/client-lex-model-building-service/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-lex-models-v2/package.json
+++ b/clients/client-lex-models-v2/package.json
@@ -11,7 +11,7 @@
     "test": "jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-lex-models-v2/package.json
+++ b/clients/client-lex-models-v2/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-lex-models-v2/tsconfig.es.json
+++ b/clients/client-lex-models-v2/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-lex-models-v2/tsconfig.json
+++ b/clients/client-lex-models-v2/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-lex-models-v2/tsconfig.types.json
+++ b/clients/client-lex-models-v2/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-lex-runtime-service/package.json
+++ b/clients/client-lex-runtime-service/package.json
@@ -13,7 +13,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-lex-runtime-service/package.json
+++ b/clients/client-lex-runtime-service/package.json
@@ -12,7 +12,7 @@
     "test": "yarn test:unit",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-lex-runtime-service/tsconfig.es.json
+++ b/clients/client-lex-runtime-service/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-lex-runtime-service/tsconfig.json
+++ b/clients/client-lex-runtime-service/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
     "outDir": "dist/cjs",
+    "removeComments": true,
     "types": ["mocha", "node"]
   },
   "typedocOptions": {

--- a/clients/client-lex-runtime-service/tsconfig.types.json
+++ b/clients/client-lex-runtime-service/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-lex-runtime-v2/package.json
+++ b/clients/client-lex-runtime-v2/package.json
@@ -11,7 +11,7 @@
     "test": "jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-lex-runtime-v2/package.json
+++ b/clients/client-lex-runtime-v2/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-lex-runtime-v2/tsconfig.es.json
+++ b/clients/client-lex-runtime-v2/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-lex-runtime-v2/tsconfig.json
+++ b/clients/client-lex-runtime-v2/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-lex-runtime-v2/tsconfig.types.json
+++ b/clients/client-lex-runtime-v2/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-license-manager/package.json
+++ b/clients/client-license-manager/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-license-manager/package.json
+++ b/clients/client-license-manager/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-license-manager/tsconfig.es.json
+++ b/clients/client-license-manager/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-license-manager/tsconfig.json
+++ b/clients/client-license-manager/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-license-manager/tsconfig.types.json
+++ b/clients/client-license-manager/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-lightsail/package.json
+++ b/clients/client-lightsail/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-lightsail/package.json
+++ b/clients/client-lightsail/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-lightsail/tsconfig.es.json
+++ b/clients/client-lightsail/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-lightsail/tsconfig.json
+++ b/clients/client-lightsail/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-lightsail/tsconfig.types.json
+++ b/clients/client-lightsail/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-location/package.json
+++ b/clients/client-location/package.json
@@ -11,7 +11,7 @@
     "test": "jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-location/package.json
+++ b/clients/client-location/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-location/tsconfig.es.json
+++ b/clients/client-location/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-location/tsconfig.json
+++ b/clients/client-location/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-location/tsconfig.types.json
+++ b/clients/client-location/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-lookoutequipment/package.json
+++ b/clients/client-lookoutequipment/package.json
@@ -11,7 +11,7 @@
     "test": "jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-lookoutequipment/package.json
+++ b/clients/client-lookoutequipment/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-lookoutequipment/tsconfig.es.json
+++ b/clients/client-lookoutequipment/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-lookoutequipment/tsconfig.json
+++ b/clients/client-lookoutequipment/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-lookoutequipment/tsconfig.types.json
+++ b/clients/client-lookoutequipment/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-lookoutmetrics/package.json
+++ b/clients/client-lookoutmetrics/package.json
@@ -11,7 +11,7 @@
     "test": "jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-lookoutmetrics/package.json
+++ b/clients/client-lookoutmetrics/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-lookoutmetrics/tsconfig.es.json
+++ b/clients/client-lookoutmetrics/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-lookoutmetrics/tsconfig.json
+++ b/clients/client-lookoutmetrics/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-lookoutmetrics/tsconfig.types.json
+++ b/clients/client-lookoutmetrics/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-lookoutvision/package.json
+++ b/clients/client-lookoutvision/package.json
@@ -11,7 +11,7 @@
     "test": "jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-lookoutvision/package.json
+++ b/clients/client-lookoutvision/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-lookoutvision/tsconfig.es.json
+++ b/clients/client-lookoutvision/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-lookoutvision/tsconfig.json
+++ b/clients/client-lookoutvision/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-lookoutvision/tsconfig.types.json
+++ b/clients/client-lookoutvision/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-machine-learning/package.json
+++ b/clients/client-machine-learning/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-machine-learning/package.json
+++ b/clients/client-machine-learning/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-machine-learning/tsconfig.es.json
+++ b/clients/client-machine-learning/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-machine-learning/tsconfig.json
+++ b/clients/client-machine-learning/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-machine-learning/tsconfig.types.json
+++ b/clients/client-machine-learning/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-macie/package.json
+++ b/clients/client-macie/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-macie/package.json
+++ b/clients/client-macie/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-macie/tsconfig.es.json
+++ b/clients/client-macie/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-macie/tsconfig.json
+++ b/clients/client-macie/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-macie/tsconfig.types.json
+++ b/clients/client-macie/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-macie2/package.json
+++ b/clients/client-macie2/package.json
@@ -11,7 +11,7 @@
     "test": "jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-macie2/package.json
+++ b/clients/client-macie2/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-macie2/tsconfig.es.json
+++ b/clients/client-macie2/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-macie2/tsconfig.json
+++ b/clients/client-macie2/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-macie2/tsconfig.types.json
+++ b/clients/client-macie2/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-managedblockchain/package.json
+++ b/clients/client-managedblockchain/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-managedblockchain/package.json
+++ b/clients/client-managedblockchain/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-managedblockchain/tsconfig.es.json
+++ b/clients/client-managedblockchain/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-managedblockchain/tsconfig.json
+++ b/clients/client-managedblockchain/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-managedblockchain/tsconfig.types.json
+++ b/clients/client-managedblockchain/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-marketplace-catalog/package.json
+++ b/clients/client-marketplace-catalog/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-marketplace-catalog/package.json
+++ b/clients/client-marketplace-catalog/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-marketplace-catalog/tsconfig.es.json
+++ b/clients/client-marketplace-catalog/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-marketplace-catalog/tsconfig.json
+++ b/clients/client-marketplace-catalog/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-marketplace-catalog/tsconfig.types.json
+++ b/clients/client-marketplace-catalog/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-marketplace-commerce-analytics/package.json
+++ b/clients/client-marketplace-commerce-analytics/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-marketplace-commerce-analytics/package.json
+++ b/clients/client-marketplace-commerce-analytics/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-marketplace-commerce-analytics/tsconfig.es.json
+++ b/clients/client-marketplace-commerce-analytics/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-marketplace-commerce-analytics/tsconfig.json
+++ b/clients/client-marketplace-commerce-analytics/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-marketplace-commerce-analytics/tsconfig.types.json
+++ b/clients/client-marketplace-commerce-analytics/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-marketplace-entitlement-service/package.json
+++ b/clients/client-marketplace-entitlement-service/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-marketplace-entitlement-service/package.json
+++ b/clients/client-marketplace-entitlement-service/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-marketplace-entitlement-service/tsconfig.es.json
+++ b/clients/client-marketplace-entitlement-service/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-marketplace-entitlement-service/tsconfig.json
+++ b/clients/client-marketplace-entitlement-service/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-marketplace-entitlement-service/tsconfig.types.json
+++ b/clients/client-marketplace-entitlement-service/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-marketplace-metering/package.json
+++ b/clients/client-marketplace-metering/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-marketplace-metering/package.json
+++ b/clients/client-marketplace-metering/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-marketplace-metering/tsconfig.es.json
+++ b/clients/client-marketplace-metering/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-marketplace-metering/tsconfig.json
+++ b/clients/client-marketplace-metering/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-marketplace-metering/tsconfig.types.json
+++ b/clients/client-marketplace-metering/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-mediaconnect/package.json
+++ b/clients/client-mediaconnect/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-mediaconnect/package.json
+++ b/clients/client-mediaconnect/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-mediaconnect/tsconfig.es.json
+++ b/clients/client-mediaconnect/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-mediaconnect/tsconfig.json
+++ b/clients/client-mediaconnect/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-mediaconnect/tsconfig.types.json
+++ b/clients/client-mediaconnect/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-mediaconvert/package.json
+++ b/clients/client-mediaconvert/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-mediaconvert/package.json
+++ b/clients/client-mediaconvert/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-mediaconvert/tsconfig.es.json
+++ b/clients/client-mediaconvert/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-mediaconvert/tsconfig.json
+++ b/clients/client-mediaconvert/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-mediaconvert/tsconfig.types.json
+++ b/clients/client-mediaconvert/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-medialive/package.json
+++ b/clients/client-medialive/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-medialive/package.json
+++ b/clients/client-medialive/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-medialive/tsconfig.es.json
+++ b/clients/client-medialive/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-medialive/tsconfig.json
+++ b/clients/client-medialive/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-medialive/tsconfig.types.json
+++ b/clients/client-medialive/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-mediapackage-vod/package.json
+++ b/clients/client-mediapackage-vod/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-mediapackage-vod/package.json
+++ b/clients/client-mediapackage-vod/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-mediapackage-vod/tsconfig.es.json
+++ b/clients/client-mediapackage-vod/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-mediapackage-vod/tsconfig.json
+++ b/clients/client-mediapackage-vod/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-mediapackage-vod/tsconfig.types.json
+++ b/clients/client-mediapackage-vod/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-mediapackage/package.json
+++ b/clients/client-mediapackage/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-mediapackage/package.json
+++ b/clients/client-mediapackage/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-mediapackage/tsconfig.es.json
+++ b/clients/client-mediapackage/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-mediapackage/tsconfig.json
+++ b/clients/client-mediapackage/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-mediapackage/tsconfig.types.json
+++ b/clients/client-mediapackage/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-mediastore-data/package.json
+++ b/clients/client-mediastore-data/package.json
@@ -13,7 +13,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-mediastore-data/package.json
+++ b/clients/client-mediastore-data/package.json
@@ -12,7 +12,7 @@
     "test": "yarn test:unit",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-mediastore-data/tsconfig.es.json
+++ b/clients/client-mediastore-data/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-mediastore-data/tsconfig.json
+++ b/clients/client-mediastore-data/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
     "outDir": "dist/cjs",
+    "removeComments": true,
     "types": ["mocha"]
   },
   "typedocOptions": {

--- a/clients/client-mediastore-data/tsconfig.types.json
+++ b/clients/client-mediastore-data/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-mediastore/package.json
+++ b/clients/client-mediastore/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-mediastore/package.json
+++ b/clients/client-mediastore/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-mediastore/tsconfig.es.json
+++ b/clients/client-mediastore/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-mediastore/tsconfig.json
+++ b/clients/client-mediastore/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-mediastore/tsconfig.types.json
+++ b/clients/client-mediastore/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-mediatailor/package.json
+++ b/clients/client-mediatailor/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-mediatailor/package.json
+++ b/clients/client-mediatailor/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-mediatailor/tsconfig.es.json
+++ b/clients/client-mediatailor/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-mediatailor/tsconfig.json
+++ b/clients/client-mediatailor/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-mediatailor/tsconfig.types.json
+++ b/clients/client-mediatailor/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-memorydb/package.json
+++ b/clients/client-memorydb/package.json
@@ -12,7 +12,7 @@
     "test": "jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",

--- a/clients/client-memorydb/package.json
+++ b/clients/client-memorydb/package.json
@@ -12,7 +12,8 @@
     "test": "jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-memorydb/tsconfig.es.json
+++ b/clients/client-memorydb/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-memorydb/tsconfig.json
+++ b/clients/client-memorydb/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-memorydb/tsconfig.types.json
+++ b/clients/client-memorydb/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-mgn/package.json
+++ b/clients/client-mgn/package.json
@@ -11,7 +11,7 @@
     "test": "jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-mgn/package.json
+++ b/clients/client-mgn/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-mgn/tsconfig.es.json
+++ b/clients/client-mgn/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-mgn/tsconfig.json
+++ b/clients/client-mgn/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-mgn/tsconfig.types.json
+++ b/clients/client-mgn/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-migration-hub/package.json
+++ b/clients/client-migration-hub/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-migration-hub/package.json
+++ b/clients/client-migration-hub/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-migration-hub/tsconfig.es.json
+++ b/clients/client-migration-hub/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-migration-hub/tsconfig.json
+++ b/clients/client-migration-hub/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-migration-hub/tsconfig.types.json
+++ b/clients/client-migration-hub/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-migrationhub-config/package.json
+++ b/clients/client-migrationhub-config/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-migrationhub-config/package.json
+++ b/clients/client-migrationhub-config/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-migrationhub-config/tsconfig.es.json
+++ b/clients/client-migrationhub-config/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-migrationhub-config/tsconfig.json
+++ b/clients/client-migrationhub-config/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-migrationhub-config/tsconfig.types.json
+++ b/clients/client-migrationhub-config/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-mobile/package.json
+++ b/clients/client-mobile/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-mobile/package.json
+++ b/clients/client-mobile/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-mobile/tsconfig.es.json
+++ b/clients/client-mobile/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-mobile/tsconfig.json
+++ b/clients/client-mobile/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-mobile/tsconfig.types.json
+++ b/clients/client-mobile/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-mq/package.json
+++ b/clients/client-mq/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-mq/package.json
+++ b/clients/client-mq/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-mq/tsconfig.es.json
+++ b/clients/client-mq/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-mq/tsconfig.json
+++ b/clients/client-mq/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-mq/tsconfig.types.json
+++ b/clients/client-mq/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-mturk/package.json
+++ b/clients/client-mturk/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-mturk/package.json
+++ b/clients/client-mturk/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-mturk/tsconfig.es.json
+++ b/clients/client-mturk/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-mturk/tsconfig.json
+++ b/clients/client-mturk/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-mturk/tsconfig.types.json
+++ b/clients/client-mturk/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-mwaa/package.json
+++ b/clients/client-mwaa/package.json
@@ -11,7 +11,7 @@
     "test": "jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-mwaa/package.json
+++ b/clients/client-mwaa/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-mwaa/tsconfig.es.json
+++ b/clients/client-mwaa/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-mwaa/tsconfig.json
+++ b/clients/client-mwaa/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-mwaa/tsconfig.types.json
+++ b/clients/client-mwaa/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-neptune/package.json
+++ b/clients/client-neptune/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-neptune/package.json
+++ b/clients/client-neptune/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-neptune/tsconfig.es.json
+++ b/clients/client-neptune/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-neptune/tsconfig.json
+++ b/clients/client-neptune/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-neptune/tsconfig.types.json
+++ b/clients/client-neptune/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-network-firewall/package.json
+++ b/clients/client-network-firewall/package.json
@@ -11,7 +11,7 @@
     "test": "jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-network-firewall/package.json
+++ b/clients/client-network-firewall/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-network-firewall/tsconfig.es.json
+++ b/clients/client-network-firewall/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-network-firewall/tsconfig.json
+++ b/clients/client-network-firewall/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-network-firewall/tsconfig.types.json
+++ b/clients/client-network-firewall/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-networkmanager/package.json
+++ b/clients/client-networkmanager/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-networkmanager/package.json
+++ b/clients/client-networkmanager/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-networkmanager/tsconfig.es.json
+++ b/clients/client-networkmanager/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-networkmanager/tsconfig.json
+++ b/clients/client-networkmanager/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-networkmanager/tsconfig.types.json
+++ b/clients/client-networkmanager/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-nimble/package.json
+++ b/clients/client-nimble/package.json
@@ -11,7 +11,7 @@
     "test": "jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-nimble/package.json
+++ b/clients/client-nimble/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-nimble/tsconfig.es.json
+++ b/clients/client-nimble/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-nimble/tsconfig.json
+++ b/clients/client-nimble/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-nimble/tsconfig.types.json
+++ b/clients/client-nimble/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-opensearch/package.json
+++ b/clients/client-opensearch/package.json
@@ -12,7 +12,7 @@
     "test": "jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",

--- a/clients/client-opensearch/package.json
+++ b/clients/client-opensearch/package.json
@@ -12,7 +12,8 @@
     "test": "jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-opensearch/tsconfig.es.json
+++ b/clients/client-opensearch/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-opensearch/tsconfig.json
+++ b/clients/client-opensearch/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-opensearch/tsconfig.types.json
+++ b/clients/client-opensearch/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-opsworks/package.json
+++ b/clients/client-opsworks/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-opsworks/package.json
+++ b/clients/client-opsworks/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-opsworks/tsconfig.es.json
+++ b/clients/client-opsworks/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-opsworks/tsconfig.json
+++ b/clients/client-opsworks/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-opsworks/tsconfig.types.json
+++ b/clients/client-opsworks/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-opsworkscm/package.json
+++ b/clients/client-opsworkscm/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-opsworkscm/package.json
+++ b/clients/client-opsworkscm/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-opsworkscm/tsconfig.es.json
+++ b/clients/client-opsworkscm/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-opsworkscm/tsconfig.json
+++ b/clients/client-opsworkscm/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-opsworkscm/tsconfig.types.json
+++ b/clients/client-opsworkscm/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-organizations/package.json
+++ b/clients/client-organizations/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-organizations/package.json
+++ b/clients/client-organizations/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-organizations/tsconfig.es.json
+++ b/clients/client-organizations/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-organizations/tsconfig.json
+++ b/clients/client-organizations/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-organizations/tsconfig.types.json
+++ b/clients/client-organizations/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-outposts/package.json
+++ b/clients/client-outposts/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-outposts/package.json
+++ b/clients/client-outposts/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-outposts/tsconfig.es.json
+++ b/clients/client-outposts/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-outposts/tsconfig.json
+++ b/clients/client-outposts/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-outposts/tsconfig.types.json
+++ b/clients/client-outposts/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-personalize-events/package.json
+++ b/clients/client-personalize-events/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-personalize-events/package.json
+++ b/clients/client-personalize-events/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-personalize-events/tsconfig.es.json
+++ b/clients/client-personalize-events/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-personalize-events/tsconfig.json
+++ b/clients/client-personalize-events/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-personalize-events/tsconfig.types.json
+++ b/clients/client-personalize-events/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-personalize-runtime/package.json
+++ b/clients/client-personalize-runtime/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-personalize-runtime/package.json
+++ b/clients/client-personalize-runtime/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-personalize-runtime/tsconfig.es.json
+++ b/clients/client-personalize-runtime/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-personalize-runtime/tsconfig.json
+++ b/clients/client-personalize-runtime/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-personalize-runtime/tsconfig.types.json
+++ b/clients/client-personalize-runtime/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-personalize/package.json
+++ b/clients/client-personalize/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-personalize/package.json
+++ b/clients/client-personalize/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-personalize/tsconfig.es.json
+++ b/clients/client-personalize/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-personalize/tsconfig.json
+++ b/clients/client-personalize/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-personalize/tsconfig.types.json
+++ b/clients/client-personalize/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-pi/package.json
+++ b/clients/client-pi/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-pi/package.json
+++ b/clients/client-pi/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-pi/tsconfig.es.json
+++ b/clients/client-pi/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-pi/tsconfig.json
+++ b/clients/client-pi/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-pi/tsconfig.types.json
+++ b/clients/client-pi/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-pinpoint-email/package.json
+++ b/clients/client-pinpoint-email/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-pinpoint-email/package.json
+++ b/clients/client-pinpoint-email/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-pinpoint-email/tsconfig.es.json
+++ b/clients/client-pinpoint-email/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-pinpoint-email/tsconfig.json
+++ b/clients/client-pinpoint-email/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-pinpoint-email/tsconfig.types.json
+++ b/clients/client-pinpoint-email/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-pinpoint-sms-voice/package.json
+++ b/clients/client-pinpoint-sms-voice/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-pinpoint-sms-voice/package.json
+++ b/clients/client-pinpoint-sms-voice/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-pinpoint-sms-voice/tsconfig.es.json
+++ b/clients/client-pinpoint-sms-voice/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-pinpoint-sms-voice/tsconfig.json
+++ b/clients/client-pinpoint-sms-voice/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-pinpoint-sms-voice/tsconfig.types.json
+++ b/clients/client-pinpoint-sms-voice/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-pinpoint/package.json
+++ b/clients/client-pinpoint/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-pinpoint/package.json
+++ b/clients/client-pinpoint/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-pinpoint/tsconfig.es.json
+++ b/clients/client-pinpoint/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-pinpoint/tsconfig.json
+++ b/clients/client-pinpoint/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-pinpoint/tsconfig.types.json
+++ b/clients/client-pinpoint/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-polly/package.json
+++ b/clients/client-polly/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-polly/package.json
+++ b/clients/client-polly/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-polly/tsconfig.es.json
+++ b/clients/client-polly/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-polly/tsconfig.json
+++ b/clients/client-polly/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-polly/tsconfig.types.json
+++ b/clients/client-polly/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-pricing/package.json
+++ b/clients/client-pricing/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-pricing/package.json
+++ b/clients/client-pricing/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-pricing/tsconfig.es.json
+++ b/clients/client-pricing/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-pricing/tsconfig.json
+++ b/clients/client-pricing/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-pricing/tsconfig.types.json
+++ b/clients/client-pricing/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-proton/package.json
+++ b/clients/client-proton/package.json
@@ -11,7 +11,7 @@
     "test": "jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-proton/package.json
+++ b/clients/client-proton/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-proton/tsconfig.es.json
+++ b/clients/client-proton/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-proton/tsconfig.json
+++ b/clients/client-proton/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-proton/tsconfig.types.json
+++ b/clients/client-proton/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-qldb-session/package.json
+++ b/clients/client-qldb-session/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-qldb-session/package.json
+++ b/clients/client-qldb-session/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-qldb-session/tsconfig.es.json
+++ b/clients/client-qldb-session/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-qldb-session/tsconfig.json
+++ b/clients/client-qldb-session/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-qldb-session/tsconfig.types.json
+++ b/clients/client-qldb-session/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-qldb/package.json
+++ b/clients/client-qldb/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-qldb/package.json
+++ b/clients/client-qldb/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-qldb/tsconfig.es.json
+++ b/clients/client-qldb/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-qldb/tsconfig.json
+++ b/clients/client-qldb/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-qldb/tsconfig.types.json
+++ b/clients/client-qldb/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-quicksight/package.json
+++ b/clients/client-quicksight/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-quicksight/package.json
+++ b/clients/client-quicksight/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-quicksight/tsconfig.es.json
+++ b/clients/client-quicksight/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-quicksight/tsconfig.json
+++ b/clients/client-quicksight/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-quicksight/tsconfig.types.json
+++ b/clients/client-quicksight/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-ram/package.json
+++ b/clients/client-ram/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-ram/package.json
+++ b/clients/client-ram/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-ram/tsconfig.es.json
+++ b/clients/client-ram/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-ram/tsconfig.json
+++ b/clients/client-ram/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-ram/tsconfig.types.json
+++ b/clients/client-ram/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-rds-data/package.json
+++ b/clients/client-rds-data/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-rds-data/package.json
+++ b/clients/client-rds-data/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-rds-data/tsconfig.es.json
+++ b/clients/client-rds-data/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-rds-data/tsconfig.json
+++ b/clients/client-rds-data/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-rds-data/tsconfig.types.json
+++ b/clients/client-rds-data/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-rds/package.json
+++ b/clients/client-rds/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-rds/package.json
+++ b/clients/client-rds/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-rds/tsconfig.es.json
+++ b/clients/client-rds/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-rds/tsconfig.json
+++ b/clients/client-rds/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-rds/tsconfig.types.json
+++ b/clients/client-rds/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-redshift-data/package.json
+++ b/clients/client-redshift-data/package.json
@@ -11,7 +11,7 @@
     "test": "jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-redshift-data/package.json
+++ b/clients/client-redshift-data/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-redshift-data/tsconfig.es.json
+++ b/clients/client-redshift-data/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-redshift-data/tsconfig.json
+++ b/clients/client-redshift-data/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-redshift-data/tsconfig.types.json
+++ b/clients/client-redshift-data/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-redshift/package.json
+++ b/clients/client-redshift/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-redshift/package.json
+++ b/clients/client-redshift/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-redshift/tsconfig.es.json
+++ b/clients/client-redshift/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-redshift/tsconfig.json
+++ b/clients/client-redshift/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-redshift/tsconfig.types.json
+++ b/clients/client-redshift/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-rekognition/package.json
+++ b/clients/client-rekognition/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-rekognition/package.json
+++ b/clients/client-rekognition/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-rekognition/tsconfig.es.json
+++ b/clients/client-rekognition/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-rekognition/tsconfig.json
+++ b/clients/client-rekognition/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-rekognition/tsconfig.types.json
+++ b/clients/client-rekognition/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-resource-groups-tagging-api/package.json
+++ b/clients/client-resource-groups-tagging-api/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-resource-groups-tagging-api/package.json
+++ b/clients/client-resource-groups-tagging-api/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-resource-groups-tagging-api/tsconfig.es.json
+++ b/clients/client-resource-groups-tagging-api/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-resource-groups-tagging-api/tsconfig.json
+++ b/clients/client-resource-groups-tagging-api/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-resource-groups-tagging-api/tsconfig.types.json
+++ b/clients/client-resource-groups-tagging-api/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-resource-groups/package.json
+++ b/clients/client-resource-groups/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-resource-groups/package.json
+++ b/clients/client-resource-groups/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-resource-groups/tsconfig.es.json
+++ b/clients/client-resource-groups/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-resource-groups/tsconfig.json
+++ b/clients/client-resource-groups/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-resource-groups/tsconfig.types.json
+++ b/clients/client-resource-groups/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-robomaker/package.json
+++ b/clients/client-robomaker/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-robomaker/package.json
+++ b/clients/client-robomaker/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-robomaker/tsconfig.es.json
+++ b/clients/client-robomaker/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-robomaker/tsconfig.json
+++ b/clients/client-robomaker/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-robomaker/tsconfig.types.json
+++ b/clients/client-robomaker/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-route-53-domains/package.json
+++ b/clients/client-route-53-domains/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-route-53-domains/package.json
+++ b/clients/client-route-53-domains/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-route-53-domains/tsconfig.es.json
+++ b/clients/client-route-53-domains/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-route-53-domains/tsconfig.json
+++ b/clients/client-route-53-domains/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-route-53-domains/tsconfig.types.json
+++ b/clients/client-route-53-domains/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-route-53/package.json
+++ b/clients/client-route-53/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-route-53/package.json
+++ b/clients/client-route-53/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-route-53/tsconfig.es.json
+++ b/clients/client-route-53/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-route-53/tsconfig.json
+++ b/clients/client-route-53/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-route-53/tsconfig.types.json
+++ b/clients/client-route-53/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-route53-recovery-cluster/package.json
+++ b/clients/client-route53-recovery-cluster/package.json
@@ -12,7 +12,7 @@
     "test": "jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",

--- a/clients/client-route53-recovery-cluster/package.json
+++ b/clients/client-route53-recovery-cluster/package.json
@@ -12,7 +12,8 @@
     "test": "jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-route53-recovery-cluster/tsconfig.es.json
+++ b/clients/client-route53-recovery-cluster/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-route53-recovery-cluster/tsconfig.json
+++ b/clients/client-route53-recovery-cluster/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-route53-recovery-cluster/tsconfig.types.json
+++ b/clients/client-route53-recovery-cluster/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-route53-recovery-control-config/package.json
+++ b/clients/client-route53-recovery-control-config/package.json
@@ -12,7 +12,7 @@
     "test": "jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",

--- a/clients/client-route53-recovery-control-config/package.json
+++ b/clients/client-route53-recovery-control-config/package.json
@@ -12,7 +12,8 @@
     "test": "jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-route53-recovery-control-config/tsconfig.es.json
+++ b/clients/client-route53-recovery-control-config/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-route53-recovery-control-config/tsconfig.json
+++ b/clients/client-route53-recovery-control-config/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-route53-recovery-control-config/tsconfig.types.json
+++ b/clients/client-route53-recovery-control-config/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-route53-recovery-readiness/package.json
+++ b/clients/client-route53-recovery-readiness/package.json
@@ -12,7 +12,7 @@
     "test": "jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",

--- a/clients/client-route53-recovery-readiness/package.json
+++ b/clients/client-route53-recovery-readiness/package.json
@@ -12,7 +12,8 @@
     "test": "jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-route53-recovery-readiness/tsconfig.es.json
+++ b/clients/client-route53-recovery-readiness/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-route53-recovery-readiness/tsconfig.json
+++ b/clients/client-route53-recovery-readiness/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-route53-recovery-readiness/tsconfig.types.json
+++ b/clients/client-route53-recovery-readiness/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-route53resolver/package.json
+++ b/clients/client-route53resolver/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-route53resolver/package.json
+++ b/clients/client-route53resolver/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-route53resolver/tsconfig.es.json
+++ b/clients/client-route53resolver/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-route53resolver/tsconfig.json
+++ b/clients/client-route53resolver/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-route53resolver/tsconfig.types.json
+++ b/clients/client-route53resolver/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-s3-control/package.json
+++ b/clients/client-s3-control/package.json
@@ -13,7 +13,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-s3-control/package.json
+++ b/clients/client-s3-control/package.json
@@ -12,7 +12,7 @@
     "test": "yarn test:unit",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-s3-control/tsconfig.es.json
+++ b/clients/client-s3-control/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-s3-control/tsconfig.json
+++ b/clients/client-s3-control/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
     "outDir": "dist/cjs",
+    "removeComments": true,
     "types": ["mocha", "node"]
   },
   "typedocOptions": {

--- a/clients/client-s3-control/tsconfig.types.json
+++ b/clients/client-s3-control/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-s3/package.json
+++ b/clients/client-s3/package.json
@@ -14,7 +14,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-s3/package.json
+++ b/clients/client-s3/package.json
@@ -13,7 +13,7 @@
     "test": "yarn test:unit",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-s3/tsconfig.es.json
+++ b/clients/client-s3/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-s3/tsconfig.json
+++ b/clients/client-s3/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
     "outDir": "dist/cjs",
+    "removeComments": true,
     "types": ["mocha", "node"]
   },
   "typedocOptions": {

--- a/clients/client-s3/tsconfig.types.json
+++ b/clients/client-s3/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-s3outposts/package.json
+++ b/clients/client-s3outposts/package.json
@@ -11,7 +11,7 @@
     "test": "jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-s3outposts/package.json
+++ b/clients/client-s3outposts/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-s3outposts/tsconfig.es.json
+++ b/clients/client-s3outposts/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-s3outposts/tsconfig.json
+++ b/clients/client-s3outposts/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-s3outposts/tsconfig.types.json
+++ b/clients/client-s3outposts/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-sagemaker-a2i-runtime/package.json
+++ b/clients/client-sagemaker-a2i-runtime/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-sagemaker-a2i-runtime/package.json
+++ b/clients/client-sagemaker-a2i-runtime/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-sagemaker-a2i-runtime/tsconfig.es.json
+++ b/clients/client-sagemaker-a2i-runtime/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-sagemaker-a2i-runtime/tsconfig.json
+++ b/clients/client-sagemaker-a2i-runtime/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-sagemaker-a2i-runtime/tsconfig.types.json
+++ b/clients/client-sagemaker-a2i-runtime/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-sagemaker-edge/package.json
+++ b/clients/client-sagemaker-edge/package.json
@@ -11,7 +11,7 @@
     "test": "jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-sagemaker-edge/package.json
+++ b/clients/client-sagemaker-edge/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-sagemaker-edge/tsconfig.es.json
+++ b/clients/client-sagemaker-edge/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-sagemaker-edge/tsconfig.json
+++ b/clients/client-sagemaker-edge/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-sagemaker-edge/tsconfig.types.json
+++ b/clients/client-sagemaker-edge/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-sagemaker-featurestore-runtime/package.json
+++ b/clients/client-sagemaker-featurestore-runtime/package.json
@@ -11,7 +11,7 @@
     "test": "jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-sagemaker-featurestore-runtime/package.json
+++ b/clients/client-sagemaker-featurestore-runtime/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-sagemaker-featurestore-runtime/tsconfig.es.json
+++ b/clients/client-sagemaker-featurestore-runtime/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-sagemaker-featurestore-runtime/tsconfig.json
+++ b/clients/client-sagemaker-featurestore-runtime/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-sagemaker-featurestore-runtime/tsconfig.types.json
+++ b/clients/client-sagemaker-featurestore-runtime/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-sagemaker-runtime/package.json
+++ b/clients/client-sagemaker-runtime/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-sagemaker-runtime/package.json
+++ b/clients/client-sagemaker-runtime/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-sagemaker-runtime/tsconfig.es.json
+++ b/clients/client-sagemaker-runtime/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-sagemaker-runtime/tsconfig.json
+++ b/clients/client-sagemaker-runtime/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-sagemaker-runtime/tsconfig.types.json
+++ b/clients/client-sagemaker-runtime/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-sagemaker/package.json
+++ b/clients/client-sagemaker/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-sagemaker/package.json
+++ b/clients/client-sagemaker/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-sagemaker/tsconfig.es.json
+++ b/clients/client-sagemaker/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-sagemaker/tsconfig.json
+++ b/clients/client-sagemaker/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-sagemaker/tsconfig.types.json
+++ b/clients/client-sagemaker/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-savingsplans/package.json
+++ b/clients/client-savingsplans/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-savingsplans/package.json
+++ b/clients/client-savingsplans/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-savingsplans/tsconfig.es.json
+++ b/clients/client-savingsplans/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-savingsplans/tsconfig.json
+++ b/clients/client-savingsplans/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-savingsplans/tsconfig.types.json
+++ b/clients/client-savingsplans/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-schemas/package.json
+++ b/clients/client-schemas/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-schemas/package.json
+++ b/clients/client-schemas/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-schemas/tsconfig.es.json
+++ b/clients/client-schemas/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-schemas/tsconfig.json
+++ b/clients/client-schemas/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-schemas/tsconfig.types.json
+++ b/clients/client-schemas/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-secrets-manager/package.json
+++ b/clients/client-secrets-manager/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-secrets-manager/package.json
+++ b/clients/client-secrets-manager/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-secrets-manager/tsconfig.es.json
+++ b/clients/client-secrets-manager/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-secrets-manager/tsconfig.json
+++ b/clients/client-secrets-manager/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-secrets-manager/tsconfig.types.json
+++ b/clients/client-secrets-manager/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-securityhub/package.json
+++ b/clients/client-securityhub/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-securityhub/package.json
+++ b/clients/client-securityhub/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-securityhub/tsconfig.es.json
+++ b/clients/client-securityhub/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-securityhub/tsconfig.json
+++ b/clients/client-securityhub/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-securityhub/tsconfig.types.json
+++ b/clients/client-securityhub/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-serverlessapplicationrepository/package.json
+++ b/clients/client-serverlessapplicationrepository/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-serverlessapplicationrepository/package.json
+++ b/clients/client-serverlessapplicationrepository/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-serverlessapplicationrepository/tsconfig.es.json
+++ b/clients/client-serverlessapplicationrepository/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-serverlessapplicationrepository/tsconfig.json
+++ b/clients/client-serverlessapplicationrepository/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-serverlessapplicationrepository/tsconfig.types.json
+++ b/clients/client-serverlessapplicationrepository/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-service-catalog-appregistry/package.json
+++ b/clients/client-service-catalog-appregistry/package.json
@@ -11,7 +11,7 @@
     "test": "jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-service-catalog-appregistry/package.json
+++ b/clients/client-service-catalog-appregistry/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-service-catalog-appregistry/tsconfig.es.json
+++ b/clients/client-service-catalog-appregistry/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-service-catalog-appregistry/tsconfig.json
+++ b/clients/client-service-catalog-appregistry/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-service-catalog-appregistry/tsconfig.types.json
+++ b/clients/client-service-catalog-appregistry/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-service-catalog/package.json
+++ b/clients/client-service-catalog/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-service-catalog/package.json
+++ b/clients/client-service-catalog/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-service-catalog/tsconfig.es.json
+++ b/clients/client-service-catalog/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-service-catalog/tsconfig.json
+++ b/clients/client-service-catalog/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-service-catalog/tsconfig.types.json
+++ b/clients/client-service-catalog/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-service-quotas/package.json
+++ b/clients/client-service-quotas/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-service-quotas/package.json
+++ b/clients/client-service-quotas/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-service-quotas/tsconfig.es.json
+++ b/clients/client-service-quotas/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-service-quotas/tsconfig.json
+++ b/clients/client-service-quotas/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-service-quotas/tsconfig.types.json
+++ b/clients/client-service-quotas/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-servicediscovery/package.json
+++ b/clients/client-servicediscovery/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-servicediscovery/package.json
+++ b/clients/client-servicediscovery/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-servicediscovery/tsconfig.es.json
+++ b/clients/client-servicediscovery/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-servicediscovery/tsconfig.json
+++ b/clients/client-servicediscovery/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-servicediscovery/tsconfig.types.json
+++ b/clients/client-servicediscovery/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-ses/package.json
+++ b/clients/client-ses/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-ses/package.json
+++ b/clients/client-ses/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-ses/tsconfig.es.json
+++ b/clients/client-ses/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-ses/tsconfig.json
+++ b/clients/client-ses/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-ses/tsconfig.types.json
+++ b/clients/client-ses/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-sesv2/package.json
+++ b/clients/client-sesv2/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-sesv2/package.json
+++ b/clients/client-sesv2/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-sesv2/tsconfig.es.json
+++ b/clients/client-sesv2/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-sesv2/tsconfig.json
+++ b/clients/client-sesv2/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-sesv2/tsconfig.types.json
+++ b/clients/client-sesv2/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-sfn/package.json
+++ b/clients/client-sfn/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-sfn/package.json
+++ b/clients/client-sfn/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-sfn/tsconfig.es.json
+++ b/clients/client-sfn/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-sfn/tsconfig.json
+++ b/clients/client-sfn/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-sfn/tsconfig.types.json
+++ b/clients/client-sfn/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-shield/package.json
+++ b/clients/client-shield/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-shield/package.json
+++ b/clients/client-shield/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-shield/tsconfig.es.json
+++ b/clients/client-shield/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-shield/tsconfig.json
+++ b/clients/client-shield/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-shield/tsconfig.types.json
+++ b/clients/client-shield/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-signer/package.json
+++ b/clients/client-signer/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-signer/package.json
+++ b/clients/client-signer/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-signer/tsconfig.es.json
+++ b/clients/client-signer/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-signer/tsconfig.json
+++ b/clients/client-signer/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-signer/tsconfig.types.json
+++ b/clients/client-signer/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-sms/package.json
+++ b/clients/client-sms/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-sms/package.json
+++ b/clients/client-sms/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-sms/tsconfig.es.json
+++ b/clients/client-sms/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-sms/tsconfig.json
+++ b/clients/client-sms/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-sms/tsconfig.types.json
+++ b/clients/client-sms/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-snow-device-management/package.json
+++ b/clients/client-snow-device-management/package.json
@@ -12,7 +12,7 @@
     "test": "jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",

--- a/clients/client-snow-device-management/package.json
+++ b/clients/client-snow-device-management/package.json
@@ -12,7 +12,8 @@
     "test": "jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es"
+    "build": "yarn build:cjs && yarn build:es",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-snow-device-management/tsconfig.es.json
+++ b/clients/client-snow-device-management/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-snow-device-management/tsconfig.json
+++ b/clients/client-snow-device-management/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-snow-device-management/tsconfig.types.json
+++ b/clients/client-snow-device-management/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-snowball/package.json
+++ b/clients/client-snowball/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-snowball/package.json
+++ b/clients/client-snowball/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-snowball/tsconfig.es.json
+++ b/clients/client-snowball/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-snowball/tsconfig.json
+++ b/clients/client-snowball/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-snowball/tsconfig.types.json
+++ b/clients/client-snowball/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-sns/package.json
+++ b/clients/client-sns/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-sns/package.json
+++ b/clients/client-sns/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-sns/tsconfig.es.json
+++ b/clients/client-sns/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-sns/tsconfig.json
+++ b/clients/client-sns/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-sns/tsconfig.types.json
+++ b/clients/client-sns/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-sqs/package.json
+++ b/clients/client-sqs/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-sqs/package.json
+++ b/clients/client-sqs/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-sqs/tsconfig.es.json
+++ b/clients/client-sqs/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-sqs/tsconfig.json
+++ b/clients/client-sqs/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-sqs/tsconfig.types.json
+++ b/clients/client-sqs/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-ssm-contacts/package.json
+++ b/clients/client-ssm-contacts/package.json
@@ -11,7 +11,7 @@
     "test": "jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-ssm-contacts/package.json
+++ b/clients/client-ssm-contacts/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-ssm-contacts/tsconfig.es.json
+++ b/clients/client-ssm-contacts/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-ssm-contacts/tsconfig.json
+++ b/clients/client-ssm-contacts/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-ssm-contacts/tsconfig.types.json
+++ b/clients/client-ssm-contacts/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-ssm-incidents/package.json
+++ b/clients/client-ssm-incidents/package.json
@@ -11,7 +11,7 @@
     "test": "jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-ssm-incidents/package.json
+++ b/clients/client-ssm-incidents/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-ssm-incidents/tsconfig.es.json
+++ b/clients/client-ssm-incidents/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-ssm-incidents/tsconfig.json
+++ b/clients/client-ssm-incidents/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-ssm-incidents/tsconfig.types.json
+++ b/clients/client-ssm-incidents/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-ssm/package.json
+++ b/clients/client-ssm/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-ssm/package.json
+++ b/clients/client-ssm/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-ssm/tsconfig.es.json
+++ b/clients/client-ssm/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-ssm/tsconfig.json
+++ b/clients/client-ssm/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-ssm/tsconfig.types.json
+++ b/clients/client-ssm/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-sso-admin/package.json
+++ b/clients/client-sso-admin/package.json
@@ -11,7 +11,7 @@
     "test": "jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-sso-admin/package.json
+++ b/clients/client-sso-admin/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-sso-admin/tsconfig.es.json
+++ b/clients/client-sso-admin/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-sso-admin/tsconfig.json
+++ b/clients/client-sso-admin/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-sso-admin/tsconfig.types.json
+++ b/clients/client-sso-admin/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-sso-oidc/package.json
+++ b/clients/client-sso-oidc/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-sso-oidc/package.json
+++ b/clients/client-sso-oidc/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-sso-oidc/tsconfig.es.json
+++ b/clients/client-sso-oidc/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-sso-oidc/tsconfig.json
+++ b/clients/client-sso-oidc/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-sso-oidc/tsconfig.types.json
+++ b/clients/client-sso-oidc/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-sso/package.json
+++ b/clients/client-sso/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-sso/package.json
+++ b/clients/client-sso/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-sso/tsconfig.es.json
+++ b/clients/client-sso/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-sso/tsconfig.json
+++ b/clients/client-sso/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-sso/tsconfig.types.json
+++ b/clients/client-sso/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-storage-gateway/package.json
+++ b/clients/client-storage-gateway/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-storage-gateway/package.json
+++ b/clients/client-storage-gateway/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-storage-gateway/tsconfig.es.json
+++ b/clients/client-storage-gateway/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-storage-gateway/tsconfig.json
+++ b/clients/client-storage-gateway/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-storage-gateway/tsconfig.types.json
+++ b/clients/client-storage-gateway/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-sts/package.json
+++ b/clients/client-sts/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-sts/package.json
+++ b/clients/client-sts/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-sts/tsconfig.es.json
+++ b/clients/client-sts/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-sts/tsconfig.json
+++ b/clients/client-sts/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-sts/tsconfig.types.json
+++ b/clients/client-sts/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-support/package.json
+++ b/clients/client-support/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-support/package.json
+++ b/clients/client-support/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-support/tsconfig.es.json
+++ b/clients/client-support/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-support/tsconfig.json
+++ b/clients/client-support/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-support/tsconfig.types.json
+++ b/clients/client-support/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-swf/package.json
+++ b/clients/client-swf/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-swf/package.json
+++ b/clients/client-swf/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-swf/tsconfig.es.json
+++ b/clients/client-swf/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-swf/tsconfig.json
+++ b/clients/client-swf/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-swf/tsconfig.types.json
+++ b/clients/client-swf/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-synthetics/package.json
+++ b/clients/client-synthetics/package.json
@@ -11,7 +11,7 @@
     "test": "jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-synthetics/package.json
+++ b/clients/client-synthetics/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-synthetics/tsconfig.es.json
+++ b/clients/client-synthetics/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-synthetics/tsconfig.json
+++ b/clients/client-synthetics/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-synthetics/tsconfig.types.json
+++ b/clients/client-synthetics/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-textract/package.json
+++ b/clients/client-textract/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-textract/package.json
+++ b/clients/client-textract/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-textract/tsconfig.es.json
+++ b/clients/client-textract/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-textract/tsconfig.json
+++ b/clients/client-textract/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-textract/tsconfig.types.json
+++ b/clients/client-textract/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-timestream-query/package.json
+++ b/clients/client-timestream-query/package.json
@@ -11,7 +11,7 @@
     "test": "jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-timestream-query/package.json
+++ b/clients/client-timestream-query/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-timestream-query/tsconfig.es.json
+++ b/clients/client-timestream-query/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-timestream-query/tsconfig.json
+++ b/clients/client-timestream-query/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-timestream-query/tsconfig.types.json
+++ b/clients/client-timestream-query/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-timestream-write/package.json
+++ b/clients/client-timestream-write/package.json
@@ -11,7 +11,7 @@
     "test": "jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-timestream-write/package.json
+++ b/clients/client-timestream-write/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-timestream-write/tsconfig.es.json
+++ b/clients/client-timestream-write/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-timestream-write/tsconfig.json
+++ b/clients/client-timestream-write/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-timestream-write/tsconfig.types.json
+++ b/clients/client-timestream-write/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-transcribe-streaming/package.json
+++ b/clients/client-transcribe-streaming/package.json
@@ -13,7 +13,7 @@
     "test:integration": "jest --config jest.integ.config.js",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "postbuild": "cp test/speech.wav dist/cjs/test",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"

--- a/clients/client-transcribe-streaming/package.json
+++ b/clients/client-transcribe-streaming/package.json
@@ -15,7 +15,8 @@
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
     "postbuild": "cp test/speech.wav dist/cjs/test",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-transcribe-streaming/tsconfig.es.json
+++ b/clients/client-transcribe-streaming/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   },

--- a/clients/client-transcribe-streaming/tsconfig.json
+++ b/clients/client-transcribe-streaming/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-transcribe-streaming/tsconfig.types.json
+++ b/clients/client-transcribe-streaming/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-transcribe/package.json
+++ b/clients/client-transcribe/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-transcribe/package.json
+++ b/clients/client-transcribe/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-transcribe/tsconfig.es.json
+++ b/clients/client-transcribe/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-transcribe/tsconfig.json
+++ b/clients/client-transcribe/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-transcribe/tsconfig.types.json
+++ b/clients/client-transcribe/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-transfer/package.json
+++ b/clients/client-transfer/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-transfer/package.json
+++ b/clients/client-transfer/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-transfer/tsconfig.es.json
+++ b/clients/client-transfer/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-transfer/tsconfig.json
+++ b/clients/client-transfer/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-transfer/tsconfig.types.json
+++ b/clients/client-transfer/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-translate/package.json
+++ b/clients/client-translate/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-translate/package.json
+++ b/clients/client-translate/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-translate/tsconfig.es.json
+++ b/clients/client-translate/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-translate/tsconfig.json
+++ b/clients/client-translate/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-translate/tsconfig.types.json
+++ b/clients/client-translate/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-waf-regional/package.json
+++ b/clients/client-waf-regional/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-waf-regional/package.json
+++ b/clients/client-waf-regional/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-waf-regional/tsconfig.es.json
+++ b/clients/client-waf-regional/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-waf-regional/tsconfig.json
+++ b/clients/client-waf-regional/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-waf-regional/tsconfig.types.json
+++ b/clients/client-waf-regional/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-waf/package.json
+++ b/clients/client-waf/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-waf/package.json
+++ b/clients/client-waf/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-waf/tsconfig.es.json
+++ b/clients/client-waf/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-waf/tsconfig.json
+++ b/clients/client-waf/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-waf/tsconfig.types.json
+++ b/clients/client-waf/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-wafv2/package.json
+++ b/clients/client-wafv2/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-wafv2/package.json
+++ b/clients/client-wafv2/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-wafv2/tsconfig.es.json
+++ b/clients/client-wafv2/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-wafv2/tsconfig.json
+++ b/clients/client-wafv2/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-wafv2/tsconfig.types.json
+++ b/clients/client-wafv2/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-wellarchitected/package.json
+++ b/clients/client-wellarchitected/package.json
@@ -11,7 +11,7 @@
     "test": "jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-wellarchitected/package.json
+++ b/clients/client-wellarchitected/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-wellarchitected/tsconfig.es.json
+++ b/clients/client-wellarchitected/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-wellarchitected/tsconfig.json
+++ b/clients/client-wellarchitected/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-wellarchitected/tsconfig.types.json
+++ b/clients/client-wellarchitected/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-workdocs/package.json
+++ b/clients/client-workdocs/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-workdocs/package.json
+++ b/clients/client-workdocs/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-workdocs/tsconfig.es.json
+++ b/clients/client-workdocs/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-workdocs/tsconfig.json
+++ b/clients/client-workdocs/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-workdocs/tsconfig.types.json
+++ b/clients/client-workdocs/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-worklink/package.json
+++ b/clients/client-worklink/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-worklink/package.json
+++ b/clients/client-worklink/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-worklink/tsconfig.es.json
+++ b/clients/client-worklink/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-worklink/tsconfig.json
+++ b/clients/client-worklink/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-worklink/tsconfig.types.json
+++ b/clients/client-worklink/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-workmail/package.json
+++ b/clients/client-workmail/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-workmail/package.json
+++ b/clients/client-workmail/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-workmail/tsconfig.es.json
+++ b/clients/client-workmail/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-workmail/tsconfig.json
+++ b/clients/client-workmail/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-workmail/tsconfig.types.json
+++ b/clients/client-workmail/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-workmailmessageflow/package.json
+++ b/clients/client-workmailmessageflow/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-workmailmessageflow/package.json
+++ b/clients/client-workmailmessageflow/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-workmailmessageflow/tsconfig.es.json
+++ b/clients/client-workmailmessageflow/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-workmailmessageflow/tsconfig.json
+++ b/clients/client-workmailmessageflow/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-workmailmessageflow/tsconfig.types.json
+++ b/clients/client-workmailmessageflow/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-workspaces/package.json
+++ b/clients/client-workspaces/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-workspaces/package.json
+++ b/clients/client-workspaces/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-workspaces/tsconfig.es.json
+++ b/clients/client-workspaces/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-workspaces/tsconfig.json
+++ b/clients/client-workspaces/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-workspaces/tsconfig.types.json
+++ b/clients/client-workspaces/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/clients/client-xray/package.json
+++ b/clients/client-xray/package.json
@@ -11,7 +11,7 @@
     "test": "exit 0",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/clients/client-xray/package.json
+++ b/clients/client-xray/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/clients/client-xray/tsconfig.es.json
+++ b/clients/client-xray/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/clients/client-xray/tsconfig.json
+++ b/clients/client-xray/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/clients/client-xray/tsconfig.types.json
+++ b/clients/client-xray/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/protocol_tests/aws-ec2/package.json
+++ b/protocol_tests/aws-ec2/package.json
@@ -11,7 +11,7 @@
     "test": "jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/protocol_tests/aws-ec2/package.json
+++ b/protocol_tests/aws-ec2/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/protocol_tests/aws-ec2/tsconfig.es.json
+++ b/protocol_tests/aws-ec2/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/protocol_tests/aws-ec2/tsconfig.json
+++ b/protocol_tests/aws-ec2/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/protocol_tests/aws-ec2/tsconfig.types.json
+++ b/protocol_tests/aws-ec2/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/protocol_tests/aws-json-10/package.json
+++ b/protocol_tests/aws-json-10/package.json
@@ -11,7 +11,7 @@
     "test": "jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/protocol_tests/aws-json-10/package.json
+++ b/protocol_tests/aws-json-10/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/protocol_tests/aws-json-10/tsconfig.es.json
+++ b/protocol_tests/aws-json-10/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/protocol_tests/aws-json-10/tsconfig.json
+++ b/protocol_tests/aws-json-10/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/protocol_tests/aws-json-10/tsconfig.types.json
+++ b/protocol_tests/aws-json-10/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/protocol_tests/aws-json/package.json
+++ b/protocol_tests/aws-json/package.json
@@ -11,7 +11,7 @@
     "test": "jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/protocol_tests/aws-json/package.json
+++ b/protocol_tests/aws-json/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/protocol_tests/aws-json/tsconfig.es.json
+++ b/protocol_tests/aws-json/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/protocol_tests/aws-json/tsconfig.json
+++ b/protocol_tests/aws-json/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/protocol_tests/aws-json/tsconfig.types.json
+++ b/protocol_tests/aws-json/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/protocol_tests/aws-query/package.json
+++ b/protocol_tests/aws-query/package.json
@@ -11,7 +11,7 @@
     "test": "jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/protocol_tests/aws-query/package.json
+++ b/protocol_tests/aws-query/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/protocol_tests/aws-query/tsconfig.es.json
+++ b/protocol_tests/aws-query/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/protocol_tests/aws-query/tsconfig.json
+++ b/protocol_tests/aws-query/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/protocol_tests/aws-query/tsconfig.types.json
+++ b/protocol_tests/aws-query/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/protocol_tests/aws-restjson/package.json
+++ b/protocol_tests/aws-restjson/package.json
@@ -11,7 +11,7 @@
     "test": "jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/protocol_tests/aws-restjson/package.json
+++ b/protocol_tests/aws-restjson/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/protocol_tests/aws-restjson/tsconfig.es.json
+++ b/protocol_tests/aws-restjson/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/protocol_tests/aws-restjson/tsconfig.json
+++ b/protocol_tests/aws-restjson/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/protocol_tests/aws-restjson/tsconfig.types.json
+++ b/protocol_tests/aws-restjson/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}

--- a/protocol_tests/aws-restxml/package.json
+++ b/protocol_tests/aws-restxml/package.json
@@ -11,7 +11,7 @@
     "test": "jest --coverage --passWithNoTests",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
-    "build": "yarn build:cjs && yarn build:es",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "build:types": "tsc -p tsconfig.types.json"
   },

--- a/protocol_tests/aws-restxml/package.json
+++ b/protocol_tests/aws-restxml/package.json
@@ -12,7 +12,8 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/protocol_tests/aws-restxml/tsconfig.es.json
+++ b/protocol_tests/aws-restxml/tsconfig.es.json
@@ -4,8 +4,6 @@
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "declaration": false,
-    "declarationDir": null,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist/es"
   }

--- a/protocol_tests/aws-restxml/tsconfig.json
+++ b/protocol_tests/aws-restxml/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
@@ -12,8 +11,8 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "declarationDir": "./dist/types",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "removeComments": true
   },
   "typedocOptions": {
     "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],

--- a/protocol_tests/aws-restxml/tsconfig.types.json
+++ b/protocol_tests/aws-restxml/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "removeComments": false,
+    "declaration": true,
+    "declarationDir": "dist/types"
+  }
+}


### PR DESCRIPTION
### Issue
* Refs: https://github.com/aws/aws-sdk-js-v3/issues/2797
* Experimental PR in https://github.com/trivikr/temp-client-s3/pull/9
* Codegen PR https://github.com/awslabs/smithy-typescript/pull/427

### Description
Removes comments from transpiled JS files.

<details>
<summary>Before</summary>

| Package name                                    | Unpacked size |
| ----------------------------------------------- | ------------- |
| @aws-sdk/client-accessanalyzer                  | 2.3 MB        |
| @aws-sdk/client-acm                             | 1.3 MB        |
| @aws-sdk/client-acm-pca                         | 2.1 MB        |
| @aws-sdk/client-alexa-for-business              | 5.2 MB        |
| @aws-sdk/client-amp                             | 631.8 kB      |
| @aws-sdk/client-amplify                         | 2.4 MB        |
| @aws-sdk/client-amplifybackend                  | 1.8 MB        |
| @aws-sdk/client-api-gateway                     | 7.8 MB        |
| @aws-sdk/client-apigatewaymanagementapi         | 361.7 kB      |
| @aws-sdk/client-apigatewayv2                    | 4.8 MB        |
| @aws-sdk/client-app-mesh                        | 3.9 MB        |
| @aws-sdk/client-appconfig                       | 2.2 MB        |
| @aws-sdk/client-appflow                         | 2.2 MB        |
| @aws-sdk/client-appintegrations                 | 679.3 kB      |
| @aws-sdk/client-application-auto-scaling        | 1.6 MB        |
| @aws-sdk/client-application-discovery-service   | 2.0 MB        |
| @aws-sdk/client-application-insights            | 1.8 MB        |
| @aws-sdk/client-applicationcostprofiler         | 526.8 kB      |
| @aws-sdk/client-apprunner                       | 1.6 MB        |
| @aws-sdk/client-appstream                       | 3.2 MB        |
| @aws-sdk/client-appsync                         | 2.7 MB        |
| @aws-sdk/client-athena                          | 2.3 MB        |
| @aws-sdk/client-auditmanager                    | 3.4 MB        |
| @aws-sdk/client-auto-scaling                    | 4.7 MB        |
| @aws-sdk/client-auto-scaling-plans              | 825.7 kB      |
| @aws-sdk/client-backup                          | 4.5 MB        |
| @aws-sdk/client-batch                           | 2.0 MB        |
| @aws-sdk/client-braket                          | 724.7 kB      |
| @aws-sdk/client-budgets                         | 1.8 MB        |
| @aws-sdk/client-chime                           | 12.5 MB       |
| @aws-sdk/client-chime-sdk-identity              | 1.2 MB        |
| @aws-sdk/client-chime-sdk-messaging             | 2.3 MB        |
| @aws-sdk/client-cloud9                          | 1.1 MB        |
| @aws-sdk/client-clouddirectory                  | 5.3 MB        |
| @aws-sdk/client-cloudformation                  | 5.7 MB        |
| @aws-sdk/client-cloudfront                      | 7.7 MB        |
| @aws-sdk/client-cloudhsm                        | 1.3 MB        |
| @aws-sdk/client-cloudhsm-v2                     | 1.1 MB        |
| @aws-sdk/client-cloudsearch                     | 2.0 MB        |
| @aws-sdk/client-cloudsearch-domain              | 533.9 kB      |
| @aws-sdk/client-cloudtrail                      | 1.9 MB        |
| @aws-sdk/client-cloudwatch                      | 2.9 MB        |
| @aws-sdk/client-cloudwatch-events               | 3.5 MB        |
| @aws-sdk/client-cloudwatch-logs                 | 2.7 MB        |
| @aws-sdk/client-codeartifact                    | 2.7 MB        |
| @aws-sdk/client-codebuild                       | 3.5 MB        |
| @aws-sdk/client-codecommit                      | 7.6 MB        |
| @aws-sdk/client-codedeploy                      | 4.4 MB        |
| @aws-sdk/client-codeguru-reviewer               | 1.4 MB        |
| @aws-sdk/client-codeguruprofiler                | 1.8 MB        |
| @aws-sdk/client-codepipeline                    | 3.2 MB        |
| @aws-sdk/client-codestar                        | 1.3 MB        |
| @aws-sdk/client-codestar-connections            | 850.8 kB      |
| @aws-sdk/client-codestar-notifications          | 1.0 MB        |
| @aws-sdk/client-cognito-identity                | 1.7 MB        |
| @aws-sdk/client-cognito-identity-provider       | 7.9 MB        |
| @aws-sdk/client-cognito-sync                    | 1.5 MB        |
| @aws-sdk/client-comprehend                      | 4.4 MB        |
| @aws-sdk/client-comprehendmedical               | 1.5 MB        |
| @aws-sdk/client-compute-optimizer               | 1.8 MB        |
| @aws-sdk/client-config-service                  | 6.7 MB        |
| @aws-sdk/client-connect                         | 7.2 MB        |
| @aws-sdk/client-connect-contact-lens            | 291.9 kB      |
| @aws-sdk/client-connectparticipant              | 748.3 kB      |
| @aws-sdk/client-cost-and-usage-report-service   | 480.9 kB      |
| @aws-sdk/client-cost-explorer                   | 2.9 MB        |
| @aws-sdk/client-customer-profiles               | 2.3 MB        |
| @aws-sdk/client-data-pipeline                   | 1.6 MB        |
| @aws-sdk/client-database-migration-service      | 5.0 MB        |
| @aws-sdk/client-databrew                        | 2.7 MB        |
| @aws-sdk/client-dataexchange                    | 1.7 MB        |
| @aws-sdk/client-datasync                        | 2.3 MB        |
| @aws-sdk/client-dax                             | 1.6 MB        |
| @aws-sdk/client-detective                       | 1.1 MB        |
| @aws-sdk/client-device-farm                     | 5.0 MB        |
| @aws-sdk/client-devops-guru                     | 1.9 MB        |
| @aws-sdk/client-direct-connect                  | 3.6 MB        |
| @aws-sdk/client-directory-service               | 4.2 MB        |
| @aws-sdk/client-dlm                             | 863.3 kB      |
| @aws-sdk/client-docdb                           | 4.3 MB        |
| @aws-sdk/client-dynamodb                        | 5.1 MB        |
| @aws-sdk/client-dynamodb-streams                | 592.9 kB      |
| @aws-sdk/client-ebs                             | 714.3 kB      |
| @aws-sdk/client-ec2                             | 34.1 MB       |
| @aws-sdk/client-ec2-instance-connect            | 372.6 kB      |
| @aws-sdk/client-ecr                             | 2.5 MB        |
| @aws-sdk/client-ecr-public                      | 1.7 MB        |
| @aws-sdk/client-ecs                             | 5.2 MB        |
| @aws-sdk/client-efs                             | 2.2 MB        |
| @aws-sdk/client-eks                             | 2.9 MB        |
| @aws-sdk/client-elastic-beanstalk               | 3.5 MB        |
| @aws-sdk/client-elastic-inference               | 577.9 kB      |
| @aws-sdk/client-elastic-load-balancing          | 2.3 MB        |
| @aws-sdk/client-elastic-load-balancing-v2       | 3.1 MB        |
| @aws-sdk/client-elastic-transcoder              | 2.1 MB        |
| @aws-sdk/client-elasticache                     | 6.2 MB        |
| @aws-sdk/client-elasticsearch-service           | 3.3 MB        |
| @aws-sdk/client-emr                             | 3.9 MB        |
| @aws-sdk/client-emr-containers                  | 1.1 MB        |
| @aws-sdk/client-eventbridge                     | 3.5 MB        |
| @aws-sdk/client-finspace                        | 603.1 kB      |
| @aws-sdk/client-finspace-data                   | 361.3 kB      |
| @aws-sdk/client-firehose                        | 1.8 MB        |
| @aws-sdk/client-fis                             | 1.1 MB        |
| @aws-sdk/client-fms                             | 2.1 MB        |
| @aws-sdk/client-forecast                        | 2.8 MB        |
| @aws-sdk/client-forecastquery                   | 307.3 kB      |
| @aws-sdk/client-frauddetector                   | 3.6 MB        |
| @aws-sdk/client-fsx                             | 2.9 MB        |
| @aws-sdk/client-gamelift                        | 8.1 MB        |
| @aws-sdk/client-glacier                         | 2.8 MB        |
| @aws-sdk/client-global-accelerator              | 3.3 MB        |
| @aws-sdk/client-glue                            | 10.9 MB       |
| @aws-sdk/client-greengrass                      | 5.1 MB        |
| @aws-sdk/client-greengrassv2                    | 2.0 MB        |
| @aws-sdk/client-groundstation                   | 1.8 MB        |
| @aws-sdk/client-guardduty                       | 3.7 MB        |
| @aws-sdk/client-health                          | 1.3 MB        |
| @aws-sdk/client-healthlake                      | 977.3 kB      |
| @aws-sdk/client-honeycode                       | 1.3 MB        |
| @aws-sdk/client-iam                             | 10.6 MB       |
| @aws-sdk/client-identitystore                   | 444.4 kB      |
| @aws-sdk/client-imagebuilder                    | 3.8 MB        |
| @aws-sdk/client-inspector                       | 2.7 MB        |
| @aws-sdk/client-iot                             | 15.9 MB       |
| @aws-sdk/client-iot-1click-devices-service      | 898.7 kB      |
| @aws-sdk/client-iot-1click-projects             | 1.1 MB        |
| @aws-sdk/client-iot-data-plane                  | 678.3 kB      |
| @aws-sdk/client-iot-events                      | 2.3 MB        |
| @aws-sdk/client-iot-events-data                 | 1.0 MB        |
| @aws-sdk/client-iot-jobs-data-plane             | 525.8 kB      |
| @aws-sdk/client-iot-wireless                    | 3.6 MB        |
| @aws-sdk/client-iotanalytics                    | 2.7 MB        |
| @aws-sdk/client-iotdeviceadvisor                | 921.2 kB      |
| @aws-sdk/client-iotfleethub                     | 611.1 kB      |
| @aws-sdk/client-iotsecuretunneling              | 586.3 kB      |
| @aws-sdk/client-iotsitewise                     | 4.6 MB        |
| @aws-sdk/client-iotthingsgraph                  | 2.3 MB        |
| @aws-sdk/client-ivs                             | 1.8 MB        |
| @aws-sdk/client-kafka                           | 2.3 MB        |
| @aws-sdk/client-kafkaconnect                    | 1.1 MB        |
| @aws-sdk/client-kendra                          | 3.9 MB        |
| @aws-sdk/client-kinesis                         | 2.3 MB        |
| @aws-sdk/client-kinesis-analytics               | 1.9 MB        |
| @aws-sdk/client-kinesis-analytics-v2            | 2.9 MB        |
| @aws-sdk/client-kinesis-video                   | 1.4 MB        |
| @aws-sdk/client-kinesis-video-archived-media    | 976.0 kB      |
| @aws-sdk/client-kinesis-video-media             | 329.4 kB      |
| @aws-sdk/client-kinesis-video-signaling         | 338.6 kB      |
| @aws-sdk/client-kms                             | 4.7 MB        |
| @aws-sdk/client-lakeformation                   | 1.7 MB        |
| @aws-sdk/client-lambda                          | 4.7 MB        |
| @aws-sdk/client-lex-model-building-service      | 3.5 MB        |
| @aws-sdk/client-lex-models-v2                   | 4.7 MB        |
| @aws-sdk/client-lex-runtime-service             | 956.6 kB      |
| @aws-sdk/client-lex-runtime-v2                  | 1.1 MB        |
| @aws-sdk/client-license-manager                 | 3.2 MB        |
| @aws-sdk/client-lightsail                       | 10.6 MB       |
| @aws-sdk/client-location                        | 3.7 MB        |
| @aws-sdk/client-lookoutequipment                | 1.6 MB        |
| @aws-sdk/client-lookoutmetrics                  | 1.9 MB        |
| @aws-sdk/client-lookoutvision                   | 1.5 MB        |
| @aws-sdk/client-machine-learning                | 2.3 MB        |
| @aws-sdk/client-macie                           | 643.2 kB      |
| @aws-sdk/client-macie2                          | 4.5 MB        |
| @aws-sdk/client-managedblockchain               | 1.9 MB        |
| @aws-sdk/client-marketplace-catalog             | 697.6 kB      |
| @aws-sdk/client-marketplace-commerce-analytics  | 367.4 kB      |
| @aws-sdk/client-marketplace-entitlement-service | 326.6 kB      |
| @aws-sdk/client-marketplace-metering            | 652.6 kB      |
| @aws-sdk/client-mediaconnect                    | 2.4 MB        |
| @aws-sdk/client-mediaconvert                    | 4.9 MB        |
| @aws-sdk/client-medialive                       | 6.4 MB        |
| @aws-sdk/client-mediapackage                    | 1.6 MB        |
| @aws-sdk/client-mediapackage-vod                | 1.4 MB        |
| @aws-sdk/client-mediastore                      | 1.3 MB        |
| @aws-sdk/client-mediastore-data                 | 528.0 kB      |
| @aws-sdk/client-mediatailor                     | 2.1 MB        |
| @aws-sdk/client-memorydb                        | 2.5 MB        |
| @aws-sdk/client-mgn                             | 1.9 MB        |
| @aws-sdk/client-migration-hub                   | 1.5 MB        |
| @aws-sdk/client-migrationhub-config             | 446.0 kB      |
| @aws-sdk/client-mobile                          | 793.0 kB      |
| @aws-sdk/client-mq                              | 1.7 MB        |
| @aws-sdk/client-mturk                           | 2.6 MB        |
| @aws-sdk/client-mwaa                            | 904.5 kB      |
| @aws-sdk/client-neptune                         | 5.4 MB        |
| @aws-sdk/client-network-firewall                | 2.5 MB        |
| @aws-sdk/client-networkmanager                  | 2.5 MB        |
| @aws-sdk/client-nimble                          | 3.2 MB        |
| @aws-sdk/client-opensearch                      | 3.1 MB        |
| @aws-sdk/client-opsworks                        | 4.8 MB        |
| @aws-sdk/client-opsworkscm                      | 1.5 MB        |
| @aws-sdk/client-organizations                   | 4.5 MB        |
| @aws-sdk/client-outposts                        | 844.5 kB      |
| @aws-sdk/client-personalize                     | 3.2 MB        |
| @aws-sdk/client-personalize-events              | 384.7 kB      |
| @aws-sdk/client-personalize-runtime             | 349.1 kB      |
| @aws-sdk/client-pi                              | 528.5 kB      |
| @aws-sdk/client-pinpoint                        | 8.8 MB        |
| @aws-sdk/client-pinpoint-email                  | 3.0 MB        |
| @aws-sdk/client-pinpoint-sms-voice              | 731.1 kB      |
| @aws-sdk/client-polly                           | 910.4 kB      |
| @aws-sdk/client-pricing                         | 479.0 kB      |
| @aws-sdk/client-proton                          | 3.6 MB        |
| @aws-sdk/client-qldb                            | 1.5 MB        |
| @aws-sdk/client-qldb-session                    | 412.9 kB      |
| @aws-sdk/client-quicksight                      | 9.1 MB        |
| @aws-sdk/client-ram                             | 2.0 MB        |
| @aws-sdk/client-rds                             | 12.2 MB       |
| @aws-sdk/client-rds-data                        | 796.4 kB      |
| @aws-sdk/client-redshift                        | 9.0 MB        |
| @aws-sdk/client-redshift-data                   | 925.8 kB      |
| @aws-sdk/client-rekognition                     | 4.7 MB        |
| @aws-sdk/client-resource-groups                 | 1.4 MB        |
| @aws-sdk/client-resource-groups-tagging-api     | 857.2 kB      |
| @aws-sdk/client-robomaker                       | 4.2 MB        |
| @aws-sdk/client-route-53                        | 5.3 MB        |
| @aws-sdk/client-route-53-domains                | 2.1 MB        |
| @aws-sdk/client-route53-recovery-cluster        | 390.3 kB      |
| @aws-sdk/client-route53-recovery-control-config | 1.5 MB        |
| @aws-sdk/client-route53-recovery-readiness      | 2.1 MB        |
| @aws-sdk/client-route53resolver                 | 4.3 MB        |
| @aws-sdk/client-s3                              | 9.5 MB        |
| @aws-sdk/client-s3-control                      | 4.9 MB        |
| @aws-sdk/client-s3outposts                      | 372.8 kB      |
| @aws-sdk/client-sagemaker                       | 17.6 MB       |
| @aws-sdk/client-sagemaker-a2i-runtime           | 567.1 kB      |
| @aws-sdk/client-sagemaker-edge                  | 253.3 kB      |
| @aws-sdk/client-sagemaker-featurestore-runtime  | 430.7 kB      |
| @aws-sdk/client-sagemaker-runtime               | 384.1 kB      |
| @aws-sdk/client-savingsplans                    | 819.5 kB      |
| @aws-sdk/client-schemas                         | 2.1 MB        |
| @aws-sdk/client-secrets-manager                 | 2.1 MB        |
| @aws-sdk/client-securityhub                     | 7.9 MB        |
| @aws-sdk/client-serverlessapplicationrepository | 1.3 MB        |
| @aws-sdk/client-service-catalog                 | 5.7 MB        |
| @aws-sdk/client-service-catalog-appregistry     | 1.4 MB        |
| @aws-sdk/client-service-quotas                  | 1.5 MB        |
| @aws-sdk/client-servicediscovery                | 2.1 MB        |
| @aws-sdk/client-ses                             | 4.9 MB        |
| @aws-sdk/client-sesv2                           | 5.5 MB        |
| @aws-sdk/client-sfn                             | 1.9 MB        |
| @aws-sdk/client-shield                          | 2.2 MB        |
| @aws-sdk/client-signer                          | 1.4 MB        |
| @aws-sdk/client-sms                             | 2.4 MB        |
| @aws-sdk/client-snow-device-management          | 1.0 MB        |
| @aws-sdk/client-snowball                        | 1.9 MB        |
| @aws-sdk/client-sns                             | 2.8 MB        |
| @aws-sdk/client-sqs                             | 1.8 MB        |
| @aws-sdk/client-ssm                             | 11.2 MB       |
| @aws-sdk/client-ssm-contacts                    | 1.8 MB        |
| @aws-sdk/client-ssm-incidents                   | 2.1 MB        |
| @aws-sdk/client-sso                             | 462.2 kB      |
| @aws-sdk/client-sso-admin                       | 2.2 MB        |
| @aws-sdk/client-sso-oidc                        | 481.5 kB      |
| @aws-sdk/client-storage-gateway                 | 5.7 MB        |
| @aws-sdk/client-sts                             | 1.3 MB        |
| @aws-sdk/client-support                         | 1.3 MB        |
| @aws-sdk/client-swf                             | 3.8 MB        |
| @aws-sdk/client-synthetics                      | 1.1 MB        |
| @aws-sdk/client-textract                        | 1.0 MB        |
| @aws-sdk/client-timestream-query                | 415.4 kB      |
| @aws-sdk/client-timestream-write                | 1.1 MB        |
| @aws-sdk/client-transcribe                      | 2.9 MB        |
| @aws-sdk/client-transcribe-streaming            | 3.2 MB        |
| @aws-sdk/client-transfer                        | 2.5 MB        |
| @aws-sdk/client-translate                       | 1.2 MB        |
| @aws-sdk/client-waf                             | 6.0 MB        |
| @aws-sdk/client-waf-regional                    | 6.3 MB        |
| @aws-sdk/client-wafv2                           | 3.9 MB        |
| @aws-sdk/client-wellarchitected                 | 2.3 MB        |
| @aws-sdk/client-workdocs                        | 2.9 MB        |
| @aws-sdk/client-worklink                        | 2.1 MB        |
| @aws-sdk/client-workmail                        | 3.4 MB        |
| @aws-sdk/client-workmailmessageflow             | 334.5 kB      |
| @aws-sdk/client-workspaces                      | 3.4 MB        |
| @aws-sdk/client-xray                            | 2.1 MB        |
| @aws-sdk/client-documentation-generator         | 136.6 kB      |

Total size: 804.25 MB


</details>

<details>
<summary>After</summary>

| Package name                                    | Unpacked size |
| ----------------------------------------------- | ------------- |
| @aws-sdk/client-accessanalyzer                  | 2.3 MB        |
| @aws-sdk/client-acm                             | 1.3 MB        |
| @aws-sdk/client-acm-pca                         | 2.1 MB        |
| @aws-sdk/client-alexa-for-business              | 5.1 MB        |
| @aws-sdk/client-amp                             | 618.1 kB      |
| @aws-sdk/client-amplify                         | 2.4 MB        |
| @aws-sdk/client-amplifybackend                  | 1.8 MB        |
| @aws-sdk/client-api-gateway                     | 7.7 MB        |
| @aws-sdk/client-apigatewaymanagementapi         | 355.7 kB      |
| @aws-sdk/client-apigatewayv2                    | 4.7 MB        |
| @aws-sdk/client-app-mesh                        | 3.8 MB        |
| @aws-sdk/client-appconfig                       | 2.2 MB        |
| @aws-sdk/client-appflow                         | 2.1 MB        |
| @aws-sdk/client-appintegrations                 | 663.2 kB      |
| @aws-sdk/client-application-auto-scaling        | 1.5 MB        |
| @aws-sdk/client-application-discovery-service   | 1.9 MB        |
| @aws-sdk/client-application-insights            | 1.7 MB        |
| @aws-sdk/client-applicationcostprofiler         | 514.4 kB      |
| @aws-sdk/client-apprunner                       | 1.6 MB        |
| @aws-sdk/client-appstream                       | 3.1 MB        |
| @aws-sdk/client-appsync                         | 2.6 MB        |
| @aws-sdk/client-athena                          | 2.2 MB        |
| @aws-sdk/client-auditmanager                    | 3.3 MB        |
| @aws-sdk/client-auto-scaling                    | 4.6 MB        |
| @aws-sdk/client-auto-scaling-plans              | 811.3 kB      |
| @aws-sdk/client-backup                          | 4.4 MB        |
| @aws-sdk/client-batch                           | 2.0 MB        |
| @aws-sdk/client-braket                          | 709.4 kB      |
| @aws-sdk/client-budgets                         | 1.7 MB        |
| @aws-sdk/client-chime                           | 12.1 MB       |
| @aws-sdk/client-chime-sdk-identity              | 1.2 MB        |
| @aws-sdk/client-chime-sdk-messaging             | 2.2 MB        |
| @aws-sdk/client-cloud9                          | 1.1 MB        |
| @aws-sdk/client-clouddirectory                  | 5.2 MB        |
| @aws-sdk/client-cloudformation                  | 5.6 MB        |
| @aws-sdk/client-cloudfront                      | 7.5 MB        |
| @aws-sdk/client-cloudhsm                        | 1.3 MB        |
| @aws-sdk/client-cloudhsm-v2                     | 1.1 MB        |
| @aws-sdk/client-cloudsearch                     | 2.0 MB        |
| @aws-sdk/client-cloudsearch-domain              | 523.3 kB      |
| @aws-sdk/client-cloudtrail                      | 1.9 MB        |
| @aws-sdk/client-cloudwatch                      | 2.9 MB        |
| @aws-sdk/client-cloudwatch-events               | 3.4 MB        |
| @aws-sdk/client-cloudwatch-logs                 | 2.7 MB        |
| @aws-sdk/client-codeartifact                    | 2.6 MB        |
| @aws-sdk/client-codebuild                       | 3.4 MB        |
| @aws-sdk/client-codecommit                      | 7.4 MB        |
| @aws-sdk/client-codedeploy                      | 4.3 MB        |
| @aws-sdk/client-codeguru-reviewer               | 1.4 MB        |
| @aws-sdk/client-codeguruprofiler                | 1.8 MB        |
| @aws-sdk/client-codepipeline                    | 3.1 MB        |
| @aws-sdk/client-codestar                        | 1.3 MB        |
| @aws-sdk/client-codestar-connections            | 823.0 kB      |
| @aws-sdk/client-codestar-notifications          | 994.6 kB      |
| @aws-sdk/client-cognito-identity                | 1.7 MB        |
| @aws-sdk/client-cognito-identity-provider       | 7.7 MB        |
| @aws-sdk/client-cognito-sync                    | 1.4 MB        |
| @aws-sdk/client-comprehend                      | 4.3 MB        |
| @aws-sdk/client-comprehendmedical               | 1.5 MB        |
| @aws-sdk/client-compute-optimizer               | 1.8 MB        |
| @aws-sdk/client-config-service                  | 6.5 MB        |
| @aws-sdk/client-connect                         | 7.0 MB        |
| @aws-sdk/client-connect-contact-lens            | 287.3 kB      |
| @aws-sdk/client-connectparticipant              | 731.0 kB      |
| @aws-sdk/client-cost-and-usage-report-service   | 472.0 kB      |
| @aws-sdk/client-cost-explorer                   | 2.9 MB        |
| @aws-sdk/client-customer-profiles               | 2.2 MB        |
| @aws-sdk/client-data-pipeline                   | 1.5 MB        |
| @aws-sdk/client-database-migration-service      | 4.9 MB        |
| @aws-sdk/client-databrew                        | 2.6 MB        |
| @aws-sdk/client-dataexchange                    | 1.7 MB        |
| @aws-sdk/client-datasync                        | 2.2 MB        |
| @aws-sdk/client-dax                             | 1.6 MB        |
| @aws-sdk/client-detective                       | 1.0 MB        |
| @aws-sdk/client-device-farm                     | 4.9 MB        |
| @aws-sdk/client-devops-guru                     | 1.9 MB        |
| @aws-sdk/client-direct-connect                  | 3.5 MB        |
| @aws-sdk/client-directory-service               | 4.0 MB        |
| @aws-sdk/client-dlm                             | 849.0 kB      |
| @aws-sdk/client-docdb                           | 4.2 MB        |
| @aws-sdk/client-dynamodb                        | 5.0 MB        |
| @aws-sdk/client-dynamodb-streams                | 582.9 kB      |
| @aws-sdk/client-ebs                             | 698.2 kB      |
| @aws-sdk/client-ec2                             | 33.2 MB       |
| @aws-sdk/client-ec2-instance-connect            | 367.1 kB      |
| @aws-sdk/client-ecr                             | 2.4 MB        |
| @aws-sdk/client-ecr-public                      | 1.7 MB        |
| @aws-sdk/client-ecs                             | 5.1 MB        |
| @aws-sdk/client-efs                             | 2.1 MB        |
| @aws-sdk/client-eks                             | 2.9 MB        |
| @aws-sdk/client-elastic-beanstalk               | 3.4 MB        |
| @aws-sdk/client-elastic-inference               | 567.2 kB      |
| @aws-sdk/client-elastic-load-balancing          | 2.2 MB        |
| @aws-sdk/client-elastic-load-balancing-v2       | 3.0 MB        |
| @aws-sdk/client-elastic-transcoder              | 2.1 MB        |
| @aws-sdk/client-elasticache                     | 6.0 MB        |
| @aws-sdk/client-elasticsearch-service           | 3.2 MB        |
| @aws-sdk/client-emr                             | 3.8 MB        |
| @aws-sdk/client-emr-containers                  | 1.1 MB        |
| @aws-sdk/client-eventbridge                     | 3.4 MB        |
| @aws-sdk/client-finspace                        | 590.4 kB      |
| @aws-sdk/client-finspace-data                   | 355.6 kB      |
| @aws-sdk/client-firehose                        | 1.8 MB        |
| @aws-sdk/client-fis                             | 1.0 MB        |
| @aws-sdk/client-fms                             | 2.1 MB        |
| @aws-sdk/client-forecast                        | 2.7 MB        |
| @aws-sdk/client-forecastquery                   | 303.9 kB      |
| @aws-sdk/client-frauddetector                   | 3.5 MB        |
| @aws-sdk/client-fsx                             | 2.9 MB        |
| @aws-sdk/client-gamelift                        | 7.8 MB        |
| @aws-sdk/client-glacier                         | 2.7 MB        |
| @aws-sdk/client-global-accelerator              | 3.2 MB        |
| @aws-sdk/client-glue                            | 10.6 MB       |
| @aws-sdk/client-greengrass                      | 5.0 MB        |
| @aws-sdk/client-greengrassv2                    | 2.0 MB        |
| @aws-sdk/client-groundstation                   | 1.8 MB        |
| @aws-sdk/client-guardduty                       | 3.6 MB        |
| @aws-sdk/client-health                          | 1.3 MB        |
| @aws-sdk/client-healthlake                      | 954.9 kB      |
| @aws-sdk/client-honeycode                       | 1.2 MB        |
| @aws-sdk/client-iam                             | 10.2 MB       |
| @aws-sdk/client-identitystore                   | 435.4 kB      |
| @aws-sdk/client-imagebuilder                    | 3.8 MB        |
| @aws-sdk/client-inspector                       | 2.6 MB        |
| @aws-sdk/client-iot                             | 15.4 MB       |
| @aws-sdk/client-iot-1click-devices-service      | 876.2 kB      |
| @aws-sdk/client-iot-1click-projects             | 1.1 MB        |
| @aws-sdk/client-iot-data-plane                  | 659.9 kB      |
| @aws-sdk/client-iot-events                      | 2.2 MB        |
| @aws-sdk/client-iot-events-data                 | 999.4 kB      |
| @aws-sdk/client-iot-jobs-data-plane             | 516.1 kB      |
| @aws-sdk/client-iot-wireless                    | 3.5 MB        |
| @aws-sdk/client-iotanalytics                    | 2.7 MB        |
| @aws-sdk/client-iotdeviceadvisor                | 898.9 kB      |
| @aws-sdk/client-iotfleethub                     | 596.1 kB      |
| @aws-sdk/client-iotsecuretunneling              | 574.4 kB      |
| @aws-sdk/client-iotsitewise                     | 4.4 MB        |
| @aws-sdk/client-iotthingsgraph                  | 2.3 MB        |
| @aws-sdk/client-ivs                             | 1.7 MB        |
| @aws-sdk/client-kafka                           | 2.2 MB        |
| @aws-sdk/client-kafkaconnect                    | 1.1 MB        |
| @aws-sdk/client-kendra                          | 3.8 MB        |
| @aws-sdk/client-kinesis                         | 2.2 MB        |
| @aws-sdk/client-kinesis-analytics               | 1.8 MB        |
| @aws-sdk/client-kinesis-analytics-v2            | 2.9 MB        |
| @aws-sdk/client-kinesis-video                   | 1.4 MB        |
| @aws-sdk/client-kinesis-video-archived-media    | 934.5 kB      |
| @aws-sdk/client-kinesis-video-media             | 324.1 kB      |
| @aws-sdk/client-kinesis-video-signaling         | 332.3 kB      |
| @aws-sdk/client-kms                             | 4.5 MB        |
| @aws-sdk/client-lakeformation                   | 1.7 MB        |
| @aws-sdk/client-lambda                          | 4.5 MB        |
| @aws-sdk/client-lex-model-building-service      | 3.4 MB        |
| @aws-sdk/client-lex-models-v2                   | 4.6 MB        |
| @aws-sdk/client-lex-runtime-service             | 936.6 kB      |
| @aws-sdk/client-lex-runtime-v2                  | 1.0 MB        |
| @aws-sdk/client-license-manager                 | 3.1 MB        |
| @aws-sdk/client-lightsail                       | 10.3 MB       |
| @aws-sdk/client-location                        | 3.6 MB        |
| @aws-sdk/client-lookoutequipment                | 1.6 MB        |
| @aws-sdk/client-lookoutmetrics                  | 1.9 MB        |
| @aws-sdk/client-lookoutvision                   | 1.4 MB        |
| @aws-sdk/client-machine-learning                | 2.3 MB        |
| @aws-sdk/client-macie                           | 628.8 kB      |
| @aws-sdk/client-macie2                          | 4.4 MB        |
| @aws-sdk/client-managedblockchain               | 1.9 MB        |
| @aws-sdk/client-marketplace-catalog             | 683.1 kB      |
| @aws-sdk/client-marketplace-commerce-analytics  | 362.2 kB      |
| @aws-sdk/client-marketplace-entitlement-service | 322.6 kB      |
| @aws-sdk/client-marketplace-metering            | 633.0 kB      |
| @aws-sdk/client-mediaconnect                    | 2.3 MB        |
| @aws-sdk/client-mediaconvert                    | 4.9 MB        |
| @aws-sdk/client-medialive                       | 6.3 MB        |
| @aws-sdk/client-mediapackage                    | 1.6 MB        |
| @aws-sdk/client-mediapackage-vod                | 1.4 MB        |
| @aws-sdk/client-mediastore                      | 1.3 MB        |
| @aws-sdk/client-mediastore-data                 | 518.9 kB      |
| @aws-sdk/client-mediatailor                     | 2.1 MB        |
| @aws-sdk/client-memorydb                        | 2.5 MB        |
| @aws-sdk/client-mgn                             | 1.8 MB        |
| @aws-sdk/client-migration-hub                   | 1.4 MB        |
| @aws-sdk/client-migrationhub-config             | 436.9 kB      |
| @aws-sdk/client-mobile                          | 776.3 kB      |
| @aws-sdk/client-mq                              | 1.6 MB        |
| @aws-sdk/client-mturk                           | 2.6 MB        |
| @aws-sdk/client-mwaa                            | 886.5 kB      |
| @aws-sdk/client-neptune                         | 5.2 MB        |
| @aws-sdk/client-network-firewall                | 2.4 MB        |
| @aws-sdk/client-networkmanager                  | 2.4 MB        |
| @aws-sdk/client-nimble                          | 3.1 MB        |
| @aws-sdk/client-opensearch                      | 3.0 MB        |
| @aws-sdk/client-opsworks                        | 4.6 MB        |
| @aws-sdk/client-opsworkscm                      | 1.5 MB        |
| @aws-sdk/client-organizations                   | 4.4 MB        |
| @aws-sdk/client-outposts                        | 825.4 kB      |
| @aws-sdk/client-personalize                     | 3.1 MB        |
| @aws-sdk/client-personalize-events              | 378.7 kB      |
| @aws-sdk/client-personalize-runtime             | 344.6 kB      |
| @aws-sdk/client-pi                              | 518.8 kB      |
| @aws-sdk/client-pinpoint                        | 8.6 MB        |
| @aws-sdk/client-pinpoint-email                  | 3.0 MB        |
| @aws-sdk/client-pinpoint-sms-voice              | 716.7 kB      |
| @aws-sdk/client-polly                           | 890.4 kB      |
| @aws-sdk/client-pricing                         | 467.6 kB      |
| @aws-sdk/client-proton                          | 3.5 MB        |
| @aws-sdk/client-qldb                            | 1.4 MB        |
| @aws-sdk/client-qldb-session                    | 405.5 kB      |
| @aws-sdk/client-quicksight                      | 8.9 MB        |
| @aws-sdk/client-ram                             | 1.9 MB        |
| @aws-sdk/client-rds                             | 11.9 MB       |
| @aws-sdk/client-rds-data                        | 782.9 kB      |
| @aws-sdk/client-redshift                        | 8.8 MB        |
| @aws-sdk/client-redshift-data                   | 902.1 kB      |
| @aws-sdk/client-rekognition                     | 4.5 MB        |
| @aws-sdk/client-resource-groups                 | 1.4 MB        |
| @aws-sdk/client-resource-groups-tagging-api     | 835.0 kB      |
| @aws-sdk/client-robomaker                       | 4.2 MB        |
| @aws-sdk/client-route-53                        | 5.2 MB        |
| @aws-sdk/client-route-53-domains                | 2.0 MB        |
| @aws-sdk/client-route53-recovery-cluster        | 378.3 kB      |
| @aws-sdk/client-route53-recovery-control-config | 1.5 MB        |
| @aws-sdk/client-route53-recovery-readiness      | 2.0 MB        |
| @aws-sdk/client-route53resolver                 | 4.1 MB        |
| @aws-sdk/client-s3                              | 9.0 MB        |
| @aws-sdk/client-s3-control                      | 4.7 MB        |
| @aws-sdk/client-s3outposts                      | 363.7 kB      |
| @aws-sdk/client-sagemaker                       | 17.2 MB       |
| @aws-sdk/client-sagemaker-a2i-runtime           | 552.8 kB      |
| @aws-sdk/client-sagemaker-edge                  | 249.8 kB      |
| @aws-sdk/client-sagemaker-featurestore-runtime  | 420.0 kB      |
| @aws-sdk/client-sagemaker-runtime               | 377.4 kB      |
| @aws-sdk/client-savingsplans                    | 804.4 kB      |
| @aws-sdk/client-schemas                         | 2.0 MB        |
| @aws-sdk/client-secrets-manager                 | 2.0 MB        |
| @aws-sdk/client-securityhub                     | 7.8 MB        |
| @aws-sdk/client-serverlessapplicationrepository | 1.3 MB        |
| @aws-sdk/client-service-catalog                 | 5.5 MB        |
| @aws-sdk/client-service-catalog-appregistry     | 1.4 MB        |
| @aws-sdk/client-service-quotas                  | 1.5 MB        |
| @aws-sdk/client-servicediscovery                | 2.0 MB        |
| @aws-sdk/client-ses                             | 4.7 MB        |
| @aws-sdk/client-sesv2                           | 5.3 MB        |
| @aws-sdk/client-sfn                             | 1.9 MB        |
| @aws-sdk/client-shield                          | 2.1 MB        |
| @aws-sdk/client-signer                          | 1.4 MB        |
| @aws-sdk/client-sms                             | 2.4 MB        |
| @aws-sdk/client-snow-device-management          | 999.4 kB      |
| @aws-sdk/client-snowball                        | 1.8 MB        |
| @aws-sdk/client-sns                             | 2.7 MB        |
| @aws-sdk/client-sqs                             | 1.8 MB        |
| @aws-sdk/client-ssm                             | 10.9 MB       |
| @aws-sdk/client-ssm-contacts                    | 1.7 MB        |
| @aws-sdk/client-ssm-incidents                   | 2.1 MB        |
| @aws-sdk/client-sso                             | 452.2 kB      |
| @aws-sdk/client-sso-admin                       | 2.1 MB        |
| @aws-sdk/client-sso-oidc                        | 472.4 kB      |
| @aws-sdk/client-storage-gateway                 | 5.5 MB        |
| @aws-sdk/client-sts                             | 1.3 MB        |
| @aws-sdk/client-support                         | 1.3 MB        |
| @aws-sdk/client-swf                             | 3.6 MB        |
| @aws-sdk/client-synthetics                      | 1.1 MB        |
| @aws-sdk/client-textract                        | 985.7 kB      |
| @aws-sdk/client-timestream-query                | 407.6 kB      |
| @aws-sdk/client-timestream-write                | 1.1 MB        |
| @aws-sdk/client-transcribe                      | 2.8 MB        |
| @aws-sdk/client-transcribe-streaming            | 3.2 MB        |
| @aws-sdk/client-transfer                        | 2.4 MB        |
| @aws-sdk/client-translate                       | 1.2 MB        |
| @aws-sdk/client-waf                             | 5.8 MB        |
| @aws-sdk/client-waf-regional                    | 6.1 MB        |
| @aws-sdk/client-wafv2                           | 3.8 MB        |
| @aws-sdk/client-wellarchitected                 | 2.2 MB        |
| @aws-sdk/client-workdocs                        | 2.9 MB        |
| @aws-sdk/client-worklink                        | 2.0 MB        |
| @aws-sdk/client-workmail                        | 3.3 MB        |
| @aws-sdk/client-workmailmessageflow             | 329.4 kB      |
| @aws-sdk/client-workspaces                      | 3.3 MB        |
| @aws-sdk/client-xray                            | 2.1 MB        |
| @aws-sdk/client-documentation-generator         | 136.6 kB      |

Total size: 783.76 MB

</details>

### Testing
For `client-s3`, verified that comments are:
* not present in `dist/cjs/S3.js`
* not present in `dist/es/S3.js`
* present in `dist/types/S3.d.ts`

Verified that integration tests are successful

```console
$ yarn test:integration-legacy
yarn run v1.22.11
$ cucumber-js --fail-fast
...............................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................

150 scenarios (150 passed)
523 steps (523 passed)
1m34.522s
Done in 98.86s.

$ yarn test:integration       
yarn run v1.22.11
$ jest --config jest.config.integ.js --passWithNoTests
jest-haste-map: Haste module naming collision: @aws-sdk/client-transcribe-streaming
  The following files share their name; please adjust your hasteImpl:
    * <rootDir>/package.json
    * <rootDir>/dist/cjs/package.json

 PASS  clients/client-transcribe-streaming/test/index.integ.spec.ts (31.712 s)
  TranscribeStream client
    ✓ should stream the transcript (28784 ms)

Test Suites: 1 passed, 1 total
Tests:       1 passed, 1 total
Snapshots:   0 total
Time:        32.192 s
Ran all test suites.
Done in 32.85s.
```

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
