### PR TITLE
chore(lib-storage): stop bundling fs in browsers

### DIFF
--- a/lib/lib-storage/package.json
+++ b/lib/lib-storage/package.json
@@ -53,6 +53,7 @@
     }
   },
   "browser": {
+    "fs": false,
     "stream": "stream-browserify",
     "./runtimeConfig": "./src/runtimeConfig.browser"
   },


### PR DESCRIPTION
Webpack5 fails when bundler lib-storage because it requires 'fs' module. This change explicitly disable bundling fs module in browsers.

### Issue
When bundling code bellow with Webpack 5:
```javascript
import { S3Client } from "@aws-sdk/client-s3";
import { Upload } from "@aws-sdk/lib-storage";

const Bucket = "xxx";
const Body = "xxx"

const s3 = new S3Client({
  credentials: {
    accessKeyId: "key",
    secretAccessKey: "secret"
  },
  region: "us-west-2"
});

const upload = new Upload({
  client: s3,
  params: {
    Bucket,
    Key: "xxx",
    Body
  }
})

upload.done().then(console.log).catch(console.error)
```

Webpack fail to bundle it out-of-box:
```console
Module not found: Error: Can't resolve 'fs' in '/xxx/workspace/tmp/sdk-test/lib-dynamodb'
```

This change fix the issue.

### Additional context
Add any other context about the PR here.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
