### PR TITLE
chore: remove redundant dot slash in directory configurations

### DIFF
--- a/lib/lib-dynamodb/tsconfig.cjs.json
+++ b/lib/lib-dynamodb/tsconfig.cjs.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/cjs",
     "baseUrl": "."
   },

--- a/lib/lib-dynamodb/tsconfig.cjs.json
+++ b/lib/lib-dynamodb/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "./dist/cjs",
+    "outDir": "dist/cjs",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/lib/lib-dynamodb/tsconfig.es.json
+++ b/lib/lib-dynamodb/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "lib": ["es5", "es2015.collection", "dom"],
     "rootDir": "src",
-    "outDir": "./dist/es",
+    "outDir": "dist/es",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.es.json",

--- a/lib/lib-dynamodb/tsconfig.es.json
+++ b/lib/lib-dynamodb/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es5", "es2015.collection", "dom"],
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/es",
     "baseUrl": "."
   },

--- a/lib/lib-dynamodb/tsconfig.types.json
+++ b/lib/lib-dynamodb/tsconfig.types.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "declarationDir": "./dist/types",
     "baseUrl": "."
   },

--- a/lib/lib-dynamodb/tsconfig.types.json
+++ b/lib/lib-dynamodb/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "declarationDir": "./dist/types",
+    "declarationDir": "dist/types",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.types.json",

--- a/lib/lib-storage/tsconfig.cjs.json
+++ b/lib/lib-storage/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es5", "es2015.collection", "dom"],
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/cjs",
     "baseUrl": "."
   },

--- a/lib/lib-storage/tsconfig.cjs.json
+++ b/lib/lib-storage/tsconfig.cjs.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "lib": ["es5", "es2015.collection", "dom"],
     "rootDir": "src",
-    "outDir": "./dist/cjs",
+    "outDir": "dist/cjs",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/lib/lib-storage/tsconfig.es.json
+++ b/lib/lib-storage/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "lib": ["es5", "es2015.collection", "dom"],
     "rootDir": "src",
-    "outDir": "./dist/es",
+    "outDir": "dist/es",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.es.json",

--- a/lib/lib-storage/tsconfig.es.json
+++ b/lib/lib-storage/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es5", "es2015.collection", "dom"],
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/es",
     "baseUrl": "."
   },

--- a/lib/lib-storage/tsconfig.types.json
+++ b/lib/lib-storage/tsconfig.types.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "declarationDir": "./dist/types",
     "baseUrl": "."
   },

--- a/lib/lib-storage/tsconfig.types.json
+++ b/lib/lib-storage/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "declarationDir": "./dist/types",
+    "declarationDir": "dist/types",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/abort-controller/tsconfig.cjs.json
+++ b/packages/abort-controller/tsconfig.cjs.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "stripInternal": true,
     "rootDir": "src",
-    "outDir": "./dist/cjs",
+    "outDir": "dist/cjs",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/abort-controller/tsconfig.cjs.json
+++ b/packages/abort-controller/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "stripInternal": true,
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/cjs",
     "baseUrl": "."
   },

--- a/packages/abort-controller/tsconfig.es.json
+++ b/packages/abort-controller/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "lib": ["es5", "es2015.collection"],
     "stripInternal": true,
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/es",
     "baseUrl": "."
   },

--- a/packages/abort-controller/tsconfig.es.json
+++ b/packages/abort-controller/tsconfig.es.json
@@ -3,7 +3,7 @@
     "lib": ["es5", "es2015.collection"],
     "stripInternal": true,
     "rootDir": "src",
-    "outDir": "./dist/es",
+    "outDir": "dist/es",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/abort-controller/tsconfig.types.json
+++ b/packages/abort-controller/tsconfig.types.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "declarationDir": "./dist/types",
     "baseUrl": "."
   },

--- a/packages/abort-controller/tsconfig.types.json
+++ b/packages/abort-controller/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "declarationDir": "./dist/types",
+    "declarationDir": "dist/types",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/body-checksum-browser/tsconfig.cjs.json
+++ b/packages/body-checksum-browser/tsconfig.cjs.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/cjs",
     "baseUrl": "."
   },

--- a/packages/body-checksum-browser/tsconfig.cjs.json
+++ b/packages/body-checksum-browser/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "./dist/cjs",
+    "outDir": "dist/cjs",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/body-checksum-browser/tsconfig.es.json
+++ b/packages/body-checksum-browser/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/es",
     "baseUrl": "."
   },

--- a/packages/body-checksum-browser/tsconfig.es.json
+++ b/packages/body-checksum-browser/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "rootDir": "src",
-    "outDir": "./dist/es",
+    "outDir": "dist/es",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/body-checksum-browser/tsconfig.types.json
+++ b/packages/body-checksum-browser/tsconfig.types.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "declarationDir": "./dist/types",
     "baseUrl": "."
   },

--- a/packages/body-checksum-browser/tsconfig.types.json
+++ b/packages/body-checksum-browser/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "declarationDir": "./dist/types",
+    "declarationDir": "dist/types",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/body-checksum-node/tsconfig.cjs.json
+++ b/packages/body-checksum-node/tsconfig.cjs.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/cjs",
     "baseUrl": "."
   },

--- a/packages/body-checksum-node/tsconfig.cjs.json
+++ b/packages/body-checksum-node/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "./dist/cjs",
+    "outDir": "dist/cjs",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/body-checksum-node/tsconfig.es.json
+++ b/packages/body-checksum-node/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "rootDir": "src",
-    "outDir": "./dist/es",
+    "outDir": "dist/es",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/body-checksum-node/tsconfig.es.json
+++ b/packages/body-checksum-node/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/es",
     "baseUrl": "."
   },

--- a/packages/body-checksum-node/tsconfig.types.json
+++ b/packages/body-checksum-node/tsconfig.types.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "declarationDir": "./dist/types",
     "baseUrl": "."
   },

--- a/packages/body-checksum-node/tsconfig.types.json
+++ b/packages/body-checksum-node/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "declarationDir": "./dist/types",
+    "declarationDir": "dist/types",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/chunked-blob-reader-native/tsconfig.cjs.json
+++ b/packages/chunked-blob-reader-native/tsconfig.cjs.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/cjs",
     "baseUrl": "."
   },

--- a/packages/chunked-blob-reader-native/tsconfig.cjs.json
+++ b/packages/chunked-blob-reader-native/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "./dist/cjs",
+    "outDir": "dist/cjs",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/chunked-blob-reader-native/tsconfig.es.json
+++ b/packages/chunked-blob-reader-native/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/es",
     "baseUrl": "."
   },

--- a/packages/chunked-blob-reader-native/tsconfig.es.json
+++ b/packages/chunked-blob-reader-native/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "rootDir": "src",
-    "outDir": "./dist/es",
+    "outDir": "dist/es",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/chunked-blob-reader-native/tsconfig.types.json
+++ b/packages/chunked-blob-reader-native/tsconfig.types.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "declarationDir": "./dist/types",
     "baseUrl": "."
   },

--- a/packages/chunked-blob-reader-native/tsconfig.types.json
+++ b/packages/chunked-blob-reader-native/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "declarationDir": "./dist/types",
+    "declarationDir": "dist/types",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/chunked-blob-reader/tsconfig.cjs.json
+++ b/packages/chunked-blob-reader/tsconfig.cjs.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/cjs",
     "baseUrl": "."
   },

--- a/packages/chunked-blob-reader/tsconfig.cjs.json
+++ b/packages/chunked-blob-reader/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "./dist/cjs",
+    "outDir": "dist/cjs",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/chunked-blob-reader/tsconfig.es.json
+++ b/packages/chunked-blob-reader/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/es",
     "baseUrl": "."
   },

--- a/packages/chunked-blob-reader/tsconfig.es.json
+++ b/packages/chunked-blob-reader/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "rootDir": "src",
-    "outDir": "./dist/es",
+    "outDir": "dist/es",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/chunked-blob-reader/tsconfig.types.json
+++ b/packages/chunked-blob-reader/tsconfig.types.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "declarationDir": "./dist/types",
     "baseUrl": "."
   },

--- a/packages/chunked-blob-reader/tsconfig.types.json
+++ b/packages/chunked-blob-reader/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "declarationDir": "./dist/types",
+    "declarationDir": "dist/types",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/chunked-stream-reader-node/tsconfig.cjs.json
+++ b/packages/chunked-stream-reader-node/tsconfig.cjs.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/cjs",
     "baseUrl": "."
   },

--- a/packages/chunked-stream-reader-node/tsconfig.cjs.json
+++ b/packages/chunked-stream-reader-node/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "./dist/cjs",
+    "outDir": "dist/cjs",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/chunked-stream-reader-node/tsconfig.es.json
+++ b/packages/chunked-stream-reader-node/tsconfig.es.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/es",
     "baseUrl": "."
   },

--- a/packages/chunked-stream-reader-node/tsconfig.es.json
+++ b/packages/chunked-stream-reader-node/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "./dist/es",
+    "outDir": "dist/es",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/chunked-stream-reader-node/tsconfig.types.json
+++ b/packages/chunked-stream-reader-node/tsconfig.types.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "declarationDir": "./dist/types",
     "baseUrl": "."
   },

--- a/packages/chunked-stream-reader-node/tsconfig.types.json
+++ b/packages/chunked-stream-reader-node/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "declarationDir": "./dist/types",
+    "declarationDir": "dist/types",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/client-documentation-generator/tsconfig.cjs.json
+++ b/packages/client-documentation-generator/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "strict": false,
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/cjs",
     "experimentalDecorators": true,
     "pretty": true,

--- a/packages/client-documentation-generator/tsconfig.cjs.json
+++ b/packages/client-documentation-generator/tsconfig.cjs.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "strict": false,
     "rootDir": "src",
-    "outDir": "./dist/cjs",
+    "outDir": "dist/cjs",
     "experimentalDecorators": true,
     "pretty": true,
     "baseUrl": "."

--- a/packages/client-documentation-generator/tsconfig.es.json
+++ b/packages/client-documentation-generator/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "strict": false,
     "lib": ["es2015"],
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/es",
     "experimentalDecorators": true,
     "pretty": true,

--- a/packages/client-documentation-generator/tsconfig.es.json
+++ b/packages/client-documentation-generator/tsconfig.es.json
@@ -3,7 +3,7 @@
     "strict": false,
     "lib": ["es2015"],
     "rootDir": "src",
-    "outDir": "./dist/es",
+    "outDir": "dist/es",
     "experimentalDecorators": true,
     "pretty": true,
     "baseUrl": "."

--- a/packages/client-documentation-generator/tsconfig.types.json
+++ b/packages/client-documentation-generator/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "strict": false,
-    "rootDir": "./src",
+    "rootDir": "src",
     "declarationDir": "./dist/types",
     "baseUrl": "."
   },

--- a/packages/client-documentation-generator/tsconfig.types.json
+++ b/packages/client-documentation-generator/tsconfig.types.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "strict": false,
     "rootDir": "src",
-    "declarationDir": "./dist/types",
+    "declarationDir": "dist/types",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/config-resolver/tsconfig.cjs.json
+++ b/packages/config-resolver/tsconfig.cjs.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/cjs",
     "baseUrl": "."
   },

--- a/packages/config-resolver/tsconfig.cjs.json
+++ b/packages/config-resolver/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "./dist/cjs",
+    "outDir": "dist/cjs",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/config-resolver/tsconfig.es.json
+++ b/packages/config-resolver/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "rootDir": "src",
-    "outDir": "./dist/es",
+    "outDir": "dist/es",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/config-resolver/tsconfig.es.json
+++ b/packages/config-resolver/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/es",
     "baseUrl": "."
   },

--- a/packages/config-resolver/tsconfig.types.json
+++ b/packages/config-resolver/tsconfig.types.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "declarationDir": "./dist/types",
     "baseUrl": "."
   },

--- a/packages/config-resolver/tsconfig.types.json
+++ b/packages/config-resolver/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "declarationDir": "./dist/types",
+    "declarationDir": "dist/types",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/core-packages-documentation-generator/tsconfig.cjs.json
+++ b/packages/core-packages-documentation-generator/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "strict": false,
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/cjs",
     "experimentalDecorators": true,
     "pretty": true,

--- a/packages/core-packages-documentation-generator/tsconfig.cjs.json
+++ b/packages/core-packages-documentation-generator/tsconfig.cjs.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "strict": false,
     "rootDir": "src",
-    "outDir": "./dist/cjs",
+    "outDir": "dist/cjs",
     "experimentalDecorators": true,
     "pretty": true,
     "baseUrl": "."

--- a/packages/core-packages-documentation-generator/tsconfig.es.json
+++ b/packages/core-packages-documentation-generator/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "strict": false,
     "lib": ["es2015"],
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/es",
     "experimentalDecorators": true,
     "pretty": true,

--- a/packages/core-packages-documentation-generator/tsconfig.es.json
+++ b/packages/core-packages-documentation-generator/tsconfig.es.json
@@ -3,7 +3,7 @@
     "strict": false,
     "lib": ["es2015"],
     "rootDir": "src",
-    "outDir": "./dist/es",
+    "outDir": "dist/es",
     "experimentalDecorators": true,
     "pretty": true,
     "baseUrl": "."

--- a/packages/core-packages-documentation-generator/tsconfig.types.json
+++ b/packages/core-packages-documentation-generator/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "strict": false,
-    "rootDir": "./src",
+    "rootDir": "src",
     "declarationDir": "./dist/types",
     "baseUrl": "."
   },

--- a/packages/core-packages-documentation-generator/tsconfig.types.json
+++ b/packages/core-packages-documentation-generator/tsconfig.types.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "strict": false,
     "rootDir": "src",
-    "declarationDir": "./dist/types",
+    "declarationDir": "dist/types",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/credential-provider-cognito-identity/tsconfig.cjs.json
+++ b/packages/credential-provider-cognito-identity/tsconfig.cjs.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/cjs",
     "noUnusedLocals": true,
     "baseUrl": "."

--- a/packages/credential-provider-cognito-identity/tsconfig.cjs.json
+++ b/packages/credential-provider-cognito-identity/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "./dist/cjs",
+    "outDir": "dist/cjs",
     "noUnusedLocals": true,
     "baseUrl": "."
   },

--- a/packages/credential-provider-cognito-identity/tsconfig.es.json
+++ b/packages/credential-provider-cognito-identity/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/es",
     "noUnusedLocals": true,
     "baseUrl": ".",

--- a/packages/credential-provider-cognito-identity/tsconfig.es.json
+++ b/packages/credential-provider-cognito-identity/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "rootDir": "src",
-    "outDir": "./dist/es",
+    "outDir": "dist/es",
     "noUnusedLocals": true,
     "baseUrl": ".",
     "target": "es5",

--- a/packages/credential-provider-cognito-identity/tsconfig.types.json
+++ b/packages/credential-provider-cognito-identity/tsconfig.types.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "declarationDir": "./dist/types",
     "baseUrl": "."
   },

--- a/packages/credential-provider-cognito-identity/tsconfig.types.json
+++ b/packages/credential-provider-cognito-identity/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "declarationDir": "./dist/types",
+    "declarationDir": "dist/types",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/credential-provider-env/tsconfig.cjs.json
+++ b/packages/credential-provider-env/tsconfig.cjs.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/cjs",
     "baseUrl": "."
   },

--- a/packages/credential-provider-env/tsconfig.cjs.json
+++ b/packages/credential-provider-env/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "./dist/cjs",
+    "outDir": "dist/cjs",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/credential-provider-env/tsconfig.es.json
+++ b/packages/credential-provider-env/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection"],
     "rootDir": "src",
-    "outDir": "./dist/es",
+    "outDir": "dist/es",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/credential-provider-env/tsconfig.es.json
+++ b/packages/credential-provider-env/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection"],
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/es",
     "baseUrl": "."
   },

--- a/packages/credential-provider-env/tsconfig.types.json
+++ b/packages/credential-provider-env/tsconfig.types.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "declarationDir": "./dist/types",
     "baseUrl": "."
   },

--- a/packages/credential-provider-env/tsconfig.types.json
+++ b/packages/credential-provider-env/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "declarationDir": "./dist/types",
+    "declarationDir": "dist/types",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/credential-provider-imds/tsconfig.cjs.json
+++ b/packages/credential-provider-imds/tsconfig.cjs.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/cjs",
     "baseUrl": "."
   },

--- a/packages/credential-provider-imds/tsconfig.cjs.json
+++ b/packages/credential-provider-imds/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "./dist/cjs",
+    "outDir": "dist/cjs",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/credential-provider-imds/tsconfig.es.json
+++ b/packages/credential-provider-imds/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection"],
     "rootDir": "src",
-    "outDir": "./dist/es",
+    "outDir": "dist/es",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/credential-provider-imds/tsconfig.es.json
+++ b/packages/credential-provider-imds/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection"],
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/es",
     "baseUrl": "."
   },

--- a/packages/credential-provider-imds/tsconfig.types.json
+++ b/packages/credential-provider-imds/tsconfig.types.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "declarationDir": "./dist/types",
     "baseUrl": "."
   },

--- a/packages/credential-provider-imds/tsconfig.types.json
+++ b/packages/credential-provider-imds/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "declarationDir": "./dist/types",
+    "declarationDir": "dist/types",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/credential-provider-ini/tsconfig.cjs.json
+++ b/packages/credential-provider-ini/tsconfig.cjs.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/cjs",
     "baseUrl": "."
   },

--- a/packages/credential-provider-ini/tsconfig.cjs.json
+++ b/packages/credential-provider-ini/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "./dist/cjs",
+    "outDir": "dist/cjs",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/credential-provider-ini/tsconfig.es.json
+++ b/packages/credential-provider-ini/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection"],
     "rootDir": "src",
-    "outDir": "./dist/es",
+    "outDir": "dist/es",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/credential-provider-ini/tsconfig.es.json
+++ b/packages/credential-provider-ini/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection"],
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/es",
     "baseUrl": "."
   },

--- a/packages/credential-provider-ini/tsconfig.types.json
+++ b/packages/credential-provider-ini/tsconfig.types.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "declarationDir": "./dist/types",
     "baseUrl": "."
   },

--- a/packages/credential-provider-ini/tsconfig.types.json
+++ b/packages/credential-provider-ini/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "declarationDir": "./dist/types",
+    "declarationDir": "dist/types",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/credential-provider-node/tsconfig.cjs.json
+++ b/packages/credential-provider-node/tsconfig.cjs.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/cjs",
     "baseUrl": "."
   },

--- a/packages/credential-provider-node/tsconfig.cjs.json
+++ b/packages/credential-provider-node/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "./dist/cjs",
+    "outDir": "dist/cjs",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/credential-provider-node/tsconfig.es.json
+++ b/packages/credential-provider-node/tsconfig.es.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/es",
     "baseUrl": "."
   },

--- a/packages/credential-provider-node/tsconfig.es.json
+++ b/packages/credential-provider-node/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "./dist/es",
+    "outDir": "dist/es",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/credential-provider-node/tsconfig.types.json
+++ b/packages/credential-provider-node/tsconfig.types.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "declarationDir": "./dist/types",
     "baseUrl": "."
   },

--- a/packages/credential-provider-node/tsconfig.types.json
+++ b/packages/credential-provider-node/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "declarationDir": "./dist/types",
+    "declarationDir": "dist/types",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/credential-provider-process/tsconfig.cjs.json
+++ b/packages/credential-provider-process/tsconfig.cjs.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/cjs",
     "baseUrl": "."
   },

--- a/packages/credential-provider-process/tsconfig.cjs.json
+++ b/packages/credential-provider-process/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "./dist/cjs",
+    "outDir": "dist/cjs",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/credential-provider-process/tsconfig.es.json
+++ b/packages/credential-provider-process/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection"],
     "rootDir": "src",
-    "outDir": "./dist/es",
+    "outDir": "dist/es",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/credential-provider-process/tsconfig.es.json
+++ b/packages/credential-provider-process/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection"],
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/es",
     "baseUrl": "."
   },

--- a/packages/credential-provider-process/tsconfig.types.json
+++ b/packages/credential-provider-process/tsconfig.types.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "declarationDir": "./dist/types",
     "baseUrl": "."
   },

--- a/packages/credential-provider-process/tsconfig.types.json
+++ b/packages/credential-provider-process/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "declarationDir": "./dist/types",
+    "declarationDir": "dist/types",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/credential-provider-sso/tsconfig.cjs.json
+++ b/packages/credential-provider-sso/tsconfig.cjs.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/cjs",
     "baseUrl": "."
   },

--- a/packages/credential-provider-sso/tsconfig.cjs.json
+++ b/packages/credential-provider-sso/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "./dist/cjs",
+    "outDir": "dist/cjs",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/credential-provider-sso/tsconfig.es.json
+++ b/packages/credential-provider-sso/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection"],
     "rootDir": "src",
-    "outDir": "./dist/es",
+    "outDir": "dist/es",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/credential-provider-sso/tsconfig.es.json
+++ b/packages/credential-provider-sso/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection"],
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/es",
     "baseUrl": "."
   },

--- a/packages/credential-provider-sso/tsconfig.types.json
+++ b/packages/credential-provider-sso/tsconfig.types.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "declarationDir": "./dist/types",
     "baseUrl": "."
   },

--- a/packages/credential-provider-sso/tsconfig.types.json
+++ b/packages/credential-provider-sso/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "declarationDir": "./dist/types",
+    "declarationDir": "dist/types",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/credential-provider-web-identity/tsconfig.cjs.json
+++ b/packages/credential-provider-web-identity/tsconfig.cjs.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/cjs",
     "baseUrl": "."
   },

--- a/packages/credential-provider-web-identity/tsconfig.cjs.json
+++ b/packages/credential-provider-web-identity/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "./dist/cjs",
+    "outDir": "dist/cjs",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/credential-provider-web-identity/tsconfig.es.json
+++ b/packages/credential-provider-web-identity/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection"],
     "rootDir": "src",
-    "outDir": "./dist/es",
+    "outDir": "dist/es",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/credential-provider-web-identity/tsconfig.es.json
+++ b/packages/credential-provider-web-identity/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection"],
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/es",
     "baseUrl": "."
   },

--- a/packages/credential-provider-web-identity/tsconfig.types.json
+++ b/packages/credential-provider-web-identity/tsconfig.types.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "declarationDir": "./dist/types",
     "baseUrl": "."
   },

--- a/packages/credential-provider-web-identity/tsconfig.types.json
+++ b/packages/credential-provider-web-identity/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "declarationDir": "./dist/types",
+    "declarationDir": "dist/types",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/credential-providers/tsconfig.cjs.json
+++ b/packages/credential-providers/tsconfig.cjs.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/cjs",
     "baseUrl": "."
   },

--- a/packages/credential-providers/tsconfig.cjs.json
+++ b/packages/credential-providers/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "./dist/cjs",
+    "outDir": "dist/cjs",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/credential-providers/tsconfig.es.json
+++ b/packages/credential-providers/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection"],
     "rootDir": "src",
-    "outDir": "./dist/es",
+    "outDir": "dist/es",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/credential-providers/tsconfig.es.json
+++ b/packages/credential-providers/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection"],
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/es",
     "baseUrl": "."
   },

--- a/packages/credential-providers/tsconfig.types.json
+++ b/packages/credential-providers/tsconfig.types.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "declarationDir": "./dist/types",
     "baseUrl": "."
   },

--- a/packages/credential-providers/tsconfig.types.json
+++ b/packages/credential-providers/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "declarationDir": "./dist/types",
+    "declarationDir": "dist/types",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/endpoint-cache/tsconfig.cjs.json
+++ b/packages/endpoint-cache/tsconfig.cjs.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/cjs",
     "baseUrl": "."
   },

--- a/packages/endpoint-cache/tsconfig.cjs.json
+++ b/packages/endpoint-cache/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "./dist/cjs",
+    "outDir": "dist/cjs",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/endpoint-cache/tsconfig.es.json
+++ b/packages/endpoint-cache/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.iterable"],
     "rootDir": "src",
-    "outDir": "./dist/es",
+    "outDir": "dist/es",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/endpoint-cache/tsconfig.es.json
+++ b/packages/endpoint-cache/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.iterable"],
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/es",
     "baseUrl": "."
   },

--- a/packages/endpoint-cache/tsconfig.types.json
+++ b/packages/endpoint-cache/tsconfig.types.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "declarationDir": "./dist/types",
     "baseUrl": "."
   },

--- a/packages/endpoint-cache/tsconfig.types.json
+++ b/packages/endpoint-cache/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "declarationDir": "./dist/types",
+    "declarationDir": "dist/types",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/eventstream-handler-node/tsconfig.cjs.json
+++ b/packages/eventstream-handler-node/tsconfig.cjs.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/cjs",
     "baseUrl": "."
   },

--- a/packages/eventstream-handler-node/tsconfig.cjs.json
+++ b/packages/eventstream-handler-node/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "./dist/cjs",
+    "outDir": "dist/cjs",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/eventstream-handler-node/tsconfig.es.json
+++ b/packages/eventstream-handler-node/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es2018.asynciterable"],
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/es",
     "baseUrl": "."
   },

--- a/packages/eventstream-handler-node/tsconfig.es.json
+++ b/packages/eventstream-handler-node/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "lib": ["es2018.asynciterable"],
     "rootDir": "src",
-    "outDir": "./dist/es",
+    "outDir": "dist/es",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/eventstream-handler-node/tsconfig.types.json
+++ b/packages/eventstream-handler-node/tsconfig.types.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "declarationDir": "./dist/types",
     "baseUrl": "."
   },

--- a/packages/eventstream-handler-node/tsconfig.types.json
+++ b/packages/eventstream-handler-node/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "declarationDir": "./dist/types",
+    "declarationDir": "dist/types",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/eventstream-marshaller/tsconfig.cjs.json
+++ b/packages/eventstream-marshaller/tsconfig.cjs.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/cjs",
     "baseUrl": "."
   },

--- a/packages/eventstream-marshaller/tsconfig.cjs.json
+++ b/packages/eventstream-marshaller/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "./dist/cjs",
+    "outDir": "dist/cjs",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/eventstream-marshaller/tsconfig.es.json
+++ b/packages/eventstream-marshaller/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "rootDir": "src",
-    "outDir": "./dist/es",
+    "outDir": "dist/es",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/eventstream-marshaller/tsconfig.es.json
+++ b/packages/eventstream-marshaller/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/es",
     "baseUrl": "."
   },

--- a/packages/eventstream-marshaller/tsconfig.types.json
+++ b/packages/eventstream-marshaller/tsconfig.types.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "declarationDir": "./dist/types",
     "baseUrl": "."
   },

--- a/packages/eventstream-marshaller/tsconfig.types.json
+++ b/packages/eventstream-marshaller/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "declarationDir": "./dist/types",
+    "declarationDir": "dist/types",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/eventstream-serde-browser/tsconfig.cjs.json
+++ b/packages/eventstream-serde-browser/tsconfig.cjs.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/cjs",
     "baseUrl": "."
   },

--- a/packages/eventstream-serde-browser/tsconfig.cjs.json
+++ b/packages/eventstream-serde-browser/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "./dist/cjs",
+    "outDir": "dist/cjs",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/eventstream-serde-browser/tsconfig.es.json
+++ b/packages/eventstream-serde-browser/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es2018.asynciterable", "DOM"],
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/es",
     "baseUrl": "."
   },

--- a/packages/eventstream-serde-browser/tsconfig.es.json
+++ b/packages/eventstream-serde-browser/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "lib": ["es2018.asynciterable", "DOM"],
     "rootDir": "src",
-    "outDir": "./dist/es",
+    "outDir": "dist/es",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/eventstream-serde-browser/tsconfig.types.json
+++ b/packages/eventstream-serde-browser/tsconfig.types.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "declarationDir": "./dist/types",
     "baseUrl": "."
   },

--- a/packages/eventstream-serde-browser/tsconfig.types.json
+++ b/packages/eventstream-serde-browser/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "declarationDir": "./dist/types",
+    "declarationDir": "dist/types",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/eventstream-serde-config-resolver/tsconfig.cjs.json
+++ b/packages/eventstream-serde-config-resolver/tsconfig.cjs.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/cjs",
     "baseUrl": "."
   },

--- a/packages/eventstream-serde-config-resolver/tsconfig.cjs.json
+++ b/packages/eventstream-serde-config-resolver/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "./dist/cjs",
+    "outDir": "dist/cjs",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/eventstream-serde-config-resolver/tsconfig.es.json
+++ b/packages/eventstream-serde-config-resolver/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es2018.asynciterable"],
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/es",
     "baseUrl": "."
   },

--- a/packages/eventstream-serde-config-resolver/tsconfig.es.json
+++ b/packages/eventstream-serde-config-resolver/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "lib": ["es2018.asynciterable"],
     "rootDir": "src",
-    "outDir": "./dist/es",
+    "outDir": "dist/es",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/eventstream-serde-config-resolver/tsconfig.types.json
+++ b/packages/eventstream-serde-config-resolver/tsconfig.types.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "declarationDir": "./dist/types",
     "baseUrl": "."
   },

--- a/packages/eventstream-serde-config-resolver/tsconfig.types.json
+++ b/packages/eventstream-serde-config-resolver/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "declarationDir": "./dist/types",
+    "declarationDir": "dist/types",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/eventstream-serde-node/tsconfig.cjs.json
+++ b/packages/eventstream-serde-node/tsconfig.cjs.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/cjs",
     "baseUrl": "."
   },

--- a/packages/eventstream-serde-node/tsconfig.cjs.json
+++ b/packages/eventstream-serde-node/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "./dist/cjs",
+    "outDir": "dist/cjs",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/eventstream-serde-node/tsconfig.es.json
+++ b/packages/eventstream-serde-node/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es2018.asynciterable"],
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/es",
     "baseUrl": "."
   },

--- a/packages/eventstream-serde-node/tsconfig.es.json
+++ b/packages/eventstream-serde-node/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "lib": ["es2018.asynciterable"],
     "rootDir": "src",
-    "outDir": "./dist/es",
+    "outDir": "dist/es",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/eventstream-serde-node/tsconfig.types.json
+++ b/packages/eventstream-serde-node/tsconfig.types.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "declarationDir": "./dist/types",
     "baseUrl": "."
   },

--- a/packages/eventstream-serde-node/tsconfig.types.json
+++ b/packages/eventstream-serde-node/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "declarationDir": "./dist/types",
+    "declarationDir": "dist/types",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/eventstream-serde-universal/tsconfig.cjs.json
+++ b/packages/eventstream-serde-universal/tsconfig.cjs.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/cjs",
     "baseUrl": "."
   },

--- a/packages/eventstream-serde-universal/tsconfig.cjs.json
+++ b/packages/eventstream-serde-universal/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "./dist/cjs",
+    "outDir": "dist/cjs",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/eventstream-serde-universal/tsconfig.es.json
+++ b/packages/eventstream-serde-universal/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es2018.asynciterable"],
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/es",
     "baseUrl": "."
   },

--- a/packages/eventstream-serde-universal/tsconfig.es.json
+++ b/packages/eventstream-serde-universal/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "lib": ["es2018.asynciterable"],
     "rootDir": "src",
-    "outDir": "./dist/es",
+    "outDir": "dist/es",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/eventstream-serde-universal/tsconfig.types.json
+++ b/packages/eventstream-serde-universal/tsconfig.types.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "declarationDir": "./dist/types",
     "baseUrl": "."
   },

--- a/packages/eventstream-serde-universal/tsconfig.types.json
+++ b/packages/eventstream-serde-universal/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "declarationDir": "./dist/types",
+    "declarationDir": "dist/types",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/fetch-http-handler/tsconfig.cjs.json
+++ b/packages/fetch-http-handler/tsconfig.cjs.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/cjs",
     "baseUrl": "."
   },

--- a/packages/fetch-http-handler/tsconfig.cjs.json
+++ b/packages/fetch-http-handler/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "./dist/cjs",
+    "outDir": "dist/cjs",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/fetch-http-handler/tsconfig.es.json
+++ b/packages/fetch-http-handler/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "lib": ["dom", "es5", "es2015.promise", "es2015.iterable"],
     "rootDir": "src",
-    "outDir": "./dist/es",
+    "outDir": "dist/es",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/fetch-http-handler/tsconfig.es.json
+++ b/packages/fetch-http-handler/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["dom", "es5", "es2015.promise", "es2015.iterable"],
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/es",
     "baseUrl": "."
   },

--- a/packages/fetch-http-handler/tsconfig.types.json
+++ b/packages/fetch-http-handler/tsconfig.types.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "declarationDir": "./dist/types",
     "baseUrl": "."
   },

--- a/packages/fetch-http-handler/tsconfig.types.json
+++ b/packages/fetch-http-handler/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "declarationDir": "./dist/types",
+    "declarationDir": "dist/types",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/hash-blob-browser/tsconfig.cjs.json
+++ b/packages/hash-blob-browser/tsconfig.cjs.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/cjs",
     "baseUrl": "."
   },

--- a/packages/hash-blob-browser/tsconfig.cjs.json
+++ b/packages/hash-blob-browser/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "./dist/cjs",
+    "outDir": "dist/cjs",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/hash-blob-browser/tsconfig.es.json
+++ b/packages/hash-blob-browser/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/es",
     "baseUrl": "."
   },

--- a/packages/hash-blob-browser/tsconfig.es.json
+++ b/packages/hash-blob-browser/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "rootDir": "src",
-    "outDir": "./dist/es",
+    "outDir": "dist/es",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/hash-blob-browser/tsconfig.types.json
+++ b/packages/hash-blob-browser/tsconfig.types.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "declarationDir": "./dist/types",
     "baseUrl": "."
   },

--- a/packages/hash-blob-browser/tsconfig.types.json
+++ b/packages/hash-blob-browser/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "declarationDir": "./dist/types",
+    "declarationDir": "dist/types",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/hash-node/tsconfig.cjs.json
+++ b/packages/hash-node/tsconfig.cjs.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/cjs",
     "baseUrl": "."
   },

--- a/packages/hash-node/tsconfig.cjs.json
+++ b/packages/hash-node/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "./dist/cjs",
+    "outDir": "dist/cjs",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/hash-node/tsconfig.es.json
+++ b/packages/hash-node/tsconfig.es.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/es",
     "baseUrl": "."
   },

--- a/packages/hash-node/tsconfig.es.json
+++ b/packages/hash-node/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "./dist/es",
+    "outDir": "dist/es",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/hash-node/tsconfig.types.json
+++ b/packages/hash-node/tsconfig.types.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "declarationDir": "./dist/types",
     "baseUrl": "."
   },

--- a/packages/hash-node/tsconfig.types.json
+++ b/packages/hash-node/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "declarationDir": "./dist/types",
+    "declarationDir": "dist/types",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/hash-stream-node/tsconfig.cjs.json
+++ b/packages/hash-stream-node/tsconfig.cjs.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/cjs",
     "baseUrl": "."
   },

--- a/packages/hash-stream-node/tsconfig.cjs.json
+++ b/packages/hash-stream-node/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "./dist/cjs",
+    "outDir": "dist/cjs",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/hash-stream-node/tsconfig.es.json
+++ b/packages/hash-stream-node/tsconfig.es.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/es",
     "baseUrl": "."
   },

--- a/packages/hash-stream-node/tsconfig.es.json
+++ b/packages/hash-stream-node/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "./dist/es",
+    "outDir": "dist/es",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/hash-stream-node/tsconfig.types.json
+++ b/packages/hash-stream-node/tsconfig.types.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "declarationDir": "./dist/types",
     "baseUrl": "."
   },

--- a/packages/hash-stream-node/tsconfig.types.json
+++ b/packages/hash-stream-node/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "declarationDir": "./dist/types",
+    "declarationDir": "dist/types",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/invalid-dependency/tsconfig.cjs.json
+++ b/packages/invalid-dependency/tsconfig.cjs.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/cjs",
     "baseUrl": "."
   },

--- a/packages/invalid-dependency/tsconfig.cjs.json
+++ b/packages/invalid-dependency/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "./dist/cjs",
+    "outDir": "dist/cjs",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/invalid-dependency/tsconfig.es.json
+++ b/packages/invalid-dependency/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "rootDir": "src",
-    "outDir": "./dist/es",
+    "outDir": "dist/es",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/invalid-dependency/tsconfig.es.json
+++ b/packages/invalid-dependency/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/es",
     "baseUrl": "."
   },

--- a/packages/invalid-dependency/tsconfig.types.json
+++ b/packages/invalid-dependency/tsconfig.types.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "declarationDir": "./dist/types",
     "baseUrl": "."
   },

--- a/packages/invalid-dependency/tsconfig.types.json
+++ b/packages/invalid-dependency/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "declarationDir": "./dist/types",
+    "declarationDir": "dist/types",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/is-array-buffer/tsconfig.cjs.json
+++ b/packages/is-array-buffer/tsconfig.cjs.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/cjs",
     "baseUrl": "."
   },

--- a/packages/is-array-buffer/tsconfig.cjs.json
+++ b/packages/is-array-buffer/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "./dist/cjs",
+    "outDir": "dist/cjs",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/is-array-buffer/tsconfig.es.json
+++ b/packages/is-array-buffer/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "lib": ["es5", "es2015.collection"],
     "rootDir": "src",
-    "outDir": "./dist/es",
+    "outDir": "dist/es",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/is-array-buffer/tsconfig.es.json
+++ b/packages/is-array-buffer/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es5", "es2015.collection"],
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/es",
     "baseUrl": "."
   },

--- a/packages/is-array-buffer/tsconfig.types.json
+++ b/packages/is-array-buffer/tsconfig.types.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "declarationDir": "./dist/types",
     "baseUrl": "."
   },

--- a/packages/is-array-buffer/tsconfig.types.json
+++ b/packages/is-array-buffer/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "declarationDir": "./dist/types",
+    "declarationDir": "dist/types",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/karma-credential-loader/tsconfig.cjs.json
+++ b/packages/karma-credential-loader/tsconfig.cjs.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "strict": false,
     "rootDir": "src",
-    "outDir": "./dist/cjs",
+    "outDir": "dist/cjs",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/karma-credential-loader/tsconfig.cjs.json
+++ b/packages/karma-credential-loader/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "strict": false,
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/cjs",
     "baseUrl": "."
   },

--- a/packages/karma-credential-loader/tsconfig.es.json
+++ b/packages/karma-credential-loader/tsconfig.es.json
@@ -3,7 +3,7 @@
     "strict": false,
     "lib": ["es2015"],
     "rootDir": "src",
-    "outDir": "./dist/es",
+    "outDir": "dist/es",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/karma-credential-loader/tsconfig.es.json
+++ b/packages/karma-credential-loader/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "strict": false,
     "lib": ["es2015"],
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/es",
     "baseUrl": "."
   },

--- a/packages/karma-credential-loader/tsconfig.types.json
+++ b/packages/karma-credential-loader/tsconfig.types.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "declarationDir": "./dist/types",
     "baseUrl": "."
   },

--- a/packages/karma-credential-loader/tsconfig.types.json
+++ b/packages/karma-credential-loader/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "declarationDir": "./dist/types",
+    "declarationDir": "dist/types",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/md5-js/tsconfig.cjs.json
+++ b/packages/md5-js/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "./dist/cjs",
+    "outDir": "dist/cjs",
     "baseUrl": "."
   },
   "exclude": ["./build/**"],

--- a/packages/md5-js/tsconfig.cjs.json
+++ b/packages/md5-js/tsconfig.cjs.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/cjs",
     "baseUrl": "."
   },

--- a/packages/md5-js/tsconfig.es.json
+++ b/packages/md5-js/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "rootDir": "src",
-    "outDir": "./dist/es",
+    "outDir": "dist/es",
     "baseUrl": "."
   },
   "include": ["src/"],

--- a/packages/md5-js/tsconfig.es.json
+++ b/packages/md5-js/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/es",
     "baseUrl": "."
   },

--- a/packages/md5-js/tsconfig.types.json
+++ b/packages/md5-js/tsconfig.types.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "declarationDir": "./dist/types",
     "baseUrl": "."
   },

--- a/packages/md5-js/tsconfig.types.json
+++ b/packages/md5-js/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "declarationDir": "./dist/types",
+    "declarationDir": "dist/types",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/middleware-apply-body-checksum/tsconfig.cjs.json
+++ b/packages/middleware-apply-body-checksum/tsconfig.cjs.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/cjs",
     "baseUrl": "."
   },

--- a/packages/middleware-apply-body-checksum/tsconfig.cjs.json
+++ b/packages/middleware-apply-body-checksum/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "./dist/cjs",
+    "outDir": "dist/cjs",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/middleware-apply-body-checksum/tsconfig.es.json
+++ b/packages/middleware-apply-body-checksum/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "rootDir": "src",
-    "outDir": "./dist/es",
+    "outDir": "dist/es",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/middleware-apply-body-checksum/tsconfig.es.json
+++ b/packages/middleware-apply-body-checksum/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/es",
     "baseUrl": "."
   },

--- a/packages/middleware-apply-body-checksum/tsconfig.types.json
+++ b/packages/middleware-apply-body-checksum/tsconfig.types.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "declarationDir": "./dist/types",
     "baseUrl": "."
   },

--- a/packages/middleware-apply-body-checksum/tsconfig.types.json
+++ b/packages/middleware-apply-body-checksum/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "declarationDir": "./dist/types",
+    "declarationDir": "dist/types",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/middleware-bucket-endpoint/tsconfig.cjs.json
+++ b/packages/middleware-bucket-endpoint/tsconfig.cjs.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/cjs",
     "baseUrl": "."
   },

--- a/packages/middleware-bucket-endpoint/tsconfig.cjs.json
+++ b/packages/middleware-bucket-endpoint/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "./dist/cjs",
+    "outDir": "dist/cjs",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/middleware-bucket-endpoint/tsconfig.es.json
+++ b/packages/middleware-bucket-endpoint/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "rootDir": "src",
-    "outDir": "./dist/es",
+    "outDir": "dist/es",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/middleware-bucket-endpoint/tsconfig.es.json
+++ b/packages/middleware-bucket-endpoint/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/es",
     "baseUrl": "."
   },

--- a/packages/middleware-bucket-endpoint/tsconfig.types.json
+++ b/packages/middleware-bucket-endpoint/tsconfig.types.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "declarationDir": "./dist/types",
     "baseUrl": "."
   },

--- a/packages/middleware-bucket-endpoint/tsconfig.types.json
+++ b/packages/middleware-bucket-endpoint/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "declarationDir": "./dist/types",
+    "declarationDir": "dist/types",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/middleware-content-length/tsconfig.cjs.json
+++ b/packages/middleware-content-length/tsconfig.cjs.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/cjs",
     "baseUrl": "."
   },

--- a/packages/middleware-content-length/tsconfig.cjs.json
+++ b/packages/middleware-content-length/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "./dist/cjs",
+    "outDir": "dist/cjs",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/middleware-content-length/tsconfig.es.json
+++ b/packages/middleware-content-length/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "rootDir": "src",
-    "outDir": "./dist/es",
+    "outDir": "dist/es",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/middleware-content-length/tsconfig.es.json
+++ b/packages/middleware-content-length/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/es",
     "baseUrl": "."
   },

--- a/packages/middleware-content-length/tsconfig.types.json
+++ b/packages/middleware-content-length/tsconfig.types.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "declarationDir": "./dist/types",
     "baseUrl": "."
   },

--- a/packages/middleware-content-length/tsconfig.types.json
+++ b/packages/middleware-content-length/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "declarationDir": "./dist/types",
+    "declarationDir": "dist/types",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/middleware-endpoint-discovery/tsconfig.cjs.json
+++ b/packages/middleware-endpoint-discovery/tsconfig.cjs.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/cjs",
     "baseUrl": "."
   },

--- a/packages/middleware-endpoint-discovery/tsconfig.cjs.json
+++ b/packages/middleware-endpoint-discovery/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "./dist/cjs",
+    "outDir": "dist/cjs",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/middleware-endpoint-discovery/tsconfig.es.json
+++ b/packages/middleware-endpoint-discovery/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "rootDir": "src",
-    "outDir": "./dist/es",
+    "outDir": "dist/es",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/middleware-endpoint-discovery/tsconfig.es.json
+++ b/packages/middleware-endpoint-discovery/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/es",
     "baseUrl": "."
   },

--- a/packages/middleware-endpoint-discovery/tsconfig.types.json
+++ b/packages/middleware-endpoint-discovery/tsconfig.types.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "declarationDir": "./dist/types",
     "baseUrl": "."
   },

--- a/packages/middleware-endpoint-discovery/tsconfig.types.json
+++ b/packages/middleware-endpoint-discovery/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "declarationDir": "./dist/types",
+    "declarationDir": "dist/types",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/middleware-eventstream/tsconfig.cjs.json
+++ b/packages/middleware-eventstream/tsconfig.cjs.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/cjs",
     "baseUrl": "."
   },

--- a/packages/middleware-eventstream/tsconfig.cjs.json
+++ b/packages/middleware-eventstream/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "./dist/cjs",
+    "outDir": "dist/cjs",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/middleware-eventstream/tsconfig.es.json
+++ b/packages/middleware-eventstream/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "rootDir": "src",
-    "outDir": "./dist/es",
+    "outDir": "dist/es",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/middleware-eventstream/tsconfig.es.json
+++ b/packages/middleware-eventstream/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/es",
     "baseUrl": "."
   },

--- a/packages/middleware-eventstream/tsconfig.types.json
+++ b/packages/middleware-eventstream/tsconfig.types.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "declarationDir": "./dist/types",
     "baseUrl": "."
   },

--- a/packages/middleware-eventstream/tsconfig.types.json
+++ b/packages/middleware-eventstream/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "declarationDir": "./dist/types",
+    "declarationDir": "dist/types",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/middleware-expect-continue/tsconfig.cjs.json
+++ b/packages/middleware-expect-continue/tsconfig.cjs.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/cjs",
     "baseUrl": "."
   },

--- a/packages/middleware-expect-continue/tsconfig.cjs.json
+++ b/packages/middleware-expect-continue/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "./dist/cjs",
+    "outDir": "dist/cjs",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/middleware-expect-continue/tsconfig.es.json
+++ b/packages/middleware-expect-continue/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "rootDir": "src",
-    "outDir": "./dist/es",
+    "outDir": "dist/es",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/middleware-expect-continue/tsconfig.es.json
+++ b/packages/middleware-expect-continue/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/es",
     "baseUrl": "."
   },

--- a/packages/middleware-expect-continue/tsconfig.types.json
+++ b/packages/middleware-expect-continue/tsconfig.types.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "declarationDir": "./dist/types",
     "baseUrl": "."
   },

--- a/packages/middleware-expect-continue/tsconfig.types.json
+++ b/packages/middleware-expect-continue/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "declarationDir": "./dist/types",
+    "declarationDir": "dist/types",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/middleware-header-default/tsconfig.cjs.json
+++ b/packages/middleware-header-default/tsconfig.cjs.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/cjs",
     "baseUrl": "."
   },

--- a/packages/middleware-header-default/tsconfig.cjs.json
+++ b/packages/middleware-header-default/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "./dist/cjs",
+    "outDir": "dist/cjs",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/middleware-header-default/tsconfig.es.json
+++ b/packages/middleware-header-default/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "rootDir": "src",
-    "outDir": "./dist/es",
+    "outDir": "dist/es",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/middleware-header-default/tsconfig.es.json
+++ b/packages/middleware-header-default/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/es",
     "baseUrl": "."
   },

--- a/packages/middleware-header-default/tsconfig.types.json
+++ b/packages/middleware-header-default/tsconfig.types.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "declarationDir": "./dist/types",
     "baseUrl": "."
   },

--- a/packages/middleware-header-default/tsconfig.types.json
+++ b/packages/middleware-header-default/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "declarationDir": "./dist/types",
+    "declarationDir": "dist/types",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/middleware-host-header/tsconfig.cjs.json
+++ b/packages/middleware-host-header/tsconfig.cjs.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/cjs",
     "baseUrl": "."
   },

--- a/packages/middleware-host-header/tsconfig.cjs.json
+++ b/packages/middleware-host-header/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "./dist/cjs",
+    "outDir": "dist/cjs",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/middleware-host-header/tsconfig.es.json
+++ b/packages/middleware-host-header/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "rootDir": "src",
-    "outDir": "./dist/es",
+    "outDir": "dist/es",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/middleware-host-header/tsconfig.es.json
+++ b/packages/middleware-host-header/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/es",
     "baseUrl": "."
   },

--- a/packages/middleware-host-header/tsconfig.types.json
+++ b/packages/middleware-host-header/tsconfig.types.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "declarationDir": "./dist/types",
     "baseUrl": "."
   },

--- a/packages/middleware-host-header/tsconfig.types.json
+++ b/packages/middleware-host-header/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "declarationDir": "./dist/types",
+    "declarationDir": "dist/types",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/middleware-location-constraint/tsconfig.cjs.json
+++ b/packages/middleware-location-constraint/tsconfig.cjs.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/cjs",
     "baseUrl": "."
   },

--- a/packages/middleware-location-constraint/tsconfig.cjs.json
+++ b/packages/middleware-location-constraint/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "./dist/cjs",
+    "outDir": "dist/cjs",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/middleware-location-constraint/tsconfig.es.json
+++ b/packages/middleware-location-constraint/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "rootDir": "src",
-    "outDir": "./dist/es",
+    "outDir": "dist/es",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/middleware-location-constraint/tsconfig.es.json
+++ b/packages/middleware-location-constraint/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/es",
     "baseUrl": "."
   },

--- a/packages/middleware-location-constraint/tsconfig.types.json
+++ b/packages/middleware-location-constraint/tsconfig.types.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "declarationDir": "./dist/types",
     "baseUrl": "."
   },

--- a/packages/middleware-location-constraint/tsconfig.types.json
+++ b/packages/middleware-location-constraint/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "declarationDir": "./dist/types",
+    "declarationDir": "dist/types",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/middleware-logger/tsconfig.cjs.json
+++ b/packages/middleware-logger/tsconfig.cjs.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/cjs",
     "baseUrl": "."
   },

--- a/packages/middleware-logger/tsconfig.cjs.json
+++ b/packages/middleware-logger/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "./dist/cjs",
+    "outDir": "dist/cjs",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/middleware-logger/tsconfig.es.json
+++ b/packages/middleware-logger/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.iterable"],
     "rootDir": "src",
-    "outDir": "./dist/es",
+    "outDir": "dist/es",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/middleware-logger/tsconfig.es.json
+++ b/packages/middleware-logger/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.iterable"],
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/es",
     "baseUrl": "."
   },

--- a/packages/middleware-logger/tsconfig.types.json
+++ b/packages/middleware-logger/tsconfig.types.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "declarationDir": "./dist/types",
     "baseUrl": "."
   },

--- a/packages/middleware-logger/tsconfig.types.json
+++ b/packages/middleware-logger/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "declarationDir": "./dist/types",
+    "declarationDir": "dist/types",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/middleware-retry/tsconfig.cjs.json
+++ b/packages/middleware-retry/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "noUnusedLocals": true,
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/cjs",
     "baseUrl": "."
   },

--- a/packages/middleware-retry/tsconfig.cjs.json
+++ b/packages/middleware-retry/tsconfig.cjs.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "noUnusedLocals": true,
     "rootDir": "src",
-    "outDir": "./dist/cjs",
+    "outDir": "dist/cjs",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/middleware-retry/tsconfig.es.json
+++ b/packages/middleware-retry/tsconfig.es.json
@@ -3,7 +3,7 @@
     "noUnusedLocals": true,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "rootDir": "src",
-    "outDir": "./dist/es",
+    "outDir": "dist/es",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/middleware-retry/tsconfig.es.json
+++ b/packages/middleware-retry/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "noUnusedLocals": true,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/es",
     "baseUrl": "."
   },

--- a/packages/middleware-retry/tsconfig.types.json
+++ b/packages/middleware-retry/tsconfig.types.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "declarationDir": "./dist/types",
     "baseUrl": "."
   },

--- a/packages/middleware-retry/tsconfig.types.json
+++ b/packages/middleware-retry/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "declarationDir": "./dist/types",
+    "declarationDir": "dist/types",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/middleware-sdk-api-gateway/tsconfig.cjs.json
+++ b/packages/middleware-sdk-api-gateway/tsconfig.cjs.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/cjs",
     "baseUrl": "."
   },

--- a/packages/middleware-sdk-api-gateway/tsconfig.cjs.json
+++ b/packages/middleware-sdk-api-gateway/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "./dist/cjs",
+    "outDir": "dist/cjs",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/middleware-sdk-api-gateway/tsconfig.es.json
+++ b/packages/middleware-sdk-api-gateway/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "rootDir": "src",
-    "outDir": "./dist/es",
+    "outDir": "dist/es",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/middleware-sdk-api-gateway/tsconfig.es.json
+++ b/packages/middleware-sdk-api-gateway/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/es",
     "baseUrl": "."
   },

--- a/packages/middleware-sdk-api-gateway/tsconfig.types.json
+++ b/packages/middleware-sdk-api-gateway/tsconfig.types.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "declarationDir": "./dist/types",
     "baseUrl": "."
   },

--- a/packages/middleware-sdk-api-gateway/tsconfig.types.json
+++ b/packages/middleware-sdk-api-gateway/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "declarationDir": "./dist/types",
+    "declarationDir": "dist/types",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/middleware-sdk-ec2/tsconfig.cjs.json
+++ b/packages/middleware-sdk-ec2/tsconfig.cjs.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/cjs",
     "baseUrl": "."
   },

--- a/packages/middleware-sdk-ec2/tsconfig.cjs.json
+++ b/packages/middleware-sdk-ec2/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "./dist/cjs",
+    "outDir": "dist/cjs",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/middleware-sdk-ec2/tsconfig.es.json
+++ b/packages/middleware-sdk-ec2/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "rootDir": "src",
-    "outDir": "./dist/es",
+    "outDir": "dist/es",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/middleware-sdk-ec2/tsconfig.es.json
+++ b/packages/middleware-sdk-ec2/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/es",
     "baseUrl": "."
   },

--- a/packages/middleware-sdk-ec2/tsconfig.types.json
+++ b/packages/middleware-sdk-ec2/tsconfig.types.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "declarationDir": "./dist/types",
     "baseUrl": "."
   },

--- a/packages/middleware-sdk-ec2/tsconfig.types.json
+++ b/packages/middleware-sdk-ec2/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "declarationDir": "./dist/types",
+    "declarationDir": "dist/types",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/middleware-sdk-glacier/tsconfig.cjs.json
+++ b/packages/middleware-sdk-glacier/tsconfig.cjs.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/cjs",
     "baseUrl": "."
   },

--- a/packages/middleware-sdk-glacier/tsconfig.cjs.json
+++ b/packages/middleware-sdk-glacier/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "./dist/cjs",
+    "outDir": "dist/cjs",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/middleware-sdk-glacier/tsconfig.es.json
+++ b/packages/middleware-sdk-glacier/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/es",
     "baseUrl": "."
   },

--- a/packages/middleware-sdk-glacier/tsconfig.es.json
+++ b/packages/middleware-sdk-glacier/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "rootDir": "src",
-    "outDir": "./dist/es",
+    "outDir": "dist/es",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/middleware-sdk-glacier/tsconfig.types.json
+++ b/packages/middleware-sdk-glacier/tsconfig.types.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "declarationDir": "./dist/types",
     "baseUrl": "."
   },

--- a/packages/middleware-sdk-glacier/tsconfig.types.json
+++ b/packages/middleware-sdk-glacier/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "declarationDir": "./dist/types",
+    "declarationDir": "dist/types",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/middleware-sdk-machinelearning/tsconfig.cjs.json
+++ b/packages/middleware-sdk-machinelearning/tsconfig.cjs.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/cjs",
     "baseUrl": "."
   },

--- a/packages/middleware-sdk-machinelearning/tsconfig.cjs.json
+++ b/packages/middleware-sdk-machinelearning/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "./dist/cjs",
+    "outDir": "dist/cjs",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/middleware-sdk-machinelearning/tsconfig.es.json
+++ b/packages/middleware-sdk-machinelearning/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "rootDir": "src",
-    "outDir": "./dist/es",
+    "outDir": "dist/es",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/middleware-sdk-machinelearning/tsconfig.es.json
+++ b/packages/middleware-sdk-machinelearning/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/es",
     "baseUrl": "."
   },

--- a/packages/middleware-sdk-machinelearning/tsconfig.types.json
+++ b/packages/middleware-sdk-machinelearning/tsconfig.types.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "declarationDir": "./dist/types",
     "baseUrl": "."
   },

--- a/packages/middleware-sdk-machinelearning/tsconfig.types.json
+++ b/packages/middleware-sdk-machinelearning/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "declarationDir": "./dist/types",
+    "declarationDir": "dist/types",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/middleware-sdk-rds/tsconfig.cjs.json
+++ b/packages/middleware-sdk-rds/tsconfig.cjs.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/cjs",
     "baseUrl": "."
   },

--- a/packages/middleware-sdk-rds/tsconfig.cjs.json
+++ b/packages/middleware-sdk-rds/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "./dist/cjs",
+    "outDir": "dist/cjs",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/middleware-sdk-rds/tsconfig.es.json
+++ b/packages/middleware-sdk-rds/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "rootDir": "src",
-    "outDir": "./dist/es",
+    "outDir": "dist/es",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/middleware-sdk-rds/tsconfig.es.json
+++ b/packages/middleware-sdk-rds/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/es",
     "baseUrl": "."
   },

--- a/packages/middleware-sdk-rds/tsconfig.types.json
+++ b/packages/middleware-sdk-rds/tsconfig.types.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "declarationDir": "./dist/types",
     "baseUrl": "."
   },

--- a/packages/middleware-sdk-rds/tsconfig.types.json
+++ b/packages/middleware-sdk-rds/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "declarationDir": "./dist/types",
+    "declarationDir": "dist/types",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/middleware-sdk-route53/tsconfig.cjs.json
+++ b/packages/middleware-sdk-route53/tsconfig.cjs.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/cjs",
     "baseUrl": "."
   },

--- a/packages/middleware-sdk-route53/tsconfig.cjs.json
+++ b/packages/middleware-sdk-route53/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "./dist/cjs",
+    "outDir": "dist/cjs",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/middleware-sdk-route53/tsconfig.es.json
+++ b/packages/middleware-sdk-route53/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "rootDir": "src",
-    "outDir": "./dist/es",
+    "outDir": "dist/es",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/middleware-sdk-route53/tsconfig.es.json
+++ b/packages/middleware-sdk-route53/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/es",
     "baseUrl": "."
   },

--- a/packages/middleware-sdk-route53/tsconfig.types.json
+++ b/packages/middleware-sdk-route53/tsconfig.types.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "declarationDir": "./dist/types",
     "baseUrl": "."
   },

--- a/packages/middleware-sdk-route53/tsconfig.types.json
+++ b/packages/middleware-sdk-route53/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "declarationDir": "./dist/types",
+    "declarationDir": "dist/types",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/middleware-sdk-s3-control/tsconfig.cjs.json
+++ b/packages/middleware-sdk-s3-control/tsconfig.cjs.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/cjs",
     "baseUrl": "."
   },

--- a/packages/middleware-sdk-s3-control/tsconfig.cjs.json
+++ b/packages/middleware-sdk-s3-control/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "./dist/cjs",
+    "outDir": "dist/cjs",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/middleware-sdk-s3-control/tsconfig.es.json
+++ b/packages/middleware-sdk-s3-control/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "rootDir": "src",
-    "outDir": "./dist/es",
+    "outDir": "dist/es",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/middleware-sdk-s3-control/tsconfig.es.json
+++ b/packages/middleware-sdk-s3-control/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/es",
     "baseUrl": "."
   },

--- a/packages/middleware-sdk-s3-control/tsconfig.types.json
+++ b/packages/middleware-sdk-s3-control/tsconfig.types.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "declarationDir": "./dist/types",
     "baseUrl": "."
   },

--- a/packages/middleware-sdk-s3-control/tsconfig.types.json
+++ b/packages/middleware-sdk-s3-control/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "declarationDir": "./dist/types",
+    "declarationDir": "dist/types",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/middleware-sdk-s3/tsconfig.cjs.json
+++ b/packages/middleware-sdk-s3/tsconfig.cjs.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/cjs",
     "baseUrl": "."
   },

--- a/packages/middleware-sdk-s3/tsconfig.cjs.json
+++ b/packages/middleware-sdk-s3/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "./dist/cjs",
+    "outDir": "dist/cjs",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/middleware-sdk-s3/tsconfig.es.json
+++ b/packages/middleware-sdk-s3/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "rootDir": "src",
-    "outDir": "./dist/es",
+    "outDir": "dist/es",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/middleware-sdk-s3/tsconfig.es.json
+++ b/packages/middleware-sdk-s3/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/es",
     "baseUrl": "."
   },

--- a/packages/middleware-sdk-s3/tsconfig.types.json
+++ b/packages/middleware-sdk-s3/tsconfig.types.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "declarationDir": "./dist/types",
     "baseUrl": "."
   },

--- a/packages/middleware-sdk-s3/tsconfig.types.json
+++ b/packages/middleware-sdk-s3/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "declarationDir": "./dist/types",
+    "declarationDir": "dist/types",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/middleware-sdk-sqs/tsconfig.cjs.json
+++ b/packages/middleware-sdk-sqs/tsconfig.cjs.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/cjs",
     "baseUrl": "."
   },

--- a/packages/middleware-sdk-sqs/tsconfig.cjs.json
+++ b/packages/middleware-sdk-sqs/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "./dist/cjs",
+    "outDir": "dist/cjs",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/middleware-sdk-sqs/tsconfig.es.json
+++ b/packages/middleware-sdk-sqs/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "rootDir": "src",
-    "outDir": "./dist/es",
+    "outDir": "dist/es",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/middleware-sdk-sqs/tsconfig.es.json
+++ b/packages/middleware-sdk-sqs/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/es",
     "baseUrl": "."
   },

--- a/packages/middleware-sdk-sqs/tsconfig.types.json
+++ b/packages/middleware-sdk-sqs/tsconfig.types.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "declarationDir": "./dist/types",
     "baseUrl": "."
   },

--- a/packages/middleware-sdk-sqs/tsconfig.types.json
+++ b/packages/middleware-sdk-sqs/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "declarationDir": "./dist/types",
+    "declarationDir": "dist/types",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/middleware-sdk-sts/tsconfig.cjs.json
+++ b/packages/middleware-sdk-sts/tsconfig.cjs.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/cjs",
     "baseUrl": "."
   },

--- a/packages/middleware-sdk-sts/tsconfig.cjs.json
+++ b/packages/middleware-sdk-sts/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "./dist/cjs",
+    "outDir": "dist/cjs",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/middleware-sdk-sts/tsconfig.es.json
+++ b/packages/middleware-sdk-sts/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "rootDir": "src",
-    "outDir": "./dist/es",
+    "outDir": "dist/es",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/middleware-sdk-sts/tsconfig.es.json
+++ b/packages/middleware-sdk-sts/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/es",
     "baseUrl": "."
   },

--- a/packages/middleware-sdk-sts/tsconfig.types.json
+++ b/packages/middleware-sdk-sts/tsconfig.types.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "declarationDir": "./dist/types",
     "baseUrl": "."
   },

--- a/packages/middleware-sdk-sts/tsconfig.types.json
+++ b/packages/middleware-sdk-sts/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "declarationDir": "./dist/types",
+    "declarationDir": "dist/types",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/middleware-sdk-transcribe-streaming/tsconfig.cjs.json
+++ b/packages/middleware-sdk-transcribe-streaming/tsconfig.cjs.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "stripInternal": true,
     "rootDir": "src",
-    "outDir": "./dist/cjs",
+    "outDir": "dist/cjs",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/middleware-sdk-transcribe-streaming/tsconfig.cjs.json
+++ b/packages/middleware-sdk-transcribe-streaming/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "stripInternal": true,
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/cjs",
     "baseUrl": "."
   },

--- a/packages/middleware-sdk-transcribe-streaming/tsconfig.es.json
+++ b/packages/middleware-sdk-transcribe-streaming/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection", "DOM"],
     "stripInternal": true,
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/es",
     "baseUrl": ".",
     "target": "ES2015",

--- a/packages/middleware-sdk-transcribe-streaming/tsconfig.es.json
+++ b/packages/middleware-sdk-transcribe-streaming/tsconfig.es.json
@@ -3,7 +3,7 @@
     "lib": ["es5", "es2015.promise", "es2015.collection", "DOM"],
     "stripInternal": true,
     "rootDir": "src",
-    "outDir": "./dist/es",
+    "outDir": "dist/es",
     "baseUrl": ".",
     "target": "ES2015",
     "module": "esNext",

--- a/packages/middleware-sdk-transcribe-streaming/tsconfig.types.json
+++ b/packages/middleware-sdk-transcribe-streaming/tsconfig.types.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "declarationDir": "./dist/types",
     "baseUrl": "."
   },

--- a/packages/middleware-sdk-transcribe-streaming/tsconfig.types.json
+++ b/packages/middleware-sdk-transcribe-streaming/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "declarationDir": "./dist/types",
+    "declarationDir": "dist/types",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/middleware-serde/tsconfig.cjs.json
+++ b/packages/middleware-serde/tsconfig.cjs.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/cjs",
     "baseUrl": "."
   },

--- a/packages/middleware-serde/tsconfig.cjs.json
+++ b/packages/middleware-serde/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "./dist/cjs",
+    "outDir": "dist/cjs",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/middleware-serde/tsconfig.es.json
+++ b/packages/middleware-serde/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "rootDir": "src",
-    "outDir": "./dist/es",
+    "outDir": "dist/es",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/middleware-serde/tsconfig.es.json
+++ b/packages/middleware-serde/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/es",
     "baseUrl": "."
   },

--- a/packages/middleware-serde/tsconfig.types.json
+++ b/packages/middleware-serde/tsconfig.types.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "declarationDir": "./dist/types",
     "baseUrl": "."
   },

--- a/packages/middleware-serde/tsconfig.types.json
+++ b/packages/middleware-serde/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "declarationDir": "./dist/types",
+    "declarationDir": "dist/types",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/middleware-signing/tsconfig.cjs.json
+++ b/packages/middleware-signing/tsconfig.cjs.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/cjs",
     "baseUrl": "."
   },

--- a/packages/middleware-signing/tsconfig.cjs.json
+++ b/packages/middleware-signing/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "./dist/cjs",
+    "outDir": "dist/cjs",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/middleware-signing/tsconfig.es.json
+++ b/packages/middleware-signing/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "rootDir": "src",
-    "outDir": "./dist/es",
+    "outDir": "dist/es",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/middleware-signing/tsconfig.es.json
+++ b/packages/middleware-signing/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/es",
     "baseUrl": "."
   },

--- a/packages/middleware-signing/tsconfig.types.json
+++ b/packages/middleware-signing/tsconfig.types.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "declarationDir": "./dist/types",
     "baseUrl": "."
   },

--- a/packages/middleware-signing/tsconfig.types.json
+++ b/packages/middleware-signing/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "declarationDir": "./dist/types",
+    "declarationDir": "dist/types",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/middleware-ssec/tsconfig.cjs.json
+++ b/packages/middleware-ssec/tsconfig.cjs.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/cjs",
     "baseUrl": "."
   },

--- a/packages/middleware-ssec/tsconfig.cjs.json
+++ b/packages/middleware-ssec/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "./dist/cjs",
+    "outDir": "dist/cjs",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/middleware-ssec/tsconfig.es.json
+++ b/packages/middleware-ssec/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "rootDir": "src",
-    "outDir": "./dist/es",
+    "outDir": "dist/es",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/middleware-ssec/tsconfig.es.json
+++ b/packages/middleware-ssec/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/es",
     "baseUrl": "."
   },

--- a/packages/middleware-ssec/tsconfig.types.json
+++ b/packages/middleware-ssec/tsconfig.types.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "declarationDir": "./dist/types",
     "baseUrl": "."
   },

--- a/packages/middleware-ssec/tsconfig.types.json
+++ b/packages/middleware-ssec/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "declarationDir": "./dist/types",
+    "declarationDir": "dist/types",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/middleware-stack/tsconfig.cjs.json
+++ b/packages/middleware-stack/tsconfig.cjs.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/cjs",
     "baseUrl": "."
   },

--- a/packages/middleware-stack/tsconfig.cjs.json
+++ b/packages/middleware-stack/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "./dist/cjs",
+    "outDir": "dist/cjs",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/middleware-stack/tsconfig.es.json
+++ b/packages/middleware-stack/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection"],
     "rootDir": "src",
-    "outDir": "./dist/es",
+    "outDir": "dist/es",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/middleware-stack/tsconfig.es.json
+++ b/packages/middleware-stack/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection"],
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/es",
     "baseUrl": "."
   },

--- a/packages/middleware-stack/tsconfig.types.json
+++ b/packages/middleware-stack/tsconfig.types.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "declarationDir": "./dist/types",
     "baseUrl": "."
   },

--- a/packages/middleware-stack/tsconfig.types.json
+++ b/packages/middleware-stack/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "declarationDir": "./dist/types",
+    "declarationDir": "dist/types",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/middleware-user-agent/tsconfig.cjs.json
+++ b/packages/middleware-user-agent/tsconfig.cjs.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/cjs",
     "baseUrl": "."
   },

--- a/packages/middleware-user-agent/tsconfig.cjs.json
+++ b/packages/middleware-user-agent/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "./dist/cjs",
+    "outDir": "dist/cjs",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/middleware-user-agent/tsconfig.es.json
+++ b/packages/middleware-user-agent/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "rootDir": "src",
-    "outDir": "./dist/es",
+    "outDir": "dist/es",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/middleware-user-agent/tsconfig.es.json
+++ b/packages/middleware-user-agent/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/es",
     "baseUrl": "."
   },

--- a/packages/middleware-user-agent/tsconfig.types.json
+++ b/packages/middleware-user-agent/tsconfig.types.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "declarationDir": "./dist/types",
     "baseUrl": "."
   },

--- a/packages/middleware-user-agent/tsconfig.types.json
+++ b/packages/middleware-user-agent/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "declarationDir": "./dist/types",
+    "declarationDir": "dist/types",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/node-config-provider/tsconfig.cjs.json
+++ b/packages/node-config-provider/tsconfig.cjs.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/cjs",
     "baseUrl": "."
   },

--- a/packages/node-config-provider/tsconfig.cjs.json
+++ b/packages/node-config-provider/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "./dist/cjs",
+    "outDir": "dist/cjs",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/node-config-provider/tsconfig.es.json
+++ b/packages/node-config-provider/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.iterable"],
     "rootDir": "src",
-    "outDir": "./dist/es",
+    "outDir": "dist/es",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/node-config-provider/tsconfig.es.json
+++ b/packages/node-config-provider/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.iterable"],
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/es",
     "baseUrl": "."
   },

--- a/packages/node-config-provider/tsconfig.types.json
+++ b/packages/node-config-provider/tsconfig.types.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "declarationDir": "./dist/types",
     "baseUrl": "."
   },

--- a/packages/node-config-provider/tsconfig.types.json
+++ b/packages/node-config-provider/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "declarationDir": "./dist/types",
+    "declarationDir": "dist/types",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/node-http-handler/tsconfig.cjs.json
+++ b/packages/node-http-handler/tsconfig.cjs.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/cjs",
     "baseUrl": "."
   },

--- a/packages/node-http-handler/tsconfig.cjs.json
+++ b/packages/node-http-handler/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "./dist/cjs",
+    "outDir": "dist/cjs",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/node-http-handler/tsconfig.es.json
+++ b/packages/node-http-handler/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.iterable"],
     "rootDir": "src",
-    "outDir": "./dist/es",
+    "outDir": "dist/es",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/node-http-handler/tsconfig.es.json
+++ b/packages/node-http-handler/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.iterable"],
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/es",
     "baseUrl": "."
   },

--- a/packages/node-http-handler/tsconfig.types.json
+++ b/packages/node-http-handler/tsconfig.types.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "declarationDir": "./dist/types",
     "baseUrl": "."
   },

--- a/packages/node-http-handler/tsconfig.types.json
+++ b/packages/node-http-handler/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "declarationDir": "./dist/types",
+    "declarationDir": "dist/types",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/polly-request-presigner/tsconfig.cjs.json
+++ b/packages/polly-request-presigner/tsconfig.cjs.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/cjs",
     "baseUrl": "."
   },

--- a/packages/polly-request-presigner/tsconfig.cjs.json
+++ b/packages/polly-request-presigner/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "./dist/cjs",
+    "outDir": "dist/cjs",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/polly-request-presigner/tsconfig.es.json
+++ b/packages/polly-request-presigner/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown", "dom"],
     "rootDir": "src",
-    "outDir": "./dist/es",
+    "outDir": "dist/es",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/polly-request-presigner/tsconfig.es.json
+++ b/packages/polly-request-presigner/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown", "dom"],
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/es",
     "baseUrl": "."
   },

--- a/packages/polly-request-presigner/tsconfig.types.json
+++ b/packages/polly-request-presigner/tsconfig.types.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "declarationDir": "./dist/types",
     "baseUrl": "."
   },

--- a/packages/polly-request-presigner/tsconfig.types.json
+++ b/packages/polly-request-presigner/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "declarationDir": "./dist/types",
+    "declarationDir": "dist/types",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/property-provider/tsconfig.cjs.json
+++ b/packages/property-provider/tsconfig.cjs.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/cjs",
     "baseUrl": "."
   },

--- a/packages/property-provider/tsconfig.cjs.json
+++ b/packages/property-provider/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "./dist/cjs",
+    "outDir": "dist/cjs",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/property-provider/tsconfig.es.json
+++ b/packages/property-provider/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "rootDir": "src",
-    "outDir": "./dist/es",
+    "outDir": "dist/es",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/property-provider/tsconfig.es.json
+++ b/packages/property-provider/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/es",
     "baseUrl": "."
   },

--- a/packages/property-provider/tsconfig.types.json
+++ b/packages/property-provider/tsconfig.types.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "declarationDir": "./dist/types",
     "baseUrl": "."
   },

--- a/packages/property-provider/tsconfig.types.json
+++ b/packages/property-provider/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "declarationDir": "./dist/types",
+    "declarationDir": "dist/types",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/protocol-http/tsconfig.cjs.json
+++ b/packages/protocol-http/tsconfig.cjs.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/cjs",
     "baseUrl": "."
   },

--- a/packages/protocol-http/tsconfig.cjs.json
+++ b/packages/protocol-http/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "./dist/cjs",
+    "outDir": "dist/cjs",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/protocol-http/tsconfig.es.json
+++ b/packages/protocol-http/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/es",
     "baseUrl": "."
   },

--- a/packages/protocol-http/tsconfig.es.json
+++ b/packages/protocol-http/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "rootDir": "src",
-    "outDir": "./dist/es",
+    "outDir": "dist/es",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/protocol-http/tsconfig.types.json
+++ b/packages/protocol-http/tsconfig.types.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "declarationDir": "./dist/types",
     "baseUrl": "."
   },

--- a/packages/protocol-http/tsconfig.types.json
+++ b/packages/protocol-http/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "declarationDir": "./dist/types",
+    "declarationDir": "dist/types",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/querystring-builder/tsconfig.cjs.json
+++ b/packages/querystring-builder/tsconfig.cjs.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/cjs",
     "baseUrl": "."
   },

--- a/packages/querystring-builder/tsconfig.cjs.json
+++ b/packages/querystring-builder/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "./dist/cjs",
+    "outDir": "dist/cjs",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/querystring-builder/tsconfig.es.json
+++ b/packages/querystring-builder/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "rootDir": "src",
-    "outDir": "./dist/es",
+    "outDir": "dist/es",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/querystring-builder/tsconfig.es.json
+++ b/packages/querystring-builder/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/es",
     "baseUrl": "."
   },

--- a/packages/querystring-builder/tsconfig.types.json
+++ b/packages/querystring-builder/tsconfig.types.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "declarationDir": "./dist/types",
     "baseUrl": "."
   },

--- a/packages/querystring-builder/tsconfig.types.json
+++ b/packages/querystring-builder/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "declarationDir": "./dist/types",
+    "declarationDir": "dist/types",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/querystring-parser/tsconfig.cjs.json
+++ b/packages/querystring-parser/tsconfig.cjs.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/cjs",
     "baseUrl": "."
   },

--- a/packages/querystring-parser/tsconfig.cjs.json
+++ b/packages/querystring-parser/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "./dist/cjs",
+    "outDir": "dist/cjs",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/querystring-parser/tsconfig.es.json
+++ b/packages/querystring-parser/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "rootDir": "src",
-    "outDir": "./dist/es",
+    "outDir": "dist/es",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/querystring-parser/tsconfig.es.json
+++ b/packages/querystring-parser/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/es",
     "baseUrl": "."
   },

--- a/packages/querystring-parser/tsconfig.types.json
+++ b/packages/querystring-parser/tsconfig.types.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "declarationDir": "./dist/types",
     "baseUrl": "."
   },

--- a/packages/querystring-parser/tsconfig.types.json
+++ b/packages/querystring-parser/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "declarationDir": "./dist/types",
+    "declarationDir": "dist/types",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/s3-presigned-post/tsconfig.cjs.json
+++ b/packages/s3-presigned-post/tsconfig.cjs.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/cjs",
     "baseUrl": "."
   },

--- a/packages/s3-presigned-post/tsconfig.cjs.json
+++ b/packages/s3-presigned-post/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "./dist/cjs",
+    "outDir": "dist/cjs",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/s3-presigned-post/tsconfig.es.json
+++ b/packages/s3-presigned-post/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown", "dom"],
     "rootDir": "src",
-    "outDir": "./dist/es",
+    "outDir": "dist/es",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/s3-presigned-post/tsconfig.es.json
+++ b/packages/s3-presigned-post/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown", "dom"],
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/es",
     "baseUrl": "."
   },

--- a/packages/s3-presigned-post/tsconfig.types.json
+++ b/packages/s3-presigned-post/tsconfig.types.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "declarationDir": "./dist/types",
     "baseUrl": "."
   },

--- a/packages/s3-presigned-post/tsconfig.types.json
+++ b/packages/s3-presigned-post/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "declarationDir": "./dist/types",
+    "declarationDir": "dist/types",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/s3-request-presigner/tsconfig.cjs.json
+++ b/packages/s3-request-presigner/tsconfig.cjs.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/cjs",
     "baseUrl": "."
   },

--- a/packages/s3-request-presigner/tsconfig.cjs.json
+++ b/packages/s3-request-presigner/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "./dist/cjs",
+    "outDir": "dist/cjs",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/s3-request-presigner/tsconfig.es.json
+++ b/packages/s3-request-presigner/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown", "dom"],
     "rootDir": "src",
-    "outDir": "./dist/es",
+    "outDir": "dist/es",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/s3-request-presigner/tsconfig.es.json
+++ b/packages/s3-request-presigner/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown", "dom"],
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/es",
     "baseUrl": "."
   },

--- a/packages/s3-request-presigner/tsconfig.types.json
+++ b/packages/s3-request-presigner/tsconfig.types.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "declarationDir": "./dist/types",
     "baseUrl": "."
   },

--- a/packages/s3-request-presigner/tsconfig.types.json
+++ b/packages/s3-request-presigner/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "declarationDir": "./dist/types",
+    "declarationDir": "dist/types",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/service-error-classification/tsconfig.cjs.json
+++ b/packages/service-error-classification/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "noUnusedLocals": true,
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/cjs",
     "baseUrl": "."
   },

--- a/packages/service-error-classification/tsconfig.cjs.json
+++ b/packages/service-error-classification/tsconfig.cjs.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "noUnusedLocals": true,
     "rootDir": "src",
-    "outDir": "./dist/cjs",
+    "outDir": "dist/cjs",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/service-error-classification/tsconfig.es.json
+++ b/packages/service-error-classification/tsconfig.es.json
@@ -3,7 +3,7 @@
     "noUnusedLocals": true,
     "lib": ["es5", "es2015.collection", "es2015.iterable"],
     "rootDir": "src",
-    "outDir": "./dist/es",
+    "outDir": "dist/es",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/service-error-classification/tsconfig.es.json
+++ b/packages/service-error-classification/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "noUnusedLocals": true,
     "lib": ["es5", "es2015.collection", "es2015.iterable"],
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/es",
     "baseUrl": "."
   },

--- a/packages/service-error-classification/tsconfig.types.json
+++ b/packages/service-error-classification/tsconfig.types.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "declarationDir": "./dist/types",
     "baseUrl": "."
   },

--- a/packages/service-error-classification/tsconfig.types.json
+++ b/packages/service-error-classification/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "declarationDir": "./dist/types",
+    "declarationDir": "dist/types",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/sha256-tree-hash/tsconfig.cjs.json
+++ b/packages/sha256-tree-hash/tsconfig.cjs.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/cjs",
     "baseUrl": "."
   },

--- a/packages/sha256-tree-hash/tsconfig.cjs.json
+++ b/packages/sha256-tree-hash/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "./dist/cjs",
+    "outDir": "dist/cjs",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/sha256-tree-hash/tsconfig.es.json
+++ b/packages/sha256-tree-hash/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/es",
     "baseUrl": "."
   },

--- a/packages/sha256-tree-hash/tsconfig.es.json
+++ b/packages/sha256-tree-hash/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "rootDir": "src",
-    "outDir": "./dist/es",
+    "outDir": "dist/es",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/sha256-tree-hash/tsconfig.types.json
+++ b/packages/sha256-tree-hash/tsconfig.types.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "declarationDir": "./dist/types",
     "baseUrl": "."
   },

--- a/packages/sha256-tree-hash/tsconfig.types.json
+++ b/packages/sha256-tree-hash/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "declarationDir": "./dist/types",
+    "declarationDir": "dist/types",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/shared-ini-file-loader/tsconfig.cjs.json
+++ b/packages/shared-ini-file-loader/tsconfig.cjs.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/cjs",
     "baseUrl": "."
   },

--- a/packages/shared-ini-file-loader/tsconfig.cjs.json
+++ b/packages/shared-ini-file-loader/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "./dist/cjs",
+    "outDir": "dist/cjs",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/shared-ini-file-loader/tsconfig.es.json
+++ b/packages/shared-ini-file-loader/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection"],
     "rootDir": "src",
-    "outDir": "./dist/es",
+    "outDir": "dist/es",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/shared-ini-file-loader/tsconfig.es.json
+++ b/packages/shared-ini-file-loader/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection"],
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/es",
     "baseUrl": "."
   },

--- a/packages/shared-ini-file-loader/tsconfig.types.json
+++ b/packages/shared-ini-file-loader/tsconfig.types.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "declarationDir": "./dist/types",
     "baseUrl": "."
   },

--- a/packages/shared-ini-file-loader/tsconfig.types.json
+++ b/packages/shared-ini-file-loader/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "declarationDir": "./dist/types",
+    "declarationDir": "dist/types",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/signature-v4-crt/tsconfig.cjs.json
+++ b/packages/signature-v4-crt/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "stripInternal": true,
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/cjs",
     "noUnusedLocals": true,
     "lib": ["es2016"],

--- a/packages/signature-v4-crt/tsconfig.cjs.json
+++ b/packages/signature-v4-crt/tsconfig.cjs.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "stripInternal": true,
     "rootDir": "src",
-    "outDir": "./dist/cjs",
+    "outDir": "dist/cjs",
     "noUnusedLocals": true,
     "lib": ["es2016"],
     "baseUrl": "."

--- a/packages/signature-v4-crt/tsconfig.es.json
+++ b/packages/signature-v4-crt/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "stripInternal": true,
     "rootDir": "src",
-    "outDir": "./dist/es",
+    "outDir": "dist/es",
     "noUnusedLocals": true,
     "baseUrl": ".",
     "target": "es5",

--- a/packages/signature-v4-crt/tsconfig.es.json
+++ b/packages/signature-v4-crt/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "stripInternal": true,
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/es",
     "noUnusedLocals": true,
     "baseUrl": ".",

--- a/packages/signature-v4-crt/tsconfig.types.json
+++ b/packages/signature-v4-crt/tsconfig.types.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "declarationDir": "./dist/types",
     "baseUrl": "."
   },

--- a/packages/signature-v4-crt/tsconfig.types.json
+++ b/packages/signature-v4-crt/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "declarationDir": "./dist/types",
+    "declarationDir": "dist/types",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/signature-v4/tsconfig.cjs.json
+++ b/packages/signature-v4/tsconfig.cjs.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "stripInternal": true,
     "rootDir": "src",
-    "outDir": "./dist/cjs",
+    "outDir": "dist/cjs",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/signature-v4/tsconfig.cjs.json
+++ b/packages/signature-v4/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "stripInternal": true,
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/cjs",
     "baseUrl": "."
   },

--- a/packages/signature-v4/tsconfig.es.json
+++ b/packages/signature-v4/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "stripInternal": true,
     "rootDir": "src",
-    "outDir": "./dist/es",
+    "outDir": "dist/es",
     "noUnusedLocals": true,
     "baseUrl": ".",
     "target": "es5",

--- a/packages/signature-v4/tsconfig.es.json
+++ b/packages/signature-v4/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "stripInternal": true,
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/es",
     "noUnusedLocals": true,
     "baseUrl": ".",

--- a/packages/signature-v4/tsconfig.types.json
+++ b/packages/signature-v4/tsconfig.types.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "declarationDir": "./dist/types",
     "baseUrl": "."
   },

--- a/packages/signature-v4/tsconfig.types.json
+++ b/packages/signature-v4/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "declarationDir": "./dist/types",
+    "declarationDir": "dist/types",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/smithy-client/tsconfig.cjs.json
+++ b/packages/smithy-client/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "noUnusedLocals": true,
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/cjs",
     "baseUrl": "."
   },

--- a/packages/smithy-client/tsconfig.cjs.json
+++ b/packages/smithy-client/tsconfig.cjs.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "noUnusedLocals": true,
     "rootDir": "src",
-    "outDir": "./dist/cjs",
+    "outDir": "dist/cjs",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/smithy-client/tsconfig.es.json
+++ b/packages/smithy-client/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "noUnusedLocals": true,
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/es",
     "baseUrl": "."
   },

--- a/packages/smithy-client/tsconfig.es.json
+++ b/packages/smithy-client/tsconfig.es.json
@@ -3,7 +3,7 @@
     "noUnusedLocals": true,
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "rootDir": "src",
-    "outDir": "./dist/es",
+    "outDir": "dist/es",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/smithy-client/tsconfig.types.json
+++ b/packages/smithy-client/tsconfig.types.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "declarationDir": "./dist/types",
     "baseUrl": "."
   },

--- a/packages/smithy-client/tsconfig.types.json
+++ b/packages/smithy-client/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "declarationDir": "./dist/types",
+    "declarationDir": "dist/types",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/types/tsconfig.cjs.json
+++ b/packages/types/tsconfig.cjs.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/cjs",
     "baseUrl": "."
   },

--- a/packages/types/tsconfig.cjs.json
+++ b/packages/types/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "./dist/cjs",
+    "outDir": "dist/cjs",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/types/tsconfig.es.json
+++ b/packages/types/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "rootDir": "src",
-    "outDir": "./dist/es",
+    "outDir": "dist/es",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/types/tsconfig.es.json
+++ b/packages/types/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/es",
     "baseUrl": "."
   },

--- a/packages/types/tsconfig.types.json
+++ b/packages/types/tsconfig.types.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "declarationDir": "./dist/types",
     "baseUrl": "."
   },

--- a/packages/types/tsconfig.types.json
+++ b/packages/types/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "declarationDir": "./dist/types",
+    "declarationDir": "dist/types",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/url-parser/tsconfig.cjs.json
+++ b/packages/url-parser/tsconfig.cjs.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/cjs",
     "baseUrl": "."
   },

--- a/packages/url-parser/tsconfig.cjs.json
+++ b/packages/url-parser/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "./dist/cjs",
+    "outDir": "dist/cjs",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/url-parser/tsconfig.es.json
+++ b/packages/url-parser/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/es",
     "baseUrl": "."
   },

--- a/packages/url-parser/tsconfig.es.json
+++ b/packages/url-parser/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "rootDir": "src",
-    "outDir": "./dist/es",
+    "outDir": "dist/es",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/url-parser/tsconfig.types.json
+++ b/packages/url-parser/tsconfig.types.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "declarationDir": "./dist/types",
     "baseUrl": "."
   },

--- a/packages/url-parser/tsconfig.types.json
+++ b/packages/url-parser/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "declarationDir": "./dist/types",
+    "declarationDir": "dist/types",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/util-arn-parser/tsconfig.cjs.json
+++ b/packages/util-arn-parser/tsconfig.cjs.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/cjs",
     "baseUrl": "."
   },

--- a/packages/util-arn-parser/tsconfig.cjs.json
+++ b/packages/util-arn-parser/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "./dist/cjs",
+    "outDir": "dist/cjs",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/util-arn-parser/tsconfig.es.json
+++ b/packages/util-arn-parser/tsconfig.es.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/es",
     "baseUrl": "."
   },

--- a/packages/util-arn-parser/tsconfig.es.json
+++ b/packages/util-arn-parser/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "./dist/es",
+    "outDir": "dist/es",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/util-arn-parser/tsconfig.types.json
+++ b/packages/util-arn-parser/tsconfig.types.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "declarationDir": "./dist/types",
     "baseUrl": "."
   },

--- a/packages/util-arn-parser/tsconfig.types.json
+++ b/packages/util-arn-parser/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "declarationDir": "./dist/types",
+    "declarationDir": "dist/types",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/util-base64-browser/tsconfig.cjs.json
+++ b/packages/util-base64-browser/tsconfig.cjs.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/cjs",
     "baseUrl": "."
   },

--- a/packages/util-base64-browser/tsconfig.cjs.json
+++ b/packages/util-base64-browser/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "./dist/cjs",
+    "outDir": "dist/cjs",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/util-base64-browser/tsconfig.es.json
+++ b/packages/util-base64-browser/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "lib": ["es5", "es2015.collection"],
     "rootDir": "src",
-    "outDir": "./dist/es",
+    "outDir": "dist/es",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/util-base64-browser/tsconfig.es.json
+++ b/packages/util-base64-browser/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es5", "es2015.collection"],
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/es",
     "baseUrl": "."
   },

--- a/packages/util-base64-browser/tsconfig.types.json
+++ b/packages/util-base64-browser/tsconfig.types.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "declarationDir": "./dist/types",
     "baseUrl": "."
   },

--- a/packages/util-base64-browser/tsconfig.types.json
+++ b/packages/util-base64-browser/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "declarationDir": "./dist/types",
+    "declarationDir": "dist/types",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/util-base64-node/tsconfig.cjs.json
+++ b/packages/util-base64-node/tsconfig.cjs.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/cjs",
     "baseUrl": "."
   },

--- a/packages/util-base64-node/tsconfig.cjs.json
+++ b/packages/util-base64-node/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "./dist/cjs",
+    "outDir": "dist/cjs",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/util-base64-node/tsconfig.es.json
+++ b/packages/util-base64-node/tsconfig.es.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/es",
     "baseUrl": "."
   },

--- a/packages/util-base64-node/tsconfig.es.json
+++ b/packages/util-base64-node/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "./dist/es",
+    "outDir": "dist/es",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/util-base64-node/tsconfig.types.json
+++ b/packages/util-base64-node/tsconfig.types.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "declarationDir": "./dist/types",
     "baseUrl": "."
   },

--- a/packages/util-base64-node/tsconfig.types.json
+++ b/packages/util-base64-node/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "declarationDir": "./dist/types",
+    "declarationDir": "dist/types",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/util-body-length-browser/tsconfig.cjs.json
+++ b/packages/util-body-length-browser/tsconfig.cjs.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/cjs",
     "baseUrl": "."
   },

--- a/packages/util-body-length-browser/tsconfig.cjs.json
+++ b/packages/util-body-length-browser/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "./dist/cjs",
+    "outDir": "dist/cjs",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/util-body-length-browser/tsconfig.es.json
+++ b/packages/util-body-length-browser/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown", "dom"],
     "rootDir": "src",
-    "outDir": "./dist/es",
+    "outDir": "dist/es",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/util-body-length-browser/tsconfig.es.json
+++ b/packages/util-body-length-browser/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown", "dom"],
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/es",
     "baseUrl": "."
   },

--- a/packages/util-body-length-browser/tsconfig.types.json
+++ b/packages/util-body-length-browser/tsconfig.types.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "declarationDir": "./dist/types",
     "baseUrl": "."
   },

--- a/packages/util-body-length-browser/tsconfig.types.json
+++ b/packages/util-body-length-browser/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "declarationDir": "./dist/types",
+    "declarationDir": "dist/types",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/util-body-length-node/tsconfig.cjs.json
+++ b/packages/util-body-length-node/tsconfig.cjs.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/cjs",
     "baseUrl": "."
   },

--- a/packages/util-body-length-node/tsconfig.cjs.json
+++ b/packages/util-body-length-node/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "./dist/cjs",
+    "outDir": "dist/cjs",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/util-body-length-node/tsconfig.es.json
+++ b/packages/util-body-length-node/tsconfig.es.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/es",
     "baseUrl": "."
   },

--- a/packages/util-body-length-node/tsconfig.es.json
+++ b/packages/util-body-length-node/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "./dist/es",
+    "outDir": "dist/es",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/util-body-length-node/tsconfig.types.json
+++ b/packages/util-body-length-node/tsconfig.types.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "declarationDir": "./dist/types",
     "baseUrl": "."
   },

--- a/packages/util-body-length-node/tsconfig.types.json
+++ b/packages/util-body-length-node/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "declarationDir": "./dist/types",
+    "declarationDir": "dist/types",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/util-buffer-from/tsconfig.cjs.json
+++ b/packages/util-buffer-from/tsconfig.cjs.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/cjs",
     "baseUrl": "."
   },

--- a/packages/util-buffer-from/tsconfig.cjs.json
+++ b/packages/util-buffer-from/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "./dist/cjs",
+    "outDir": "dist/cjs",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/util-buffer-from/tsconfig.es.json
+++ b/packages/util-buffer-from/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "lib": ["es5", "es2015.collection"],
     "rootDir": "src",
-    "outDir": "./dist/es",
+    "outDir": "dist/es",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/util-buffer-from/tsconfig.es.json
+++ b/packages/util-buffer-from/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es5", "es2015.collection"],
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/es",
     "baseUrl": "."
   },

--- a/packages/util-buffer-from/tsconfig.types.json
+++ b/packages/util-buffer-from/tsconfig.types.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "declarationDir": "./dist/types",
     "baseUrl": "."
   },

--- a/packages/util-buffer-from/tsconfig.types.json
+++ b/packages/util-buffer-from/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "declarationDir": "./dist/types",
+    "declarationDir": "dist/types",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/util-create-request/tsconfig.cjs.json
+++ b/packages/util-create-request/tsconfig.cjs.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/cjs",
     "baseUrl": "."
   },

--- a/packages/util-create-request/tsconfig.cjs.json
+++ b/packages/util-create-request/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "./dist/cjs",
+    "outDir": "dist/cjs",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/util-create-request/tsconfig.es.json
+++ b/packages/util-create-request/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "rootDir": "src",
-    "outDir": "./dist/es",
+    "outDir": "dist/es",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/util-create-request/tsconfig.es.json
+++ b/packages/util-create-request/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/es",
     "baseUrl": "."
   },

--- a/packages/util-create-request/tsconfig.types.json
+++ b/packages/util-create-request/tsconfig.types.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "declarationDir": "./dist/types",
     "baseUrl": "."
   },

--- a/packages/util-create-request/tsconfig.types.json
+++ b/packages/util-create-request/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "declarationDir": "./dist/types",
+    "declarationDir": "dist/types",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/util-credentials/tsconfig.cjs.json
+++ b/packages/util-credentials/tsconfig.cjs.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/cjs",
     "baseUrl": "."
   },

--- a/packages/util-credentials/tsconfig.cjs.json
+++ b/packages/util-credentials/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "./dist/cjs",
+    "outDir": "dist/cjs",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/util-credentials/tsconfig.es.json
+++ b/packages/util-credentials/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection"],
     "rootDir": "src",
-    "outDir": "./dist/es",
+    "outDir": "dist/es",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/util-credentials/tsconfig.es.json
+++ b/packages/util-credentials/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection"],
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/es",
     "baseUrl": "."
   },

--- a/packages/util-credentials/tsconfig.types.json
+++ b/packages/util-credentials/tsconfig.types.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "declarationDir": "./dist/types",
     "baseUrl": "."
   },

--- a/packages/util-credentials/tsconfig.types.json
+++ b/packages/util-credentials/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "declarationDir": "./dist/types",
+    "declarationDir": "dist/types",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/util-dynamodb/tsconfig.cjs.json
+++ b/packages/util-dynamodb/tsconfig.cjs.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/cjs",
     "baseUrl": "."
   },

--- a/packages/util-dynamodb/tsconfig.cjs.json
+++ b/packages/util-dynamodb/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "./dist/cjs",
+    "outDir": "dist/cjs",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/util-dynamodb/tsconfig.es.json
+++ b/packages/util-dynamodb/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/es",
     "baseUrl": "."
   },

--- a/packages/util-dynamodb/tsconfig.es.json
+++ b/packages/util-dynamodb/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "rootDir": "src",
-    "outDir": "./dist/es",
+    "outDir": "dist/es",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/util-dynamodb/tsconfig.types.json
+++ b/packages/util-dynamodb/tsconfig.types.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "declarationDir": "./dist/types",
     "baseUrl": "."
   },

--- a/packages/util-dynamodb/tsconfig.types.json
+++ b/packages/util-dynamodb/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "declarationDir": "./dist/types",
+    "declarationDir": "dist/types",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/util-format-url/tsconfig.cjs.json
+++ b/packages/util-format-url/tsconfig.cjs.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/cjs",
     "baseUrl": "."
   },

--- a/packages/util-format-url/tsconfig.cjs.json
+++ b/packages/util-format-url/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "./dist/cjs",
+    "outDir": "dist/cjs",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/util-format-url/tsconfig.es.json
+++ b/packages/util-format-url/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "rootDir": "src",
-    "outDir": "./dist/es",
+    "outDir": "dist/es",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/util-format-url/tsconfig.es.json
+++ b/packages/util-format-url/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/es",
     "baseUrl": "."
   },

--- a/packages/util-format-url/tsconfig.types.json
+++ b/packages/util-format-url/tsconfig.types.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "declarationDir": "./dist/types",
     "baseUrl": "."
   },

--- a/packages/util-format-url/tsconfig.types.json
+++ b/packages/util-format-url/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "declarationDir": "./dist/types",
+    "declarationDir": "dist/types",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/util-hex-encoding/tsconfig.cjs.json
+++ b/packages/util-hex-encoding/tsconfig.cjs.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/cjs",
     "baseUrl": "."
   },

--- a/packages/util-hex-encoding/tsconfig.cjs.json
+++ b/packages/util-hex-encoding/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "./dist/cjs",
+    "outDir": "dist/cjs",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/util-hex-encoding/tsconfig.es.json
+++ b/packages/util-hex-encoding/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection"],
     "rootDir": "src",
-    "outDir": "./dist/es",
+    "outDir": "dist/es",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/util-hex-encoding/tsconfig.es.json
+++ b/packages/util-hex-encoding/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection"],
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/es",
     "baseUrl": "."
   },

--- a/packages/util-hex-encoding/tsconfig.types.json
+++ b/packages/util-hex-encoding/tsconfig.types.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "declarationDir": "./dist/types",
     "baseUrl": "."
   },

--- a/packages/util-hex-encoding/tsconfig.types.json
+++ b/packages/util-hex-encoding/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "declarationDir": "./dist/types",
+    "declarationDir": "dist/types",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/util-locate-window/tsconfig.cjs.json
+++ b/packages/util-locate-window/tsconfig.cjs.json
@@ -5,7 +5,7 @@
     "noImplicitAny": true,
     "noImplicitThis": true,
     "strictNullChecks": true,
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/cjs",
     "baseUrl": "."
   },

--- a/packages/util-locate-window/tsconfig.cjs.json
+++ b/packages/util-locate-window/tsconfig.cjs.json
@@ -6,7 +6,7 @@
     "noImplicitThis": true,
     "strictNullChecks": true,
     "rootDir": "src",
-    "outDir": "./dist/cjs",
+    "outDir": "dist/cjs",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/util-locate-window/tsconfig.es.json
+++ b/packages/util-locate-window/tsconfig.es.json
@@ -7,7 +7,7 @@
     "strictNullChecks": true,
     "lib": ["dom", "es5", "es2015.collection"],
     "rootDir": "src",
-    "outDir": "./dist/es",
+    "outDir": "dist/es",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/util-locate-window/tsconfig.es.json
+++ b/packages/util-locate-window/tsconfig.es.json
@@ -6,7 +6,7 @@
     "noImplicitThis": true,
     "strictNullChecks": true,
     "lib": ["dom", "es5", "es2015.collection"],
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/es",
     "baseUrl": "."
   },

--- a/packages/util-locate-window/tsconfig.types.json
+++ b/packages/util-locate-window/tsconfig.types.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "declarationDir": "./dist/types",
     "baseUrl": "."
   },

--- a/packages/util-locate-window/tsconfig.types.json
+++ b/packages/util-locate-window/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "declarationDir": "./dist/types",
+    "declarationDir": "dist/types",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/util-uri-escape/tsconfig.cjs.json
+++ b/packages/util-uri-escape/tsconfig.cjs.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/cjs",
     "baseUrl": "."
   },

--- a/packages/util-uri-escape/tsconfig.cjs.json
+++ b/packages/util-uri-escape/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "./dist/cjs",
+    "outDir": "dist/cjs",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/util-uri-escape/tsconfig.es.json
+++ b/packages/util-uri-escape/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "rootDir": "src",
-    "outDir": "./dist/es",
+    "outDir": "dist/es",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/util-uri-escape/tsconfig.es.json
+++ b/packages/util-uri-escape/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/es",
     "baseUrl": "."
   },

--- a/packages/util-uri-escape/tsconfig.types.json
+++ b/packages/util-uri-escape/tsconfig.types.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "declarationDir": "./dist/types",
     "baseUrl": "."
   },

--- a/packages/util-uri-escape/tsconfig.types.json
+++ b/packages/util-uri-escape/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "declarationDir": "./dist/types",
+    "declarationDir": "dist/types",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/util-user-agent-browser/tsconfig.cjs.json
+++ b/packages/util-user-agent-browser/tsconfig.cjs.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/cjs",
     "baseUrl": "."
   },

--- a/packages/util-user-agent-browser/tsconfig.cjs.json
+++ b/packages/util-user-agent-browser/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "./dist/cjs",
+    "outDir": "dist/cjs",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/util-user-agent-browser/tsconfig.es.json
+++ b/packages/util-user-agent-browser/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "lib": ["es5", "es2015.collection", "dom"],
     "rootDir": "src",
-    "outDir": "./dist/es",
+    "outDir": "dist/es",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/util-user-agent-browser/tsconfig.es.json
+++ b/packages/util-user-agent-browser/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es5", "es2015.collection", "dom"],
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/es",
     "baseUrl": "."
   },

--- a/packages/util-user-agent-browser/tsconfig.types.json
+++ b/packages/util-user-agent-browser/tsconfig.types.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "declarationDir": "./dist/types",
     "baseUrl": "."
   },

--- a/packages/util-user-agent-browser/tsconfig.types.json
+++ b/packages/util-user-agent-browser/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "declarationDir": "./dist/types",
+    "declarationDir": "dist/types",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/util-user-agent-node/tsconfig.cjs.json
+++ b/packages/util-user-agent-node/tsconfig.cjs.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/cjs",
     "baseUrl": "."
   },

--- a/packages/util-user-agent-node/tsconfig.cjs.json
+++ b/packages/util-user-agent-node/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "./dist/cjs",
+    "outDir": "dist/cjs",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/util-user-agent-node/tsconfig.es.json
+++ b/packages/util-user-agent-node/tsconfig.es.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/es",
     "baseUrl": "."
   },

--- a/packages/util-user-agent-node/tsconfig.es.json
+++ b/packages/util-user-agent-node/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "./dist/es",
+    "outDir": "dist/es",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/util-user-agent-node/tsconfig.types.json
+++ b/packages/util-user-agent-node/tsconfig.types.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "declarationDir": "./dist/types",
     "baseUrl": "."
   },

--- a/packages/util-user-agent-node/tsconfig.types.json
+++ b/packages/util-user-agent-node/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "declarationDir": "./dist/types",
+    "declarationDir": "dist/types",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/util-utf8-browser/tsconfig.cjs.json
+++ b/packages/util-utf8-browser/tsconfig.cjs.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/cjs",
     "baseUrl": "."
   },

--- a/packages/util-utf8-browser/tsconfig.cjs.json
+++ b/packages/util-utf8-browser/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "./dist/cjs",
+    "outDir": "dist/cjs",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/util-utf8-browser/tsconfig.es.json
+++ b/packages/util-utf8-browser/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "lib": ["es5", "es2015.collection"],
     "rootDir": "src",
-    "outDir": "./dist/es",
+    "outDir": "dist/es",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/util-utf8-browser/tsconfig.es.json
+++ b/packages/util-utf8-browser/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es5", "es2015.collection"],
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/es",
     "baseUrl": "."
   },

--- a/packages/util-utf8-browser/tsconfig.types.json
+++ b/packages/util-utf8-browser/tsconfig.types.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "declarationDir": "./dist/types",
     "baseUrl": "."
   },

--- a/packages/util-utf8-browser/tsconfig.types.json
+++ b/packages/util-utf8-browser/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "declarationDir": "./dist/types",
+    "declarationDir": "dist/types",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/util-utf8-node/tsconfig.cjs.json
+++ b/packages/util-utf8-node/tsconfig.cjs.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/cjs",
     "baseUrl": "."
   },

--- a/packages/util-utf8-node/tsconfig.cjs.json
+++ b/packages/util-utf8-node/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "./dist/cjs",
+    "outDir": "dist/cjs",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/util-utf8-node/tsconfig.es.json
+++ b/packages/util-utf8-node/tsconfig.es.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/es",
     "baseUrl": "."
   },

--- a/packages/util-utf8-node/tsconfig.es.json
+++ b/packages/util-utf8-node/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "./dist/es",
+    "outDir": "dist/es",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/util-utf8-node/tsconfig.types.json
+++ b/packages/util-utf8-node/tsconfig.types.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "declarationDir": "./dist/types",
     "baseUrl": "."
   },

--- a/packages/util-utf8-node/tsconfig.types.json
+++ b/packages/util-utf8-node/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "declarationDir": "./dist/types",
+    "declarationDir": "dist/types",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/util-waiter/tsconfig.cjs.json
+++ b/packages/util-waiter/tsconfig.cjs.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/cjs",
     "baseUrl": "."
   },

--- a/packages/util-waiter/tsconfig.cjs.json
+++ b/packages/util-waiter/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "./dist/cjs",
+    "outDir": "dist/cjs",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/util-waiter/tsconfig.es.json
+++ b/packages/util-waiter/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "lib": ["es5", "es2015.collection"],
     "rootDir": "src",
-    "outDir": "./dist/es",
+    "outDir": "dist/es",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/util-waiter/tsconfig.es.json
+++ b/packages/util-waiter/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es5", "es2015.collection"],
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/es",
     "baseUrl": "."
   },

--- a/packages/util-waiter/tsconfig.types.json
+++ b/packages/util-waiter/tsconfig.types.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "declarationDir": "./dist/types",
     "baseUrl": "."
   },

--- a/packages/util-waiter/tsconfig.types.json
+++ b/packages/util-waiter/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "declarationDir": "./dist/types",
+    "declarationDir": "dist/types",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/xml-builder/tsconfig.cjs.json
+++ b/packages/xml-builder/tsconfig.cjs.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/cjs",
     "baseUrl": "."
   },

--- a/packages/xml-builder/tsconfig.cjs.json
+++ b/packages/xml-builder/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "./dist/cjs",
+    "outDir": "dist/cjs",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/xml-builder/tsconfig.es.json
+++ b/packages/xml-builder/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "lib": ["es5", "es2015.collection"],
     "rootDir": "src",
-    "outDir": "./dist/es",
+    "outDir": "dist/es",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/xml-builder/tsconfig.es.json
+++ b/packages/xml-builder/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es5", "es2015.collection"],
-    "rootDir": "./src",
+    "rootDir": "src",
     "outDir": "./dist/es",
     "baseUrl": "."
   },

--- a/packages/xml-builder/tsconfig.types.json
+++ b/packages/xml-builder/tsconfig.types.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "src",
     "declarationDir": "./dist/types",
     "baseUrl": "."
   },

--- a/packages/xml-builder/tsconfig.types.json
+++ b/packages/xml-builder/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "declarationDir": "./dist/types",
+    "declarationDir": "dist/types",
     "baseUrl": "."
   },
   "extends": "../../tsconfig.types.json",


### PR DESCRIPTION
### Issue
The dot slash is not used in clients
https://github.com/aws/aws-sdk-js-v3/blob/d01420b247966c8ec84c1dd0a1b42512ede10c90/clients/client-s3/tsconfig.json#L14

### Description
Remove redundant dot slash in directory configurations

### Testing
Integration tests were successful:
```console
$ yarn test:integration
yarn run v1.22.11
$ jest --config jest.config.integ.js --passWithNoTests
 PASS  clients/client-transcribe-streaming/test/index.integ.spec.ts (29.635 s)
  TranscribeStream client
    ✓ should stream the transcript (28756 ms)

Test Suites: 1 passed, 1 total
Tests:       1 passed, 1 total
Snapshots:   0 total
Time:        30.119 s, estimated 32 s
Ran all test suites.
Done in 30.78s.

$ yarn test:integration-legacy
yarn run v1.22.11
$ cucumber-js --fail-fast
...............................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................

150 scenarios (150 passed)
523 steps (523 passed)
1m38.478s
Done in 105.69s.
```

### Additional context
Noticed while removing comments in https://github.com/aws/aws-sdk-js-v3/pull/2817

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
