### PR TITLE
chore(non-clients): sort npm scripts

### DIFF
--- a/lib/lib-dynamodb/package.json
+++ b/lib/lib-dynamodb/package.json
@@ -6,10 +6,10 @@
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "scripts": {
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },

--- a/lib/lib-storage/package.json
+++ b/lib/lib-storage/package.json
@@ -6,10 +6,10 @@
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "scripts": {
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },

--- a/packages/abort-controller/package.json
+++ b/packages/abort-controller/package.json
@@ -6,10 +6,10 @@
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "scripts": {
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },

--- a/packages/body-checksum-browser/package.json
+++ b/packages/body-checksum-browser/package.json
@@ -2,10 +2,10 @@
   "name": "@aws-sdk/body-checksum-browser",
   "version": "3.32.0",
   "scripts": {
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },

--- a/packages/body-checksum-node/package.json
+++ b/packages/body-checksum-node/package.json
@@ -2,10 +2,10 @@
   "name": "@aws-sdk/body-checksum-node",
   "version": "3.32.0",
   "scripts": {
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },

--- a/packages/chunked-blob-reader-native/package.json
+++ b/packages/chunked-blob-reader-native/package.json
@@ -2,10 +2,10 @@
   "name": "@aws-sdk/chunked-blob-reader-native",
   "version": "3.32.0",
   "scripts": {
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },

--- a/packages/chunked-blob-reader/package.json
+++ b/packages/chunked-blob-reader/package.json
@@ -2,10 +2,10 @@
   "name": "@aws-sdk/chunked-blob-reader",
   "version": "3.32.0",
   "scripts": {
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },

--- a/packages/chunked-stream-reader-node/package.json
+++ b/packages/chunked-stream-reader-node/package.json
@@ -2,10 +2,10 @@
   "name": "@aws-sdk/chunked-stream-reader-node",
   "version": "3.32.0",
   "scripts": {
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },

--- a/packages/client-documentation-generator/package.json
+++ b/packages/client-documentation-generator/package.json
@@ -2,10 +2,10 @@
   "name": "@aws-sdk/client-documentation-generator",
   "version": "3.32.0",
   "scripts": {
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "exit 0"
   },

--- a/packages/config-resolver/package.json
+++ b/packages/config-resolver/package.json
@@ -2,10 +2,10 @@
   "name": "@aws-sdk/config-resolver",
   "version": "3.33.0",
   "scripts": {
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },

--- a/packages/core-packages-documentation-generator/package.json
+++ b/packages/core-packages-documentation-generator/package.json
@@ -2,10 +2,10 @@
   "name": "@aws-sdk/core-packages-documentation-generator",
   "version": "3.32.0",
   "scripts": {
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "exit 0"
   },

--- a/packages/credential-provider-cognito-identity/package.json
+++ b/packages/credential-provider-cognito-identity/package.json
@@ -2,10 +2,10 @@
   "name": "@aws-sdk/credential-provider-cognito-identity",
   "version": "3.33.0",
   "scripts": {
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },

--- a/packages/credential-provider-env/package.json
+++ b/packages/credential-provider-env/package.json
@@ -5,10 +5,10 @@
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
   "scripts": {
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },

--- a/packages/credential-provider-imds/package.json
+++ b/packages/credential-provider-imds/package.json
@@ -5,10 +5,10 @@
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
   "scripts": {
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },

--- a/packages/credential-provider-ini/package.json
+++ b/packages/credential-provider-ini/package.json
@@ -5,10 +5,10 @@
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
   "scripts": {
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },

--- a/packages/credential-provider-node/package.json
+++ b/packages/credential-provider-node/package.json
@@ -8,10 +8,10 @@
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
   "scripts": {
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },

--- a/packages/credential-provider-process/package.json
+++ b/packages/credential-provider-process/package.json
@@ -5,10 +5,10 @@
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
   "scripts": {
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },

--- a/packages/credential-provider-sso/package.json
+++ b/packages/credential-provider-sso/package.json
@@ -5,10 +5,10 @@
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
   "scripts": {
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },

--- a/packages/credential-provider-web-identity/package.json
+++ b/packages/credential-provider-web-identity/package.json
@@ -5,10 +5,10 @@
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
   "scripts": {
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },

--- a/packages/credential-providers/package.json
+++ b/packages/credential-providers/package.json
@@ -20,10 +20,10 @@
   },
   "sideEffects": false,
   "scripts": {
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },

--- a/packages/endpoint-cache/package.json
+++ b/packages/endpoint-cache/package.json
@@ -2,10 +2,10 @@
   "name": "@aws-sdk/endpoint-cache",
   "version": "3.32.0",
   "scripts": {
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest --passWithNoTests"
   },

--- a/packages/eventstream-handler-node/package.json
+++ b/packages/eventstream-handler-node/package.json
@@ -2,10 +2,10 @@
   "name": "@aws-sdk/eventstream-handler-node",
   "version": "3.32.0",
   "scripts": {
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },

--- a/packages/eventstream-marshaller/package.json
+++ b/packages/eventstream-marshaller/package.json
@@ -2,10 +2,10 @@
   "name": "@aws-sdk/eventstream-marshaller",
   "version": "3.32.0",
   "scripts": {
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest --coverage"
   },

--- a/packages/eventstream-serde-browser/package.json
+++ b/packages/eventstream-serde-browser/package.json
@@ -2,10 +2,10 @@
   "name": "@aws-sdk/eventstream-serde-browser",
   "version": "3.32.0",
   "scripts": {
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },

--- a/packages/eventstream-serde-config-resolver/package.json
+++ b/packages/eventstream-serde-config-resolver/package.json
@@ -2,10 +2,10 @@
   "name": "@aws-sdk/eventstream-serde-config-resolver",
   "version": "3.32.0",
   "scripts": {
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },

--- a/packages/eventstream-serde-node/package.json
+++ b/packages/eventstream-serde-node/package.json
@@ -2,10 +2,10 @@
   "name": "@aws-sdk/eventstream-serde-node",
   "version": "3.32.0",
   "scripts": {
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },

--- a/packages/eventstream-serde-universal/package.json
+++ b/packages/eventstream-serde-universal/package.json
@@ -2,10 +2,10 @@
   "name": "@aws-sdk/eventstream-serde-universal",
   "version": "3.32.0",
   "scripts": {
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },

--- a/packages/fetch-http-handler/package.json
+++ b/packages/fetch-http-handler/package.json
@@ -3,10 +3,10 @@
   "version": "3.32.0",
   "description": "Provides a way to make requests",
   "scripts": {
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest --coverage && karma start karma.conf.js"
   },

--- a/packages/hash-blob-browser/package.json
+++ b/packages/hash-blob-browser/package.json
@@ -2,10 +2,10 @@
   "name": "@aws-sdk/hash-blob-browser",
   "version": "3.32.0",
   "scripts": {
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "karma start karma.conf.js"
   },

--- a/packages/hash-node/package.json
+++ b/packages/hash-node/package.json
@@ -2,10 +2,10 @@
   "name": "@aws-sdk/hash-node",
   "version": "3.32.0",
   "scripts": {
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },

--- a/packages/hash-stream-node/package.json
+++ b/packages/hash-stream-node/package.json
@@ -2,10 +2,10 @@
   "name": "@aws-sdk/hash-stream-node",
   "version": "3.32.0",
   "scripts": {
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },

--- a/packages/invalid-dependency/package.json
+++ b/packages/invalid-dependency/package.json
@@ -2,10 +2,10 @@
   "name": "@aws-sdk/invalid-dependency",
   "version": "3.32.0",
   "scripts": {
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },

--- a/packages/is-array-buffer/package.json
+++ b/packages/is-array-buffer/package.json
@@ -3,10 +3,10 @@
   "version": "3.32.0",
   "description": "Provides a function for detecting if an argument is an ArrayBuffer",
   "scripts": {
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },

--- a/packages/karma-credential-loader/package.json
+++ b/packages/karma-credential-loader/package.json
@@ -2,10 +2,10 @@
   "name": "@aws-sdk/karma-credential-loader",
   "version": "3.33.0",
   "scripts": {
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest --passWithNoTests"
   },

--- a/packages/md5-js/package.json
+++ b/packages/md5-js/package.json
@@ -2,10 +2,10 @@
   "name": "@aws-sdk/md5-js",
   "version": "3.32.0",
   "scripts": {
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },

--- a/packages/middleware-apply-body-checksum/package.json
+++ b/packages/middleware-apply-body-checksum/package.json
@@ -2,10 +2,10 @@
   "name": "@aws-sdk/middleware-apply-body-checksum",
   "version": "3.32.0",
   "scripts": {
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest --coverage"
   },

--- a/packages/middleware-bucket-endpoint/package.json
+++ b/packages/middleware-bucket-endpoint/package.json
@@ -2,10 +2,10 @@
   "name": "@aws-sdk/middleware-bucket-endpoint",
   "version": "3.33.0",
   "scripts": {
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },

--- a/packages/middleware-content-length/package.json
+++ b/packages/middleware-content-length/package.json
@@ -2,10 +2,10 @@
   "name": "@aws-sdk/middleware-content-length",
   "version": "3.32.0",
   "scripts": {
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },

--- a/packages/middleware-endpoint-discovery/package.json
+++ b/packages/middleware-endpoint-discovery/package.json
@@ -2,10 +2,10 @@
   "name": "@aws-sdk/middleware-endpoint-discovery",
   "version": "3.33.0",
   "scripts": {
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },

--- a/packages/middleware-eventstream/package.json
+++ b/packages/middleware-eventstream/package.json
@@ -2,10 +2,10 @@
   "name": "@aws-sdk/middleware-eventstream",
   "version": "3.32.0",
   "scripts": {
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },

--- a/packages/middleware-expect-continue/package.json
+++ b/packages/middleware-expect-continue/package.json
@@ -2,10 +2,10 @@
   "name": "@aws-sdk/middleware-expect-continue",
   "version": "3.32.0",
   "scripts": {
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },

--- a/packages/middleware-header-default/package.json
+++ b/packages/middleware-header-default/package.json
@@ -2,10 +2,10 @@
   "name": "@aws-sdk/middleware-header-default",
   "version": "3.32.0",
   "scripts": {
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },

--- a/packages/middleware-host-header/package.json
+++ b/packages/middleware-host-header/package.json
@@ -2,10 +2,10 @@
   "name": "@aws-sdk/middleware-host-header",
   "version": "3.32.0",
   "scripts": {
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },

--- a/packages/middleware-location-constraint/package.json
+++ b/packages/middleware-location-constraint/package.json
@@ -2,10 +2,10 @@
   "name": "@aws-sdk/middleware-location-constraint",
   "version": "3.32.0",
   "scripts": {
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },

--- a/packages/middleware-logger/package.json
+++ b/packages/middleware-logger/package.json
@@ -2,10 +2,10 @@
   "name": "@aws-sdk/middleware-logger",
   "version": "3.32.0",
   "scripts": {
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest --passWithNoTests"
   },

--- a/packages/middleware-retry/package.json
+++ b/packages/middleware-retry/package.json
@@ -2,10 +2,10 @@
   "name": "@aws-sdk/middleware-retry",
   "version": "3.32.0",
   "scripts": {
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },

--- a/packages/middleware-sdk-api-gateway/package.json
+++ b/packages/middleware-sdk-api-gateway/package.json
@@ -2,10 +2,10 @@
   "name": "@aws-sdk/middleware-sdk-api-gateway",
   "version": "3.32.0",
   "scripts": {
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },

--- a/packages/middleware-sdk-ec2/package.json
+++ b/packages/middleware-sdk-ec2/package.json
@@ -2,10 +2,10 @@
   "name": "@aws-sdk/middleware-sdk-ec2",
   "version": "3.33.0",
   "scripts": {
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },

--- a/packages/middleware-sdk-glacier/package.json
+++ b/packages/middleware-sdk-glacier/package.json
@@ -2,10 +2,10 @@
   "name": "@aws-sdk/middleware-sdk-glacier",
   "version": "3.32.0",
   "scripts": {
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },

--- a/packages/middleware-sdk-machinelearning/package.json
+++ b/packages/middleware-sdk-machinelearning/package.json
@@ -2,10 +2,10 @@
   "name": "@aws-sdk/middleware-sdk-machinelearning",
   "version": "3.32.0",
   "scripts": {
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },

--- a/packages/middleware-sdk-rds/package.json
+++ b/packages/middleware-sdk-rds/package.json
@@ -2,10 +2,10 @@
   "name": "@aws-sdk/middleware-sdk-rds",
   "version": "3.33.0",
   "scripts": {
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },

--- a/packages/middleware-sdk-route53/package.json
+++ b/packages/middleware-sdk-route53/package.json
@@ -2,10 +2,10 @@
   "name": "@aws-sdk/middleware-sdk-route53",
   "version": "3.32.0",
   "scripts": {
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },

--- a/packages/middleware-sdk-s3-control/package.json
+++ b/packages/middleware-sdk-s3-control/package.json
@@ -2,10 +2,10 @@
   "name": "@aws-sdk/middleware-sdk-s3-control",
   "version": "3.33.0",
   "scripts": {
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },

--- a/packages/middleware-sdk-s3/package.json
+++ b/packages/middleware-sdk-s3/package.json
@@ -2,10 +2,10 @@
   "name": "@aws-sdk/middleware-sdk-s3",
   "version": "3.33.0",
   "scripts": {
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },

--- a/packages/middleware-sdk-sqs/package.json
+++ b/packages/middleware-sdk-sqs/package.json
@@ -2,10 +2,10 @@
   "name": "@aws-sdk/middleware-sdk-sqs",
   "version": "3.32.0",
   "scripts": {
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },

--- a/packages/middleware-sdk-sts/package.json
+++ b/packages/middleware-sdk-sts/package.json
@@ -2,10 +2,10 @@
   "name": "@aws-sdk/middleware-sdk-sts",
   "version": "3.33.0",
   "scripts": {
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },

--- a/packages/middleware-sdk-transcribe-streaming/package.json
+++ b/packages/middleware-sdk-transcribe-streaming/package.json
@@ -5,10 +5,10 @@
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "scripts": {
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "pretest": "yarn build",
     "test": "jest --passWithNoTests"

--- a/packages/middleware-serde/package.json
+++ b/packages/middleware-serde/package.json
@@ -2,10 +2,10 @@
   "name": "@aws-sdk/middleware-serde",
   "version": "3.32.0",
   "scripts": {
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },

--- a/packages/middleware-signing/package.json
+++ b/packages/middleware-signing/package.json
@@ -2,10 +2,10 @@
   "name": "@aws-sdk/middleware-signing",
   "version": "3.33.0",
   "scripts": {
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },

--- a/packages/middleware-ssec/package.json
+++ b/packages/middleware-ssec/package.json
@@ -2,10 +2,10 @@
   "name": "@aws-sdk/middleware-ssec",
   "version": "3.32.0",
   "scripts": {
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },

--- a/packages/middleware-stack/package.json
+++ b/packages/middleware-stack/package.json
@@ -3,10 +3,10 @@
   "version": "3.32.0",
   "description": "Provides a means for composing multiple middleware functions into a single handler",
   "scripts": {
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },

--- a/packages/middleware-user-agent/package.json
+++ b/packages/middleware-user-agent/package.json
@@ -2,10 +2,10 @@
   "name": "@aws-sdk/middleware-user-agent",
   "version": "3.32.0",
   "scripts": {
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest --passWithNoTests"
   },

--- a/packages/node-config-provider/package.json
+++ b/packages/node-config-provider/package.json
@@ -3,10 +3,10 @@
   "version": "3.32.0",
   "description": "Load config default values from ini config files and environmental variable",
   "scripts": {
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest --passWithNoTests"
   },

--- a/packages/node-http-handler/package.json
+++ b/packages/node-http-handler/package.json
@@ -3,10 +3,10 @@
   "version": "3.32.0",
   "description": "Provides a way to make requests",
   "scripts": {
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest --coverage"
   },

--- a/packages/polly-request-presigner/package.json
+++ b/packages/polly-request-presigner/package.json
@@ -2,10 +2,10 @@
   "name": "@aws-sdk/polly-request-presigner",
   "version": "3.33.0",
   "scripts": {
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },

--- a/packages/property-provider/package.json
+++ b/packages/property-provider/package.json
@@ -2,10 +2,10 @@
   "name": "@aws-sdk/property-provider",
   "version": "3.32.0",
   "scripts": {
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },

--- a/packages/protocol-http/package.json
+++ b/packages/protocol-http/package.json
@@ -2,10 +2,10 @@
   "name": "@aws-sdk/protocol-http",
   "version": "3.32.0",
   "scripts": {
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },

--- a/packages/querystring-builder/package.json
+++ b/packages/querystring-builder/package.json
@@ -2,10 +2,10 @@
   "name": "@aws-sdk/querystring-builder",
   "version": "3.32.0",
   "scripts": {
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },

--- a/packages/querystring-parser/package.json
+++ b/packages/querystring-parser/package.json
@@ -2,10 +2,10 @@
   "name": "@aws-sdk/querystring-parser",
   "version": "3.32.0",
   "scripts": {
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },

--- a/packages/s3-presigned-post/package.json
+++ b/packages/s3-presigned-post/package.json
@@ -2,10 +2,10 @@
   "name": "@aws-sdk/s3-presigned-post",
   "version": "3.33.0",
   "scripts": {
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },

--- a/packages/s3-request-presigner/package.json
+++ b/packages/s3-request-presigner/package.json
@@ -2,10 +2,10 @@
   "name": "@aws-sdk/s3-request-presigner",
   "version": "3.33.0",
   "scripts": {
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },

--- a/packages/service-error-classification/package.json
+++ b/packages/service-error-classification/package.json
@@ -2,10 +2,10 @@
   "name": "@aws-sdk/service-error-classification",
   "version": "3.32.0",
   "scripts": {
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },

--- a/packages/sha256-tree-hash/package.json
+++ b/packages/sha256-tree-hash/package.json
@@ -2,10 +2,10 @@
   "name": "@aws-sdk/sha256-tree-hash",
   "version": "3.32.0",
   "scripts": {
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },

--- a/packages/shared-ini-file-loader/package.json
+++ b/packages/shared-ini-file-loader/package.json
@@ -11,10 +11,10 @@
     "typescript": "~4.3.5"
   },
   "scripts": {
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },

--- a/packages/signature-v4-crt/package.json
+++ b/packages/signature-v4-crt/package.json
@@ -6,10 +6,10 @@
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "scripts": {
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest --coverage"
   },

--- a/packages/signature-v4/package.json
+++ b/packages/signature-v4/package.json
@@ -6,10 +6,10 @@
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "scripts": {
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "pretest": "yarn build",
     "test": "jest --coverage"

--- a/packages/smithy-client/package.json
+++ b/packages/smithy-client/package.json
@@ -2,10 +2,10 @@
   "name": "@aws-sdk/smithy-client",
   "version": "3.32.0",
   "scripts": {
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest --passWithNoTests"
   },

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -9,10 +9,10 @@
     "typescript": "~4.3.5"
   },
   "scripts": {
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "exit 0"
   },

--- a/packages/url-parser/package.json
+++ b/packages/url-parser/package.json
@@ -2,10 +2,10 @@
   "name": "@aws-sdk/url-parser",
   "version": "3.32.0",
   "scripts": {
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },

--- a/packages/util-arn-parser/package.json
+++ b/packages/util-arn-parser/package.json
@@ -5,10 +5,10 @@
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
   "scripts": {
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },

--- a/packages/util-base64-browser/package.json
+++ b/packages/util-base64-browser/package.json
@@ -5,10 +5,10 @@
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
   "scripts": {
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },

--- a/packages/util-base64-node/package.json
+++ b/packages/util-base64-node/package.json
@@ -5,10 +5,10 @@
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
   "scripts": {
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },

--- a/packages/util-body-length-browser/package.json
+++ b/packages/util-body-length-browser/package.json
@@ -3,10 +3,10 @@
   "description": "Determines the length of a request body in browsers",
   "version": "3.32.0",
   "scripts": {
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },

--- a/packages/util-body-length-node/package.json
+++ b/packages/util-body-length-node/package.json
@@ -3,10 +3,10 @@
   "description": "Determines the length of a request body in node.js",
   "version": "3.32.0",
   "scripts": {
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },

--- a/packages/util-buffer-from/package.json
+++ b/packages/util-buffer-from/package.json
@@ -2,10 +2,10 @@
   "name": "@aws-sdk/util-buffer-from",
   "version": "3.32.0",
   "scripts": {
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },

--- a/packages/util-create-request/package.json
+++ b/packages/util-create-request/package.json
@@ -2,10 +2,10 @@
   "name": "@aws-sdk/util-create-request",
   "version": "3.32.0",
   "scripts": {
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },

--- a/packages/util-credentials/package.json
+++ b/packages/util-credentials/package.json
@@ -5,10 +5,10 @@
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
   "scripts": {
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },

--- a/packages/util-dynamodb/package.json
+++ b/packages/util-dynamodb/package.json
@@ -2,10 +2,10 @@
   "name": "@aws-sdk/util-dynamodb",
   "version": "3.33.0",
   "scripts": {
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },

--- a/packages/util-format-url/package.json
+++ b/packages/util-format-url/package.json
@@ -2,10 +2,10 @@
   "name": "@aws-sdk/util-format-url",
   "version": "3.32.0",
   "scripts": {
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },

--- a/packages/util-hex-encoding/package.json
+++ b/packages/util-hex-encoding/package.json
@@ -3,10 +3,10 @@
   "version": "3.32.0",
   "description": "Converts binary buffers to and from lowercase hexadecimal encoding",
   "scripts": {
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },

--- a/packages/util-locate-window/package.json
+++ b/packages/util-locate-window/package.json
@@ -2,10 +2,10 @@
   "name": "@aws-sdk/util-locate-window",
   "version": "3.32.0",
   "scripts": {
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },

--- a/packages/util-uri-escape/package.json
+++ b/packages/util-uri-escape/package.json
@@ -2,10 +2,10 @@
   "name": "@aws-sdk/util-uri-escape",
   "version": "3.32.0",
   "scripts": {
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },

--- a/packages/util-user-agent-browser/package.json
+++ b/packages/util-user-agent-browser/package.json
@@ -2,10 +2,10 @@
   "name": "@aws-sdk/util-user-agent-browser",
   "version": "3.32.0",
   "scripts": {
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },

--- a/packages/util-user-agent-node/package.json
+++ b/packages/util-user-agent-node/package.json
@@ -2,10 +2,10 @@
   "name": "@aws-sdk/util-user-agent-node",
   "version": "3.33.0",
   "scripts": {
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },

--- a/packages/util-utf8-browser/package.json
+++ b/packages/util-utf8-browser/package.json
@@ -5,10 +5,10 @@
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
   "scripts": {
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },

--- a/packages/util-utf8-node/package.json
+++ b/packages/util-utf8-node/package.json
@@ -5,10 +5,10 @@
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
   "scripts": {
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },

--- a/packages/util-waiter/package.json
+++ b/packages/util-waiter/package.json
@@ -13,10 +13,10 @@
     "typescript": "~4.3.5"
   },
   "scripts": {
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },

--- a/packages/xml-builder/package.json
+++ b/packages/xml-builder/package.json
@@ -11,10 +11,10 @@
     "typescript": "~4.3.5"
   },
   "scripts": {
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
     "test": "jest"
   },


### PR DESCRIPTION
### Issue
Follow-up to https://github.com/aws/aws-sdk-js-v3/pull/2821

### Description
Sorts npm scripts in alphabetical order

Achieved by running the following script in `packages` and `lib`:
```js
const { readdirSync, readFileSync, writeFileSync } = require("fs");
const { join } = require("path");

readdirSync(join(process.cwd()), { withFileTypes: true })
  .filter((dirent) => dirent.isDirectory())
  .map((dirent) => dirent.name)
  .forEach((workspaceName) => {
    const packageJsonPath = join(process.cwd(), workspaceName, "package.json");
    const packageJson = JSON.parse(readFileSync(packageJsonPath).toString());
    packageJson.scripts = Object.fromEntries(Object.entries(packageJson.scripts).sort());
    writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, 2).concat(`\n`));
  });
```

### Testing
N/A

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
