### PR TITLE
chore(tsconfig): remove default and redundant options

### DIFF
--- a/packages/client-documentation-generator/tsconfig.types.json
+++ b/packages/client-documentation-generator/tsconfig.types.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "declarationDir": "dist/types",
+    "experimentalDecorators": true,
     "rootDir": "src",
     "strict": false
   },

--- a/packages/core-packages-documentation-generator/tsconfig.types.json
+++ b/packages/core-packages-documentation-generator/tsconfig.types.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "declarationDir": "dist/types",
+    "experimentalDecorators": true,
     "rootDir": "src",
     "strict": false
   },

--- a/packages/credential-provider-cognito-identity/tsconfig.es.json
+++ b/packages/credential-provider-cognito-identity/tsconfig.es.json
@@ -2,12 +2,9 @@
   "compilerOptions": {
     "baseUrl": ".",
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "module": "esnext",
-    "moduleResolution": "node",
     "noUnusedLocals": true,
     "outDir": "dist/es",
-    "rootDir": "src",
-    "target": "es5"
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",
   "include": ["src/"]

--- a/packages/middleware-sdk-transcribe-streaming/tsconfig.es.json
+++ b/packages/middleware-sdk-transcribe-streaming/tsconfig.es.json
@@ -1,14 +1,10 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "incremental": true,
     "lib": ["es5", "es2015.promise", "es2015.collection", "DOM"],
-    "module": "esNext",
-    "moduleResolution": "node",
     "outDir": "dist/es",
     "rootDir": "src",
-    "stripInternal": true,
-    "target": "ES2015"
+    "stripInternal": true
   },
   "extends": "../../tsconfig.es.json",
   "include": ["src/"]

--- a/packages/signature-v4-crt/tsconfig.es.json
+++ b/packages/signature-v4-crt/tsconfig.es.json
@@ -1,15 +1,11 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "incremental": true,
     "lib": ["es5", "es2015.promise", "es2015.collection"],
-    "module": "esNext",
-    "moduleResolution": "node",
     "noUnusedLocals": true,
     "outDir": "dist/es",
     "rootDir": "src",
-    "stripInternal": true,
-    "target": "es5"
+    "stripInternal": true
   },
   "extends": "../../tsconfig.es.json",
   "include": ["src/"]

--- a/packages/signature-v4/tsconfig.es.json
+++ b/packages/signature-v4/tsconfig.es.json
@@ -1,15 +1,11 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "incremental": true,
     "lib": ["es5", "es2015.promise", "es2015.collection"],
-    "module": "esNext",
-    "moduleResolution": "node",
     "noUnusedLocals": true,
     "outDir": "dist/es",
     "rootDir": "src",
-    "stripInternal": true,
-    "target": "es5"
+    "stripInternal": true
   },
   "extends": "../../tsconfig.es.json",
   "include": ["src/"]

--- a/tsconfig.cjs.json
+++ b/tsconfig.cjs.json
@@ -1,14 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "importHelpers": true,
-    "inlineSourceMap": true,
-    "inlineSources": true,
     "module": "commonjs",
-    "moduleResolution": "node",
-    "noEmitHelpers": true,
-    "sourceMap": false,
-    "strict": true,
     "target": "ES2018"
   }
 }

--- a/tsconfig.cjs.json
+++ b/tsconfig.cjs.json
@@ -7,7 +7,6 @@
     "module": "commonjs",
     "moduleResolution": "node",
     "noEmitHelpers": true,
-    "removeComments": true,
     "sourceMap": false,
     "strict": true,
     "target": "ES2018"

--- a/tsconfig.cjs.json
+++ b/tsconfig.cjs.json
@@ -1,7 +1,10 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "importHelpers": true,
     "module": "commonjs",
-    "target": "ES2018"
+    "noEmitHelpers": true,
+    "target": "ES2018",
+    "strict": true
   }
 }

--- a/tsconfig.es.json
+++ b/tsconfig.es.json
@@ -1,7 +1,6 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "downlevelIteration": true,
     "importHelpers": true,
     "inlineSourceMap": true,
     "inlineSources": true,

--- a/tsconfig.es.json
+++ b/tsconfig.es.json
@@ -1,7 +1,10 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "importHelpers": true,
     "module": "esnext",
-    "target": "es5"
+    "noEmitHelpers": true,
+    "target": "es5",
+    "strict": true
   }
 }

--- a/tsconfig.es.json
+++ b/tsconfig.es.json
@@ -1,14 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "importHelpers": true,
-    "inlineSourceMap": true,
-    "inlineSources": true,
     "module": "esnext",
-    "moduleResolution": "node",
-    "noEmitHelpers": true,
-    "sourceMap": false,
-    "strict": true,
     "target": "es5"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "downlevelIteration": true,
+    "esModuleInterop": true,
     "resolveJsonModule": true,
     "incremental": true,
     "lib": ["es2015", "dom"],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,15 +1,14 @@
 {
   "compilerOptions": {
-    "baseUrl": ".",
     "downlevelIteration": true,
-    "esModuleInterop": true,
-    "experimentalDecorators": true,
+    "resolveJsonModule": true,
+    "noUnusedParameters": false,
+    "removeComments": false,
     "incremental": true,
     "lib": ["es2015", "dom"],
     "module": "commonjs",
     "moduleResolution": "node",
     "noFallthroughCasesInSwitch": true,
-    "noUnusedParameters": false,
     "paths": {
       "@aws-sdk/*": ["packages/*/src"],
       "@aws-sdk/client-*": ["clients/client-*/"],
@@ -17,8 +16,6 @@
       "@aws-sdk/lib-*": ["lib/*"]
     },
     "preserveConstEnums": true,
-    "removeComments": false,
-    "resolveJsonModule": true,
     "sourceMap": true,
     "target": "es5"
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,12 +1,16 @@
 {
   "compilerOptions": {
+    "baseUrl": ".",
     "downlevelIteration": true,
     "esModuleInterop": true,
-    "resolveJsonModule": true,
+    "importHelpers": true,
+    "inlineSourceMap": true,
+    "inlineSources": true,
     "incremental": true,
     "lib": ["es2015", "dom"],
     "module": "commonjs",
     "moduleResolution": "node",
+    "noEmitHelpers": true,
     "noFallthroughCasesInSwitch": true,
     "paths": {
       "@aws-sdk/*": ["packages/*/src"],
@@ -16,7 +20,8 @@
     },
     "preserveConstEnums": true,
     "removeComments": true,
-    "sourceMap": true,
+    "resolveJsonModule": true,
+    "strict": true,
     "target": "es5"
   },
   "include": ["packages/", "lib/"],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,6 +15,7 @@
       "@aws-sdk/lib-*": ["lib/*"]
     },
     "preserveConstEnums": true,
+    "removeComments": true,
     "sourceMap": true,
     "target": "es5"
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,8 +2,6 @@
   "compilerOptions": {
     "downlevelIteration": true,
     "resolveJsonModule": true,
-    "noUnusedParameters": false,
-    "removeComments": false,
     "incremental": true,
     "lib": ["es2015", "dom"],
     "module": "commonjs",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,14 +3,12 @@
     "baseUrl": ".",
     "downlevelIteration": true,
     "esModuleInterop": true,
-    "importHelpers": true,
     "inlineSourceMap": true,
     "inlineSources": true,
     "incremental": true,
     "lib": ["es2015", "dom"],
     "module": "commonjs",
     "moduleResolution": "node",
-    "noEmitHelpers": true,
     "noFallthroughCasesInSwitch": true,
     "paths": {
       "@aws-sdk/*": ["packages/*/src"],
@@ -21,7 +19,6 @@
     "preserveConstEnums": true,
     "removeComments": true,
     "resolveJsonModule": true,
-    "strict": true,
     "target": "es5"
   },
   "include": ["packages/", "lib/"],

--- a/tsconfig.types.json
+++ b/tsconfig.types.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "declaration": true,
     "emitDeclarationOnly": true,
-    "strict": true
+    "strict": true,
+    "removeComments": false
   }
 }

--- a/tsconfig.types.json
+++ b/tsconfig.types.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "declaration": true,
     "emitDeclarationOnly": true,
-    "removeComments": false
+    "removeComments": false,
+    "strict": true
   }
 }

--- a/tsconfig.types.json
+++ b/tsconfig.types.json
@@ -3,7 +3,6 @@
   "compilerOptions": {
     "declaration": true,
     "emitDeclarationOnly": true,
-    "strict": true,
     "removeComments": false
   }
 }


### PR DESCRIPTION
### Issue
Internal JS-2845

### Description
Cleans up tsconfig by removing default and redundant options

### Testing
Integration tests are successful:

```console
$ yarn test:integration
yarn run v1.22.11
$ jest --config jest.config.integ.js --passWithNoTests
 PASS  clients/client-transcribe-streaming/test/index.integ.spec.ts (31.608 s)
  TranscribeStream client
    ✓ should stream the transcript (28774 ms)

Test Suites: 1 passed, 1 total
Tests:       1 passed, 1 total
Snapshots:   0 total
Time:        32.093 s
Ran all test suites.
Done in 32.76s.

$ yarn test:integration-legacy
yarn run v1.22.11
$ cucumber-js --fail-fast
...............................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................

150 scenarios (150 passed)
523 steps (523 passed)
1m34.657s
Done in 98.88s.
```

The remaining tests will be run in as a dry-run release after merging.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
