### PR TITLE
chore(non-clients): sort tsconfig compilerOptions

### DIFF
--- a/lib/lib-dynamodb/tsconfig.cjs.json
+++ b/lib/lib-dynamodb/tsconfig.cjs.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "outDir": "dist/cjs",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",
   "include": ["src/"]

--- a/lib/lib-dynamodb/tsconfig.es.json
+++ b/lib/lib-dynamodb/tsconfig.es.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
+    "baseUrl": ".",
     "lib": ["es5", "es2015.collection", "dom"],
-    "rootDir": "src",
     "outDir": "dist/es",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",
   "include": ["src/"]

--- a/lib/lib-dynamodb/tsconfig.types.json
+++ b/lib/lib-dynamodb/tsconfig.types.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "declarationDir": "dist/types",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",
   "include": ["src/"]

--- a/lib/lib-storage/tsconfig.cjs.json
+++ b/lib/lib-storage/tsconfig.cjs.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
+    "baseUrl": ".",
     "lib": ["es5", "es2015.collection", "dom"],
-    "rootDir": "src",
     "outDir": "dist/cjs",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",
   "include": ["src/"]

--- a/lib/lib-storage/tsconfig.es.json
+++ b/lib/lib-storage/tsconfig.es.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
+    "baseUrl": ".",
     "lib": ["es5", "es2015.collection", "dom"],
-    "rootDir": "src",
     "outDir": "dist/es",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",
   "include": ["src/"]

--- a/lib/lib-storage/tsconfig.types.json
+++ b/lib/lib-storage/tsconfig.types.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "declarationDir": "dist/types",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",
   "include": ["src/"]

--- a/packages/abort-controller/tsconfig.cjs.json
+++ b/packages/abort-controller/tsconfig.cjs.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
-    "stripInternal": true,
-    "rootDir": "src",
+    "baseUrl": ".",
     "outDir": "dist/cjs",
-    "baseUrl": "."
+    "rootDir": "src",
+    "stripInternal": true
   },
   "extends": "../../tsconfig.cjs.json",
   "include": ["src/"]

--- a/packages/abort-controller/tsconfig.es.json
+++ b/packages/abort-controller/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "compilerOptions": {
+    "baseUrl": ".",
     "lib": ["es5", "es2015.collection"],
-    "stripInternal": true,
-    "rootDir": "src",
     "outDir": "dist/es",
-    "baseUrl": "."
+    "rootDir": "src",
+    "stripInternal": true
   },
   "extends": "../../tsconfig.es.json",
   "include": ["src/"]

--- a/packages/abort-controller/tsconfig.types.json
+++ b/packages/abort-controller/tsconfig.types.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "declarationDir": "dist/types",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",
   "include": ["src/"]

--- a/packages/body-checksum-browser/tsconfig.cjs.json
+++ b/packages/body-checksum-browser/tsconfig.cjs.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "outDir": "dist/cjs",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",
   "include": ["src/"]

--- a/packages/body-checksum-browser/tsconfig.es.json
+++ b/packages/body-checksum-browser/tsconfig.es.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
+    "baseUrl": ".",
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "rootDir": "src",
     "outDir": "dist/es",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",
   "include": ["src/"]

--- a/packages/body-checksum-browser/tsconfig.types.json
+++ b/packages/body-checksum-browser/tsconfig.types.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "declarationDir": "dist/types",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",
   "include": ["src/"]

--- a/packages/body-checksum-node/tsconfig.cjs.json
+++ b/packages/body-checksum-node/tsconfig.cjs.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "outDir": "dist/cjs",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",
   "include": ["src/"]

--- a/packages/body-checksum-node/tsconfig.es.json
+++ b/packages/body-checksum-node/tsconfig.es.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
+    "baseUrl": ".",
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "rootDir": "src",
     "outDir": "dist/es",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",
   "include": ["src/"]

--- a/packages/body-checksum-node/tsconfig.types.json
+++ b/packages/body-checksum-node/tsconfig.types.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "declarationDir": "dist/types",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",
   "include": ["src/"]

--- a/packages/chunked-blob-reader-native/tsconfig.cjs.json
+++ b/packages/chunked-blob-reader-native/tsconfig.cjs.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "outDir": "dist/cjs",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",
   "include": ["src/"]

--- a/packages/chunked-blob-reader-native/tsconfig.es.json
+++ b/packages/chunked-blob-reader-native/tsconfig.es.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
+    "baseUrl": ".",
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "rootDir": "src",
     "outDir": "dist/es",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",
   "include": ["src/"]

--- a/packages/chunked-blob-reader-native/tsconfig.types.json
+++ b/packages/chunked-blob-reader-native/tsconfig.types.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "declarationDir": "dist/types",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",
   "include": ["src/"]

--- a/packages/chunked-blob-reader/tsconfig.cjs.json
+++ b/packages/chunked-blob-reader/tsconfig.cjs.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "outDir": "dist/cjs",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",
   "include": ["src/"]

--- a/packages/chunked-blob-reader/tsconfig.es.json
+++ b/packages/chunked-blob-reader/tsconfig.es.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
+    "baseUrl": ".",
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "rootDir": "src",
     "outDir": "dist/es",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",
   "include": ["src/"]

--- a/packages/chunked-blob-reader/tsconfig.types.json
+++ b/packages/chunked-blob-reader/tsconfig.types.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "declarationDir": "dist/types",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",
   "include": ["src/"]

--- a/packages/chunked-stream-reader-node/tsconfig.cjs.json
+++ b/packages/chunked-stream-reader-node/tsconfig.cjs.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "outDir": "dist/cjs",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",
   "include": ["src/"]

--- a/packages/chunked-stream-reader-node/tsconfig.es.json
+++ b/packages/chunked-stream-reader-node/tsconfig.es.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "outDir": "dist/es",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",
   "include": ["src/"]

--- a/packages/chunked-stream-reader-node/tsconfig.types.json
+++ b/packages/chunked-stream-reader-node/tsconfig.types.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "declarationDir": "dist/types",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",
   "include": ["src/"]

--- a/packages/client-documentation-generator/tsconfig.cjs.json
+++ b/packages/client-documentation-generator/tsconfig.cjs.json
@@ -1,11 +1,11 @@
 {
   "compilerOptions": {
-    "strict": false,
-    "rootDir": "src",
-    "outDir": "dist/cjs",
+    "baseUrl": ".",
     "experimentalDecorators": true,
+    "outDir": "dist/cjs",
     "pretty": true,
-    "baseUrl": "."
+    "rootDir": "src",
+    "strict": false
   },
   "extends": "../../tsconfig.cjs.json",
   "include": ["src/"]

--- a/packages/client-documentation-generator/tsconfig.es.json
+++ b/packages/client-documentation-generator/tsconfig.es.json
@@ -1,12 +1,12 @@
 {
   "compilerOptions": {
-    "strict": false,
-    "lib": ["es2015"],
-    "rootDir": "src",
-    "outDir": "dist/es",
+    "baseUrl": ".",
     "experimentalDecorators": true,
+    "lib": ["es2015"],
+    "outDir": "dist/es",
     "pretty": true,
-    "baseUrl": "."
+    "rootDir": "src",
+    "strict": false
   },
   "extends": "../../tsconfig.es.json",
   "include": ["src/"]

--- a/packages/client-documentation-generator/tsconfig.types.json
+++ b/packages/client-documentation-generator/tsconfig.types.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
-    "strict": false,
-    "rootDir": "src",
+    "baseUrl": ".",
     "declarationDir": "dist/types",
-    "baseUrl": "."
+    "rootDir": "src",
+    "strict": false
   },
   "extends": "../../tsconfig.types.json",
   "include": ["src/"]

--- a/packages/config-resolver/tsconfig.cjs.json
+++ b/packages/config-resolver/tsconfig.cjs.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "outDir": "dist/cjs",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",
   "include": ["src/"]

--- a/packages/config-resolver/tsconfig.es.json
+++ b/packages/config-resolver/tsconfig.es.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
+    "baseUrl": ".",
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "rootDir": "src",
     "outDir": "dist/es",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",
   "include": ["src/"]

--- a/packages/config-resolver/tsconfig.types.json
+++ b/packages/config-resolver/tsconfig.types.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "declarationDir": "dist/types",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",
   "include": ["src/"]

--- a/packages/core-packages-documentation-generator/tsconfig.cjs.json
+++ b/packages/core-packages-documentation-generator/tsconfig.cjs.json
@@ -1,11 +1,11 @@
 {
   "compilerOptions": {
-    "strict": false,
-    "rootDir": "src",
-    "outDir": "dist/cjs",
+    "baseUrl": ".",
     "experimentalDecorators": true,
+    "outDir": "dist/cjs",
     "pretty": true,
-    "baseUrl": "."
+    "rootDir": "src",
+    "strict": false
   },
   "extends": "../../tsconfig.cjs.json",
   "include": ["src/"]

--- a/packages/core-packages-documentation-generator/tsconfig.es.json
+++ b/packages/core-packages-documentation-generator/tsconfig.es.json
@@ -1,12 +1,12 @@
 {
   "compilerOptions": {
-    "strict": false,
-    "lib": ["es2015"],
-    "rootDir": "src",
-    "outDir": "dist/es",
+    "baseUrl": ".",
     "experimentalDecorators": true,
+    "lib": ["es2015"],
+    "outDir": "dist/es",
     "pretty": true,
-    "baseUrl": "."
+    "rootDir": "src",
+    "strict": false
   },
   "extends": "../../tsconfig.es.json",
   "include": ["src/"]

--- a/packages/core-packages-documentation-generator/tsconfig.types.json
+++ b/packages/core-packages-documentation-generator/tsconfig.types.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
-    "strict": false,
-    "rootDir": "src",
+    "baseUrl": ".",
     "declarationDir": "dist/types",
-    "baseUrl": "."
+    "rootDir": "src",
+    "strict": false
   },
   "extends": "../../tsconfig.types.json",
   "include": ["src/"]

--- a/packages/credential-provider-cognito-identity/tsconfig.cjs.json
+++ b/packages/credential-provider-cognito-identity/tsconfig.cjs.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
-    "outDir": "dist/cjs",
+    "baseUrl": ".",
     "noUnusedLocals": true,
-    "baseUrl": "."
+    "outDir": "dist/cjs",
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",
   "include": ["src/"]

--- a/packages/credential-provider-cognito-identity/tsconfig.es.json
+++ b/packages/credential-provider-cognito-identity/tsconfig.es.json
@@ -1,13 +1,13 @@
 {
   "compilerOptions": {
-    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "rootDir": "src",
-    "outDir": "dist/es",
-    "noUnusedLocals": true,
     "baseUrl": ".",
-    "target": "es5",
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "module": "esnext",
-    "moduleResolution": "node"
+    "moduleResolution": "node",
+    "noUnusedLocals": true,
+    "outDir": "dist/es",
+    "rootDir": "src",
+    "target": "es5"
   },
   "extends": "../../tsconfig.es.json",
   "include": ["src/"]

--- a/packages/credential-provider-cognito-identity/tsconfig.types.json
+++ b/packages/credential-provider-cognito-identity/tsconfig.types.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "declarationDir": "dist/types",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",
   "include": ["src/"]

--- a/packages/credential-provider-env/tsconfig.cjs.json
+++ b/packages/credential-provider-env/tsconfig.cjs.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "outDir": "dist/cjs",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",
   "include": ["src/"]

--- a/packages/credential-provider-env/tsconfig.es.json
+++ b/packages/credential-provider-env/tsconfig.es.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
+    "baseUrl": ".",
     "lib": ["es5", "es2015.promise", "es2015.collection"],
-    "rootDir": "src",
     "outDir": "dist/es",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",
   "include": ["src/"]

--- a/packages/credential-provider-env/tsconfig.types.json
+++ b/packages/credential-provider-env/tsconfig.types.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "declarationDir": "dist/types",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",
   "include": ["src/"]

--- a/packages/credential-provider-imds/tsconfig.cjs.json
+++ b/packages/credential-provider-imds/tsconfig.cjs.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "outDir": "dist/cjs",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",
   "include": ["src/"]

--- a/packages/credential-provider-imds/tsconfig.es.json
+++ b/packages/credential-provider-imds/tsconfig.es.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
+    "baseUrl": ".",
     "lib": ["es5", "es2015.promise", "es2015.collection"],
-    "rootDir": "src",
     "outDir": "dist/es",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",
   "include": ["src/"]

--- a/packages/credential-provider-imds/tsconfig.types.json
+++ b/packages/credential-provider-imds/tsconfig.types.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "declarationDir": "dist/types",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",
   "include": ["src/"]

--- a/packages/credential-provider-ini/tsconfig.cjs.json
+++ b/packages/credential-provider-ini/tsconfig.cjs.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "outDir": "dist/cjs",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",
   "include": ["src/"]

--- a/packages/credential-provider-ini/tsconfig.es.json
+++ b/packages/credential-provider-ini/tsconfig.es.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
+    "baseUrl": ".",
     "lib": ["es5", "es2015.promise", "es2015.collection"],
-    "rootDir": "src",
     "outDir": "dist/es",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",
   "include": ["src/"]

--- a/packages/credential-provider-ini/tsconfig.types.json
+++ b/packages/credential-provider-ini/tsconfig.types.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "declarationDir": "dist/types",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",
   "include": ["src/"]

--- a/packages/credential-provider-node/tsconfig.cjs.json
+++ b/packages/credential-provider-node/tsconfig.cjs.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "outDir": "dist/cjs",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",
   "include": ["src/"]

--- a/packages/credential-provider-node/tsconfig.es.json
+++ b/packages/credential-provider-node/tsconfig.es.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "outDir": "dist/es",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",
   "include": ["src/"]

--- a/packages/credential-provider-node/tsconfig.types.json
+++ b/packages/credential-provider-node/tsconfig.types.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "declarationDir": "dist/types",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",
   "include": ["src/"]

--- a/packages/credential-provider-process/tsconfig.cjs.json
+++ b/packages/credential-provider-process/tsconfig.cjs.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "outDir": "dist/cjs",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",
   "include": ["src/"]

--- a/packages/credential-provider-process/tsconfig.es.json
+++ b/packages/credential-provider-process/tsconfig.es.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
+    "baseUrl": ".",
     "lib": ["es5", "es2015.promise", "es2015.collection"],
-    "rootDir": "src",
     "outDir": "dist/es",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",
   "include": ["src/"]

--- a/packages/credential-provider-process/tsconfig.types.json
+++ b/packages/credential-provider-process/tsconfig.types.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "declarationDir": "dist/types",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",
   "include": ["src/"]

--- a/packages/credential-provider-sso/tsconfig.cjs.json
+++ b/packages/credential-provider-sso/tsconfig.cjs.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "outDir": "dist/cjs",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",
   "include": ["src/"]

--- a/packages/credential-provider-sso/tsconfig.es.json
+++ b/packages/credential-provider-sso/tsconfig.es.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
+    "baseUrl": ".",
     "lib": ["es5", "es2015.promise", "es2015.collection"],
-    "rootDir": "src",
     "outDir": "dist/es",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",
   "include": ["src/"]

--- a/packages/credential-provider-sso/tsconfig.types.json
+++ b/packages/credential-provider-sso/tsconfig.types.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "declarationDir": "dist/types",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",
   "include": ["src/"]

--- a/packages/credential-provider-web-identity/tsconfig.cjs.json
+++ b/packages/credential-provider-web-identity/tsconfig.cjs.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "outDir": "dist/cjs",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",
   "include": ["src/"]

--- a/packages/credential-provider-web-identity/tsconfig.es.json
+++ b/packages/credential-provider-web-identity/tsconfig.es.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
+    "baseUrl": ".",
     "lib": ["es5", "es2015.promise", "es2015.collection"],
-    "rootDir": "src",
     "outDir": "dist/es",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",
   "include": ["src/"]

--- a/packages/credential-provider-web-identity/tsconfig.types.json
+++ b/packages/credential-provider-web-identity/tsconfig.types.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "declarationDir": "dist/types",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",
   "include": ["src/"]

--- a/packages/credential-providers/tsconfig.cjs.json
+++ b/packages/credential-providers/tsconfig.cjs.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "outDir": "dist/cjs",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",
   "include": ["src/"]

--- a/packages/credential-providers/tsconfig.es.json
+++ b/packages/credential-providers/tsconfig.es.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
+    "baseUrl": ".",
     "lib": ["es5", "es2015.promise", "es2015.collection"],
-    "rootDir": "src",
     "outDir": "dist/es",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",
   "include": ["src/"]

--- a/packages/credential-providers/tsconfig.types.json
+++ b/packages/credential-providers/tsconfig.types.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "declarationDir": "dist/types",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",
   "include": ["src/"]

--- a/packages/endpoint-cache/tsconfig.cjs.json
+++ b/packages/endpoint-cache/tsconfig.cjs.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "outDir": "dist/cjs",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",
   "include": ["src/"]

--- a/packages/endpoint-cache/tsconfig.es.json
+++ b/packages/endpoint-cache/tsconfig.es.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
+    "baseUrl": ".",
     "lib": ["es5", "es2015.promise", "es2015.iterable"],
-    "rootDir": "src",
     "outDir": "dist/es",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",
   "include": ["src/"]

--- a/packages/endpoint-cache/tsconfig.types.json
+++ b/packages/endpoint-cache/tsconfig.types.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "declarationDir": "dist/types",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",
   "include": ["src/"]

--- a/packages/eventstream-handler-node/tsconfig.cjs.json
+++ b/packages/eventstream-handler-node/tsconfig.cjs.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "outDir": "dist/cjs",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",
   "include": ["src/"]

--- a/packages/eventstream-handler-node/tsconfig.es.json
+++ b/packages/eventstream-handler-node/tsconfig.es.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
+    "baseUrl": ".",
     "lib": ["es2018.asynciterable"],
-    "rootDir": "src",
     "outDir": "dist/es",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",
   "include": ["src/"]

--- a/packages/eventstream-handler-node/tsconfig.types.json
+++ b/packages/eventstream-handler-node/tsconfig.types.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "declarationDir": "dist/types",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",
   "include": ["src/"]

--- a/packages/eventstream-marshaller/tsconfig.cjs.json
+++ b/packages/eventstream-marshaller/tsconfig.cjs.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "outDir": "dist/cjs",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",
   "include": ["src/"]

--- a/packages/eventstream-marshaller/tsconfig.es.json
+++ b/packages/eventstream-marshaller/tsconfig.es.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
+    "baseUrl": ".",
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "rootDir": "src",
     "outDir": "dist/es",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",
   "include": ["src/"]

--- a/packages/eventstream-marshaller/tsconfig.types.json
+++ b/packages/eventstream-marshaller/tsconfig.types.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "declarationDir": "dist/types",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",
   "include": ["src/"]

--- a/packages/eventstream-serde-browser/tsconfig.cjs.json
+++ b/packages/eventstream-serde-browser/tsconfig.cjs.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "outDir": "dist/cjs",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",
   "include": ["src/"]

--- a/packages/eventstream-serde-browser/tsconfig.es.json
+++ b/packages/eventstream-serde-browser/tsconfig.es.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
+    "baseUrl": ".",
     "lib": ["es2018.asynciterable", "DOM"],
-    "rootDir": "src",
     "outDir": "dist/es",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",
   "include": ["src/"]

--- a/packages/eventstream-serde-browser/tsconfig.types.json
+++ b/packages/eventstream-serde-browser/tsconfig.types.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "declarationDir": "dist/types",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",
   "include": ["src/"]

--- a/packages/eventstream-serde-config-resolver/tsconfig.cjs.json
+++ b/packages/eventstream-serde-config-resolver/tsconfig.cjs.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "outDir": "dist/cjs",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",
   "include": ["src/"]

--- a/packages/eventstream-serde-config-resolver/tsconfig.es.json
+++ b/packages/eventstream-serde-config-resolver/tsconfig.es.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
+    "baseUrl": ".",
     "lib": ["es2018.asynciterable"],
-    "rootDir": "src",
     "outDir": "dist/es",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",
   "include": ["src/"]

--- a/packages/eventstream-serde-config-resolver/tsconfig.types.json
+++ b/packages/eventstream-serde-config-resolver/tsconfig.types.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "declarationDir": "dist/types",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",
   "include": ["src/"]

--- a/packages/eventstream-serde-node/tsconfig.cjs.json
+++ b/packages/eventstream-serde-node/tsconfig.cjs.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "outDir": "dist/cjs",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",
   "include": ["src/"]

--- a/packages/eventstream-serde-node/tsconfig.es.json
+++ b/packages/eventstream-serde-node/tsconfig.es.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
+    "baseUrl": ".",
     "lib": ["es2018.asynciterable"],
-    "rootDir": "src",
     "outDir": "dist/es",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",
   "include": ["src/"]

--- a/packages/eventstream-serde-node/tsconfig.types.json
+++ b/packages/eventstream-serde-node/tsconfig.types.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "declarationDir": "dist/types",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",
   "include": ["src/"]

--- a/packages/eventstream-serde-universal/tsconfig.cjs.json
+++ b/packages/eventstream-serde-universal/tsconfig.cjs.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "outDir": "dist/cjs",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",
   "include": ["src/"]

--- a/packages/eventstream-serde-universal/tsconfig.es.json
+++ b/packages/eventstream-serde-universal/tsconfig.es.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
+    "baseUrl": ".",
     "lib": ["es2018.asynciterable"],
-    "rootDir": "src",
     "outDir": "dist/es",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",
   "include": ["src/"]

--- a/packages/eventstream-serde-universal/tsconfig.types.json
+++ b/packages/eventstream-serde-universal/tsconfig.types.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "declarationDir": "dist/types",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",
   "include": ["src/"]

--- a/packages/fetch-http-handler/tsconfig.cjs.json
+++ b/packages/fetch-http-handler/tsconfig.cjs.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "outDir": "dist/cjs",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",
   "include": ["src/"]

--- a/packages/fetch-http-handler/tsconfig.es.json
+++ b/packages/fetch-http-handler/tsconfig.es.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
+    "baseUrl": ".",
     "lib": ["dom", "es5", "es2015.promise", "es2015.iterable"],
-    "rootDir": "src",
     "outDir": "dist/es",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",
   "include": ["src/"]

--- a/packages/fetch-http-handler/tsconfig.types.json
+++ b/packages/fetch-http-handler/tsconfig.types.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "declarationDir": "dist/types",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",
   "include": ["src/"]

--- a/packages/hash-blob-browser/tsconfig.cjs.json
+++ b/packages/hash-blob-browser/tsconfig.cjs.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "outDir": "dist/cjs",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",
   "include": ["src/"]

--- a/packages/hash-blob-browser/tsconfig.es.json
+++ b/packages/hash-blob-browser/tsconfig.es.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
+    "baseUrl": ".",
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "rootDir": "src",
     "outDir": "dist/es",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",
   "include": ["src/"]

--- a/packages/hash-blob-browser/tsconfig.types.json
+++ b/packages/hash-blob-browser/tsconfig.types.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "declarationDir": "dist/types",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",
   "include": ["src/"]

--- a/packages/hash-node/tsconfig.cjs.json
+++ b/packages/hash-node/tsconfig.cjs.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "outDir": "dist/cjs",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",
   "include": ["src/"]

--- a/packages/hash-node/tsconfig.es.json
+++ b/packages/hash-node/tsconfig.es.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "outDir": "dist/es",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",
   "include": ["src/"]

--- a/packages/hash-node/tsconfig.types.json
+++ b/packages/hash-node/tsconfig.types.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "declarationDir": "dist/types",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",
   "include": ["src/"]

--- a/packages/hash-stream-node/tsconfig.cjs.json
+++ b/packages/hash-stream-node/tsconfig.cjs.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "outDir": "dist/cjs",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",
   "include": ["src/"]

--- a/packages/hash-stream-node/tsconfig.es.json
+++ b/packages/hash-stream-node/tsconfig.es.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "outDir": "dist/es",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",
   "include": ["src/"]

--- a/packages/hash-stream-node/tsconfig.types.json
+++ b/packages/hash-stream-node/tsconfig.types.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "declarationDir": "dist/types",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",
   "include": ["src/"]

--- a/packages/invalid-dependency/tsconfig.cjs.json
+++ b/packages/invalid-dependency/tsconfig.cjs.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "outDir": "dist/cjs",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",
   "include": ["src/"]

--- a/packages/invalid-dependency/tsconfig.es.json
+++ b/packages/invalid-dependency/tsconfig.es.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
+    "baseUrl": ".",
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "rootDir": "src",
     "outDir": "dist/es",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",
   "include": ["src/"]

--- a/packages/invalid-dependency/tsconfig.types.json
+++ b/packages/invalid-dependency/tsconfig.types.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "declarationDir": "dist/types",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",
   "include": ["src/"]

--- a/packages/is-array-buffer/tsconfig.cjs.json
+++ b/packages/is-array-buffer/tsconfig.cjs.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "outDir": "dist/cjs",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",
   "include": ["src/"]

--- a/packages/is-array-buffer/tsconfig.es.json
+++ b/packages/is-array-buffer/tsconfig.es.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
+    "baseUrl": ".",
     "lib": ["es5", "es2015.collection"],
-    "rootDir": "src",
     "outDir": "dist/es",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",
   "include": ["src/"]

--- a/packages/is-array-buffer/tsconfig.types.json
+++ b/packages/is-array-buffer/tsconfig.types.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "declarationDir": "dist/types",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",
   "include": ["src/"]

--- a/packages/karma-credential-loader/tsconfig.cjs.json
+++ b/packages/karma-credential-loader/tsconfig.cjs.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
-    "strict": false,
-    "rootDir": "src",
+    "baseUrl": ".",
     "outDir": "dist/cjs",
-    "baseUrl": "."
+    "rootDir": "src",
+    "strict": false
   },
   "extends": "../../tsconfig.cjs.json",
   "include": ["src/"]

--- a/packages/karma-credential-loader/tsconfig.es.json
+++ b/packages/karma-credential-loader/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "compilerOptions": {
-    "strict": false,
+    "baseUrl": ".",
     "lib": ["es2015"],
-    "rootDir": "src",
     "outDir": "dist/es",
-    "baseUrl": "."
+    "rootDir": "src",
+    "strict": false
   },
   "extends": "../../tsconfig.es.json",
   "include": ["src/"]

--- a/packages/karma-credential-loader/tsconfig.types.json
+++ b/packages/karma-credential-loader/tsconfig.types.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "declarationDir": "dist/types",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",
   "include": ["src/"]

--- a/packages/md5-js/tsconfig.cjs.json
+++ b/packages/md5-js/tsconfig.cjs.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "outDir": "dist/cjs",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "exclude": ["./build/**"],
   "include": ["src/"],

--- a/packages/md5-js/tsconfig.es.json
+++ b/packages/md5-js/tsconfig.es.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
+    "baseUrl": ".",
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "rootDir": "src",
     "outDir": "dist/es",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "include": ["src/"],
   "extends": "../../tsconfig.es.json"

--- a/packages/md5-js/tsconfig.types.json
+++ b/packages/md5-js/tsconfig.types.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "declarationDir": "dist/types",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",
   "include": ["src/"]

--- a/packages/middleware-apply-body-checksum/tsconfig.cjs.json
+++ b/packages/middleware-apply-body-checksum/tsconfig.cjs.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "outDir": "dist/cjs",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",
   "include": ["src/"]

--- a/packages/middleware-apply-body-checksum/tsconfig.es.json
+++ b/packages/middleware-apply-body-checksum/tsconfig.es.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
+    "baseUrl": ".",
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "rootDir": "src",
     "outDir": "dist/es",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",
   "include": ["src/"]

--- a/packages/middleware-apply-body-checksum/tsconfig.types.json
+++ b/packages/middleware-apply-body-checksum/tsconfig.types.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "declarationDir": "dist/types",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",
   "include": ["src/"]

--- a/packages/middleware-bucket-endpoint/tsconfig.cjs.json
+++ b/packages/middleware-bucket-endpoint/tsconfig.cjs.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "outDir": "dist/cjs",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",
   "include": ["src/"]

--- a/packages/middleware-bucket-endpoint/tsconfig.es.json
+++ b/packages/middleware-bucket-endpoint/tsconfig.es.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
+    "baseUrl": ".",
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "rootDir": "src",
     "outDir": "dist/es",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",
   "include": ["src/"]

--- a/packages/middleware-bucket-endpoint/tsconfig.types.json
+++ b/packages/middleware-bucket-endpoint/tsconfig.types.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "declarationDir": "dist/types",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",
   "include": ["src/"]

--- a/packages/middleware-content-length/tsconfig.cjs.json
+++ b/packages/middleware-content-length/tsconfig.cjs.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "outDir": "dist/cjs",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",
   "include": ["src/"]

--- a/packages/middleware-content-length/tsconfig.es.json
+++ b/packages/middleware-content-length/tsconfig.es.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
+    "baseUrl": ".",
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "rootDir": "src",
     "outDir": "dist/es",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",
   "include": ["src/"]

--- a/packages/middleware-content-length/tsconfig.types.json
+++ b/packages/middleware-content-length/tsconfig.types.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "declarationDir": "dist/types",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",
   "include": ["src/"]

--- a/packages/middleware-endpoint-discovery/tsconfig.cjs.json
+++ b/packages/middleware-endpoint-discovery/tsconfig.cjs.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "outDir": "dist/cjs",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",
   "include": ["src/"]

--- a/packages/middleware-endpoint-discovery/tsconfig.es.json
+++ b/packages/middleware-endpoint-discovery/tsconfig.es.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
+    "baseUrl": ".",
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "rootDir": "src",
     "outDir": "dist/es",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",
   "include": ["src/"]

--- a/packages/middleware-endpoint-discovery/tsconfig.types.json
+++ b/packages/middleware-endpoint-discovery/tsconfig.types.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "declarationDir": "dist/types",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",
   "include": ["src/"]

--- a/packages/middleware-eventstream/tsconfig.cjs.json
+++ b/packages/middleware-eventstream/tsconfig.cjs.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "outDir": "dist/cjs",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",
   "include": ["src/"]

--- a/packages/middleware-eventstream/tsconfig.es.json
+++ b/packages/middleware-eventstream/tsconfig.es.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
+    "baseUrl": ".",
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "rootDir": "src",
     "outDir": "dist/es",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",
   "include": ["src/"]

--- a/packages/middleware-eventstream/tsconfig.types.json
+++ b/packages/middleware-eventstream/tsconfig.types.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "declarationDir": "dist/types",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",
   "include": ["src/"]

--- a/packages/middleware-expect-continue/tsconfig.cjs.json
+++ b/packages/middleware-expect-continue/tsconfig.cjs.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "outDir": "dist/cjs",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",
   "include": ["src/"]

--- a/packages/middleware-expect-continue/tsconfig.es.json
+++ b/packages/middleware-expect-continue/tsconfig.es.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
+    "baseUrl": ".",
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "rootDir": "src",
     "outDir": "dist/es",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",
   "include": ["src/"]

--- a/packages/middleware-expect-continue/tsconfig.types.json
+++ b/packages/middleware-expect-continue/tsconfig.types.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "declarationDir": "dist/types",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",
   "include": ["src/"]

--- a/packages/middleware-header-default/tsconfig.cjs.json
+++ b/packages/middleware-header-default/tsconfig.cjs.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "outDir": "dist/cjs",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",
   "include": ["src/"]

--- a/packages/middleware-header-default/tsconfig.es.json
+++ b/packages/middleware-header-default/tsconfig.es.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
+    "baseUrl": ".",
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "rootDir": "src",
     "outDir": "dist/es",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",
   "include": ["src/"]

--- a/packages/middleware-header-default/tsconfig.types.json
+++ b/packages/middleware-header-default/tsconfig.types.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "declarationDir": "dist/types",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",
   "include": ["src/"]

--- a/packages/middleware-host-header/tsconfig.cjs.json
+++ b/packages/middleware-host-header/tsconfig.cjs.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "outDir": "dist/cjs",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",
   "include": ["src/"]

--- a/packages/middleware-host-header/tsconfig.es.json
+++ b/packages/middleware-host-header/tsconfig.es.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
+    "baseUrl": ".",
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "rootDir": "src",
     "outDir": "dist/es",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",
   "include": ["src/"]

--- a/packages/middleware-host-header/tsconfig.types.json
+++ b/packages/middleware-host-header/tsconfig.types.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "declarationDir": "dist/types",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",
   "include": ["src/"]

--- a/packages/middleware-location-constraint/tsconfig.cjs.json
+++ b/packages/middleware-location-constraint/tsconfig.cjs.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "outDir": "dist/cjs",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",
   "include": ["src/"]

--- a/packages/middleware-location-constraint/tsconfig.es.json
+++ b/packages/middleware-location-constraint/tsconfig.es.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
+    "baseUrl": ".",
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "rootDir": "src",
     "outDir": "dist/es",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",
   "include": ["src/"]

--- a/packages/middleware-location-constraint/tsconfig.types.json
+++ b/packages/middleware-location-constraint/tsconfig.types.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "declarationDir": "dist/types",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",
   "include": ["src/"]

--- a/packages/middleware-logger/tsconfig.cjs.json
+++ b/packages/middleware-logger/tsconfig.cjs.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "outDir": "dist/cjs",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",
   "include": ["src/"]

--- a/packages/middleware-logger/tsconfig.es.json
+++ b/packages/middleware-logger/tsconfig.es.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
+    "baseUrl": ".",
     "lib": ["es5", "es2015.promise", "es2015.iterable"],
-    "rootDir": "src",
     "outDir": "dist/es",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",
   "include": ["src/"]

--- a/packages/middleware-logger/tsconfig.types.json
+++ b/packages/middleware-logger/tsconfig.types.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "declarationDir": "dist/types",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",
   "include": ["src/"]

--- a/packages/middleware-retry/tsconfig.cjs.json
+++ b/packages/middleware-retry/tsconfig.cjs.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
+    "baseUrl": ".",
     "noUnusedLocals": true,
-    "rootDir": "src",
     "outDir": "dist/cjs",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",
   "include": ["src/"]

--- a/packages/middleware-retry/tsconfig.es.json
+++ b/packages/middleware-retry/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "compilerOptions": {
-    "noUnusedLocals": true,
+    "baseUrl": ".",
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "rootDir": "src",
+    "noUnusedLocals": true,
     "outDir": "dist/es",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",
   "include": ["src/"]

--- a/packages/middleware-retry/tsconfig.types.json
+++ b/packages/middleware-retry/tsconfig.types.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "declarationDir": "dist/types",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",
   "include": ["src/"]

--- a/packages/middleware-sdk-api-gateway/tsconfig.cjs.json
+++ b/packages/middleware-sdk-api-gateway/tsconfig.cjs.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "outDir": "dist/cjs",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",
   "include": ["src/"]

--- a/packages/middleware-sdk-api-gateway/tsconfig.es.json
+++ b/packages/middleware-sdk-api-gateway/tsconfig.es.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
+    "baseUrl": ".",
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "rootDir": "src",
     "outDir": "dist/es",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",
   "include": ["src/"]

--- a/packages/middleware-sdk-api-gateway/tsconfig.types.json
+++ b/packages/middleware-sdk-api-gateway/tsconfig.types.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "declarationDir": "dist/types",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",
   "include": ["src/"]

--- a/packages/middleware-sdk-ec2/tsconfig.cjs.json
+++ b/packages/middleware-sdk-ec2/tsconfig.cjs.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "outDir": "dist/cjs",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",
   "include": ["src/"]

--- a/packages/middleware-sdk-ec2/tsconfig.es.json
+++ b/packages/middleware-sdk-ec2/tsconfig.es.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
+    "baseUrl": ".",
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "rootDir": "src",
     "outDir": "dist/es",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",
   "include": ["src/"]

--- a/packages/middleware-sdk-ec2/tsconfig.types.json
+++ b/packages/middleware-sdk-ec2/tsconfig.types.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "declarationDir": "dist/types",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",
   "include": ["src/"]

--- a/packages/middleware-sdk-glacier/tsconfig.cjs.json
+++ b/packages/middleware-sdk-glacier/tsconfig.cjs.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "outDir": "dist/cjs",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",
   "include": ["src/"]

--- a/packages/middleware-sdk-glacier/tsconfig.es.json
+++ b/packages/middleware-sdk-glacier/tsconfig.es.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
+    "baseUrl": ".",
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "rootDir": "src",
     "outDir": "dist/es",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",
   "include": ["src/"]

--- a/packages/middleware-sdk-glacier/tsconfig.types.json
+++ b/packages/middleware-sdk-glacier/tsconfig.types.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "declarationDir": "dist/types",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",
   "include": ["src/"]

--- a/packages/middleware-sdk-machinelearning/tsconfig.cjs.json
+++ b/packages/middleware-sdk-machinelearning/tsconfig.cjs.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "outDir": "dist/cjs",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",
   "include": ["src/"]

--- a/packages/middleware-sdk-machinelearning/tsconfig.es.json
+++ b/packages/middleware-sdk-machinelearning/tsconfig.es.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
+    "baseUrl": ".",
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "rootDir": "src",
     "outDir": "dist/es",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",
   "include": ["src/"]

--- a/packages/middleware-sdk-machinelearning/tsconfig.types.json
+++ b/packages/middleware-sdk-machinelearning/tsconfig.types.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "declarationDir": "dist/types",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",
   "include": ["src/"]

--- a/packages/middleware-sdk-rds/tsconfig.cjs.json
+++ b/packages/middleware-sdk-rds/tsconfig.cjs.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "outDir": "dist/cjs",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",
   "include": ["src/"]

--- a/packages/middleware-sdk-rds/tsconfig.es.json
+++ b/packages/middleware-sdk-rds/tsconfig.es.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
+    "baseUrl": ".",
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "rootDir": "src",
     "outDir": "dist/es",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",
   "include": ["src/"]

--- a/packages/middleware-sdk-rds/tsconfig.types.json
+++ b/packages/middleware-sdk-rds/tsconfig.types.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "declarationDir": "dist/types",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",
   "include": ["src/"]

--- a/packages/middleware-sdk-route53/tsconfig.cjs.json
+++ b/packages/middleware-sdk-route53/tsconfig.cjs.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "outDir": "dist/cjs",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",
   "include": ["src/"]

--- a/packages/middleware-sdk-route53/tsconfig.es.json
+++ b/packages/middleware-sdk-route53/tsconfig.es.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
+    "baseUrl": ".",
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "rootDir": "src",
     "outDir": "dist/es",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",
   "include": ["src/"]

--- a/packages/middleware-sdk-route53/tsconfig.types.json
+++ b/packages/middleware-sdk-route53/tsconfig.types.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "declarationDir": "dist/types",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",
   "include": ["src/"]

--- a/packages/middleware-sdk-s3-control/tsconfig.cjs.json
+++ b/packages/middleware-sdk-s3-control/tsconfig.cjs.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "outDir": "dist/cjs",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",
   "include": ["src/"]

--- a/packages/middleware-sdk-s3-control/tsconfig.es.json
+++ b/packages/middleware-sdk-s3-control/tsconfig.es.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
+    "baseUrl": ".",
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "rootDir": "src",
     "outDir": "dist/es",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",
   "include": ["src/"]

--- a/packages/middleware-sdk-s3-control/tsconfig.types.json
+++ b/packages/middleware-sdk-s3-control/tsconfig.types.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "declarationDir": "dist/types",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",
   "include": ["src/"]

--- a/packages/middleware-sdk-s3/tsconfig.cjs.json
+++ b/packages/middleware-sdk-s3/tsconfig.cjs.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "outDir": "dist/cjs",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",
   "include": ["src/"]

--- a/packages/middleware-sdk-s3/tsconfig.es.json
+++ b/packages/middleware-sdk-s3/tsconfig.es.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
+    "baseUrl": ".",
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "rootDir": "src",
     "outDir": "dist/es",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",
   "include": ["src/"]

--- a/packages/middleware-sdk-s3/tsconfig.types.json
+++ b/packages/middleware-sdk-s3/tsconfig.types.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "declarationDir": "dist/types",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",
   "include": ["src/"]

--- a/packages/middleware-sdk-sqs/tsconfig.cjs.json
+++ b/packages/middleware-sdk-sqs/tsconfig.cjs.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "outDir": "dist/cjs",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",
   "include": ["src/"]

--- a/packages/middleware-sdk-sqs/tsconfig.es.json
+++ b/packages/middleware-sdk-sqs/tsconfig.es.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
+    "baseUrl": ".",
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "rootDir": "src",
     "outDir": "dist/es",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",
   "include": ["src/"]

--- a/packages/middleware-sdk-sqs/tsconfig.types.json
+++ b/packages/middleware-sdk-sqs/tsconfig.types.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "declarationDir": "dist/types",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",
   "include": ["src/"]

--- a/packages/middleware-sdk-sts/tsconfig.cjs.json
+++ b/packages/middleware-sdk-sts/tsconfig.cjs.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "outDir": "dist/cjs",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",
   "include": ["src/"]

--- a/packages/middleware-sdk-sts/tsconfig.es.json
+++ b/packages/middleware-sdk-sts/tsconfig.es.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
+    "baseUrl": ".",
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "rootDir": "src",
     "outDir": "dist/es",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",
   "include": ["src/"]

--- a/packages/middleware-sdk-sts/tsconfig.types.json
+++ b/packages/middleware-sdk-sts/tsconfig.types.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "declarationDir": "dist/types",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",
   "include": ["src/"]

--- a/packages/middleware-sdk-transcribe-streaming/tsconfig.cjs.json
+++ b/packages/middleware-sdk-transcribe-streaming/tsconfig.cjs.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
-    "stripInternal": true,
-    "rootDir": "src",
+    "baseUrl": ".",
     "outDir": "dist/cjs",
-    "baseUrl": "."
+    "rootDir": "src",
+    "stripInternal": true
   },
   "extends": "../../tsconfig.cjs.json",
   "include": ["src/"]

--- a/packages/middleware-sdk-transcribe-streaming/tsconfig.es.json
+++ b/packages/middleware-sdk-transcribe-streaming/tsconfig.es.json
@@ -1,14 +1,14 @@
 {
   "compilerOptions": {
-    "lib": ["es5", "es2015.promise", "es2015.collection", "DOM"],
-    "stripInternal": true,
-    "rootDir": "src",
-    "outDir": "dist/es",
     "baseUrl": ".",
-    "target": "ES2015",
+    "incremental": true,
+    "lib": ["es5", "es2015.promise", "es2015.collection", "DOM"],
     "module": "esNext",
     "moduleResolution": "node",
-    "incremental": true
+    "outDir": "dist/es",
+    "rootDir": "src",
+    "stripInternal": true,
+    "target": "ES2015"
   },
   "extends": "../../tsconfig.es.json",
   "include": ["src/"]

--- a/packages/middleware-sdk-transcribe-streaming/tsconfig.types.json
+++ b/packages/middleware-sdk-transcribe-streaming/tsconfig.types.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "declarationDir": "dist/types",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",
   "include": ["src/"]

--- a/packages/middleware-serde/tsconfig.cjs.json
+++ b/packages/middleware-serde/tsconfig.cjs.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "outDir": "dist/cjs",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",
   "include": ["src/"]

--- a/packages/middleware-serde/tsconfig.es.json
+++ b/packages/middleware-serde/tsconfig.es.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
+    "baseUrl": ".",
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "rootDir": "src",
     "outDir": "dist/es",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",
   "include": ["src/"]

--- a/packages/middleware-serde/tsconfig.types.json
+++ b/packages/middleware-serde/tsconfig.types.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "declarationDir": "dist/types",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",
   "include": ["src/"]

--- a/packages/middleware-signing/tsconfig.cjs.json
+++ b/packages/middleware-signing/tsconfig.cjs.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "outDir": "dist/cjs",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",
   "include": ["src/"]

--- a/packages/middleware-signing/tsconfig.es.json
+++ b/packages/middleware-signing/tsconfig.es.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
+    "baseUrl": ".",
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "rootDir": "src",
     "outDir": "dist/es",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",
   "include": ["src/"]

--- a/packages/middleware-signing/tsconfig.types.json
+++ b/packages/middleware-signing/tsconfig.types.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "declarationDir": "dist/types",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",
   "include": ["src/"]

--- a/packages/middleware-ssec/tsconfig.cjs.json
+++ b/packages/middleware-ssec/tsconfig.cjs.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "outDir": "dist/cjs",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",
   "include": ["src/"]

--- a/packages/middleware-ssec/tsconfig.es.json
+++ b/packages/middleware-ssec/tsconfig.es.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
+    "baseUrl": ".",
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "rootDir": "src",
     "outDir": "dist/es",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",
   "include": ["src/"]

--- a/packages/middleware-ssec/tsconfig.types.json
+++ b/packages/middleware-ssec/tsconfig.types.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "declarationDir": "dist/types",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",
   "include": ["src/"]

--- a/packages/middleware-stack/tsconfig.cjs.json
+++ b/packages/middleware-stack/tsconfig.cjs.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "outDir": "dist/cjs",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",
   "include": ["src/"]

--- a/packages/middleware-stack/tsconfig.es.json
+++ b/packages/middleware-stack/tsconfig.es.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
+    "baseUrl": ".",
     "lib": ["es5", "es2015.promise", "es2015.collection"],
-    "rootDir": "src",
     "outDir": "dist/es",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",
   "include": ["src/"]

--- a/packages/middleware-stack/tsconfig.types.json
+++ b/packages/middleware-stack/tsconfig.types.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "declarationDir": "dist/types",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",
   "include": ["src/"]

--- a/packages/middleware-user-agent/tsconfig.cjs.json
+++ b/packages/middleware-user-agent/tsconfig.cjs.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "outDir": "dist/cjs",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",
   "include": ["src/"]

--- a/packages/middleware-user-agent/tsconfig.es.json
+++ b/packages/middleware-user-agent/tsconfig.es.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
+    "baseUrl": ".",
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "rootDir": "src",
     "outDir": "dist/es",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",
   "include": ["src/"]

--- a/packages/middleware-user-agent/tsconfig.types.json
+++ b/packages/middleware-user-agent/tsconfig.types.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "declarationDir": "dist/types",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",
   "include": ["src/"]

--- a/packages/node-config-provider/tsconfig.cjs.json
+++ b/packages/node-config-provider/tsconfig.cjs.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "outDir": "dist/cjs",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",
   "include": ["src/"]

--- a/packages/node-config-provider/tsconfig.es.json
+++ b/packages/node-config-provider/tsconfig.es.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
+    "baseUrl": ".",
     "lib": ["es5", "es2015.promise", "es2015.iterable"],
-    "rootDir": "src",
     "outDir": "dist/es",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",
   "include": ["src/"]

--- a/packages/node-config-provider/tsconfig.types.json
+++ b/packages/node-config-provider/tsconfig.types.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "declarationDir": "dist/types",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",
   "include": ["src/"]

--- a/packages/node-http-handler/tsconfig.cjs.json
+++ b/packages/node-http-handler/tsconfig.cjs.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "outDir": "dist/cjs",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",
   "include": ["src/"]

--- a/packages/node-http-handler/tsconfig.es.json
+++ b/packages/node-http-handler/tsconfig.es.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
+    "baseUrl": ".",
     "lib": ["es5", "es2015.promise", "es2015.iterable"],
-    "rootDir": "src",
     "outDir": "dist/es",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",
   "include": ["src/"]

--- a/packages/node-http-handler/tsconfig.types.json
+++ b/packages/node-http-handler/tsconfig.types.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "declarationDir": "dist/types",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",
   "include": ["src/"]

--- a/packages/polly-request-presigner/tsconfig.cjs.json
+++ b/packages/polly-request-presigner/tsconfig.cjs.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "outDir": "dist/cjs",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",
   "include": ["src/"]

--- a/packages/polly-request-presigner/tsconfig.es.json
+++ b/packages/polly-request-presigner/tsconfig.es.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
+    "baseUrl": ".",
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown", "dom"],
-    "rootDir": "src",
     "outDir": "dist/es",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",
   "include": ["src/"]

--- a/packages/polly-request-presigner/tsconfig.types.json
+++ b/packages/polly-request-presigner/tsconfig.types.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "declarationDir": "dist/types",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",
   "include": ["src/"]

--- a/packages/property-provider/tsconfig.cjs.json
+++ b/packages/property-provider/tsconfig.cjs.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "outDir": "dist/cjs",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",
   "include": ["src/"]

--- a/packages/property-provider/tsconfig.es.json
+++ b/packages/property-provider/tsconfig.es.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
+    "baseUrl": ".",
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "rootDir": "src",
     "outDir": "dist/es",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",
   "include": ["src/"]

--- a/packages/property-provider/tsconfig.types.json
+++ b/packages/property-provider/tsconfig.types.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "declarationDir": "dist/types",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",
   "include": ["src/"]

--- a/packages/protocol-http/tsconfig.cjs.json
+++ b/packages/protocol-http/tsconfig.cjs.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "outDir": "dist/cjs",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",
   "include": ["src/"]

--- a/packages/protocol-http/tsconfig.es.json
+++ b/packages/protocol-http/tsconfig.es.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
+    "baseUrl": ".",
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "rootDir": "src",
     "outDir": "dist/es",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",
   "include": ["src/"]

--- a/packages/protocol-http/tsconfig.types.json
+++ b/packages/protocol-http/tsconfig.types.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "declarationDir": "dist/types",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",
   "include": ["src/"]

--- a/packages/querystring-builder/tsconfig.cjs.json
+++ b/packages/querystring-builder/tsconfig.cjs.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "outDir": "dist/cjs",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",
   "include": ["src/"]

--- a/packages/querystring-builder/tsconfig.es.json
+++ b/packages/querystring-builder/tsconfig.es.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
+    "baseUrl": ".",
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "rootDir": "src",
     "outDir": "dist/es",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",
   "include": ["src/"]

--- a/packages/querystring-builder/tsconfig.types.json
+++ b/packages/querystring-builder/tsconfig.types.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "declarationDir": "dist/types",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",
   "include": ["src/"]

--- a/packages/querystring-parser/tsconfig.cjs.json
+++ b/packages/querystring-parser/tsconfig.cjs.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "outDir": "dist/cjs",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",
   "include": ["src/"]

--- a/packages/querystring-parser/tsconfig.es.json
+++ b/packages/querystring-parser/tsconfig.es.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
+    "baseUrl": ".",
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "rootDir": "src",
     "outDir": "dist/es",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",
   "include": ["src/"]

--- a/packages/querystring-parser/tsconfig.types.json
+++ b/packages/querystring-parser/tsconfig.types.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "declarationDir": "dist/types",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",
   "include": ["src/"]

--- a/packages/s3-presigned-post/tsconfig.cjs.json
+++ b/packages/s3-presigned-post/tsconfig.cjs.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "outDir": "dist/cjs",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",
   "include": ["src/"]

--- a/packages/s3-presigned-post/tsconfig.es.json
+++ b/packages/s3-presigned-post/tsconfig.es.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
+    "baseUrl": ".",
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown", "dom"],
-    "rootDir": "src",
     "outDir": "dist/es",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",
   "include": ["src/"]

--- a/packages/s3-presigned-post/tsconfig.types.json
+++ b/packages/s3-presigned-post/tsconfig.types.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "declarationDir": "dist/types",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",
   "include": ["src/"]

--- a/packages/s3-request-presigner/tsconfig.cjs.json
+++ b/packages/s3-request-presigner/tsconfig.cjs.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "outDir": "dist/cjs",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",
   "include": ["src/"]

--- a/packages/s3-request-presigner/tsconfig.es.json
+++ b/packages/s3-request-presigner/tsconfig.es.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
+    "baseUrl": ".",
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown", "dom"],
-    "rootDir": "src",
     "outDir": "dist/es",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",
   "include": ["src/"]

--- a/packages/s3-request-presigner/tsconfig.types.json
+++ b/packages/s3-request-presigner/tsconfig.types.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "declarationDir": "dist/types",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",
   "include": ["src/"]

--- a/packages/service-error-classification/tsconfig.cjs.json
+++ b/packages/service-error-classification/tsconfig.cjs.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
+    "baseUrl": ".",
     "noUnusedLocals": true,
-    "rootDir": "src",
     "outDir": "dist/cjs",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",
   "include": ["src/"]

--- a/packages/service-error-classification/tsconfig.es.json
+++ b/packages/service-error-classification/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "compilerOptions": {
-    "noUnusedLocals": true,
+    "baseUrl": ".",
     "lib": ["es5", "es2015.collection", "es2015.iterable"],
-    "rootDir": "src",
+    "noUnusedLocals": true,
     "outDir": "dist/es",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",
   "include": ["src/"]

--- a/packages/service-error-classification/tsconfig.types.json
+++ b/packages/service-error-classification/tsconfig.types.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "declarationDir": "dist/types",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",
   "include": ["src/"]

--- a/packages/sha256-tree-hash/tsconfig.cjs.json
+++ b/packages/sha256-tree-hash/tsconfig.cjs.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "outDir": "dist/cjs",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",
   "include": ["src/"]

--- a/packages/sha256-tree-hash/tsconfig.es.json
+++ b/packages/sha256-tree-hash/tsconfig.es.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
+    "baseUrl": ".",
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "rootDir": "src",
     "outDir": "dist/es",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",
   "include": ["src/"]

--- a/packages/sha256-tree-hash/tsconfig.types.json
+++ b/packages/sha256-tree-hash/tsconfig.types.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "declarationDir": "dist/types",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",
   "include": ["src/"]

--- a/packages/shared-ini-file-loader/tsconfig.cjs.json
+++ b/packages/shared-ini-file-loader/tsconfig.cjs.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "outDir": "dist/cjs",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",
   "include": ["src/"]

--- a/packages/shared-ini-file-loader/tsconfig.es.json
+++ b/packages/shared-ini-file-loader/tsconfig.es.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
+    "baseUrl": ".",
     "lib": ["es5", "es2015.promise", "es2015.collection"],
-    "rootDir": "src",
     "outDir": "dist/es",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",
   "include": ["src/"]

--- a/packages/shared-ini-file-loader/tsconfig.types.json
+++ b/packages/shared-ini-file-loader/tsconfig.types.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "declarationDir": "dist/types",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",
   "include": ["src/"]

--- a/packages/signature-v4-crt/tsconfig.cjs.json
+++ b/packages/signature-v4-crt/tsconfig.cjs.json
@@ -1,11 +1,11 @@
 {
   "compilerOptions": {
-    "stripInternal": true,
-    "rootDir": "src",
-    "outDir": "dist/cjs",
-    "noUnusedLocals": true,
+    "baseUrl": ".",
     "lib": ["es2016"],
-    "baseUrl": "."
+    "noUnusedLocals": true,
+    "outDir": "dist/cjs",
+    "rootDir": "src",
+    "stripInternal": true
   },
   "extends": "../../tsconfig.cjs.json",
   "include": ["src/"]

--- a/packages/signature-v4-crt/tsconfig.es.json
+++ b/packages/signature-v4-crt/tsconfig.es.json
@@ -1,15 +1,15 @@
 {
   "compilerOptions": {
-    "stripInternal": true,
-    "rootDir": "src",
-    "outDir": "dist/es",
-    "noUnusedLocals": true,
     "baseUrl": ".",
-    "target": "es5",
+    "incremental": true,
+    "lib": ["es5", "es2015.promise", "es2015.collection"],
     "module": "esNext",
     "moduleResolution": "node",
-    "lib": ["es5", "es2015.promise", "es2015.collection"],
-    "incremental": true
+    "noUnusedLocals": true,
+    "outDir": "dist/es",
+    "rootDir": "src",
+    "stripInternal": true,
+    "target": "es5"
   },
   "extends": "../../tsconfig.es.json",
   "include": ["src/"]

--- a/packages/signature-v4-crt/tsconfig.types.json
+++ b/packages/signature-v4-crt/tsconfig.types.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "declarationDir": "dist/types",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",
   "include": ["src/"]

--- a/packages/signature-v4/tsconfig.cjs.json
+++ b/packages/signature-v4/tsconfig.cjs.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
-    "stripInternal": true,
-    "rootDir": "src",
+    "baseUrl": ".",
     "outDir": "dist/cjs",
-    "baseUrl": "."
+    "rootDir": "src",
+    "stripInternal": true
   },
   "extends": "../../tsconfig.cjs.json",
   "include": ["src/"]

--- a/packages/signature-v4/tsconfig.es.json
+++ b/packages/signature-v4/tsconfig.es.json
@@ -1,15 +1,15 @@
 {
   "compilerOptions": {
-    "stripInternal": true,
-    "rootDir": "src",
-    "outDir": "dist/es",
-    "noUnusedLocals": true,
     "baseUrl": ".",
-    "target": "es5",
+    "incremental": true,
+    "lib": ["es5", "es2015.promise", "es2015.collection"],
     "module": "esNext",
     "moduleResolution": "node",
-    "lib": ["es5", "es2015.promise", "es2015.collection"],
-    "incremental": true
+    "noUnusedLocals": true,
+    "outDir": "dist/es",
+    "rootDir": "src",
+    "stripInternal": true,
+    "target": "es5"
   },
   "extends": "../../tsconfig.es.json",
   "include": ["src/"]

--- a/packages/signature-v4/tsconfig.types.json
+++ b/packages/signature-v4/tsconfig.types.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "declarationDir": "dist/types",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",
   "include": ["src/"]

--- a/packages/smithy-client/tsconfig.cjs.json
+++ b/packages/smithy-client/tsconfig.cjs.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
+    "baseUrl": ".",
     "noUnusedLocals": true,
-    "rootDir": "src",
     "outDir": "dist/cjs",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",
   "include": ["src/"]

--- a/packages/smithy-client/tsconfig.es.json
+++ b/packages/smithy-client/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "compilerOptions": {
-    "noUnusedLocals": true,
+    "baseUrl": ".",
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "rootDir": "src",
+    "noUnusedLocals": true,
     "outDir": "dist/es",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",
   "include": ["src/"]

--- a/packages/smithy-client/tsconfig.types.json
+++ b/packages/smithy-client/tsconfig.types.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "declarationDir": "dist/types",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",
   "include": ["src/"]

--- a/packages/types/tsconfig.cjs.json
+++ b/packages/types/tsconfig.cjs.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "outDir": "dist/cjs",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",
   "include": ["src/"]

--- a/packages/types/tsconfig.es.json
+++ b/packages/types/tsconfig.es.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
+    "baseUrl": ".",
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "rootDir": "src",
     "outDir": "dist/es",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",
   "include": ["src/"]

--- a/packages/types/tsconfig.types.json
+++ b/packages/types/tsconfig.types.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "declarationDir": "dist/types",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",
   "include": ["src/"]

--- a/packages/url-parser/tsconfig.cjs.json
+++ b/packages/url-parser/tsconfig.cjs.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "outDir": "dist/cjs",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",
   "include": ["src/"]

--- a/packages/url-parser/tsconfig.es.json
+++ b/packages/url-parser/tsconfig.es.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
+    "baseUrl": ".",
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "rootDir": "src",
     "outDir": "dist/es",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",
   "include": ["src/"]

--- a/packages/url-parser/tsconfig.types.json
+++ b/packages/url-parser/tsconfig.types.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "declarationDir": "dist/types",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",
   "include": ["src/"]

--- a/packages/util-arn-parser/tsconfig.cjs.json
+++ b/packages/util-arn-parser/tsconfig.cjs.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "outDir": "dist/cjs",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",
   "include": ["src/"]

--- a/packages/util-arn-parser/tsconfig.es.json
+++ b/packages/util-arn-parser/tsconfig.es.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "outDir": "dist/es",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",
   "include": ["src/"]

--- a/packages/util-arn-parser/tsconfig.types.json
+++ b/packages/util-arn-parser/tsconfig.types.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "declarationDir": "dist/types",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",
   "include": ["src/"]

--- a/packages/util-base64-browser/tsconfig.cjs.json
+++ b/packages/util-base64-browser/tsconfig.cjs.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "outDir": "dist/cjs",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",
   "include": ["src/"]

--- a/packages/util-base64-browser/tsconfig.es.json
+++ b/packages/util-base64-browser/tsconfig.es.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
+    "baseUrl": ".",
     "lib": ["es5", "es2015.collection"],
-    "rootDir": "src",
     "outDir": "dist/es",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",
   "include": ["src/"]

--- a/packages/util-base64-browser/tsconfig.types.json
+++ b/packages/util-base64-browser/tsconfig.types.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "declarationDir": "dist/types",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",
   "include": ["src/"]

--- a/packages/util-base64-node/tsconfig.cjs.json
+++ b/packages/util-base64-node/tsconfig.cjs.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "outDir": "dist/cjs",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",
   "include": ["src/"]

--- a/packages/util-base64-node/tsconfig.es.json
+++ b/packages/util-base64-node/tsconfig.es.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "outDir": "dist/es",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",
   "include": ["src/"]

--- a/packages/util-base64-node/tsconfig.types.json
+++ b/packages/util-base64-node/tsconfig.types.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "declarationDir": "dist/types",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",
   "include": ["src/"]

--- a/packages/util-body-length-browser/tsconfig.cjs.json
+++ b/packages/util-body-length-browser/tsconfig.cjs.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "outDir": "dist/cjs",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",
   "include": ["src/"]

--- a/packages/util-body-length-browser/tsconfig.es.json
+++ b/packages/util-body-length-browser/tsconfig.es.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
+    "baseUrl": ".",
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown", "dom"],
-    "rootDir": "src",
     "outDir": "dist/es",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",
   "include": ["src/"]

--- a/packages/util-body-length-browser/tsconfig.types.json
+++ b/packages/util-body-length-browser/tsconfig.types.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "declarationDir": "dist/types",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",
   "include": ["src/"]

--- a/packages/util-body-length-node/tsconfig.cjs.json
+++ b/packages/util-body-length-node/tsconfig.cjs.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "outDir": "dist/cjs",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",
   "include": ["src/"]

--- a/packages/util-body-length-node/tsconfig.es.json
+++ b/packages/util-body-length-node/tsconfig.es.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "outDir": "dist/es",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",
   "include": ["src/"]

--- a/packages/util-body-length-node/tsconfig.types.json
+++ b/packages/util-body-length-node/tsconfig.types.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "declarationDir": "dist/types",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",
   "include": ["src/"]

--- a/packages/util-buffer-from/tsconfig.cjs.json
+++ b/packages/util-buffer-from/tsconfig.cjs.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "outDir": "dist/cjs",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",
   "include": ["src/"]

--- a/packages/util-buffer-from/tsconfig.es.json
+++ b/packages/util-buffer-from/tsconfig.es.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
+    "baseUrl": ".",
     "lib": ["es5", "es2015.collection"],
-    "rootDir": "src",
     "outDir": "dist/es",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",
   "include": ["src/"]

--- a/packages/util-buffer-from/tsconfig.types.json
+++ b/packages/util-buffer-from/tsconfig.types.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "declarationDir": "dist/types",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",
   "include": ["src/"]

--- a/packages/util-create-request/tsconfig.cjs.json
+++ b/packages/util-create-request/tsconfig.cjs.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "outDir": "dist/cjs",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",
   "include": ["src/"]

--- a/packages/util-create-request/tsconfig.es.json
+++ b/packages/util-create-request/tsconfig.es.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
+    "baseUrl": ".",
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "rootDir": "src",
     "outDir": "dist/es",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",
   "include": ["src/"]

--- a/packages/util-create-request/tsconfig.types.json
+++ b/packages/util-create-request/tsconfig.types.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "declarationDir": "dist/types",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",
   "include": ["src/"]

--- a/packages/util-credentials/tsconfig.cjs.json
+++ b/packages/util-credentials/tsconfig.cjs.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "outDir": "dist/cjs",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",
   "include": ["src/"]

--- a/packages/util-credentials/tsconfig.es.json
+++ b/packages/util-credentials/tsconfig.es.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
+    "baseUrl": ".",
     "lib": ["es5", "es2015.promise", "es2015.collection"],
-    "rootDir": "src",
     "outDir": "dist/es",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",
   "include": ["src/"]

--- a/packages/util-credentials/tsconfig.types.json
+++ b/packages/util-credentials/tsconfig.types.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "declarationDir": "dist/types",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",
   "include": ["src/"]

--- a/packages/util-dynamodb/tsconfig.cjs.json
+++ b/packages/util-dynamodb/tsconfig.cjs.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "outDir": "dist/cjs",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",
   "include": ["src/"]

--- a/packages/util-dynamodb/tsconfig.es.json
+++ b/packages/util-dynamodb/tsconfig.es.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
+    "baseUrl": ".",
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "rootDir": "src",
     "outDir": "dist/es",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",
   "include": ["src/"]

--- a/packages/util-dynamodb/tsconfig.types.json
+++ b/packages/util-dynamodb/tsconfig.types.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "declarationDir": "dist/types",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",
   "include": ["src/"]

--- a/packages/util-format-url/tsconfig.cjs.json
+++ b/packages/util-format-url/tsconfig.cjs.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "outDir": "dist/cjs",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",
   "include": ["src/"]

--- a/packages/util-format-url/tsconfig.es.json
+++ b/packages/util-format-url/tsconfig.es.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
+    "baseUrl": ".",
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "rootDir": "src",
     "outDir": "dist/es",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",
   "include": ["src/"]

--- a/packages/util-format-url/tsconfig.types.json
+++ b/packages/util-format-url/tsconfig.types.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "declarationDir": "dist/types",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",
   "include": ["src/"]

--- a/packages/util-hex-encoding/tsconfig.cjs.json
+++ b/packages/util-hex-encoding/tsconfig.cjs.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "outDir": "dist/cjs",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",
   "include": ["src/"]

--- a/packages/util-hex-encoding/tsconfig.es.json
+++ b/packages/util-hex-encoding/tsconfig.es.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
+    "baseUrl": ".",
     "lib": ["es5", "es2015.promise", "es2015.collection"],
-    "rootDir": "src",
     "outDir": "dist/es",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",
   "include": ["src/"]

--- a/packages/util-hex-encoding/tsconfig.types.json
+++ b/packages/util-hex-encoding/tsconfig.types.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "declarationDir": "dist/types",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",
   "include": ["src/"]

--- a/packages/util-locate-window/tsconfig.cjs.json
+++ b/packages/util-locate-window/tsconfig.cjs.json
@@ -1,13 +1,13 @@
 {
   "compilerOptions": {
-    "strict": false,
-    "noImplicitUseStrict": true,
+    "baseUrl": ".",
     "noImplicitAny": true,
     "noImplicitThis": true,
-    "strictNullChecks": true,
-    "rootDir": "src",
+    "noImplicitUseStrict": true,
     "outDir": "dist/cjs",
-    "baseUrl": "."
+    "rootDir": "src",
+    "strict": false,
+    "strictNullChecks": true
   },
   "extends": "../../tsconfig.cjs.json",
   "include": ["src/"]

--- a/packages/util-locate-window/tsconfig.es.json
+++ b/packages/util-locate-window/tsconfig.es.json
@@ -1,14 +1,14 @@
 {
   "compilerOptions": {
-    "strict": false,
-    "noImplicitUseStrict": true,
+    "baseUrl": ".",
+    "lib": ["dom", "es5", "es2015.collection"],
     "noImplicitAny": true,
     "noImplicitThis": true,
-    "strictNullChecks": true,
-    "lib": ["dom", "es5", "es2015.collection"],
-    "rootDir": "src",
+    "noImplicitUseStrict": true,
     "outDir": "dist/es",
-    "baseUrl": "."
+    "rootDir": "src",
+    "strict": false,
+    "strictNullChecks": true
   },
   "extends": "../../tsconfig.es.json",
   "include": ["src/"]

--- a/packages/util-locate-window/tsconfig.types.json
+++ b/packages/util-locate-window/tsconfig.types.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "declarationDir": "dist/types",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",
   "include": ["src/"]

--- a/packages/util-uri-escape/tsconfig.cjs.json
+++ b/packages/util-uri-escape/tsconfig.cjs.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "outDir": "dist/cjs",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",
   "include": ["src/"]

--- a/packages/util-uri-escape/tsconfig.es.json
+++ b/packages/util-uri-escape/tsconfig.es.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
+    "baseUrl": ".",
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "rootDir": "src",
     "outDir": "dist/es",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",
   "include": ["src/"]

--- a/packages/util-uri-escape/tsconfig.types.json
+++ b/packages/util-uri-escape/tsconfig.types.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "declarationDir": "dist/types",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",
   "include": ["src/"]

--- a/packages/util-user-agent-browser/tsconfig.cjs.json
+++ b/packages/util-user-agent-browser/tsconfig.cjs.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "outDir": "dist/cjs",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",
   "include": ["src/"]

--- a/packages/util-user-agent-browser/tsconfig.es.json
+++ b/packages/util-user-agent-browser/tsconfig.es.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
+    "baseUrl": ".",
     "lib": ["es5", "es2015.collection", "dom"],
-    "rootDir": "src",
     "outDir": "dist/es",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",
   "include": ["src/"]

--- a/packages/util-user-agent-browser/tsconfig.types.json
+++ b/packages/util-user-agent-browser/tsconfig.types.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "declarationDir": "dist/types",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",
   "include": ["src/"]

--- a/packages/util-user-agent-node/tsconfig.cjs.json
+++ b/packages/util-user-agent-node/tsconfig.cjs.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "outDir": "dist/cjs",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",
   "include": ["src/"]

--- a/packages/util-user-agent-node/tsconfig.es.json
+++ b/packages/util-user-agent-node/tsconfig.es.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "outDir": "dist/es",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",
   "include": ["src/"]

--- a/packages/util-user-agent-node/tsconfig.types.json
+++ b/packages/util-user-agent-node/tsconfig.types.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "declarationDir": "dist/types",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",
   "include": ["src/"]

--- a/packages/util-utf8-browser/tsconfig.cjs.json
+++ b/packages/util-utf8-browser/tsconfig.cjs.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "outDir": "dist/cjs",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",
   "include": ["src/"]

--- a/packages/util-utf8-browser/tsconfig.es.json
+++ b/packages/util-utf8-browser/tsconfig.es.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
+    "baseUrl": ".",
     "lib": ["es5", "es2015.collection"],
-    "rootDir": "src",
     "outDir": "dist/es",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",
   "include": ["src/"]

--- a/packages/util-utf8-browser/tsconfig.types.json
+++ b/packages/util-utf8-browser/tsconfig.types.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "declarationDir": "dist/types",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",
   "include": ["src/"]

--- a/packages/util-utf8-node/tsconfig.cjs.json
+++ b/packages/util-utf8-node/tsconfig.cjs.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "outDir": "dist/cjs",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",
   "include": ["src/"]

--- a/packages/util-utf8-node/tsconfig.es.json
+++ b/packages/util-utf8-node/tsconfig.es.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "outDir": "dist/es",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",
   "include": ["src/"]

--- a/packages/util-utf8-node/tsconfig.types.json
+++ b/packages/util-utf8-node/tsconfig.types.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "declarationDir": "dist/types",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",
   "include": ["src/"]

--- a/packages/util-waiter/tsconfig.cjs.json
+++ b/packages/util-waiter/tsconfig.cjs.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "outDir": "dist/cjs",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",
   "include": ["src/"]

--- a/packages/util-waiter/tsconfig.es.json
+++ b/packages/util-waiter/tsconfig.es.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
+    "baseUrl": ".",
     "lib": ["es5", "es2015.collection"],
-    "rootDir": "src",
     "outDir": "dist/es",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",
   "include": ["src/"]

--- a/packages/util-waiter/tsconfig.types.json
+++ b/packages/util-waiter/tsconfig.types.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "declarationDir": "dist/types",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",
   "include": ["src/"]

--- a/packages/xml-builder/tsconfig.cjs.json
+++ b/packages/xml-builder/tsconfig.cjs.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "outDir": "dist/cjs",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",
   "include": ["src/"]

--- a/packages/xml-builder/tsconfig.es.json
+++ b/packages/xml-builder/tsconfig.es.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
+    "baseUrl": ".",
     "lib": ["es5", "es2015.collection"],
-    "rootDir": "src",
     "outDir": "dist/es",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",
   "include": ["src/"]

--- a/packages/xml-builder/tsconfig.types.json
+++ b/packages/xml-builder/tsconfig.types.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": "src",
+    "baseUrl": ".",
     "declarationDir": "dist/types",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",
   "include": ["src/"]

--- a/tsconfig.cjs.json
+++ b/tsconfig.cjs.json
@@ -1,15 +1,15 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "module": "commonjs",
-    "moduleResolution": "node",
-    "target": "ES2018",
-    "strict": true,
     "importHelpers": true,
-    "noEmitHelpers": true,
-    "sourceMap": false,
     "inlineSourceMap": true,
     "inlineSources": true,
-    "removeComments": true
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "noEmitHelpers": true,
+    "removeComments": true,
+    "sourceMap": false,
+    "strict": true,
+    "target": "ES2018"
   }
 }

--- a/tsconfig.es.json
+++ b/tsconfig.es.json
@@ -1,15 +1,15 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "target": "es5",
-    "module": "esnext",
-    "moduleResolution": "node",
-    "strict": true,
-    "sourceMap": false,
+    "downlevelIteration": true,
     "importHelpers": true,
-    "noEmitHelpers": true,
     "inlineSourceMap": true,
     "inlineSources": true,
-    "downlevelIteration": true
+    "module": "esnext",
+    "moduleResolution": "node",
+    "noEmitHelpers": true,
+    "sourceMap": false,
+    "strict": true,
+    "target": "es5"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,29 +1,26 @@
 {
   "compilerOptions": {
-    /**
-     * Must allow:
-     */
+    "baseUrl": ".",
     "downlevelIteration": true,
-    "resolveJsonModule": true,
-    "experimentalDecorators": true,
-    "noUnusedParameters": false,
-    "removeComments": false,
-    "incremental": true,
-    "sourceMap": true,
-    "preserveConstEnums": true,
-    "noFallthroughCasesInSwitch": true,
     "esModuleInterop": true,
+    "experimentalDecorators": true,
+    "incremental": true,
+    "lib": ["es2015", "dom"],
     "module": "commonjs",
     "moduleResolution": "node",
-    "target": "es5",
-    "lib": ["es2015", "dom"],
-    "baseUrl": ".",
+    "noFallthroughCasesInSwitch": true,
+    "noUnusedParameters": false,
     "paths": {
       "@aws-sdk/*": ["packages/*/src"],
       "@aws-sdk/client-*": ["clients/client-*/"],
       "@aws-sdk/aws-*": ["protocol_tests/aws-*/"],
       "@aws-sdk/lib-*": ["lib/*"]
-    }
+    },
+    "preserveConstEnums": true,
+    "removeComments": false,
+    "resolveJsonModule": true,
+    "sourceMap": true,
+    "target": "es5"
   },
   "include": ["packages/", "lib/"],
   "exclude": ["node_modules/", "**/*.spec.ts"],

--- a/tsconfig.types.json
+++ b/tsconfig.types.json
@@ -1,8 +1,8 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "strict": true,
     "declaration": true,
-    "emitDeclarationOnly": true
+    "emitDeclarationOnly": true,
+    "strict": true
   }
 }


### PR DESCRIPTION
### Issue
Similar to https://github.com/aws/aws-sdk-js-v3/pull/2821
* Precursor to tsconfig cleanup prioritized in JS-2845.
* Changes for tsconfig in clients will be taken up when extending them from root tsconfig in JS-2844.

### Description
Sorts compilerOptions in tsconfig

Achieved by running the following script in `packages`, `lib` and root folder:
```js
const { readdirSync, readFileSync, existsSync, writeFileSync } = require("fs");
const { join } = require("path");

readdirSync(join(process.cwd()), { withFileTypes: true })
  .filter((dirent) => dirent.isDirectory())
  .map((dirent) => dirent.name)
  .forEach((workspaceName) => {
    [
      "tsconfig.json",
      "tsconfig.cjs.json",
      "tsconfig.es.json",
      "tsconfig.types.json",
    ].forEach((tsConfigFilname) => {
      const tsConfigPath = join(workspaceName, tsConfigFilname);
      if (existsSync(tsConfigPath)) {
        const tsConfig = JSON.parse(readFileSync(tsConfigPath).toString());
        tsConfig.compilerOptions = Object.fromEntries(
          Object.entries(tsConfig.compilerOptions).sort()
        );
        writeFileSync(
          tsConfigPath,
          JSON.stringify(tsConfig, null, 2).concat(`\n`)
        );
      }
    });
  });

```

### Testing
N/A

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
