### PR TITLE
fix(client-s3): use member xmlname if applicable

### DIFF
--- a/clients/client-s3/protocols/Aws_restXml.ts
+++ b/clients/client-s3/protocols/Aws_restXml.ts
@@ -518,6 +518,7 @@ export const serializeAws_restXmlCompleteMultipartUploadCommand = async (
   let contents: any;
   if (input.MultipartUpload !== undefined) {
     contents = serializeAws_restXmlCompletedMultipartUpload(input.MultipartUpload, context);
+    contents = contents.withName("CompleteMultipartUpload");
     body = '<?xml version="1.0" encoding="UTF-8"?>';
     contents.addAttribute("xmlns", "http://s3.amazonaws.com/doc/2006-03-01/");
     body += contents.toString();
@@ -3493,6 +3494,7 @@ export const serializeAws_restXmlPutBucketLifecycleConfigurationCommand = async 
   let contents: any;
   if (input.LifecycleConfiguration !== undefined) {
     contents = serializeAws_restXmlBucketLifecycleConfiguration(input.LifecycleConfiguration, context);
+    contents = contents.withName("LifecycleConfiguration");
     body = '<?xml version="1.0" encoding="UTF-8"?>';
     contents.addAttribute("xmlns", "http://s3.amazonaws.com/doc/2006-03-01/");
     body += contents.toString();
@@ -4228,6 +4230,7 @@ export const serializeAws_restXmlPutObjectLegalHoldCommand = async (
   let contents: any;
   if (input.LegalHold !== undefined) {
     contents = serializeAws_restXmlObjectLockLegalHold(input.LegalHold, context);
+    contents = contents.withName("LegalHold");
     body = '<?xml version="1.0" encoding="UTF-8"?>';
     contents.addAttribute("xmlns", "http://s3.amazonaws.com/doc/2006-03-01/");
     body += contents.toString();
@@ -4346,6 +4349,7 @@ export const serializeAws_restXmlPutObjectRetentionCommand = async (
   let contents: any;
   if (input.Retention !== undefined) {
     contents = serializeAws_restXmlObjectLockRetention(input.Retention, context);
+    contents = contents.withName("Retention");
     body = '<?xml version="1.0" encoding="UTF-8"?>';
     contents.addAttribute("xmlns", "http://s3.amazonaws.com/doc/2006-03-01/");
     body += contents.toString();

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsRestXml.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsRestXml.java
@@ -272,6 +272,16 @@ final class AwsRestXml extends HttpBindingProtocolGenerator {
             writer.write("contents = $L;",
                     getInputValue(context, Location.PAYLOAD, "input." + memberName, member, target));
 
+            String targetName = target.getTrait(XmlNameTrait.class)
+                            .map(XmlNameTrait::getValue)
+                            .orElse(target.getId().getName());
+            if (
+                member.hasTrait(XmlNameTrait.class)
+                && !member.getTrait(XmlNameTrait.class).get().getValue().equals(targetName)
+            ) {
+                writer.write("contents = contents.withName($S);", member.getTrait(XmlNameTrait.class).get().getValue());
+            }
+
             // XmlNode will serialize Structure and non-streaming Union payloads as XML documents.
             if (target instanceof StructureShape
                     || (target instanceof UnionShape && !target.hasTrait(StreamingTrait.class))

--- a/protocol_tests/aws-restxml/protocols/Aws_restXml.ts
+++ b/protocol_tests/aws-restxml/protocols/Aws_restXml.ts
@@ -656,6 +656,7 @@ export const serializeAws_restXmlHttpPayloadWithMemberXmlNameCommand = async (
   let contents: any;
   if (input.nested !== undefined) {
     contents = serializeAws_restXmlPayloadWithXmlName(input.nested, context);
+    contents = contents.withName("Hola");
     body = '<?xml version="1.0" encoding="UTF-8"?>';
     body += contents.toString();
   }


### PR DESCRIPTION
### Issue
Resolves #1814 
Resolves #2445 

### Description
When the payload member has xmlname trait, we need to use the xmlname value for the member rather than the target shape's name.

Cross validate the diffs with the V2 SDK.

Smithy doc: https://awslabs.github.io/smithy/1.0/spec/core/xml-traits.html#xmlname-trait

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
