### PR TITLE
fix(scripts): run downlevel-dts script in parallel

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "main": "index.js",
   "scripts": {
     "copy-models": "node ./scripts/copy-models",
-    "downlevel-dts": "node ./scripts/downlevel-dts",
+    "downlevel-dts": "node --es-module-specifier-resolution=node ./scripts/downlevel-dts",
     "generate-clients": "node ./scripts/generate-clients",
     "bootstrap": "yarn",
     "clean": "yarn clear-build-cache && yarn clear-build-info && lerna clean",

--- a/package.json
+++ b/package.json
@@ -87,7 +87,6 @@
     "mocha": "^8.0.1",
     "prettier": "2.3.0",
     "puppeteer": "^5.1.0",
-    "run-parallel-limit": "1.1.0",
     "strip-comments": "2.0.1",
     "ts-jest": "^26.4.1",
     "ts-loader": "^7.0.5",

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "@types/jest": "^26.0.4",
     "@typescript-eslint/eslint-plugin": "4.30.0",
     "@typescript-eslint/parser": "4.30.0",
+    "async": "3.2.1",
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
     "codecov": "^3.4.0",

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "mocha": "^8.0.1",
     "prettier": "2.3.0",
     "puppeteer": "^5.1.0",
+    "run-parallel-limit": "1.1.0",
     "strip-comments": "2.0.1",
     "ts-jest": "^26.4.1",
     "ts-loader": "^7.0.5",

--- a/scripts/downlevel-dts/README.md
+++ b/scripts/downlevel-dts/README.md
@@ -10,7 +10,7 @@
 Runs downlevel-dts npm script (if present) in each workspace of monorepo, and
 strips comments from *.d.ts files.
 
-Usage: index.js
+Usage: index.mjs
 
 Options:
   --version   Show version number                                      [boolean]

--- a/scripts/downlevel-dts/downlevelWorkspace.js
+++ b/scripts/downlevel-dts/downlevelWorkspace.js
@@ -1,0 +1,59 @@
+const { access, readFile, writeFile } = require("fs/promises");
+const { join } = require("path");
+const { promisify } = require("util");
+const exec = promisify(require("child_process").exec);
+const stripComments = require("strip-comments");
+
+const downlevelWorkspace = async (workspacesDir, workspaceName) => {
+  const workspaceDir = join(workspacesDir, workspaceName);
+
+  const packageJsonPath = join(workspaceDir, "package.json");
+  const packageJson = JSON.parse((await readFile(packageJsonPath)).toString());
+  if (!packageJson.scripts["downlevel-dts"]) {
+    console.error(`The "downlevel-dts" script is not defined for "${workspaceDir}"`);
+    return;
+  }
+  const downlevelArgs = packageJson.scripts["downlevel-dts"].split(" ");
+  const downlevelDirname = downlevelArgs[2].replace(`${downlevelArgs[1]}/`, "");
+
+  const tsTypesConfigPath = join(workspaceDir, "tsconfig.types.json");
+  const declarationDirname = JSON.parse((await readFile(tsTypesConfigPath)).toString()).compilerOptions.declarationDir;
+
+  if (!declarationDirname) {
+    throw new Error(`The declarationDir is not defined in "${tsTypesConfigPath}".`);
+  }
+
+  const declarationDir = join(workspaceDir, declarationDirname);
+  try {
+    await access(declarationDir);
+  } catch (error) {
+    throw new Error(
+      `The types for "${workspaceName}" do not exist.\n` +
+        `Please build types for workspace "${workspaceDir}" before running downlevel-dts script.`
+    );
+  }
+
+  const downlevelDir = join(declarationDir, downlevelDirname);
+  // Create downlevel-dts folder if it doesn't exist
+  try {
+    await access(downlevelDir);
+  } catch (error) {
+    await exec(["yarn", "downlevel-dts"].join(" "), { cwd: workspaceDir });
+  }
+
+  // Strip comments from downlevel-dts files
+  try {
+    await access(downlevelDir);
+    getAllFiles(downlevelDir).forEach(async (downlevelTypesFilepath) => {
+      try {
+        const content = await readFile(downlevelTypesFilepath, "utf8");
+        await writeFile(downlevelTypesFilepath, stripComments(content));
+      } catch (error) {
+        console.error(`Error while stripping comments from "${downlevelTypesFilepath.replace(process.cwd(), "")}"`);
+        console.error(error);
+      }
+    });
+  } catch (error) {}
+};
+
+module.exports = { downlevelWorkspace };

--- a/scripts/downlevel-dts/downlevelWorkspace.mjs
+++ b/scripts/downlevel-dts/downlevelWorkspace.mjs
@@ -37,7 +37,8 @@ export const downlevelWorkspace = async (workspacesDir, workspaceName) => {
   // Strip comments from downlevel-dts files
   try {
     await access(downlevelDir);
-    getAllFiles(downlevelDir).forEach(async (downlevelTypesFilepath) => {
+    const files = await getAllFiles(downlevelDir);
+    files.forEach(async (downlevelTypesFilepath) => {
       try {
         const content = await readFile(downlevelTypesFilepath, "utf8");
         await writeFile(downlevelTypesFilepath, stripComments(content));

--- a/scripts/downlevel-dts/downlevelWorkspace.mjs
+++ b/scripts/downlevel-dts/downlevelWorkspace.mjs
@@ -38,7 +38,7 @@ export const downlevelWorkspace = async (workspacesDir, workspaceName) => {
   try {
     await access(downlevelDir);
     const files = await getAllFiles(downlevelDir);
-    files.forEach(async (downlevelTypesFilepath) => {
+    for (const downlevelTypesFilepath of files) {
       try {
         const content = await readFile(downlevelTypesFilepath, "utf8");
         await writeFile(downlevelTypesFilepath, stripComments(content));
@@ -46,6 +46,8 @@ export const downlevelWorkspace = async (workspacesDir, workspaceName) => {
         console.error(`Error while stripping comments from "${downlevelTypesFilepath.replace(process.cwd(), "")}"`);
         console.error(error);
       }
-    });
-  } catch (error) {}
+    }
+  } catch (error) {
+    // downlevelDir is not present, do nothing.
+  }
 };

--- a/scripts/downlevel-dts/downlevelWorkspace.mjs
+++ b/scripts/downlevel-dts/downlevelWorkspace.mjs
@@ -1,10 +1,12 @@
-const { access, readFile, writeFile } = require("fs/promises");
-const { join } = require("path");
-const { promisify } = require("util");
-const exec = promisify(require("child_process").exec);
-const stripComments = require("strip-comments");
+import { exec } from "child_process";
+import { access, readFile, writeFile } from "fs/promises";
+import { join } from "path";
+import stripComments from "strip-comments";
+import { promisify } from "util";
 
-const downlevelWorkspace = async (workspacesDir, workspaceName) => {
+const execPromise = promisify(exec);
+
+export const downlevelWorkspace = async (workspacesDir, workspaceName) => {
   const workspaceDir = join(workspacesDir, workspaceName);
 
   const packageJsonPath = join(workspaceDir, "package.json");
@@ -38,7 +40,7 @@ const downlevelWorkspace = async (workspacesDir, workspaceName) => {
   try {
     await access(downlevelDir);
   } catch (error) {
-    await exec(["yarn", "downlevel-dts"].join(" "), { cwd: workspaceDir });
+    await execPromise(["yarn", "downlevel-dts"].join(" "), { cwd: workspaceDir });
   }
 
   // Strip comments from downlevel-dts files
@@ -55,5 +57,3 @@ const downlevelWorkspace = async (workspacesDir, workspaceName) => {
     });
   } catch (error) {}
 };
-
-module.exports = { downlevelWorkspace };

--- a/scripts/downlevel-dts/getAllFiles.mjs
+++ b/scripts/downlevel-dts/getAllFiles.mjs
@@ -1,16 +1,17 @@
-import { readdirSync, statSync } from "fs";
+import { readdir, stat } from "fs/promises";
 
-export const getAllFiles = (dirPath, arrayOfFiles = []) => {
-  const files = readdirSync(dirPath);
+export const getAllFiles = async (dirPath, arrayOfFiles = []) => {
+  const files = await readdir(dirPath);
 
-  files.forEach((file) => {
-    const { isDirectory } = statSync(dirPath + "/" + file);
+  for (const file of files) {
+    const { isDirectory } = await stat(dirPath + "/" + file);
     if (isDirectory()) {
-      arrayOfFiles = getAllFiles(dirPath + "/" + file, arrayOfFiles);
+      const filesInDirectory = await getAllFiles(dirPath + "/" + file, arrayOfFiles);
+      arrayOfFiles.push(filesInDirectory);
     } else {
       arrayOfFiles.push(join(dirPath, "/", file));
     }
-  });
+  }
 
   return arrayOfFiles;
 };

--- a/scripts/downlevel-dts/getAllFiles.mjs
+++ b/scripts/downlevel-dts/getAllFiles.mjs
@@ -1,0 +1,16 @@
+import { readdirSync, statSync } from "fs";
+
+export const getAllFiles = (dirPath, arrayOfFiles = []) => {
+  const files = readdirSync(dirPath);
+
+  files.forEach((file) => {
+    const { isDirectory } = statSync(dirPath + "/" + file);
+    if (isDirectory()) {
+      arrayOfFiles = getAllFiles(dirPath + "/" + file, arrayOfFiles);
+    } else {
+      arrayOfFiles.push(join(dirPath, "/", file));
+    }
+  });
+
+  return arrayOfFiles;
+};

--- a/scripts/downlevel-dts/getDeclarationDirname.mjs
+++ b/scripts/downlevel-dts/getDeclarationDirname.mjs
@@ -1,0 +1,14 @@
+import { readFile } from "fs/promises";
+import { join } from "path";
+
+export const getDeclarationDirname = async (workspaceDir) => {
+  const tsTypesConfigPath = join(workspaceDir, "tsconfig.types.json");
+  const tsTypesConfigJson = JSON.parse((await readFile(tsTypesConfigPath)).toString());
+
+  const declarationDirname = tsTypesConfigJson.compilerOptions.declarationDir;
+  if (!declarationDirname) {
+    throw new Error(`The declarationDir is not defined in "${tsTypesConfigPath}".`);
+  }
+
+  return declarationDirname;
+};

--- a/scripts/downlevel-dts/getDownlevelDirname.mjs
+++ b/scripts/downlevel-dts/getDownlevelDirname.mjs
@@ -1,0 +1,13 @@
+import { readFile } from "fs/promises";
+import { join } from "path";
+
+export const getDownlevelDirname = async (workspaceDir) => {
+  const packageJsonPath = join(workspaceDir, "package.json");
+  const packageJson = JSON.parse((await readFile(packageJsonPath)).toString());
+  if (!packageJson.scripts["downlevel-dts"]) {
+    console.error(`The "downlevel-dts" script is not defined for "${workspaceDir}"`);
+    return;
+  }
+  const downlevelArgs = packageJson.scripts["downlevel-dts"].split(" ");
+  return downlevelArgs[2].replace(`${downlevelArgs[1]}/`, "");
+};

--- a/scripts/downlevel-dts/getWorkspaces.mjs
+++ b/scripts/downlevel-dts/getWorkspaces.mjs
@@ -1,0 +1,13 @@
+import { readdirSync, readFileSync } from "fs";
+import { join } from "path";
+
+export const getWorkspaces = (rootDir) => {
+  const { packages } = JSON.parse(readFileSync(join(rootDir, "package.json")).toString()).workspaces;
+  return packages
+    .map((dir) => dir.replace("/*", ""))
+    .flatMap((workspacesDir) =>
+      readdirSync(join(rootDir, workspacesDir), { withFileTypes: true })
+        .filter((dirent) => dirent.isDirectory())
+        .map((dirent) => ({ workspacesDir, workspaceName: dirent.name }))
+    );
+};

--- a/scripts/downlevel-dts/index.js
+++ b/scripts/downlevel-dts/index.js
@@ -2,12 +2,9 @@
 const yargs = require("yargs");
 
 const { readFileSync, readdirSync, statSync } = require("fs");
-const { access, readFile, writeFile } = require("fs/promises");
 const { join } = require("path");
-const { promisify } = require("util");
-const exec = promisify(require("child_process").exec);
-const stripComments = require("strip-comments");
 const { cpus } = require("os");
+const { downlevelWorkspace } = require("./downlevelWorkspace");
 const parallelLimit = require("async/parallelLimit");
 
 // ToDo: Write downlevel-dts as a yargs command, and import yargs in scripts instead.
@@ -34,58 +31,6 @@ const getAllFiles = (dirPath, arrayOfFiles = []) => {
   });
 
   return arrayOfFiles;
-};
-
-const downlevelWorkspace = async (workspacesDir, workspaceName) => {
-  const workspaceDir = join(workspacesDir, workspaceName);
-
-  const packageJsonPath = join(workspaceDir, "package.json");
-  const packageJson = JSON.parse((await readFile(packageJsonPath)).toString());
-  if (!packageJson.scripts["downlevel-dts"]) {
-    console.error(`The "downlevel-dts" script is not defined for "${workspaceDir}"`);
-    return;
-  }
-  const downlevelArgs = packageJson.scripts["downlevel-dts"].split(" ");
-  const downlevelDirname = downlevelArgs[2].replace(`${downlevelArgs[1]}/`, "");
-
-  const tsTypesConfigPath = join(workspaceDir, "tsconfig.types.json");
-  const declarationDirname = JSON.parse((await readFile(tsTypesConfigPath)).toString()).compilerOptions.declarationDir;
-
-  if (!declarationDirname) {
-    throw new Error(`The declarationDir is not defined in "${tsTypesConfigPath}".`);
-  }
-
-  const declarationDir = join(workspaceDir, declarationDirname);
-  try {
-    await access(declarationDir);
-  } catch (error) {
-    throw new Error(
-      `The types for "${workspaceName}" do not exist.\n` +
-        `Please build types for workspace "${workspaceDir}" before running downlevel-dts script.`
-    );
-  }
-
-  const downlevelDir = join(declarationDir, downlevelDirname);
-  // Create downlevel-dts folder if it doesn't exist
-  try {
-    await access(downlevelDir);
-  } catch (error) {
-    await exec(["yarn", "downlevel-dts"].join(" "), { cwd: workspaceDir });
-  }
-
-  // Strip comments from downlevel-dts files
-  try {
-    await access(downlevelDir);
-    getAllFiles(downlevelDir).forEach(async (downlevelTypesFilepath) => {
-      try {
-        const content = await readFile(downlevelTypesFilepath, "utf8");
-        await writeFile(downlevelTypesFilepath, stripComments(content));
-      } catch (error) {
-        console.error(`Error while stripping comments from "${downlevelTypesFilepath.replace(process.cwd(), "")}"`);
-        console.error(error);
-      }
-    });
-  } catch (error) {}
 };
 
 const workspaces = packages

--- a/scripts/downlevel-dts/index.js
+++ b/scripts/downlevel-dts/index.js
@@ -1,10 +1,14 @@
 // @ts-check
 const yargs = require("yargs");
 
-const { existsSync, readdirSync, readFileSync, statSync, writeFileSync } = require("fs");
+const { readFileSync, readdirSync, statSync } = require("fs");
+const { access, readFile, writeFile } = require("fs/promises");
 const { join } = require("path");
-const { execSync } = require("child_process");
+const { promisify } = require("util");
+const exec = promisify(require("child_process").exec);
 const stripComments = require("strip-comments");
+const { cpus } = require("os");
+const parallelLimit = require("async/parallelLimit");
 
 // ToDo: Write downlevel-dts as a yargs command, and import yargs in scripts instead.
 yargs
@@ -32,60 +36,72 @@ const getAllFiles = (dirPath, arrayOfFiles = []) => {
   return arrayOfFiles;
 };
 
-packages
+const downlevelWorkspace = async (workspacesDir, workspaceName) => {
+  const workspaceDir = join(workspacesDir, workspaceName);
+
+  const packageJsonPath = join(workspaceDir, "package.json");
+  const packageJson = JSON.parse((await readFile(packageJsonPath)).toString());
+  if (!packageJson.scripts["downlevel-dts"]) {
+    console.error(`The "downlevel-dts" script is not defined for "${workspaceDir}"`);
+    return;
+  }
+  const downlevelArgs = packageJson.scripts["downlevel-dts"].split(" ");
+  const downlevelDirname = downlevelArgs[2].replace(`${downlevelArgs[1]}/`, "");
+
+  const tsTypesConfigPath = join(workspaceDir, "tsconfig.types.json");
+  const declarationDirname = JSON.parse((await readFile(tsTypesConfigPath)).toString()).compilerOptions.declarationDir;
+
+  if (!declarationDirname) {
+    throw new Error(`The declarationDir is not defined in "${tsTypesConfigPath}".`);
+  }
+
+  const declarationDir = join(workspaceDir, declarationDirname);
+  try {
+    await access(declarationDir);
+  } catch (error) {
+    throw new Error(
+      `The types for "${workspaceName}" do not exist.\n` +
+        `Please build types for workspace "${workspaceDir}" before running downlevel-dts script.`
+    );
+  }
+
+  const downlevelDir = join(declarationDir, downlevelDirname);
+  // Create downlevel-dts folder if it doesn't exist
+  try {
+    await access(downlevelDir);
+  } catch (error) {
+    await exec(["yarn", "downlevel-dts"].join(" "), { cwd: workspaceDir });
+  }
+
+  // Strip comments from downlevel-dts files
+  try {
+    await access(downlevelDir);
+    getAllFiles(downlevelDir).forEach(async (downlevelTypesFilepath) => {
+      try {
+        const content = await readFile(downlevelTypesFilepath, "utf8");
+        await writeFile(downlevelTypesFilepath, stripComments(content));
+      } catch (error) {
+        console.error(`Error while stripping comments from "${downlevelTypesFilepath.replace(process.cwd(), "")}"`);
+        console.error(error);
+      }
+    });
+  } catch (error) {}
+};
+
+const workspaces = packages
   .map((dir) => dir.replace("/*", ""))
-  .forEach((workspacesDir) => {
-    // Process each workspace in workspace directory
+  .flatMap((workspacesDir) =>
     readdirSync(join(process.cwd(), workspacesDir), { withFileTypes: true })
       .filter((dirent) => dirent.isDirectory())
-      .map((dirent) => dirent.name)
-      .forEach((workspaceName) => {
-        const workspaceDir = join(workspacesDir, workspaceName);
+      .map((dirent) => ({ workspacesDir, workspaceName: dirent.name }))
+  );
 
-        const packageJsonPath = join(workspaceDir, "package.json");
-        const packageJson = JSON.parse(readFileSync(packageJsonPath).toString());
-        if (!packageJson.scripts["downlevel-dts"]) {
-          console.error(`The "downlevel-dts" script is not defined for "${workspaceDir}"`);
-          return;
-        }
-        const downlevelArgs = packageJson.scripts["downlevel-dts"].split(" ");
-        const downlevelDirname = downlevelArgs[2].replace(`${downlevelArgs[1]}/`, "");
+const tasks = workspaces.map(({ workspacesDir, workspaceName }) => async () => {
+  await downlevelWorkspace(workspacesDir, workspaceName);
+});
 
-        const tsTypesConfigPath = join(workspaceDir, "tsconfig.types.json");
-        const declarationDirname = JSON.parse(readFileSync(tsTypesConfigPath).toString()).compilerOptions
-          .declarationDir;
-
-        if (!declarationDirname) {
-          throw new Error(`The declarationDir is not defined in "${tsTypesConfigPath}".`);
-        }
-
-        const declarationDir = join(workspaceDir, declarationDirname);
-        if (!existsSync(declarationDir)) {
-          throw new Error(
-            `The types for "${workspaceName}" do not exist.\n` +
-              `Please build types for workspace "${workspaceDir}" before running downlevel-dts script.`
-          );
-        }
-
-        const downlevelDir = join(declarationDir, downlevelDirname);
-        // Create downlevel-dts folder if it doesn't exist
-        if (!existsSync(downlevelDir)) {
-          execSync(["yarn", "downlevel-dts"].join(" "), { cwd: workspaceDir });
-        }
-
-        // Strip comments from downlevel-dts files
-        if (existsSync(downlevelDir)) {
-          getAllFiles(downlevelDir).forEach((downlevelTypesFilepath) => {
-            try {
-              const content = readFileSync(downlevelTypesFilepath, "utf8");
-              writeFileSync(downlevelTypesFilepath, stripComments(content));
-            } catch (error) {
-              console.error(
-                `Error while stripping comments from "${downlevelTypesFilepath.replace(process.cwd(), "")}"`
-              );
-              console.error(error);
-            }
-          });
-        }
-      });
-  });
+parallelLimit(tasks, cpus().length, function (err) {
+  if (err) {
+    throw err;
+  }
+});

--- a/scripts/downlevel-dts/index.mjs
+++ b/scripts/downlevel-dts/index.mjs
@@ -1,18 +1,18 @@
 // @ts-check
-const yargs = require("yargs");
+import parallelLimit from "async/parallelLimit";
+import { readdirSync, readFileSync, statSync } from "fs";
+import { cpus } from "os";
+import { join } from "path";
+import yargs from "yargs";
 
-const { readFileSync, readdirSync, statSync } = require("fs");
-const { join } = require("path");
-const { cpus } = require("os");
-const { downlevelWorkspace } = require("./downlevelWorkspace");
-const parallelLimit = require("async/parallelLimit");
+import { downlevelWorkspace } from "./downlevelWorkspace.mjs";
 
 // ToDo: Write downlevel-dts as a yargs command, and import yargs in scripts instead.
 yargs
   .usage(
     "Runs downlevel-dts npm script (if present) in each workspace of monorepo," +
       " and strips comments from *.d.ts files.\n\n" +
-      "Usage: index.js"
+      "Usage: index.mjs"
   )
   .help()
   .alias("h", "help").argv;

--- a/yarn.lock
+++ b/yarn.lock
@@ -10462,6 +10462,13 @@ run-async@^2.2.0:
   resolved "https://registry.yarnpkg.com/run-async/-/run-async-2.4.1.tgz#8440eccf99ea3e70bd409d49aab88e10c189a455"
   integrity sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==
 
+run-parallel-limit@1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/run-parallel-limit/-/run-parallel-limit-1.1.0.tgz#be80e936f5768623a38a963262d6bef8ff11e7ba"
+  integrity sha512-jJA7irRNM91jaKc3Hcl1npHsFLOXOoTkPCUL1JEa1R82O2miplXXRaGdjW/KM/98YQWDhJLiSs793CnXfblJUw==
+  dependencies:
+    queue-microtask "^1.2.2"
+
 run-parallel@^1.1.9:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/run-parallel/-/run-parallel-1.2.0.tgz#66d1368da7bdf921eb9d95bd1a9229e7f21a43ee"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2601,6 +2601,11 @@ async@3.2.0, async@^3.0.1:
   resolved "https://registry.yarnpkg.com/async/-/async-3.2.0.tgz#b3a2685c5ebb641d3de02d161002c60fc9f85720"
   integrity sha512-TR2mEZFVOj2pLStYxLht7TyfuRzaydfpxr3k9RpHIzMgw7A64dzsdqCxH1WJyQdoe8T10nDXd9wnEigmiuHIZw==
 
+async@3.2.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/async/-/async-3.2.1.tgz#d3274ec66d107a47476a4c49136aacdb00665fc8"
+  integrity sha512-XdD5lRO/87udXCMC9meWdYiR+Nq6ZjUfXidViUZGu2F1MO4T3XwZ1et0hb2++BgLfhyJwy44BGB/yx80ABx8hg==
+
 asynckit@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"

--- a/yarn.lock
+++ b/yarn.lock
@@ -10467,13 +10467,6 @@ run-async@^2.2.0:
   resolved "https://registry.yarnpkg.com/run-async/-/run-async-2.4.1.tgz#8440eccf99ea3e70bd409d49aab88e10c189a455"
   integrity sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==
 
-run-parallel-limit@1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/run-parallel-limit/-/run-parallel-limit-1.1.0.tgz#be80e936f5768623a38a963262d6bef8ff11e7ba"
-  integrity sha512-jJA7irRNM91jaKc3Hcl1npHsFLOXOoTkPCUL1JEa1R82O2miplXXRaGdjW/KM/98YQWDhJLiSs793CnXfblJUw==
-  dependencies:
-    queue-microtask "^1.2.2"
-
 run-parallel@^1.1.9:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/run-parallel/-/run-parallel-1.2.0.tgz#66d1368da7bdf921eb9d95bd1a9229e7f21a43ee"


### PR DESCRIPTION
### Issue
Refs: https://github.com/aws/aws-sdk-js-v3/pull/2834#issuecomment-928178784

### Description
Runs downlevel-dts scripts in parallel to improve performance.

<details>
<summary>Before</summary>

```console
$ foreach dir ("lib" "packages" "clients" "protocol_tests")
  for d in $dir/* ;do (cd "$d" && rm -rf dist/types/ts3.4); done
end

$ time yarn downlevel-dts
yarn run v1.22.11
$ node ./scripts/downlevel-dts
Done in 699.06s.
yarn downlevel-dts  1165.78s user 64.57s system 175% cpu 11:39.19 total
```

</details>

<details>
<summary>After</summary>

```console
$ foreach dir ("lib" "packages" "clients" "protocol_tests")
  for d in $dir/* ;do (cd "$d" && rm -rf dist/types/ts3.4); done
end

$ time yarn downlevel-dts
yarn run v1.22.11
$ node --es-module-specifier-resolution=node ./scripts/downlevel-dts
Done in 58.73s.
yarn downlevel-dts  1977.88s user 84.27s system 3503% cpu 58.863 total
```

</details>

### Testing
Verified that comments are removed from `*.d.ts` files.

Tested by running manually running local `downlevel-dts` in `packages/abort-controller` followed by running global `downlevel-dts`:

<details>
<summary>Before</summary>

```console
$ head dist/types/ts3.4/AbortSignal.d.ts
import { AbortHandler, AbortSignal as IAbortSignal } from "@aws-sdk/types";
export declare class AbortSignal implements IAbortSignal {
    onabort: AbortHandler | null;
    private _aborted;
    constructor();
    /*
    * Whether the associated operation has already been cancelled.
    */
    readonly aborted: boolean;
    /**
```

</details>

<details>
<summary>After</summary>

```console
$ head dist/types/ts3.4/AbortSignal.d.ts
import { AbortHandler, AbortSignal as IAbortSignal } from "@aws-sdk/types";
export declare class AbortSignal implements IAbortSignal {
    onabort: AbortHandler | null;
    private _aborted;
    constructor();

    readonly aborted: boolean;

    abort(): void;
}
```

</details>


---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
