### PR TITLE
feat(scripts): add script to eslint --fix clients source code

### DIFF
--- a/scripts/generate-clients/code-eslint-fix.js
+++ b/scripts/generate-clients/code-eslint-fix.js
@@ -1,0 +1,17 @@
+// @ts-check
+const { spawnProcess } = require("../utils/spawn-process");
+const path = require("path");
+
+const eslintFixCode = async (dir) => {
+  await spawnProcess(path.join(__dirname, "..", "..", "node_modules", ".bin", "eslint"), [
+    "--fix",
+    "--quiet",
+    "--rule",
+    `{'prefer-const': 'off'}`,
+    `${dir}/*/typescript-codegen/**/*.ts`,
+  ]);
+};
+
+module.exports = {
+  eslintFixCode,
+};

--- a/scripts/generate-clients/index.js
+++ b/scripts/generate-clients/index.js
@@ -10,6 +10,7 @@ const {
   TEMP_CODE_GEN_INPUT_DIR,
 } = require("./code-gen-dir");
 const { prettifyCode } = require("./code-prettify");
+const { eslintFixCode } = require("./code-eslint-fix");
 
 const SDK_CLIENTS_DIR = path.normalize(path.join(__dirname, "..", "..", "clients"));
 const PROTOCOL_TESTS_CLIENTS_DIR = path.normalize(path.join(__dirname, "..", "..", "protocol_tests"));
@@ -58,8 +59,12 @@ const {
     await generateClients(models || globs);
     if (!noProtocolTest) await generateProtocolTests();
 
+    await eslintFixCode(CODE_GEN_SDK_OUTPUT_DIR);
     await prettifyCode(CODE_GEN_SDK_OUTPUT_DIR);
-    if (!noProtocolTest) await prettifyCode(CODE_GEN_PROTOCOL_TESTS_OUTPUT_DIR);
+    if (!noProtocolTest) {
+      await eslintFixCode(CODE_GEN_PROTOCOL_TESTS_OUTPUT_DIR);
+      await prettifyCode(CODE_GEN_PROTOCOL_TESTS_OUTPUT_DIR);
+    }
 
     await copyToClients(CODE_GEN_SDK_OUTPUT_DIR, clientsDir);
     if (!noProtocolTest) await copyToClients(CODE_GEN_PROTOCOL_TESTS_OUTPUT_DIR, PROTOCOL_TESTS_CLIENTS_DIR);


### PR DESCRIPTION
### Issue
N/A

### Description
Adds script to `eslint --fix` source code for clients.

<details>
<summary>Before</summary>

```console
$ time yarn generate-clients
...
Done in 70.78s.
yarn generate-clients  10.71s user 2.41s system 18% cpu 1:10.91 total
```

</details>

<details>
<summary>After</summary>

```console
$ time yarn generate-clients
...
Done in 394.65s.
yarn generate-clients  407.29s user 13.74s system 106% cpu 6:34.78 total
```

</details>


### Testing
Verified that source code is linted.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
