### PR TITLE
test(protocol): compare xml payload correctly

### DIFF
--- a/protocol_tests/aws-restxml/test/functional/restxml.spec.ts
+++ b/protocol_tests/aws-restxml/test/functional/restxml.spec.ts
@@ -6768,7 +6768,7 @@ const compareEquivalentXmlBodies = (expectedBody: string, generatedBody: string)
       parsedObjToReturn[key] = parsedObjToReturn[textNodeName];
       delete parsedObjToReturn[textNodeName];
     }
-    return parsedObjToReturn;
+    return parsedObj;
   };
 
   const expectedParts = parseXmlBody(expectedBody);


### PR DESCRIPTION
### Issue
Followup to #2835
Related to https://github.com/awslabs/smithy-typescript/pull/433

### Description
Previously the protocol test won't throw if the xml payload's outmost node name is different. For example, it succeeded if payload is `<Hola><name>Phreddy</name></Hola>` but expected `<Hello><name>Phreddy</name></Hello>`. This change fixes it.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
