### PR TITLE
chore(codegen): gitignore files auto-created by VSCode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,5 +45,9 @@ dist
 *.tsbuildinfo
 
 codegen/.project
+codegen/.classpath
+codegen/.settings/
 codegen/*/.project
+codegen/*/.classpath
+codegen/*/.settings/
 codegen/*/bin

--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,7 @@ dist
 !/verdaccio/config.yaml
 
 *.tsbuildinfo
+
+codegen/.project
+codegen/*/.project
+codegen/*/bin


### PR DESCRIPTION
### Issue
Refs: https://github.com/awslabs/smithy-typescript/issues/425

### Description
gitignore files auto-created by VSCode in codegen

### Testing
N/A

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
