### PR TITLE
feat(codegen): move source files to 'src' folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ codegen/sdk-codegen/smithy-build.json
 
 coverage
 dist
+dist-*
 
 /verdaccio/*
 !/verdaccio/config.yaml

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddAwsAuthPlugin.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddAwsAuthPlugin.java
@@ -179,7 +179,7 @@ public final class AddAwsAuthPlugin implements TypeScriptIntegration {
                                     AwsDependency.STS_CLIENT.packageName);
                         } else {
                             writer.addImport("decorateDefaultCredentialProvider", "decorateDefaultCredentialProvider",
-                                    "./" + STS_ROLE_ASSUMERS_FILE);
+                                    "./src/" + STS_ROLE_ASSUMERS_FILE);
                         }
                         writer.addDependency(AwsDependency.CREDENTIAL_PROVIDER_NODE);
                         writer.addImport("defaultProvider", "credentialDefaultProvider",
@@ -206,19 +206,19 @@ public final class AddAwsAuthPlugin implements TypeScriptIntegration {
         String noTouchNoticePrefix = "// Please do not touch this file. It's generated from template in:\n"
                 + "// https://github.com/aws/aws-sdk-js-v3/blob/main/codegen/smithy-aws-typescript-codegen/"
                 + "src/main/resources/software/amazon/smithy/aws/typescript/codegen/";
-        writerFactory.accept("defaultRoleAssumers.ts", writer -> {
+        writerFactory.accept("src/defaultRoleAssumers.ts", writer -> {
             String resourceName = String.format("%s%s.ts", STS_CLIENT_PREFIX, ROLE_ASSUMERS_FILE);
             String source = IoUtils.readUtf8Resource(getClass(), resourceName);
             writer.write("$L$L", noTouchNoticePrefix, resourceName);
             writer.write("$L", source);
         });
-        writerFactory.accept("defaultStsRoleAssumers.ts", writer -> {
+        writerFactory.accept("src/defaultStsRoleAssumers.ts", writer -> {
             String resourceName = String.format("%s%s.ts", STS_CLIENT_PREFIX, STS_ROLE_ASSUMERS_FILE);
             String source = IoUtils.readUtf8Resource(getClass(), resourceName);
             writer.write("$L$L", noTouchNoticePrefix, resourceName);
             writer.write("$L", source);
         });
-        writerFactory.accept("defaultRoleAssumers.spec.ts", writer -> {
+        writerFactory.accept("test/defaultRoleAssumers.spec.ts", writer -> {
             String resourceName = String.format("%s%s.ts", STS_CLIENT_PREFIX, ROLE_ASSUMERS_TEST_FILE);
             String source = IoUtils.readUtf8Resource(getClass(), resourceName);
             writer.write("$L$L", noTouchNoticePrefix, resourceName);

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddAwsAuthPlugin.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddAwsAuthPlugin.java
@@ -37,6 +37,7 @@ import software.amazon.smithy.model.shapes.OperationShape;
 import software.amazon.smithy.model.shapes.ServiceShape;
 import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.traits.OptionalAuthTrait;
+import software.amazon.smithy.typescript.codegen.CodegenUtils;
 import software.amazon.smithy.typescript.codegen.LanguageTarget;
 import software.amazon.smithy.typescript.codegen.TypeScriptDependency;
 import software.amazon.smithy.typescript.codegen.TypeScriptSettings;
@@ -179,7 +180,7 @@ public final class AddAwsAuthPlugin implements TypeScriptIntegration {
                                     AwsDependency.STS_CLIENT.packageName);
                         } else {
                             writer.addImport("decorateDefaultCredentialProvider", "decorateDefaultCredentialProvider",
-                                    "./src/" + STS_ROLE_ASSUMERS_FILE);
+                                    "./" + CodegenUtils.SOURCE_FOLDER + "/" + STS_ROLE_ASSUMERS_FILE);
                         }
                         writer.addDependency(AwsDependency.CREDENTIAL_PROVIDER_NODE);
                         writer.addImport("defaultProvider", "credentialDefaultProvider",
@@ -206,13 +207,13 @@ public final class AddAwsAuthPlugin implements TypeScriptIntegration {
         String noTouchNoticePrefix = "// Please do not touch this file. It's generated from template in:\n"
                 + "// https://github.com/aws/aws-sdk-js-v3/blob/main/codegen/smithy-aws-typescript-codegen/"
                 + "src/main/resources/software/amazon/smithy/aws/typescript/codegen/";
-        writerFactory.accept("src/defaultRoleAssumers.ts", writer -> {
+        writerFactory.accept(CodegenUtils.SOURCE_FOLDER + "/defaultRoleAssumers.ts", writer -> {
             String resourceName = String.format("%s%s.ts", STS_CLIENT_PREFIX, ROLE_ASSUMERS_FILE);
             String source = IoUtils.readUtf8Resource(getClass(), resourceName);
             writer.write("$L$L", noTouchNoticePrefix, resourceName);
             writer.write("$L", source);
         });
-        writerFactory.accept("src/defaultStsRoleAssumers.ts", writer -> {
+        writerFactory.accept(CodegenUtils.SOURCE_FOLDER + "/defaultStsRoleAssumers.ts", writer -> {
             String resourceName = String.format("%s%s.ts", STS_CLIENT_PREFIX, STS_ROLE_ASSUMERS_FILE);
             String source = IoUtils.readUtf8Resource(getClass(), resourceName);
             writer.write("$L$L", noTouchNoticePrefix, resourceName);

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsEndpointGeneratorIntegration.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsEndpointGeneratorIntegration.java
@@ -23,6 +23,7 @@ import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import software.amazon.smithy.codegen.core.SymbolProvider;
 import software.amazon.smithy.model.Model;
+import software.amazon.smithy.typescript.codegen.CodegenUtils;
 import software.amazon.smithy.typescript.codegen.LanguageTarget;
 import software.amazon.smithy.typescript.codegen.TypeScriptDependency;
 import software.amazon.smithy.typescript.codegen.TypeScriptSettings;
@@ -47,7 +48,7 @@ public final class AwsEndpointGeneratorIntegration implements TypeScriptIntegrat
             return;
         }
 
-        writerFactory.accept("endpoints.ts", writer -> {
+        writerFactory.accept(CodegenUtils.SOURCE_FOLDER + "/endpoints.ts", writer -> {
             new EndpointGenerator(settings.getService(model), writer).run();
         });
     }
@@ -83,7 +84,8 @@ public final class AwsEndpointGeneratorIntegration implements TypeScriptIntegrat
         switch (target) {
             case SHARED:
                 return MapUtils.of("regionInfoProvider", writer -> {
-                    writer.addImport("defaultRegionInfoProvider", "defaultRegionInfoProvider", "./endpoints");
+                    writer.addImport("defaultRegionInfoProvider", "defaultRegionInfoProvider",
+                            "./" + CodegenUtils.SOURCE_FOLDER + "/endpoints");
                     writer.write("defaultRegionInfoProvider");
                 });
             default:

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsServiceIdIntegration.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsServiceIdIntegration.java
@@ -65,8 +65,8 @@ public final class AwsServiceIdIntegration implements TypeScriptIntegration {
                 .collect(Collectors.joining("")) + "Client";
         return symbol.toBuilder()
                 .name(name)
-                .namespace("./" + name, "/")
-                .definitionFile(name + ".ts")
+                .namespace("./src/" + name, "/")
+                .definitionFile("./src/" + name + ".ts")
                 .build();
     }
 }

--- a/codegen/smithy-aws-typescript-codegen/src/main/resources/software/amazon/smithy/aws/typescript/codegen/gitignore
+++ b/codegen/smithy-aws-typescript-codegen/src/main/resources/software/amazon/smithy/aws/typescript/codegen/gitignore
@@ -2,7 +2,7 @@
 /build/
 /coverage/
 /docs/
-/dist/
+/dist-*
 *.tsbuildinfo
 *.tgz
 *.log

--- a/codegen/smithy-aws-typescript-codegen/src/main/resources/software/amazon/smithy/aws/typescript/codegen/sts-client-defaultRoleAssumers.spec.ts
+++ b/codegen/smithy-aws-typescript-codegen/src/main/resources/software/amazon/smithy/aws/typescript/codegen/sts-client-defaultRoleAssumers.spec.ts
@@ -15,10 +15,11 @@ jest.mock("@aws-sdk/node-http-handler", () => ({
   streamCollector: jest.fn(),
 }));
 
-import { getDefaultRoleAssumer, getDefaultRoleAssumerWithWebIdentity } from "./defaultRoleAssumers";
-import type { AssumeRoleCommandInput } from "./commands/AssumeRoleCommand";
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
-import { AssumeRoleWithWebIdentityCommandInput } from "./commands/AssumeRoleWithWebIdentityCommand";
+
+import type { AssumeRoleCommandInput } from "../src/commands/AssumeRoleCommand";
+import { AssumeRoleWithWebIdentityCommandInput } from "../src/commands/AssumeRoleWithWebIdentityCommand";
+import { getDefaultRoleAssumer, getDefaultRoleAssumerWithWebIdentity } from "../src/defaultRoleAssumers";
 const mockConstructorInput = jest.fn();
 jest.mock("./STSClient", () => ({
   STSClient: function (params: any) {

--- a/codegen/smithy-aws-typescript-codegen/src/test/java/software/amazon/smithy/aws/typescript/codegen/AddAwsAuthPluginTest.java
+++ b/codegen/smithy-aws-typescript-codegen/src/test/java/software/amazon/smithy/aws/typescript/codegen/AddAwsAuthPluginTest.java
@@ -9,6 +9,7 @@ import software.amazon.smithy.build.MockManifest;
 import software.amazon.smithy.build.PluginContext;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.typescript.codegen.CodegenUtils;
 import software.amazon.smithy.typescript.codegen.TypeScriptCodegenPlugin;
 
 public class AddAwsAuthPluginTest {
@@ -37,18 +38,18 @@ public class AddAwsAuthPluginTest {
                 containsString(AwsDependency.CREDENTIAL_PROVIDER_NODE.packageName));
 
         // Check config interface fields
-        assertThat(manifest.getFileString("NotSameClient.ts").get(), containsString("credentialDefaultProvider?"));
-        assertThat(manifest.getFileString("NotSameClient.ts").get(), not(containsString("signingName")));
+        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/NotSameClient.ts").get(), containsString("credentialDefaultProvider?"));
+        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/NotSameClient.ts").get(), not(containsString("signingName")));
 
         // Check config files
-        assertThat(manifest.getFileString("runtimeConfig.ts").get(),
+        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/runtimeConfig.ts").get(),
                 containsString("decorateDefaultCredentialProvider"));
-        assertThat(manifest.getFileString("runtimeConfig.browser.ts").get(), containsString("Credential is missing"));
-        assertThat(manifest.getFileString("runtimeConfig.shared.ts").get(), not(containsString("signingName:")));
+        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/runtimeConfig.browser.ts").get(), containsString("Credential is missing"));
+        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/runtimeConfig.shared.ts").get(), not(containsString("signingName:")));
 
         // Check the config resolution and middleware plugin
-        assertThat(manifest.getFileString("NotSameClient.ts").get(), containsString("resolveAwsAuthConfig"));
-        assertThat(manifest.getFileString("NotSameClient.ts").get(), containsString("getAwsAuthPlugin"));
+        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/NotSameClient.ts").get(), containsString("resolveAwsAuthConfig"));
+        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/NotSameClient.ts").get(), containsString("getAwsAuthPlugin"));
     }
 
     @Test
@@ -76,18 +77,18 @@ public class AddAwsAuthPluginTest {
                 containsString(AwsDependency.CREDENTIAL_PROVIDER_NODE.packageName));
 
         // Check config interface fields
-        assertThat(manifest.getFileString("SsdkExampleSigV4Client.ts").get(), containsString("credentialDefaultProvider?"));
-        assertThat(manifest.getFileString("SsdkExampleSigV4Client.ts").get(), containsString("signingName?"));
+        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/SsdkExampleSigV4Client.ts").get(), containsString("credentialDefaultProvider?"));
+        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/SsdkExampleSigV4Client.ts").get(), containsString("signingName?"));
 
         // Check config files
-        assertThat(manifest.getFileString("runtimeConfig.ts").get(),
+        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/runtimeConfig.ts").get(),
                 containsString("decorateDefaultCredentialProvider"));
-        assertThat(manifest.getFileString("runtimeConfig.browser.ts").get(), containsString("Credential is missing"));
-        assertThat(manifest.getFileString("runtimeConfig.shared.ts").get(), containsString("signingName:"));
+        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/runtimeConfig.browser.ts").get(), containsString("Credential is missing"));
+        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/runtimeConfig.shared.ts").get(), containsString("signingName:"));
 
         // Check the config resolution and middleware plugin
-        assertThat(manifest.getFileString("SsdkExampleSigV4Client.ts").get(), containsString("resolveSigV4AuthConfig"));
-        assertThat(manifest.getFileString("SsdkExampleSigV4Client.ts").get(), containsString("getSigV4AuthPlugin"));
+        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/SsdkExampleSigV4Client.ts").get(), containsString("resolveSigV4AuthConfig"));
+        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/SsdkExampleSigV4Client.ts").get(), containsString("getSigV4AuthPlugin"));
     }
 
     @Test
@@ -115,17 +116,17 @@ public class AddAwsAuthPluginTest {
                 not(containsString(AwsDependency.CREDENTIAL_PROVIDER_NODE.packageName)));
 
         // Check config interface fields
-        assertThat(manifest.getFileString("SsdkExampleClient.ts").get(), not(containsString("credentialDefaultProvider?")));
-        assertThat(manifest.getFileString("SsdkExampleClient.ts").get(), not(containsString("signingName?")));
+        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/SsdkExampleClient.ts").get(), not(containsString("credentialDefaultProvider?")));
+        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/SsdkExampleClient.ts").get(), not(containsString("signingName?")));
 
         // Check config files
-        assertThat(manifest.getFileString("runtimeConfig.ts").get(),
+        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/runtimeConfig.ts").get(),
                 not(containsString("decorateDefaultCredentialProvider")));
-        assertThat(manifest.getFileString("runtimeConfig.browser.ts").get(), not(containsString("Credential is missing")));
-        assertThat(manifest.getFileString("runtimeConfig.shared.ts").get(), not(containsString("signingName:")));
+        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/runtimeConfig.browser.ts").get(), not(containsString("Credential is missing")));
+        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/runtimeConfig.shared.ts").get(), not(containsString("signingName:")));
 
         // Check the config resolution and middleware plugin
-        assertThat(manifest.getFileString("SsdkExampleClient.ts").get(), not(containsString("resolveSigV4AuthConfig")));
-        assertThat(manifest.getFileString("SsdkExampleClient.ts").get(), not(containsString("resolveAwsV4AuthConfig")));
+        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/SsdkExampleClient.ts").get(), not(containsString("resolveSigV4AuthConfig")));
+        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/SsdkExampleClient.ts").get(), not(containsString("resolveAwsV4AuthConfig")));
     }
 }

--- a/codegen/smithy-aws-typescript-codegen/src/test/java/software/amazon/smithy/aws/typescript/codegen/AddAwsRuntimeConfigTest.java
+++ b/codegen/smithy-aws-typescript-codegen/src/test/java/software/amazon/smithy/aws/typescript/codegen/AddAwsRuntimeConfigTest.java
@@ -9,6 +9,7 @@ import software.amazon.smithy.build.MockManifest;
 import software.amazon.smithy.build.PluginContext;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.typescript.codegen.CodegenUtils;
 import software.amazon.smithy.typescript.codegen.TypeScriptCodegenPlugin;
 import software.amazon.smithy.typescript.codegen.TypeScriptDependency;
 
@@ -40,13 +41,13 @@ public class AddAwsRuntimeConfigTest {
                 containsString(TypeScriptDependency.CONFIG_RESOLVER.packageName));
 
         // Check config interface fields
-        assertThat(manifest.getFileString("NotSameClient.ts").get(), containsString("serviceId?:"));
-        assertThat(manifest.getFileString("NotSameClient.ts").get(), containsString("region?:"));
+        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/NotSameClient.ts").get(), containsString("serviceId?:"));
+        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/NotSameClient.ts").get(), containsString("region?:"));
 
         // Check config files
-        assertThat(manifest.getFileString("runtimeConfig.shared.ts").get(), containsString("serviceId: config?.serviceId ?? \"Not Same\""));
-        assertThat(manifest.getFileString("runtimeConfig.browser.ts").get(), containsString("region: config?.region ?? invalidProvider"));
-        assertThat(manifest.getFileString("runtimeConfig.ts").get(), containsString("region: config?.region ?? loadNodeConfig"));
+        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/runtimeConfig.shared.ts").get(), containsString("serviceId: config?.serviceId ?? \"Not Same\""));
+        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/runtimeConfig.browser.ts").get(), containsString("region: config?.region ?? invalidProvider"));
+        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/runtimeConfig.ts").get(), containsString("region: config?.region ?? loadNodeConfig"));
     }
 
     @Test
@@ -76,13 +77,13 @@ public class AddAwsRuntimeConfigTest {
                 containsString(TypeScriptDependency.CONFIG_RESOLVER.packageName));
 
         // Check config interface fields
-        assertThat(manifest.getFileString("SsdkExampleSigV4Client.ts").get(), not(containsString("serviceId?:")));
-        assertThat(manifest.getFileString("SsdkExampleSigV4Client.ts").get(), containsString("region?:"));
+        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/SsdkExampleSigV4Client.ts").get(), not(containsString("serviceId?:")));
+        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/SsdkExampleSigV4Client.ts").get(), containsString("region?:"));
 
         // Check config files
-        assertThat(manifest.getFileString("runtimeConfig.shared.ts").get(), not(containsString("serviceId:")));
-        assertThat(manifest.getFileString("runtimeConfig.browser.ts").get(), containsString("region: config?.region ?? invalidProvider"));
-        assertThat(manifest.getFileString("runtimeConfig.ts").get(), containsString("region: config?.region ?? loadNodeConfig"));
+        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/runtimeConfig.shared.ts").get(), not(containsString("serviceId:")));
+        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/runtimeConfig.browser.ts").get(), containsString("region: config?.region ?? invalidProvider"));
+        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/runtimeConfig.ts").get(), containsString("region: config?.region ?? loadNodeConfig"));
     }
 
     @Test
@@ -112,12 +113,12 @@ public class AddAwsRuntimeConfigTest {
                 containsString(TypeScriptDependency.CONFIG_RESOLVER.packageName));
 
         // Check config interface fields
-        assertThat(manifest.getFileString("SsdkExampleClient.ts").get(), not(containsString("serviceId?:")));
-        assertThat(manifest.getFileString("SsdkExampleClient.ts").get(), not(containsString("region?:")));
+        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/SsdkExampleClient.ts").get(), not(containsString("serviceId?:")));
+        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/SsdkExampleClient.ts").get(), not(containsString("region?:")));
 
         // Check config files
-        assertThat(manifest.getFileString("runtimeConfig.shared.ts").get(), not(containsString("serviceId:")));
-        assertThat(manifest.getFileString("runtimeConfig.browser.ts").get(), not(containsString("region:")));
-        assertThat(manifest.getFileString("runtimeConfig.ts").get(), not(containsString("region:")));
+        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/runtimeConfig.shared.ts").get(), not(containsString("serviceId:")));
+        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/runtimeConfig.browser.ts").get(), not(containsString("region:")));
+        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/runtimeConfig.ts").get(), not(containsString("region:")));
     }
 }

--- a/codegen/smithy-aws-typescript-codegen/src/test/java/software/amazon/smithy/aws/typescript/codegen/AddBuiltinPluginsTest.java
+++ b/codegen/smithy-aws-typescript-codegen/src/test/java/software/amazon/smithy/aws/typescript/codegen/AddBuiltinPluginsTest.java
@@ -9,6 +9,7 @@ import software.amazon.smithy.build.MockManifest;
 import software.amazon.smithy.build.PluginContext;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.typescript.codegen.CodegenUtils;
 import software.amazon.smithy.typescript.codegen.TypeScriptCodegenPlugin;
 
 public class AddBuiltinPluginsTest {
@@ -33,13 +34,13 @@ public class AddBuiltinPluginsTest {
         new TypeScriptCodegenPlugin().execute(context);
 
         // Check the config resolution and middleware plugin
-        assertThat(manifest.getFileString("NotSameClient.ts").get(), containsString("resolveRegionConfig"));
-        assertThat(manifest.getFileString("NotSameClient.ts").get(), containsString("resolveEndpointsConfig"));
-        assertThat(manifest.getFileString("NotSameClient.ts").get(), containsString("resolveRetryConfig"));
-        assertThat(manifest.getFileString("NotSameClient.ts").get(), containsString("getRetryPlugin"));
-        assertThat(manifest.getFileString("NotSameClient.ts").get(), containsString("getContentLengthPlugin"));
-        assertThat(manifest.getFileString("NotSameClient.ts").get(), containsString("getHostHeaderPlugin"));
-        assertThat(manifest.getFileString("NotSameClient.ts").get(), containsString("getLoggerPlugin"));
+        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/NotSameClient.ts").get(), containsString("resolveRegionConfig"));
+        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/NotSameClient.ts").get(), containsString("resolveEndpointsConfig"));
+        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/NotSameClient.ts").get(), containsString("resolveRetryConfig"));
+        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/NotSameClient.ts").get(), containsString("getRetryPlugin"));
+        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/NotSameClient.ts").get(), containsString("getContentLengthPlugin"));
+        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/NotSameClient.ts").get(), containsString("getHostHeaderPlugin"));
+        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/NotSameClient.ts").get(), containsString("getLoggerPlugin"));
     }
 
     @Test
@@ -63,13 +64,13 @@ public class AddBuiltinPluginsTest {
         new TypeScriptCodegenPlugin().execute(context);
 
         // Check the config resolution and middleware plugin
-        assertThat(manifest.getFileString("SsdkExampleSigV4Client.ts").get(), containsString("resolveRegionConfig"));
-        assertThat(manifest.getFileString("SsdkExampleSigV4Client.ts").get(), containsString("resolveCustomEndpointsConfig"));
-        assertThat(manifest.getFileString("SsdkExampleSigV4Client.ts").get(), containsString("resolveRetryConfig"));
-        assertThat(manifest.getFileString("SsdkExampleSigV4Client.ts").get(), containsString("getRetryPlugin"));
-        assertThat(manifest.getFileString("SsdkExampleSigV4Client.ts").get(), containsString("getContentLengthPlugin"));
-        assertThat(manifest.getFileString("SsdkExampleSigV4Client.ts").get(), containsString("getHostHeaderPlugin"));
-        assertThat(manifest.getFileString("SsdkExampleSigV4Client.ts").get(), containsString("getLoggerPlugin"));
+        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/SsdkExampleSigV4Client.ts").get(), containsString("resolveRegionConfig"));
+        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/SsdkExampleSigV4Client.ts").get(), containsString("resolveCustomEndpointsConfig"));
+        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/SsdkExampleSigV4Client.ts").get(), containsString("resolveRetryConfig"));
+        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/SsdkExampleSigV4Client.ts").get(), containsString("getRetryPlugin"));
+        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/SsdkExampleSigV4Client.ts").get(), containsString("getContentLengthPlugin"));
+        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/SsdkExampleSigV4Client.ts").get(), containsString("getHostHeaderPlugin"));
+        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/SsdkExampleSigV4Client.ts").get(), containsString("getLoggerPlugin"));
     }
 
     @Test
@@ -93,12 +94,12 @@ public class AddBuiltinPluginsTest {
         new TypeScriptCodegenPlugin().execute(context);
 
         // Check the config resolution and middleware plugin
-        assertThat(manifest.getFileString("SsdkExampleClient.ts").get(), not(containsString("resolveRegionConfig")));
-        assertThat(manifest.getFileString("SsdkExampleClient.ts").get(), containsString("resolveCustomEndpointsConfig"));
-        assertThat(manifest.getFileString("SsdkExampleClient.ts").get(), containsString("resolveRetryConfig"));
-        assertThat(manifest.getFileString("SsdkExampleClient.ts").get(), containsString("getRetryPlugin"));
-        assertThat(manifest.getFileString("SsdkExampleClient.ts").get(), containsString("getContentLengthPlugin"));
-        assertThat(manifest.getFileString("SsdkExampleClient.ts").get(), containsString("getHostHeaderPlugin"));
-        assertThat(manifest.getFileString("SsdkExampleClient.ts").get(), containsString("getLoggerPlugin"));
+        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/SsdkExampleClient.ts").get(), not(containsString("resolveRegionConfig")));
+        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/SsdkExampleClient.ts").get(), containsString("resolveCustomEndpointsConfig"));
+        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/SsdkExampleClient.ts").get(), containsString("resolveRetryConfig"));
+        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/SsdkExampleClient.ts").get(), containsString("getRetryPlugin"));
+        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/SsdkExampleClient.ts").get(), containsString("getContentLengthPlugin"));
+        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/SsdkExampleClient.ts").get(), containsString("getHostHeaderPlugin"));
+        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/SsdkExampleClient.ts").get(), containsString("getLoggerPlugin"));
     }
 }

--- a/codegen/smithy-aws-typescript-codegen/src/test/java/software/amazon/smithy/aws/typescript/codegen/AddClientRuntimeConfigTest.java
+++ b/codegen/smithy-aws-typescript-codegen/src/test/java/software/amazon/smithy/aws/typescript/codegen/AddClientRuntimeConfigTest.java
@@ -8,6 +8,7 @@ import software.amazon.smithy.build.MockManifest;
 import software.amazon.smithy.build.PluginContext;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.typescript.codegen.CodegenUtils;
 import software.amazon.smithy.typescript.codegen.TypeScriptCodegenPlugin;
 import software.amazon.smithy.typescript.codegen.TypeScriptDependency;
 
@@ -41,18 +42,18 @@ public class AddClientRuntimeConfigTest {
                 containsString(TypeScriptDependency.MIDDLEWARE_RETRY.packageName));
 
         // Check config interface fields
-        assertThat(manifest.getFileString("NotSameClient.ts").get(), containsString("maxAttempts?:"));
-        assertThat(manifest.getFileString("NotSameClient.ts").get(), containsString("retryMode?:"));
-        assertThat(manifest.getFileString("NotSameClient.ts").get(), containsString("logger?:"));
+        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/NotSameClient.ts").get(), containsString("maxAttempts?:"));
+        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/NotSameClient.ts").get(), containsString("retryMode?:"));
+        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/NotSameClient.ts").get(), containsString("logger?:"));
 
         // Check config files
-        assertThat(manifest.getFileString("runtimeConfig.shared.ts").get(), containsString("logger:"));
+        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/runtimeConfig.shared.ts").get(), containsString("logger:"));
 
-        assertThat(manifest.getFileString("runtimeConfig.browser.ts").get(), containsString("maxAttempts:"));
-        assertThat(manifest.getFileString("runtimeConfig.browser.ts").get(), containsString("retryMode:"));
+        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/runtimeConfig.browser.ts").get(), containsString("maxAttempts:"));
+        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/runtimeConfig.browser.ts").get(), containsString("retryMode:"));
 
-        assertThat(manifest.getFileString("runtimeConfig.ts").get(), containsString("maxAttempts:"));
-        assertThat(manifest.getFileString("runtimeConfig.ts").get(), containsString("retryMode:"));
+        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/runtimeConfig.ts").get(), containsString("maxAttempts:"));
+        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/runtimeConfig.ts").get(), containsString("retryMode:"));
     }
 
     @Test
@@ -84,18 +85,21 @@ public class AddClientRuntimeConfigTest {
                 containsString(TypeScriptDependency.MIDDLEWARE_RETRY.packageName));
 
         // Check config interface fields
-        assertThat(manifest.getFileString("SsdkExampleSigV4Client.ts").get(), containsString("maxAttempts?:"));
-        assertThat(manifest.getFileString("SsdkExampleSigV4Client.ts").get(), containsString("retryMode?:"));
-        assertThat(manifest.getFileString("SsdkExampleSigV4Client.ts").get(), containsString("logger?:"));
+        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/SsdkExampleSigV4Client.ts").get(),
+                containsString("maxAttempts?:"));
+        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/SsdkExampleSigV4Client.ts").get(),
+                containsString("retryMode?:"));
+        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/SsdkExampleSigV4Client.ts").get(),
+                containsString("logger?:"));
 
         // Check config files
-        assertThat(manifest.getFileString("runtimeConfig.shared.ts").get(), containsString("logger:"));
+        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/runtimeConfig.shared.ts").get(), containsString("logger:"));
 
-        assertThat(manifest.getFileString("runtimeConfig.browser.ts").get(), containsString("maxAttempts:"));
-        assertThat(manifest.getFileString("runtimeConfig.browser.ts").get(), containsString("retryMode:"));
+        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/runtimeConfig.browser.ts").get(), containsString("maxAttempts:"));
+        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/runtimeConfig.browser.ts").get(), containsString("retryMode:"));
 
-        assertThat(manifest.getFileString("runtimeConfig.ts").get(), containsString("maxAttempts:"));
-        assertThat(manifest.getFileString("runtimeConfig.ts").get(), containsString("retryMode:"));
+        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/runtimeConfig.ts").get(), containsString("maxAttempts:"));
+        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/runtimeConfig.ts").get(), containsString("retryMode:"));
     }
 
     @Test
@@ -127,17 +131,17 @@ public class AddClientRuntimeConfigTest {
                 containsString(TypeScriptDependency.MIDDLEWARE_RETRY.packageName));
 
         // Check config interface fields
-        assertThat(manifest.getFileString("SsdkExampleClient.ts").get(), containsString("maxAttempts?:"));
-        assertThat(manifest.getFileString("SsdkExampleClient.ts").get(), containsString("retryMode?:"));
-        assertThat(manifest.getFileString("SsdkExampleClient.ts").get(), containsString("logger?:"));
+        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/SsdkExampleClient.ts").get(), containsString("maxAttempts?:"));
+        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/SsdkExampleClient.ts").get(), containsString("retryMode?:"));
+        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/SsdkExampleClient.ts").get(), containsString("logger?:"));
 
         // Check config files
-        assertThat(manifest.getFileString("runtimeConfig.shared.ts").get(), containsString("logger:"));
+        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/runtimeConfig.shared.ts").get(), containsString("logger:"));
 
-        assertThat(manifest.getFileString("runtimeConfig.browser.ts").get(), containsString("maxAttempts:"));
-        assertThat(manifest.getFileString("runtimeConfig.browser.ts").get(), containsString("retryMode:"));
+        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/runtimeConfig.browser.ts").get(), containsString("maxAttempts:"));
+        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/runtimeConfig.browser.ts").get(), containsString("retryMode:"));
 
-        assertThat(manifest.getFileString("runtimeConfig.ts").get(), containsString("maxAttempts:"));
-        assertThat(manifest.getFileString("runtimeConfig.ts").get(), containsString("retryMode:"));
+        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/runtimeConfig.ts").get(), containsString("maxAttempts:"));
+        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/runtimeConfig.ts").get(), containsString("retryMode:"));
     }
 }

--- a/codegen/smithy-aws-typescript-codegen/src/test/java/software/amazon/smithy/aws/typescript/codegen/AddUserAgentDependencyTest.java
+++ b/codegen/smithy-aws-typescript-codegen/src/test/java/software/amazon/smithy/aws/typescript/codegen/AddUserAgentDependencyTest.java
@@ -9,6 +9,7 @@ import software.amazon.smithy.build.MockManifest;
 import software.amazon.smithy.build.PluginContext;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.typescript.codegen.CodegenUtils;
 import software.amazon.smithy.typescript.codegen.TypeScriptCodegenPlugin;
 
 public class AddUserAgentDependencyTest {
@@ -37,20 +38,20 @@ public class AddUserAgentDependencyTest {
                    containsString(AwsDependency.AWS_SDK_UTIL_USER_AGENT_NODE.packageName));
 
         // Check config interface fields
-        assertThat(manifest.getFileString("NotSameClient.ts").get(), containsString("defaultUserAgentProvider?"));
+        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/NotSameClient.ts").get(), containsString("defaultUserAgentProvider?"));
 
         // Check config files
-        assertThat(manifest.getFileString("runtimeConfig.ts").get(), containsString("defaultUserAgent"));
-        assertThat(manifest.getFileString("runtimeConfig.ts").get(), containsString("packageInfo.version"));
-        assertThat(manifest.getFileString("runtimeConfig.ts").get(), containsString("clientSharedValues.serviceId"));
+        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/runtimeConfig.ts").get(), containsString("defaultUserAgent"));
+        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/runtimeConfig.ts").get(), containsString("packageInfo.version"));
+        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/runtimeConfig.ts").get(), containsString("clientSharedValues.serviceId"));
 
-        assertThat(manifest.getFileString("runtimeConfig.browser.ts").get(), containsString("defaultUserAgent"));
-        assertThat(manifest.getFileString("runtimeConfig.browser.ts").get(), containsString("packageInfo.version"));
-        assertThat(manifest.getFileString("runtimeConfig.browser.ts").get(), containsString("clientSharedValues.serviceId"));
+        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/runtimeConfig.browser.ts").get(), containsString("defaultUserAgent"));
+        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/runtimeConfig.browser.ts").get(), containsString("packageInfo.version"));
+        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/runtimeConfig.browser.ts").get(), containsString("clientSharedValues.serviceId"));
 
         // Check the config resolution and middleware plugin
-        assertThat(manifest.getFileString("NotSameClient.ts").get(), containsString("resolveUserAgentConfig"));
-        assertThat(manifest.getFileString("NotSameClient.ts").get(), containsString("getUserAgentPlugin"));
+        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/NotSameClient.ts").get(), containsString("resolveUserAgentConfig"));
+        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/NotSameClient.ts").get(), containsString("getUserAgentPlugin"));
     }
 
     @Test
@@ -78,19 +79,19 @@ public class AddUserAgentDependencyTest {
                 containsString(AwsDependency.AWS_SDK_UTIL_USER_AGENT_NODE.packageName));
 
         // Check config interface fields
-        assertThat(manifest.getFileString("ExampleServiceClient.ts").get(), containsString("defaultUserAgentProvider?"));
+        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/ExampleServiceClient.ts").get(), containsString("defaultUserAgentProvider?"));
 
         // Check config files
-        assertThat(manifest.getFileString("runtimeConfig.ts").get(), containsString("defaultUserAgent"));
-        assertThat(manifest.getFileString("runtimeConfig.ts").get(), containsString("packageInfo.version"));
-        assertThat(manifest.getFileString("runtimeConfig.ts").get(), not(containsString("ClientSharedValues.serviceId")));
+        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/runtimeConfig.ts").get(), containsString("defaultUserAgent"));
+        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/runtimeConfig.ts").get(), containsString("packageInfo.version"));
+        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/runtimeConfig.ts").get(), not(containsString("ClientSharedValues.serviceId")));
 
-        assertThat(manifest.getFileString("runtimeConfig.browser.ts").get(), containsString("defaultUserAgent"));
-        assertThat(manifest.getFileString("runtimeConfig.browser.ts").get(), containsString("packageInfo.version"));
-        assertThat(manifest.getFileString("runtimeConfig.browser.ts").get(), not(containsString("ClientSharedValues.serviceId")));
+        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/runtimeConfig.browser.ts").get(), containsString("defaultUserAgent"));
+        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/runtimeConfig.browser.ts").get(), containsString("packageInfo.version"));
+        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/runtimeConfig.browser.ts").get(), not(containsString("ClientSharedValues.serviceId")));
 
         // Check the config resolution and middleware plugin
-        assertThat(manifest.getFileString("ExampleServiceClient.ts").get(), containsString("resolveUserAgentConfig"));
-        assertThat(manifest.getFileString("ExampleServiceClient.ts").get(), containsString("getUserAgentPlugin"));
+        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/ExampleServiceClient.ts").get(), containsString("resolveUserAgentConfig"));
+        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/ExampleServiceClient.ts").get(), containsString("getUserAgentPlugin"));
     }
 }

--- a/codegen/smithy-aws-typescript-codegen/src/test/java/software/amazon/smithy/aws/typescript/codegen/AwsEndpointGeneratorIntegrationTest.java
+++ b/codegen/smithy-aws-typescript-codegen/src/test/java/software/amazon/smithy/aws/typescript/codegen/AwsEndpointGeneratorIntegrationTest.java
@@ -8,6 +8,7 @@ import software.amazon.smithy.build.MockManifest;
 import software.amazon.smithy.build.PluginContext;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.typescript.codegen.CodegenUtils;
 import software.amazon.smithy.typescript.codegen.TypeScriptCodegenPlugin;
 import software.amazon.smithy.typescript.codegen.TypeScriptServerCodegenPlugin;
 
@@ -32,7 +33,7 @@ public class AwsEndpointGeneratorIntegrationTest {
                 .build();
         new TypeScriptCodegenPlugin().execute(context);
 
-        assertTrue(manifest.getFileString("endpoints.ts").isPresent());
+        assertTrue(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/endpoints.ts").isPresent());
     }
 
     @Test
@@ -55,7 +56,7 @@ public class AwsEndpointGeneratorIntegrationTest {
                 .build();
         new TypeScriptCodegenPlugin().execute(context);
 
-        assertFalse(manifest.getFileString("endpoints.ts").isPresent());
+        assertFalse(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/endpoints.ts").isPresent());
     }
 
     @Test
@@ -79,6 +80,6 @@ public class AwsEndpointGeneratorIntegrationTest {
                 .build();
         new TypeScriptServerCodegenPlugin().execute(context);
 
-        assertFalse(manifest.getFileString("endpoints.ts").isPresent());
+        assertFalse(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/endpoints.ts").isPresent());
     }
 }

--- a/codegen/smithy-aws-typescript-codegen/src/test/java/software/amazon/smithy/aws/typescript/codegen/AwsPackageFixturesGeneratorIntegrationTest.java
+++ b/codegen/smithy-aws-typescript-codegen/src/test/java/software/amazon/smithy/aws/typescript/codegen/AwsPackageFixturesGeneratorIntegrationTest.java
@@ -10,6 +10,7 @@ import software.amazon.smithy.build.MockManifest;
 import software.amazon.smithy.build.PluginContext;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.typescript.codegen.CodegenUtils;
 import software.amazon.smithy.typescript.codegen.TypeScriptCodegenPlugin;
 import software.amazon.smithy.typescript.codegen.TypeScriptServerCodegenPlugin;
 

--- a/codegen/smithy-aws-typescript-codegen/src/test/java/software/amazon/smithy/aws/typescript/codegen/AwsServiceIdIntegrationTest.java
+++ b/codegen/smithy-aws-typescript-codegen/src/test/java/software/amazon/smithy/aws/typescript/codegen/AwsServiceIdIntegrationTest.java
@@ -12,6 +12,7 @@ import software.amazon.smithy.codegen.core.SymbolProvider;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.typescript.codegen.CodegenUtils;
 import software.amazon.smithy.typescript.codegen.TypeScriptCodegenPlugin;
 import software.amazon.smithy.typescript.codegen.TypeScriptSettings;
 
@@ -31,8 +32,8 @@ public class AwsServiceIdIntegrationTest {
         Symbol symbol = decorated.toSymbol(service);
 
         assertThat(symbol.getName(), equalTo("NotSameClient"));
-        assertThat(symbol.getNamespace(), equalTo("./NotSameClient"));
-        assertThat(symbol.getDefinitionFile(), equalTo("NotSameClient.ts"));
+        assertThat(symbol.getNamespace(), equalTo("./" + CodegenUtils.SOURCE_FOLDER + "/NotSameClient"));
+        assertThat(symbol.getDefinitionFile(), equalTo("./" + CodegenUtils.SOURCE_FOLDER + "/NotSameClient.ts"));
     }
 
     @Test
@@ -50,8 +51,9 @@ public class AwsServiceIdIntegrationTest {
         Symbol symbol = decorated.toSymbol(service);
 
         assertThat(symbol.getName(), equalTo("FirstNotCapitalizedClient"));
-        assertThat(symbol.getNamespace(), equalTo("./FirstNotCapitalizedClient"));
-        assertThat(symbol.getDefinitionFile(), equalTo("FirstNotCapitalizedClient.ts"));
+        assertThat(symbol.getNamespace(), equalTo("./" + CodegenUtils.SOURCE_FOLDER + "/FirstNotCapitalizedClient"));
+        assertThat(symbol.getDefinitionFile(),
+            equalTo("./" + CodegenUtils.SOURCE_FOLDER + "/FirstNotCapitalizedClient.ts"));
     }
 
     @Test
@@ -69,7 +71,8 @@ public class AwsServiceIdIntegrationTest {
         Symbol symbol = decorated.toSymbol(service);
 
         assertThat(symbol.getName(), equalTo("RestNotCapitalizedClient"));
-        assertThat(symbol.getNamespace(), equalTo("./RestNotCapitalizedClient"));
-        assertThat(symbol.getDefinitionFile(), equalTo("RestNotCapitalizedClient.ts"));
+        assertThat(symbol.getNamespace(), equalTo("./" + CodegenUtils.SOURCE_FOLDER + "/RestNotCapitalizedClient"));
+        assertThat(symbol.getDefinitionFile(),
+            equalTo("./" + CodegenUtils.SOURCE_FOLDER + "/RestNotCapitalizedClient.ts"));
     }
 }

--- a/scripts/generate-clients/copy-to-clients.js
+++ b/scripts/generate-clients/copy-to-clients.js
@@ -15,7 +15,7 @@ const getOverwritableDirectories = (subDirectories, packageName) => {
   return subDirectories.filter((subDirectory) => {
     return (
       overwritableDirectories.indexOf(subDirectory) >= 0 ||
-      (packageName.startsWith("aws-") && subDirectory === "tests") ||
+      (packageName.startsWith("aws-") && subDirectory === "test") ||
       additionalGeneratedFiles[packageName]?.indexOf(subDirectory) >= 0
     );
   });

--- a/scripts/generate-clients/copy-to-clients.js
+++ b/scripts/generate-clients/copy-to-clients.js
@@ -8,29 +8,13 @@ const getOverwritableDirectories = (subDirectories, packageName) => {
     "@aws-sdk/client-sts": ["defaultRoleAssumers.ts", "defaultStsRoleAssumers.ts", "defaultRoleAssumers.spec.ts"],
   };
   const overwritableDirectories = [
-    "commands",
-    "models",
-    "protocols",
-    "pagination",
-    "tests",
-    "waiters",
+    "src", // contains all source files
+    "tests", // protocol_tests
     "LICENCE",
-    "runtimeConfig.ts",
-    "runtimeConfig.browser.ts",
-    "runtimeConfig.shared.ts",
-    "runtimeConfig.native.ts",
-    "index.ts",
-    "endpoints.ts",
     "README.md",
   ];
   return subDirectories.filter((subDirectory) => {
-    const isBareBoneClient =
-      subDirectory.endsWith("Client.ts") && subDirectories.indexOf(subDirectory.replace("Client.ts", ".ts")) >= 0;
-    const isAggregateClient =
-      subDirectory.endsWith(".ts") && subDirectories.indexOf(subDirectory.replace(".ts", "Client.ts")) >= 0;
     return (
-      isBareBoneClient ||
-      isAggregateClient ||
       overwritableDirectories.indexOf(subDirectory) >= 0 ||
       additionalGeneratedFiles[packageName]?.indexOf(subDirectory) >= 0
     );
@@ -152,6 +136,19 @@ const copyToClients = async (sourceDir, destinationDir) => {
         });
       }
     }
+
+    // Add @ts-ignore to packageInfo import from AddUserAgentDependency.java
+    ["src/runtimeConfig.ts", "src/runtimeConfig.browser.ts"].forEach((runtimeConfigFileName) => {
+      const runtimeConfigFilepath = join(destPath, runtimeConfigFileName);
+      const content = readFileSync(runtimeConfigFilepath).toString();
+      writeFileSync(
+        runtimeConfigFilepath,
+        content.replace(
+          `import packageInfo`,
+          `// @ts-ignore: package.json will be imported from dist folders\nimport packageInfo`
+        )
+      );
+    });
   }
 };
 

--- a/scripts/generate-clients/copy-to-clients.js
+++ b/scripts/generate-clients/copy-to-clients.js
@@ -9,13 +9,13 @@ const getOverwritableDirectories = (subDirectories, packageName) => {
   };
   const overwritableDirectories = [
     "src", // contains all source files
-    "tests", // protocol_tests
     "LICENCE",
     "README.md",
   ];
   return subDirectories.filter((subDirectory) => {
     return (
       overwritableDirectories.indexOf(subDirectory) >= 0 ||
+      (packageName.startsWith("aws-") && subDirectory === "tests") ||
       additionalGeneratedFiles[packageName]?.indexOf(subDirectory) >= 0
     );
   });


### PR DESCRIPTION
### Issue
Refs: aws/aws-sdk-js-v3#1306

### Description
The changes in scripts and codegen to move source files to 'src' folder.
* smithy-ts PR posted at https://github.com/awslabs/smithy-typescript/pull/434
* clients are updated in https://github.com/aws/aws-sdk-js-v3/pull/2845

### Testing
Check testing section of https://github.com/aws/aws-sdk-js-v3/pull/2845

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
