### PR TITLE
chore(non-clients): transpile to dist-* folders

### DIFF
--- a/lib/lib-dynamodb/package.json
+++ b/lib/lib-dynamodb/package.json
@@ -2,15 +2,15 @@
   "name": "@aws-sdk/lib-dynamodb",
   "version": "3.34.0",
   "description": "The document client simplifies working with items in Amazon DynamoDB by abstracting away the notion of attribute values.",
-  "main": "./dist/cjs/index.js",
-  "module": "./dist/es/index.js",
-  "types": "./dist/types/index.d.ts",
+  "main": "./dist-cjs/index.js",
+  "module": "./dist-es/index.js",
+  "types": "./dist-types/index.d.ts",
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
     "test": "jest"
   },
   "engines": {
@@ -41,8 +41,8 @@
   },
   "typesVersions": {
     "<4.0": {
-      "dist/types/*": [
-        "dist/types/ts3.4/*"
+      "dist-types/*": [
+        "dist-types/ts3.4/*"
       ]
     }
   },

--- a/lib/lib-dynamodb/tsconfig.cjs.json
+++ b/lib/lib-dynamodb/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "outDir": "dist/cjs",
+    "outDir": "dist-cjs",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",

--- a/lib/lib-dynamodb/tsconfig.es.json
+++ b/lib/lib-dynamodb/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "lib": ["es5", "es2015.collection", "dom"],
-    "outDir": "dist/es",
+    "outDir": "dist-es",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",

--- a/lib/lib-dynamodb/tsconfig.types.json
+++ b/lib/lib-dynamodb/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "declarationDir": "dist/types",
+    "declarationDir": "dist-types",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",

--- a/lib/lib-storage/package.json
+++ b/lib/lib-storage/package.json
@@ -2,15 +2,15 @@
   "name": "@aws-sdk/lib-storage",
   "version": "3.34.0",
   "description": "Storage higher order operation",
-  "main": "./dist/cjs/index.js",
-  "module": "./dist/es/index.js",
-  "types": "./dist/types/index.d.ts",
+  "main": "./dist-cjs/index.js",
+  "module": "./dist-es/index.js",
+  "types": "./dist-types/index.d.ts",
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
     "test": "jest"
   },
   "engines": {
@@ -48,8 +48,8 @@
   },
   "typesVersions": {
     "<4.0": {
-      "dist/types/*": [
-        "dist/types/ts3.4/*"
+      "dist-types/*": [
+        "dist-types/ts3.4/*"
       ]
     }
   },

--- a/lib/lib-storage/tsconfig.cjs.json
+++ b/lib/lib-storage/tsconfig.cjs.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "lib": ["es5", "es2015.collection", "dom"],
-    "outDir": "dist/cjs",
+    "outDir": "dist-cjs",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",

--- a/lib/lib-storage/tsconfig.es.json
+++ b/lib/lib-storage/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "lib": ["es5", "es2015.collection", "dom"],
-    "outDir": "dist/es",
+    "outDir": "dist-es",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",

--- a/lib/lib-storage/tsconfig.types.json
+++ b/lib/lib-storage/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "declarationDir": "dist/types",
+    "declarationDir": "dist-types",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/abort-controller/package.json
+++ b/packages/abort-controller/package.json
@@ -2,15 +2,15 @@
   "name": "@aws-sdk/abort-controller",
   "version": "3.34.0",
   "description": "A simple abort controller library",
-  "main": "./dist/cjs/index.js",
-  "module": "./dist/es/index.js",
-  "types": "./dist/types/index.d.ts",
+  "main": "./dist-cjs/index.js",
+  "module": "./dist-es/index.js",
+  "types": "./dist-types/index.d.ts",
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
     "test": "jest"
   },
   "author": {
@@ -32,8 +32,8 @@
   },
   "typesVersions": {
     "<4.0": {
-      "dist/types/*": [
-        "dist/types/ts3.4/*"
+      "dist-types/*": [
+        "dist-types/ts3.4/*"
       ]
     }
   },

--- a/packages/abort-controller/tsconfig.cjs.json
+++ b/packages/abort-controller/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "outDir": "dist/cjs",
+    "outDir": "dist-cjs",
     "rootDir": "src",
     "stripInternal": true
   },

--- a/packages/abort-controller/tsconfig.es.json
+++ b/packages/abort-controller/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "lib": ["es5", "es2015.collection"],
-    "outDir": "dist/es",
+    "outDir": "dist-es",
     "rootDir": "src",
     "stripInternal": true
   },

--- a/packages/abort-controller/tsconfig.types.json
+++ b/packages/abort-controller/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "declarationDir": "dist/types",
+    "declarationDir": "dist-types",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/body-checksum-browser/package.json
+++ b/packages/body-checksum-browser/package.json
@@ -6,12 +6,12 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
     "test": "jest"
   },
-  "main": "./dist/cjs/index.js",
-  "module": "./dist/es/index.js",
-  "types": "./dist/types/index.d.ts",
+  "main": "./dist-cjs/index.js",
+  "module": "./dist-es/index.js",
+  "types": "./dist-types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"
@@ -34,8 +34,8 @@
   },
   "typesVersions": {
     "<4.0": {
-      "dist/types/*": [
-        "dist/types/ts3.4/*"
+      "dist-types/*": [
+        "dist-types/ts3.4/*"
       ]
     }
   },

--- a/packages/body-checksum-browser/tsconfig.cjs.json
+++ b/packages/body-checksum-browser/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "outDir": "dist/cjs",
+    "outDir": "dist-cjs",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/body-checksum-browser/tsconfig.es.json
+++ b/packages/body-checksum-browser/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "outDir": "dist/es",
+    "outDir": "dist-es",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/body-checksum-browser/tsconfig.types.json
+++ b/packages/body-checksum-browser/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "declarationDir": "dist/types",
+    "declarationDir": "dist-types",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/body-checksum-node/package.json
+++ b/packages/body-checksum-node/package.json
@@ -6,12 +6,12 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
     "test": "jest"
   },
-  "main": "./dist/cjs/index.js",
-  "module": "./dist/es/index.js",
-  "types": "./dist/types/index.d.ts",
+  "main": "./dist-cjs/index.js",
+  "module": "./dist-es/index.js",
+  "types": "./dist-types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"
@@ -38,8 +38,8 @@
   },
   "typesVersions": {
     "<4.0": {
-      "dist/types/*": [
-        "dist/types/ts3.4/*"
+      "dist-types/*": [
+        "dist-types/ts3.4/*"
       ]
     }
   },

--- a/packages/body-checksum-node/tsconfig.cjs.json
+++ b/packages/body-checksum-node/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "outDir": "dist/cjs",
+    "outDir": "dist-cjs",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/body-checksum-node/tsconfig.es.json
+++ b/packages/body-checksum-node/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "outDir": "dist/es",
+    "outDir": "dist-es",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/body-checksum-node/tsconfig.types.json
+++ b/packages/body-checksum-node/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "declarationDir": "dist/types",
+    "declarationDir": "dist-types",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/chunked-blob-reader-native/package.json
+++ b/packages/chunked-blob-reader-native/package.json
@@ -6,12 +6,12 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
     "test": "jest"
   },
-  "main": "./dist/cjs/index.js",
-  "module": "./dist/es/index.js",
-  "types": "./dist/types/index.d.ts",
+  "main": "./dist-cjs/index.js",
+  "module": "./dist-es/index.js",
+  "types": "./dist-types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"
@@ -28,8 +28,8 @@
   },
   "typesVersions": {
     "<4.0": {
-      "dist/types/*": [
-        "dist/types/ts3.4/*"
+      "dist-types/*": [
+        "dist-types/ts3.4/*"
       ]
     }
   },

--- a/packages/chunked-blob-reader-native/tsconfig.cjs.json
+++ b/packages/chunked-blob-reader-native/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "outDir": "dist/cjs",
+    "outDir": "dist-cjs",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/chunked-blob-reader-native/tsconfig.es.json
+++ b/packages/chunked-blob-reader-native/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "outDir": "dist/es",
+    "outDir": "dist-es",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/chunked-blob-reader-native/tsconfig.types.json
+++ b/packages/chunked-blob-reader-native/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "declarationDir": "dist/types",
+    "declarationDir": "dist-types",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/chunked-blob-reader/package.json
+++ b/packages/chunked-blob-reader/package.json
@@ -6,12 +6,12 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
     "test": "jest"
   },
-  "main": "./dist/cjs/index.js",
-  "module": "./dist/es/index.js",
-  "types": "./dist/types/index.d.ts",
+  "main": "./dist-cjs/index.js",
+  "module": "./dist-es/index.js",
+  "types": "./dist-types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"
@@ -27,8 +27,8 @@
   },
   "typesVersions": {
     "<4.0": {
-      "dist/types/*": [
-        "dist/types/ts3.4/*"
+      "dist-types/*": [
+        "dist-types/ts3.4/*"
       ]
     }
   },

--- a/packages/chunked-blob-reader/tsconfig.cjs.json
+++ b/packages/chunked-blob-reader/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "outDir": "dist/cjs",
+    "outDir": "dist-cjs",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/chunked-blob-reader/tsconfig.es.json
+++ b/packages/chunked-blob-reader/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "outDir": "dist/es",
+    "outDir": "dist-es",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/chunked-blob-reader/tsconfig.types.json
+++ b/packages/chunked-blob-reader/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "declarationDir": "dist/types",
+    "declarationDir": "dist-types",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/chunked-stream-reader-node/package.json
+++ b/packages/chunked-stream-reader-node/package.json
@@ -6,12 +6,12 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
     "test": "jest"
   },
-  "main": "./dist/cjs/index.js",
-  "module": "./dist/es/index.js",
-  "types": "./dist/types/index.d.ts",
+  "main": "./dist-cjs/index.js",
+  "module": "./dist-es/index.js",
+  "types": "./dist-types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"
@@ -31,8 +31,8 @@
   },
   "typesVersions": {
     "<4.0": {
-      "dist/types/*": [
-        "dist/types/ts3.4/*"
+      "dist-types/*": [
+        "dist-types/ts3.4/*"
       ]
     }
   },

--- a/packages/chunked-stream-reader-node/tsconfig.cjs.json
+++ b/packages/chunked-stream-reader-node/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "outDir": "dist/cjs",
+    "outDir": "dist-cjs",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/chunked-stream-reader-node/tsconfig.es.json
+++ b/packages/chunked-stream-reader-node/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "outDir": "dist/es",
+    "outDir": "dist-es",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/chunked-stream-reader-node/tsconfig.types.json
+++ b/packages/chunked-stream-reader-node/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "declarationDir": "dist/types",
+    "declarationDir": "dist-types",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/client-documentation-generator/package.json
+++ b/packages/client-documentation-generator/package.json
@@ -6,12 +6,12 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
     "test": "exit 0"
   },
-  "main": "./dist/cjs/index.js",
-  "module": "./dist/es/index.js",
-  "types": "./dist/types/index.d.ts",
+  "main": "./dist-cjs/index.js",
+  "module": "./dist-es/index.js",
+  "types": "./dist-types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"
@@ -32,8 +32,8 @@
   },
   "typesVersions": {
     "<4.0": {
-      "dist/types/*": [
-        "dist/types/ts3.4/*"
+      "dist-types/*": [
+        "dist-types/ts3.4/*"
       ]
     }
   },

--- a/packages/client-documentation-generator/tsconfig.cjs.json
+++ b/packages/client-documentation-generator/tsconfig.cjs.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "experimentalDecorators": true,
-    "outDir": "dist/cjs",
+    "outDir": "dist-cjs",
     "pretty": true,
     "rootDir": "src",
     "strict": false

--- a/packages/client-documentation-generator/tsconfig.es.json
+++ b/packages/client-documentation-generator/tsconfig.es.json
@@ -3,7 +3,7 @@
     "baseUrl": ".",
     "experimentalDecorators": true,
     "lib": ["es2015"],
-    "outDir": "dist/es",
+    "outDir": "dist-es",
     "pretty": true,
     "rootDir": "src",
     "strict": false

--- a/packages/client-documentation-generator/tsconfig.types.json
+++ b/packages/client-documentation-generator/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "declarationDir": "dist/types",
+    "declarationDir": "dist-types",
     "experimentalDecorators": true,
     "rootDir": "src",
     "strict": false

--- a/packages/config-resolver/package.json
+++ b/packages/config-resolver/package.json
@@ -6,12 +6,12 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
     "test": "jest"
   },
-  "main": "./dist/cjs/index.js",
-  "module": "./dist/es/index.js",
-  "types": "./dist/types/index.d.ts",
+  "main": "./dist-cjs/index.js",
+  "module": "./dist-es/index.js",
+  "types": "./dist-types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"
@@ -33,8 +33,8 @@
   },
   "typesVersions": {
     "<4.0": {
-      "dist/types/*": [
-        "dist/types/ts3.4/*"
+      "dist-types/*": [
+        "dist-types/ts3.4/*"
       ]
     }
   },

--- a/packages/config-resolver/tsconfig.cjs.json
+++ b/packages/config-resolver/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "outDir": "dist/cjs",
+    "outDir": "dist-cjs",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/config-resolver/tsconfig.es.json
+++ b/packages/config-resolver/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "outDir": "dist/es",
+    "outDir": "dist-es",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/config-resolver/tsconfig.types.json
+++ b/packages/config-resolver/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "declarationDir": "dist/types",
+    "declarationDir": "dist-types",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/core-packages-documentation-generator/package.json
+++ b/packages/core-packages-documentation-generator/package.json
@@ -6,12 +6,12 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
     "test": "exit 0"
   },
-  "main": "./dist/cjs/index.js",
-  "module": "./dist/es/index.js",
-  "types": "./dist/types/index.d.ts",
+  "main": "./dist-cjs/index.js",
+  "module": "./dist-es/index.js",
+  "types": "./dist-types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"
@@ -33,8 +33,8 @@
   "private": true,
   "typesVersions": {
     "<4.0": {
-      "dist/types/*": [
-        "dist/types/ts3.4/*"
+      "dist-types/*": [
+        "dist-types/ts3.4/*"
       ]
     }
   },

--- a/packages/core-packages-documentation-generator/tsconfig.cjs.json
+++ b/packages/core-packages-documentation-generator/tsconfig.cjs.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "experimentalDecorators": true,
-    "outDir": "dist/cjs",
+    "outDir": "dist-cjs",
     "pretty": true,
     "rootDir": "src",
     "strict": false

--- a/packages/core-packages-documentation-generator/tsconfig.es.json
+++ b/packages/core-packages-documentation-generator/tsconfig.es.json
@@ -3,7 +3,7 @@
     "baseUrl": ".",
     "experimentalDecorators": true,
     "lib": ["es2015"],
-    "outDir": "dist/es",
+    "outDir": "dist-es",
     "pretty": true,
     "rootDir": "src",
     "strict": false

--- a/packages/core-packages-documentation-generator/tsconfig.types.json
+++ b/packages/core-packages-documentation-generator/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "declarationDir": "dist/types",
+    "declarationDir": "dist-types",
     "experimentalDecorators": true,
     "rootDir": "src",
     "strict": false

--- a/packages/credential-provider-cognito-identity/package.json
+++ b/packages/credential-provider-cognito-identity/package.json
@@ -6,12 +6,12 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
     "test": "jest"
   },
-  "main": "./dist/cjs/index.js",
-  "module": "./dist/es/index.js",
-  "types": "./dist/types/index.d.ts",
+  "main": "./dist-cjs/index.js",
+  "module": "./dist-es/index.js",
+  "types": "./dist-types/index.d.ts",
   "sideEffects": false,
   "author": {
     "name": "AWS SDK for JavaScript Team",
@@ -34,8 +34,8 @@
   },
   "typesVersions": {
     "<4.0": {
-      "dist/types/*": [
-        "dist/types/ts3.4/*"
+      "dist-types/*": [
+        "dist-types/ts3.4/*"
       ]
     }
   },

--- a/packages/credential-provider-cognito-identity/tsconfig.cjs.json
+++ b/packages/credential-provider-cognito-identity/tsconfig.cjs.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "noUnusedLocals": true,
-    "outDir": "dist/cjs",
+    "outDir": "dist-cjs",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/credential-provider-cognito-identity/tsconfig.es.json
+++ b/packages/credential-provider-cognito-identity/tsconfig.es.json
@@ -3,7 +3,7 @@
     "baseUrl": ".",
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "noUnusedLocals": true,
-    "outDir": "dist/es",
+    "outDir": "dist-es",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/credential-provider-cognito-identity/tsconfig.types.json
+++ b/packages/credential-provider-cognito-identity/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "declarationDir": "dist/types",
+    "declarationDir": "dist-types",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/credential-provider-env/package.json
+++ b/packages/credential-provider-env/package.json
@@ -2,14 +2,14 @@
   "name": "@aws-sdk/credential-provider-env",
   "version": "3.34.0",
   "description": "AWS credential provider that sources credentials from known environment variables",
-  "main": "./dist/cjs/index.js",
-  "module": "./dist/es/index.js",
+  "main": "./dist-cjs/index.js",
+  "module": "./dist-es/index.js",
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
     "test": "jest"
   },
   "keywords": [
@@ -32,14 +32,14 @@
     "jest": "^26.1.0",
     "typescript": "~4.3.5"
   },
-  "types": "./dist/types/index.d.ts",
+  "types": "./dist-types/index.d.ts",
   "engines": {
     "node": ">= 10.0.0"
   },
   "typesVersions": {
     "<4.0": {
-      "dist/types/*": [
-        "dist/types/ts3.4/*"
+      "dist-types/*": [
+        "dist-types/ts3.4/*"
       ]
     }
   },

--- a/packages/credential-provider-env/tsconfig.cjs.json
+++ b/packages/credential-provider-env/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "outDir": "dist/cjs",
+    "outDir": "dist-cjs",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/credential-provider-env/tsconfig.es.json
+++ b/packages/credential-provider-env/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "lib": ["es5", "es2015.promise", "es2015.collection"],
-    "outDir": "dist/es",
+    "outDir": "dist-es",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/credential-provider-env/tsconfig.types.json
+++ b/packages/credential-provider-env/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "declarationDir": "dist/types",
+    "declarationDir": "dist-types",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/credential-provider-imds/package.json
+++ b/packages/credential-provider-imds/package.json
@@ -2,14 +2,14 @@
   "name": "@aws-sdk/credential-provider-imds",
   "version": "3.34.0",
   "description": "AWS credential provider that sources credentials from the EC2 instance metadata service and ECS container metadata service",
-  "main": "./dist/cjs/index.js",
-  "module": "./dist/es/index.js",
+  "main": "./dist-cjs/index.js",
+  "module": "./dist-es/index.js",
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
     "test": "jest"
   },
   "keywords": [
@@ -35,14 +35,14 @@
     "nock": "^13.0.2",
     "typescript": "~4.3.5"
   },
-  "types": "./dist/types/index.d.ts",
+  "types": "./dist-types/index.d.ts",
   "engines": {
     "node": ">= 10.0.0"
   },
   "typesVersions": {
     "<4.0": {
-      "dist/types/*": [
-        "dist/types/ts3.4/*"
+      "dist-types/*": [
+        "dist-types/ts3.4/*"
       ]
     }
   },

--- a/packages/credential-provider-imds/tsconfig.cjs.json
+++ b/packages/credential-provider-imds/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "outDir": "dist/cjs",
+    "outDir": "dist-cjs",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/credential-provider-imds/tsconfig.es.json
+++ b/packages/credential-provider-imds/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "lib": ["es5", "es2015.promise", "es2015.collection"],
-    "outDir": "dist/es",
+    "outDir": "dist-es",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/credential-provider-imds/tsconfig.types.json
+++ b/packages/credential-provider-imds/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "declarationDir": "dist/types",
+    "declarationDir": "dist-types",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/credential-provider-ini/package.json
+++ b/packages/credential-provider-ini/package.json
@@ -2,14 +2,14 @@
   "name": "@aws-sdk/credential-provider-ini",
   "version": "3.34.0",
   "description": "AWS credential provider that sources credentials from ~/.aws/credentials and ~/.aws/config",
-  "main": "./dist/cjs/index.js",
-  "module": "./dist/es/index.js",
+  "main": "./dist-cjs/index.js",
+  "module": "./dist-es/index.js",
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
     "test": "jest"
   },
   "keywords": [
@@ -38,14 +38,14 @@
     "jest": "^26.1.0",
     "typescript": "~4.3.5"
   },
-  "types": "./dist/types/index.d.ts",
+  "types": "./dist-types/index.d.ts",
   "engines": {
     "node": ">= 10.0.0"
   },
   "typesVersions": {
     "<4.0": {
-      "dist/types/*": [
-        "dist/types/ts3.4/*"
+      "dist-types/*": [
+        "dist-types/ts3.4/*"
       ]
     }
   },

--- a/packages/credential-provider-ini/tsconfig.cjs.json
+++ b/packages/credential-provider-ini/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "outDir": "dist/cjs",
+    "outDir": "dist-cjs",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/credential-provider-ini/tsconfig.es.json
+++ b/packages/credential-provider-ini/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "lib": ["es5", "es2015.promise", "es2015.collection"],
-    "outDir": "dist/es",
+    "outDir": "dist-es",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/credential-provider-ini/tsconfig.types.json
+++ b/packages/credential-provider-ini/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "declarationDir": "dist/types",
+    "declarationDir": "dist-types",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/credential-provider-node/package.json
+++ b/packages/credential-provider-node/package.json
@@ -5,14 +5,14 @@
   "engines": {
     "node": ">=10.0.0"
   },
-  "main": "./dist/cjs/index.js",
-  "module": "./dist/es/index.js",
+  "main": "./dist-cjs/index.js",
+  "module": "./dist-es/index.js",
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
     "test": "jest"
   },
   "keywords": [
@@ -43,11 +43,11 @@
     "jest": "^26.1.0",
     "typescript": "~4.3.5"
   },
-  "types": "./dist/types/index.d.ts",
+  "types": "./dist-types/index.d.ts",
   "typesVersions": {
     "<4.0": {
-      "dist/types/*": [
-        "dist/types/ts3.4/*"
+      "dist-types/*": [
+        "dist-types/ts3.4/*"
       ]
     }
   },

--- a/packages/credential-provider-node/tsconfig.cjs.json
+++ b/packages/credential-provider-node/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "outDir": "dist/cjs",
+    "outDir": "dist-cjs",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/credential-provider-node/tsconfig.es.json
+++ b/packages/credential-provider-node/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "outDir": "dist/es",
+    "outDir": "dist-es",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/credential-provider-node/tsconfig.types.json
+++ b/packages/credential-provider-node/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "declarationDir": "dist/types",
+    "declarationDir": "dist-types",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/credential-provider-process/package.json
+++ b/packages/credential-provider-process/package.json
@@ -2,14 +2,14 @@
   "name": "@aws-sdk/credential-provider-process",
   "version": "3.34.0",
   "description": "AWS credential provider that sources credential_process from ~/.aws/credentials and ~/.aws/config",
-  "main": "./dist/cjs/index.js",
-  "module": "./dist/es/index.js",
+  "main": "./dist-cjs/index.js",
+  "module": "./dist-es/index.js",
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
     "test": "jest"
   },
   "keywords": [
@@ -34,14 +34,14 @@
     "jest": "^26.1.0",
     "typescript": "~4.3.5"
   },
-  "types": "./dist/types/index.d.ts",
+  "types": "./dist-types/index.d.ts",
   "engines": {
     "node": ">= 10.0.0"
   },
   "typesVersions": {
     "<4.0": {
-      "dist/types/*": [
-        "dist/types/ts3.4/*"
+      "dist-types/*": [
+        "dist-types/ts3.4/*"
       ]
     }
   },

--- a/packages/credential-provider-process/tsconfig.cjs.json
+++ b/packages/credential-provider-process/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "outDir": "dist/cjs",
+    "outDir": "dist-cjs",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/credential-provider-process/tsconfig.es.json
+++ b/packages/credential-provider-process/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "lib": ["es5", "es2015.promise", "es2015.collection"],
-    "outDir": "dist/es",
+    "outDir": "dist-es",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/credential-provider-process/tsconfig.types.json
+++ b/packages/credential-provider-process/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "declarationDir": "dist/types",
+    "declarationDir": "dist-types",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/credential-provider-sso/package.json
+++ b/packages/credential-provider-sso/package.json
@@ -2,14 +2,14 @@
   "name": "@aws-sdk/credential-provider-sso",
   "version": "3.34.0",
   "description": "AWS credential provider that exchanges a resolved SSO login token file for temporary AWS credentials",
-  "main": "./dist/cjs/index.js",
-  "module": "./dist/es/index.js",
+  "main": "./dist-cjs/index.js",
+  "module": "./dist-es/index.js",
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
     "test": "jest"
   },
   "keywords": [
@@ -35,14 +35,14 @@
     "jest": "^26.1.0",
     "typescript": "~4.3.5"
   },
-  "types": "./dist/types/index.d.ts",
+  "types": "./dist-types/index.d.ts",
   "engines": {
     "node": ">= 10.0.0"
   },
   "typesVersions": {
     "<4.0": {
-      "dist/types/*": [
-        "dist/types/ts3.4/*"
+      "dist-types/*": [
+        "dist-types/ts3.4/*"
       ]
     }
   },

--- a/packages/credential-provider-sso/tsconfig.cjs.json
+++ b/packages/credential-provider-sso/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "outDir": "dist/cjs",
+    "outDir": "dist-cjs",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/credential-provider-sso/tsconfig.es.json
+++ b/packages/credential-provider-sso/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "lib": ["es5", "es2015.promise", "es2015.collection"],
-    "outDir": "dist/es",
+    "outDir": "dist-es",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/credential-provider-sso/tsconfig.types.json
+++ b/packages/credential-provider-sso/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "declarationDir": "dist/types",
+    "declarationDir": "dist-types",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/credential-provider-web-identity/package.json
+++ b/packages/credential-provider-web-identity/package.json
@@ -2,14 +2,14 @@
   "name": "@aws-sdk/credential-provider-web-identity",
   "version": "3.34.0",
   "description": "AWS credential provider that calls STS assumeRole for temporary AWS credentials",
-  "main": "./dist/cjs/index.js",
-  "module": "./dist/es/index.js",
+  "main": "./dist-cjs/index.js",
+  "module": "./dist-es/index.js",
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
     "test": "jest"
   },
   "keywords": [
@@ -32,14 +32,14 @@
     "jest": "^26.1.0",
     "typescript": "~4.3.5"
   },
-  "types": "./dist/types/index.d.ts",
+  "types": "./dist-types/index.d.ts",
   "engines": {
     "node": ">= 10.0.0"
   },
   "typesVersions": {
     "<4.0": {
-      "dist/types/*": [
-        "dist/types/ts3.4/*"
+      "dist-types/*": [
+        "dist-types/ts3.4/*"
       ]
     }
   },

--- a/packages/credential-provider-web-identity/tsconfig.cjs.json
+++ b/packages/credential-provider-web-identity/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "outDir": "dist/cjs",
+    "outDir": "dist-cjs",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/credential-provider-web-identity/tsconfig.es.json
+++ b/packages/credential-provider-web-identity/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "lib": ["es5", "es2015.promise", "es2015.collection"],
-    "outDir": "dist/es",
+    "outDir": "dist-es",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/credential-provider-web-identity/tsconfig.types.json
+++ b/packages/credential-provider-web-identity/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "declarationDir": "dist/types",
+    "declarationDir": "dist-types",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/credential-providers/package.json
+++ b/packages/credential-providers/package.json
@@ -2,8 +2,8 @@
   "name": "@aws-sdk/credential-providers",
   "version": "3.34.0",
   "description": "A collection of credential providers, without requiring service clients like STS, Cognito",
-  "main": "./dist/cjs/index.js",
-  "module": "./dist/es/index.js",
+  "main": "./dist-cjs/index.js",
+  "module": "./dist-es/index.js",
   "browser": {
     "@aws-sdk/credential-provider-env": false,
     "@aws-sdk/credential-provider-imds": false,
@@ -24,7 +24,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
     "test": "jest"
   },
   "keywords": [
@@ -59,14 +59,14 @@
     "jest": "^26.1.0",
     "typescript": "~4.3.5"
   },
-  "types": "./dist/types/index.d.ts",
+  "types": "./dist-types/index.d.ts",
   "engines": {
     "node": ">= 10.0.0"
   },
   "typesVersions": {
     "<4.0": {
-      "dist/types/*": [
-        "dist/types/ts3.4/*"
+      "dist-types/*": [
+        "dist-types/ts3.4/*"
       ]
     }
   },

--- a/packages/credential-providers/tsconfig.cjs.json
+++ b/packages/credential-providers/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "outDir": "dist/cjs",
+    "outDir": "dist-cjs",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/credential-providers/tsconfig.es.json
+++ b/packages/credential-providers/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "lib": ["es5", "es2015.promise", "es2015.collection"],
-    "outDir": "dist/es",
+    "outDir": "dist-es",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/credential-providers/tsconfig.types.json
+++ b/packages/credential-providers/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "declarationDir": "dist/types",
+    "declarationDir": "dist-types",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/endpoint-cache/package.json
+++ b/packages/endpoint-cache/package.json
@@ -6,7 +6,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
     "test": "jest --passWithNoTests"
   },
   "author": {
@@ -14,9 +14,9 @@
     "url": "https://aws.amazon.com/javascript/"
   },
   "license": "Apache-2.0",
-  "main": "./dist/cjs/index.js",
-  "module": "./dist/es/index.js",
-  "types": "./dist/types/index.d.ts",
+  "main": "./dist-cjs/index.js",
+  "module": "./dist-es/index.js",
+  "types": "./dist-types/index.d.ts",
   "dependencies": {
     "mnemonist": "0.38.3",
     "tslib": "^2.3.0"
@@ -32,8 +32,8 @@
   },
   "typesVersions": {
     "<4.0": {
-      "dist/types/*": [
-        "dist/types/ts3.4/*"
+      "dist-types/*": [
+        "dist-types/ts3.4/*"
       ]
     }
   },

--- a/packages/endpoint-cache/tsconfig.cjs.json
+++ b/packages/endpoint-cache/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "outDir": "dist/cjs",
+    "outDir": "dist-cjs",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/endpoint-cache/tsconfig.es.json
+++ b/packages/endpoint-cache/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "lib": ["es5", "es2015.promise", "es2015.iterable"],
-    "outDir": "dist/es",
+    "outDir": "dist-es",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/endpoint-cache/tsconfig.types.json
+++ b/packages/endpoint-cache/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "declarationDir": "dist/types",
+    "declarationDir": "dist-types",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/eventstream-handler-node/package.json
+++ b/packages/eventstream-handler-node/package.json
@@ -6,12 +6,12 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
     "test": "jest"
   },
-  "main": "./dist/cjs/index.js",
-  "module": "./dist/es/index.js",
-  "types": "./dist/types/index.d.ts",
+  "main": "./dist-cjs/index.js",
+  "module": "./dist-es/index.js",
+  "types": "./dist-types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"
@@ -33,8 +33,8 @@
   },
   "typesVersions": {
     "<4.0": {
-      "dist/types/*": [
-        "dist/types/ts3.4/*"
+      "dist-types/*": [
+        "dist-types/ts3.4/*"
       ]
     }
   },

--- a/packages/eventstream-handler-node/tsconfig.cjs.json
+++ b/packages/eventstream-handler-node/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "outDir": "dist/cjs",
+    "outDir": "dist-cjs",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/eventstream-handler-node/tsconfig.es.json
+++ b/packages/eventstream-handler-node/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "lib": ["es2018.asynciterable"],
-    "outDir": "dist/es",
+    "outDir": "dist-es",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/eventstream-handler-node/tsconfig.types.json
+++ b/packages/eventstream-handler-node/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "declarationDir": "dist/types",
+    "declarationDir": "dist-types",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/eventstream-marshaller/package.json
+++ b/packages/eventstream-marshaller/package.json
@@ -6,12 +6,12 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
     "test": "jest --coverage"
   },
-  "main": "./dist/cjs/index.js",
-  "module": "./dist/es/index.js",
-  "types": "./dist/types/index.d.ts",
+  "main": "./dist-cjs/index.js",
+  "module": "./dist-es/index.js",
+  "types": "./dist-types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"
@@ -39,8 +39,8 @@
   },
   "typesVersions": {
     "<4.0": {
-      "dist/types/*": [
-        "dist/types/ts3.4/*"
+      "dist-types/*": [
+        "dist-types/ts3.4/*"
       ]
     }
   },

--- a/packages/eventstream-marshaller/tsconfig.cjs.json
+++ b/packages/eventstream-marshaller/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "outDir": "dist/cjs",
+    "outDir": "dist-cjs",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/eventstream-marshaller/tsconfig.es.json
+++ b/packages/eventstream-marshaller/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "outDir": "dist/es",
+    "outDir": "dist-es",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/eventstream-marshaller/tsconfig.types.json
+++ b/packages/eventstream-marshaller/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "declarationDir": "dist/types",
+    "declarationDir": "dist-types",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/eventstream-serde-browser/package.json
+++ b/packages/eventstream-serde-browser/package.json
@@ -6,12 +6,12 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
     "test": "jest"
   },
-  "main": "./dist/cjs/index.js",
-  "module": "./dist/es/index.js",
-  "types": "./dist/types/index.d.ts",
+  "main": "./dist-cjs/index.js",
+  "module": "./dist-es/index.js",
+  "types": "./dist-types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"
@@ -33,8 +33,8 @@
   },
   "typesVersions": {
     "<4.0": {
-      "dist/types/*": [
-        "dist/types/ts3.4/*"
+      "dist-types/*": [
+        "dist-types/ts3.4/*"
       ]
     }
   },

--- a/packages/eventstream-serde-browser/tsconfig.cjs.json
+++ b/packages/eventstream-serde-browser/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "outDir": "dist/cjs",
+    "outDir": "dist-cjs",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/eventstream-serde-browser/tsconfig.es.json
+++ b/packages/eventstream-serde-browser/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "lib": ["es2018.asynciterable", "DOM"],
-    "outDir": "dist/es",
+    "outDir": "dist-es",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/eventstream-serde-browser/tsconfig.types.json
+++ b/packages/eventstream-serde-browser/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "declarationDir": "dist/types",
+    "declarationDir": "dist-types",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/eventstream-serde-config-resolver/package.json
+++ b/packages/eventstream-serde-config-resolver/package.json
@@ -6,12 +6,12 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
     "test": "jest"
   },
-  "main": "./dist/cjs/index.js",
-  "module": "./dist/es/index.js",
-  "types": "./dist/types/index.d.ts",
+  "main": "./dist-cjs/index.js",
+  "module": "./dist-es/index.js",
+  "types": "./dist-types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"
@@ -31,8 +31,8 @@
   },
   "typesVersions": {
     "<4.0": {
-      "dist/types/*": [
-        "dist/types/ts3.4/*"
+      "dist-types/*": [
+        "dist-types/ts3.4/*"
       ]
     }
   },

--- a/packages/eventstream-serde-config-resolver/tsconfig.cjs.json
+++ b/packages/eventstream-serde-config-resolver/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "outDir": "dist/cjs",
+    "outDir": "dist-cjs",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/eventstream-serde-config-resolver/tsconfig.es.json
+++ b/packages/eventstream-serde-config-resolver/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "lib": ["es2018.asynciterable"],
-    "outDir": "dist/es",
+    "outDir": "dist-es",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/eventstream-serde-config-resolver/tsconfig.types.json
+++ b/packages/eventstream-serde-config-resolver/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "declarationDir": "dist/types",
+    "declarationDir": "dist-types",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/eventstream-serde-node/package.json
+++ b/packages/eventstream-serde-node/package.json
@@ -6,12 +6,12 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
     "test": "jest"
   },
-  "main": "./dist/cjs/index.js",
-  "module": "./dist/es/index.js",
-  "types": "./dist/types/index.d.ts",
+  "main": "./dist-cjs/index.js",
+  "module": "./dist-es/index.js",
+  "types": "./dist-types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"
@@ -34,8 +34,8 @@
   },
   "typesVersions": {
     "<4.0": {
-      "dist/types/*": [
-        "dist/types/ts3.4/*"
+      "dist-types/*": [
+        "dist-types/ts3.4/*"
       ]
     }
   },

--- a/packages/eventstream-serde-node/tsconfig.cjs.json
+++ b/packages/eventstream-serde-node/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "outDir": "dist/cjs",
+    "outDir": "dist-cjs",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/eventstream-serde-node/tsconfig.es.json
+++ b/packages/eventstream-serde-node/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "lib": ["es2018.asynciterable"],
-    "outDir": "dist/es",
+    "outDir": "dist-es",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/eventstream-serde-node/tsconfig.types.json
+++ b/packages/eventstream-serde-node/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "declarationDir": "dist/types",
+    "declarationDir": "dist-types",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/eventstream-serde-universal/package.json
+++ b/packages/eventstream-serde-universal/package.json
@@ -6,12 +6,12 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
     "test": "jest"
   },
-  "main": "./dist/cjs/index.js",
-  "module": "./dist/es/index.js",
-  "types": "./dist/types/index.d.ts",
+  "main": "./dist-cjs/index.js",
+  "module": "./dist-es/index.js",
+  "types": "./dist-types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"
@@ -33,8 +33,8 @@
   },
   "typesVersions": {
     "<4.0": {
-      "dist/types/*": [
-        "dist/types/ts3.4/*"
+      "dist-types/*": [
+        "dist-types/ts3.4/*"
       ]
     }
   },

--- a/packages/eventstream-serde-universal/tsconfig.cjs.json
+++ b/packages/eventstream-serde-universal/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "outDir": "dist/cjs",
+    "outDir": "dist-cjs",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/eventstream-serde-universal/tsconfig.es.json
+++ b/packages/eventstream-serde-universal/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "lib": ["es2018.asynciterable"],
-    "outDir": "dist/es",
+    "outDir": "dist-es",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/eventstream-serde-universal/tsconfig.types.json
+++ b/packages/eventstream-serde-universal/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "declarationDir": "dist/types",
+    "declarationDir": "dist-types",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/fetch-http-handler/package.json
+++ b/packages/fetch-http-handler/package.json
@@ -7,7 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
     "test": "jest --coverage && karma start karma.conf.js"
   },
   "author": {
@@ -15,9 +15,9 @@
     "url": "https://aws.amazon.com/javascript/"
   },
   "license": "Apache-2.0",
-  "main": "./dist/cjs/index.js",
-  "module": "./dist/es/index.js",
-  "types": "./dist/types/index.d.ts",
+  "main": "./dist-cjs/index.js",
+  "module": "./dist-es/index.js",
+  "types": "./dist-types/index.d.ts",
   "dependencies": {
     "@aws-sdk/protocol-http": "3.34.0",
     "@aws-sdk/querystring-builder": "3.34.0",
@@ -32,8 +32,8 @@
   },
   "typesVersions": {
     "<4.0": {
-      "dist/types/*": [
-        "dist/types/ts3.4/*"
+      "dist-types/*": [
+        "dist-types/ts3.4/*"
       ]
     }
   },

--- a/packages/fetch-http-handler/tsconfig.cjs.json
+++ b/packages/fetch-http-handler/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "outDir": "dist/cjs",
+    "outDir": "dist-cjs",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/fetch-http-handler/tsconfig.es.json
+++ b/packages/fetch-http-handler/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "lib": ["dom", "es5", "es2015.promise", "es2015.iterable"],
-    "outDir": "dist/es",
+    "outDir": "dist-es",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/fetch-http-handler/tsconfig.types.json
+++ b/packages/fetch-http-handler/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "declarationDir": "dist/types",
+    "declarationDir": "dist-types",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/hash-blob-browser/package.json
+++ b/packages/hash-blob-browser/package.json
@@ -6,12 +6,12 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
     "test": "karma start karma.conf.js"
   },
-  "main": "./dist/cjs/index.js",
-  "module": "./dist/es/index.js",
-  "types": "./dist/types/index.d.ts",
+  "main": "./dist-cjs/index.js",
+  "module": "./dist-es/index.js",
+  "types": "./dist-types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"
@@ -35,8 +35,8 @@
   },
   "typesVersions": {
     "<4.0": {
-      "dist/types/*": [
-        "dist/types/ts3.4/*"
+      "dist-types/*": [
+        "dist-types/ts3.4/*"
       ]
     }
   },

--- a/packages/hash-blob-browser/tsconfig.cjs.json
+++ b/packages/hash-blob-browser/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "outDir": "dist/cjs",
+    "outDir": "dist-cjs",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/hash-blob-browser/tsconfig.es.json
+++ b/packages/hash-blob-browser/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "outDir": "dist/es",
+    "outDir": "dist-es",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/hash-blob-browser/tsconfig.types.json
+++ b/packages/hash-blob-browser/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "declarationDir": "dist/types",
+    "declarationDir": "dist-types",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/hash-node/package.json
+++ b/packages/hash-node/package.json
@@ -6,12 +6,12 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
     "test": "jest"
   },
-  "main": "./dist/cjs/index.js",
-  "module": "./dist/es/index.js",
-  "types": "./dist/types/index.d.ts",
+  "main": "./dist-cjs/index.js",
+  "module": "./dist-es/index.js",
+  "types": "./dist-types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"
@@ -34,8 +34,8 @@
   },
   "typesVersions": {
     "<4.0": {
-      "dist/types/*": [
-        "dist/types/ts3.4/*"
+      "dist-types/*": [
+        "dist-types/ts3.4/*"
       ]
     }
   },

--- a/packages/hash-node/tsconfig.cjs.json
+++ b/packages/hash-node/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "outDir": "dist/cjs",
+    "outDir": "dist-cjs",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/hash-node/tsconfig.es.json
+++ b/packages/hash-node/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "outDir": "dist/es",
+    "outDir": "dist-es",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/hash-node/tsconfig.types.json
+++ b/packages/hash-node/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "declarationDir": "dist/types",
+    "declarationDir": "dist-types",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/hash-stream-node/package.json
+++ b/packages/hash-stream-node/package.json
@@ -6,12 +6,12 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
     "test": "jest"
   },
-  "main": "./dist/cjs/index.js",
-  "module": "./dist/es/index.js",
-  "types": "./dist/types/index.d.ts",
+  "main": "./dist-cjs/index.js",
+  "module": "./dist-es/index.js",
+  "types": "./dist-types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"
@@ -34,8 +34,8 @@
   },
   "typesVersions": {
     "<4.0": {
-      "dist/types/*": [
-        "dist/types/ts3.4/*"
+      "dist-types/*": [
+        "dist-types/ts3.4/*"
       ]
     }
   },

--- a/packages/hash-stream-node/tsconfig.cjs.json
+++ b/packages/hash-stream-node/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "outDir": "dist/cjs",
+    "outDir": "dist-cjs",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/hash-stream-node/tsconfig.es.json
+++ b/packages/hash-stream-node/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "outDir": "dist/es",
+    "outDir": "dist-es",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/hash-stream-node/tsconfig.types.json
+++ b/packages/hash-stream-node/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "declarationDir": "dist/types",
+    "declarationDir": "dist-types",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/invalid-dependency/package.json
+++ b/packages/invalid-dependency/package.json
@@ -6,12 +6,12 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
     "test": "jest"
   },
-  "main": "./dist/cjs/index.js",
-  "module": "./dist/es/index.js",
-  "types": "./dist/types/index.d.ts",
+  "main": "./dist-cjs/index.js",
+  "module": "./dist-es/index.js",
+  "types": "./dist-types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"
@@ -28,8 +28,8 @@
   },
   "typesVersions": {
     "<4.0": {
-      "dist/types/*": [
-        "dist/types/ts3.4/*"
+      "dist-types/*": [
+        "dist-types/ts3.4/*"
       ]
     }
   },

--- a/packages/invalid-dependency/tsconfig.cjs.json
+++ b/packages/invalid-dependency/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "outDir": "dist/cjs",
+    "outDir": "dist-cjs",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/invalid-dependency/tsconfig.es.json
+++ b/packages/invalid-dependency/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "outDir": "dist/es",
+    "outDir": "dist-es",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/invalid-dependency/tsconfig.types.json
+++ b/packages/invalid-dependency/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "declarationDir": "dist/types",
+    "declarationDir": "dist-types",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/is-array-buffer/package.json
+++ b/packages/is-array-buffer/package.json
@@ -7,7 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
     "test": "jest"
   },
   "author": {
@@ -15,14 +15,14 @@
     "url": "https://aws.amazon.com/javascript/"
   },
   "license": "Apache-2.0",
-  "main": "./dist/cjs/index.js",
-  "module": "./dist/es/index.js",
+  "main": "./dist-cjs/index.js",
+  "module": "./dist-es/index.js",
   "devDependencies": {
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
     "typescript": "~4.3.5"
   },
-  "types": "./dist/types/index.d.ts",
+  "types": "./dist-types/index.d.ts",
   "dependencies": {
     "tslib": "^2.3.0"
   },
@@ -31,8 +31,8 @@
   },
   "typesVersions": {
     "<4.0": {
-      "dist/types/*": [
-        "dist/types/ts3.4/*"
+      "dist-types/*": [
+        "dist-types/ts3.4/*"
       ]
     }
   },

--- a/packages/is-array-buffer/tsconfig.cjs.json
+++ b/packages/is-array-buffer/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "outDir": "dist/cjs",
+    "outDir": "dist-cjs",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/is-array-buffer/tsconfig.es.json
+++ b/packages/is-array-buffer/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "lib": ["es5", "es2015.collection"],
-    "outDir": "dist/es",
+    "outDir": "dist-es",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/is-array-buffer/tsconfig.types.json
+++ b/packages/is-array-buffer/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "declarationDir": "dist/types",
+    "declarationDir": "dist-types",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/karma-credential-loader/package.json
+++ b/packages/karma-credential-loader/package.json
@@ -6,12 +6,12 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
     "test": "jest --passWithNoTests"
   },
-  "main": "./dist/cjs/index.js",
-  "module": "./dist/es/index.js",
-  "types": "./dist/types/index.d.ts",
+  "main": "./dist-cjs/index.js",
+  "module": "./dist-es/index.js",
+  "types": "./dist-types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"
@@ -32,8 +32,8 @@
   },
   "typesVersions": {
     "<4.0": {
-      "dist/types/*": [
-        "dist/types/ts3.4/*"
+      "dist-types/*": [
+        "dist-types/ts3.4/*"
       ]
     }
   },

--- a/packages/karma-credential-loader/tsconfig.cjs.json
+++ b/packages/karma-credential-loader/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "outDir": "dist/cjs",
+    "outDir": "dist-cjs",
     "rootDir": "src",
     "strict": false
   },

--- a/packages/karma-credential-loader/tsconfig.es.json
+++ b/packages/karma-credential-loader/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "lib": ["es2015"],
-    "outDir": "dist/es",
+    "outDir": "dist-es",
     "rootDir": "src",
     "strict": false
   },

--- a/packages/karma-credential-loader/tsconfig.types.json
+++ b/packages/karma-credential-loader/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "declarationDir": "dist/types",
+    "declarationDir": "dist-types",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/md5-js/package.json
+++ b/packages/md5-js/package.json
@@ -6,12 +6,12 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
     "test": "jest"
   },
-  "main": "./dist/cjs/index.js",
-  "module": "./dist/es/index.js",
-  "types": "./dist/types/index.d.ts",
+  "main": "./dist-cjs/index.js",
+  "module": "./dist-es/index.js",
+  "types": "./dist-types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"
@@ -43,8 +43,8 @@
   },
   "typesVersions": {
     "<4.0": {
-      "dist/types/*": [
-        "dist/types/ts3.4/*"
+      "dist-types/*": [
+        "dist-types/ts3.4/*"
       ]
     }
   },

--- a/packages/md5-js/tsconfig.cjs.json
+++ b/packages/md5-js/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "outDir": "dist/cjs",
+    "outDir": "dist-cjs",
     "rootDir": "src"
   },
   "exclude": ["./build/**"],

--- a/packages/md5-js/tsconfig.es.json
+++ b/packages/md5-js/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "outDir": "dist/es",
+    "outDir": "dist-es",
     "rootDir": "src"
   },
   "include": ["src/"],

--- a/packages/md5-js/tsconfig.types.json
+++ b/packages/md5-js/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "declarationDir": "dist/types",
+    "declarationDir": "dist-types",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/middleware-apply-body-checksum/package.json
+++ b/packages/middleware-apply-body-checksum/package.json
@@ -6,12 +6,12 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
     "test": "jest --coverage"
   },
-  "main": "./dist/cjs/index.js",
-  "module": "./dist/es/index.js",
-  "types": "./dist/types/index.d.ts",
+  "main": "./dist-cjs/index.js",
+  "module": "./dist-es/index.js",
+  "types": "./dist-types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"
@@ -33,8 +33,8 @@
   },
   "typesVersions": {
     "<4.0": {
-      "dist/types/*": [
-        "dist/types/ts3.4/*"
+      "dist-types/*": [
+        "dist-types/ts3.4/*"
       ]
     }
   },

--- a/packages/middleware-apply-body-checksum/tsconfig.cjs.json
+++ b/packages/middleware-apply-body-checksum/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "outDir": "dist/cjs",
+    "outDir": "dist-cjs",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/middleware-apply-body-checksum/tsconfig.es.json
+++ b/packages/middleware-apply-body-checksum/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "outDir": "dist/es",
+    "outDir": "dist-es",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/middleware-apply-body-checksum/tsconfig.types.json
+++ b/packages/middleware-apply-body-checksum/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "declarationDir": "dist/types",
+    "declarationDir": "dist-types",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/middleware-bucket-endpoint/package.json
+++ b/packages/middleware-bucket-endpoint/package.json
@@ -6,12 +6,12 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
     "test": "jest"
   },
-  "main": "./dist/cjs/index.js",
-  "module": "./dist/es/index.js",
-  "types": "./dist/types/index.d.ts",
+  "main": "./dist-cjs/index.js",
+  "module": "./dist-es/index.js",
+  "types": "./dist-types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"
@@ -35,8 +35,8 @@
   },
   "typesVersions": {
     "<4.0": {
-      "dist/types/*": [
-        "dist/types/ts3.4/*"
+      "dist-types/*": [
+        "dist-types/ts3.4/*"
       ]
     }
   },

--- a/packages/middleware-bucket-endpoint/tsconfig.cjs.json
+++ b/packages/middleware-bucket-endpoint/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "outDir": "dist/cjs",
+    "outDir": "dist-cjs",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/middleware-bucket-endpoint/tsconfig.es.json
+++ b/packages/middleware-bucket-endpoint/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "outDir": "dist/es",
+    "outDir": "dist-es",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/middleware-bucket-endpoint/tsconfig.types.json
+++ b/packages/middleware-bucket-endpoint/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "declarationDir": "dist/types",
+    "declarationDir": "dist-types",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/middleware-content-length/package.json
+++ b/packages/middleware-content-length/package.json
@@ -6,12 +6,12 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
     "test": "jest"
   },
-  "main": "./dist/cjs/index.js",
-  "module": "./dist/es/index.js",
-  "types": "./dist/types/index.d.ts",
+  "main": "./dist-cjs/index.js",
+  "module": "./dist-es/index.js",
+  "types": "./dist-types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"
@@ -32,8 +32,8 @@
   },
   "typesVersions": {
     "<4.0": {
-      "dist/types/*": [
-        "dist/types/ts3.4/*"
+      "dist-types/*": [
+        "dist-types/ts3.4/*"
       ]
     }
   },

--- a/packages/middleware-content-length/tsconfig.cjs.json
+++ b/packages/middleware-content-length/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "outDir": "dist/cjs",
+    "outDir": "dist-cjs",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/middleware-content-length/tsconfig.es.json
+++ b/packages/middleware-content-length/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "outDir": "dist/es",
+    "outDir": "dist-es",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/middleware-content-length/tsconfig.types.json
+++ b/packages/middleware-content-length/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "declarationDir": "dist/types",
+    "declarationDir": "dist-types",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/middleware-endpoint-discovery/package.json
+++ b/packages/middleware-endpoint-discovery/package.json
@@ -6,12 +6,12 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
     "test": "jest"
   },
-  "main": "./dist/cjs/index.js",
-  "module": "./dist/es/index.js",
-  "types": "./dist/types/index.d.ts",
+  "main": "./dist-cjs/index.js",
+  "module": "./dist-es/index.js",
+  "types": "./dist-types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"
@@ -35,8 +35,8 @@
   },
   "typesVersions": {
     "<4.0": {
-      "dist/types/*": [
-        "dist/types/ts3.4/*"
+      "dist-types/*": [
+        "dist-types/ts3.4/*"
       ]
     }
   },

--- a/packages/middleware-endpoint-discovery/tsconfig.cjs.json
+++ b/packages/middleware-endpoint-discovery/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "outDir": "dist/cjs",
+    "outDir": "dist-cjs",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/middleware-endpoint-discovery/tsconfig.es.json
+++ b/packages/middleware-endpoint-discovery/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "outDir": "dist/es",
+    "outDir": "dist-es",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/middleware-endpoint-discovery/tsconfig.types.json
+++ b/packages/middleware-endpoint-discovery/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "declarationDir": "dist/types",
+    "declarationDir": "dist-types",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/middleware-eventstream/package.json
+++ b/packages/middleware-eventstream/package.json
@@ -6,12 +6,12 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
     "test": "jest"
   },
-  "main": "./dist/cjs/index.js",
-  "module": "./dist/es/index.js",
-  "types": "./dist/types/index.d.ts",
+  "main": "./dist-cjs/index.js",
+  "module": "./dist-es/index.js",
+  "types": "./dist-types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"
@@ -32,8 +32,8 @@
   },
   "typesVersions": {
     "<4.0": {
-      "dist/types/*": [
-        "dist/types/ts3.4/*"
+      "dist-types/*": [
+        "dist-types/ts3.4/*"
       ]
     }
   },

--- a/packages/middleware-eventstream/tsconfig.cjs.json
+++ b/packages/middleware-eventstream/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "outDir": "dist/cjs",
+    "outDir": "dist-cjs",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/middleware-eventstream/tsconfig.es.json
+++ b/packages/middleware-eventstream/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "outDir": "dist/es",
+    "outDir": "dist-es",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/middleware-eventstream/tsconfig.types.json
+++ b/packages/middleware-eventstream/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "declarationDir": "dist/types",
+    "declarationDir": "dist-types",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/middleware-expect-continue/package.json
+++ b/packages/middleware-expect-continue/package.json
@@ -6,12 +6,12 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
     "test": "jest"
   },
-  "main": "./dist/cjs/index.js",
-  "module": "./dist/es/index.js",
-  "types": "./dist/types/index.d.ts",
+  "main": "./dist-cjs/index.js",
+  "module": "./dist-es/index.js",
+  "types": "./dist-types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"
@@ -33,8 +33,8 @@
   },
   "typesVersions": {
     "<4.0": {
-      "dist/types/*": [
-        "dist/types/ts3.4/*"
+      "dist-types/*": [
+        "dist-types/ts3.4/*"
       ]
     }
   },

--- a/packages/middleware-expect-continue/tsconfig.cjs.json
+++ b/packages/middleware-expect-continue/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "outDir": "dist/cjs",
+    "outDir": "dist-cjs",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/middleware-expect-continue/tsconfig.es.json
+++ b/packages/middleware-expect-continue/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "outDir": "dist/es",
+    "outDir": "dist-es",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/middleware-expect-continue/tsconfig.types.json
+++ b/packages/middleware-expect-continue/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "declarationDir": "dist/types",
+    "declarationDir": "dist-types",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/middleware-header-default/package.json
+++ b/packages/middleware-header-default/package.json
@@ -6,12 +6,12 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
     "test": "jest"
   },
-  "main": "./dist/cjs/index.js",
-  "module": "./dist/es/index.js",
-  "types": "./dist/types/index.d.ts",
+  "main": "./dist-cjs/index.js",
+  "module": "./dist-es/index.js",
+  "types": "./dist-types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"
@@ -32,8 +32,8 @@
   },
   "typesVersions": {
     "<4.0": {
-      "dist/types/*": [
-        "dist/types/ts3.4/*"
+      "dist-types/*": [
+        "dist-types/ts3.4/*"
       ]
     }
   },

--- a/packages/middleware-header-default/tsconfig.cjs.json
+++ b/packages/middleware-header-default/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "outDir": "dist/cjs",
+    "outDir": "dist-cjs",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/middleware-header-default/tsconfig.es.json
+++ b/packages/middleware-header-default/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "outDir": "dist/es",
+    "outDir": "dist-es",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/middleware-header-default/tsconfig.types.json
+++ b/packages/middleware-header-default/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "declarationDir": "dist/types",
+    "declarationDir": "dist-types",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/middleware-host-header/package.json
+++ b/packages/middleware-host-header/package.json
@@ -6,12 +6,12 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
     "test": "jest"
   },
-  "main": "./dist/cjs/index.js",
-  "module": "./dist/es/index.js",
-  "types": "./dist/types/index.d.ts",
+  "main": "./dist-cjs/index.js",
+  "module": "./dist-es/index.js",
+  "types": "./dist-types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"
@@ -32,8 +32,8 @@
   },
   "typesVersions": {
     "<4.0": {
-      "dist/types/*": [
-        "dist/types/ts3.4/*"
+      "dist-types/*": [
+        "dist-types/ts3.4/*"
       ]
     }
   },

--- a/packages/middleware-host-header/tsconfig.cjs.json
+++ b/packages/middleware-host-header/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "outDir": "dist/cjs",
+    "outDir": "dist-cjs",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/middleware-host-header/tsconfig.es.json
+++ b/packages/middleware-host-header/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "outDir": "dist/es",
+    "outDir": "dist-es",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/middleware-host-header/tsconfig.types.json
+++ b/packages/middleware-host-header/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "declarationDir": "dist/types",
+    "declarationDir": "dist-types",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/middleware-location-constraint/package.json
+++ b/packages/middleware-location-constraint/package.json
@@ -6,12 +6,12 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
     "test": "jest"
   },
-  "main": "./dist/cjs/index.js",
-  "module": "./dist/es/index.js",
-  "types": "./dist/types/index.d.ts",
+  "main": "./dist-cjs/index.js",
+  "module": "./dist-es/index.js",
+  "types": "./dist-types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"
@@ -31,8 +31,8 @@
   },
   "typesVersions": {
     "<4.0": {
-      "dist/types/*": [
-        "dist/types/ts3.4/*"
+      "dist-types/*": [
+        "dist-types/ts3.4/*"
       ]
     }
   },

--- a/packages/middleware-location-constraint/tsconfig.cjs.json
+++ b/packages/middleware-location-constraint/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "outDir": "dist/cjs",
+    "outDir": "dist-cjs",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/middleware-location-constraint/tsconfig.es.json
+++ b/packages/middleware-location-constraint/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "outDir": "dist/es",
+    "outDir": "dist-es",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/middleware-location-constraint/tsconfig.types.json
+++ b/packages/middleware-location-constraint/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "declarationDir": "dist/types",
+    "declarationDir": "dist-types",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/middleware-logger/package.json
+++ b/packages/middleware-logger/package.json
@@ -6,7 +6,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
     "test": "jest --passWithNoTests"
   },
   "author": {
@@ -15,9 +15,9 @@
     "url": "https://aws.amazon.com/javascript/"
   },
   "license": "Apache-2.0",
-  "main": "./dist/cjs/index.js",
-  "module": "./dist/es/index.js",
-  "types": "./dist/types/index.d.ts",
+  "main": "./dist-cjs/index.js",
+  "module": "./dist-es/index.js",
+  "types": "./dist-types/index.d.ts",
   "dependencies": {
     "@aws-sdk/types": "3.34.0",
     "tslib": "^2.3.0"
@@ -34,8 +34,8 @@
   },
   "typesVersions": {
     "<4.0": {
-      "dist/types/*": [
-        "dist/types/ts3.4/*"
+      "dist-types/*": [
+        "dist-types/ts3.4/*"
       ]
     }
   },

--- a/packages/middleware-logger/tsconfig.cjs.json
+++ b/packages/middleware-logger/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "outDir": "dist/cjs",
+    "outDir": "dist-cjs",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/middleware-logger/tsconfig.es.json
+++ b/packages/middleware-logger/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "lib": ["es5", "es2015.promise", "es2015.iterable"],
-    "outDir": "dist/es",
+    "outDir": "dist-es",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/middleware-logger/tsconfig.types.json
+++ b/packages/middleware-logger/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "declarationDir": "dist/types",
+    "declarationDir": "dist-types",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/middleware-retry/package.json
+++ b/packages/middleware-retry/package.json
@@ -6,12 +6,12 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
     "test": "jest"
   },
-  "main": "./dist/cjs/index.js",
-  "module": "./dist/es/index.js",
-  "types": "./dist/types/index.d.ts",
+  "main": "./dist-cjs/index.js",
+  "module": "./dist-es/index.js",
+  "types": "./dist-types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"
@@ -35,8 +35,8 @@
   },
   "typesVersions": {
     "<4.0": {
-      "dist/types/*": [
-        "dist/types/ts3.4/*"
+      "dist-types/*": [
+        "dist-types/ts3.4/*"
       ]
     }
   },

--- a/packages/middleware-retry/tsconfig.cjs.json
+++ b/packages/middleware-retry/tsconfig.cjs.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "noUnusedLocals": true,
-    "outDir": "dist/cjs",
+    "outDir": "dist-cjs",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/middleware-retry/tsconfig.es.json
+++ b/packages/middleware-retry/tsconfig.es.json
@@ -3,7 +3,7 @@
     "baseUrl": ".",
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "noUnusedLocals": true,
-    "outDir": "dist/es",
+    "outDir": "dist-es",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/middleware-retry/tsconfig.types.json
+++ b/packages/middleware-retry/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "declarationDir": "dist/types",
+    "declarationDir": "dist-types",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/middleware-sdk-api-gateway/package.json
+++ b/packages/middleware-sdk-api-gateway/package.json
@@ -6,12 +6,12 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
     "test": "jest"
   },
-  "main": "./dist/cjs/index.js",
-  "module": "./dist/es/index.js",
-  "types": "./dist/types/index.d.ts",
+  "main": "./dist-cjs/index.js",
+  "module": "./dist-es/index.js",
+  "types": "./dist-types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"
@@ -32,8 +32,8 @@
   },
   "typesVersions": {
     "<4.0": {
-      "dist/types/*": [
-        "dist/types/ts3.4/*"
+      "dist-types/*": [
+        "dist-types/ts3.4/*"
       ]
     }
   },

--- a/packages/middleware-sdk-api-gateway/tsconfig.cjs.json
+++ b/packages/middleware-sdk-api-gateway/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "outDir": "dist/cjs",
+    "outDir": "dist-cjs",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/middleware-sdk-api-gateway/tsconfig.es.json
+++ b/packages/middleware-sdk-api-gateway/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "outDir": "dist/es",
+    "outDir": "dist-es",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/middleware-sdk-api-gateway/tsconfig.types.json
+++ b/packages/middleware-sdk-api-gateway/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "declarationDir": "dist/types",
+    "declarationDir": "dist-types",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/middleware-sdk-ec2/package.json
+++ b/packages/middleware-sdk-ec2/package.json
@@ -6,12 +6,12 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
     "test": "jest"
   },
-  "main": "./dist/cjs/index.js",
-  "module": "./dist/es/index.js",
-  "types": "./dist/types/index.d.ts",
+  "main": "./dist-cjs/index.js",
+  "module": "./dist-es/index.js",
+  "types": "./dist-types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"
@@ -35,8 +35,8 @@
   },
   "typesVersions": {
     "<4.0": {
-      "dist/types/*": [
-        "dist/types/ts3.4/*"
+      "dist-types/*": [
+        "dist-types/ts3.4/*"
       ]
     }
   },

--- a/packages/middleware-sdk-ec2/tsconfig.cjs.json
+++ b/packages/middleware-sdk-ec2/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "outDir": "dist/cjs",
+    "outDir": "dist-cjs",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/middleware-sdk-ec2/tsconfig.es.json
+++ b/packages/middleware-sdk-ec2/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "outDir": "dist/es",
+    "outDir": "dist-es",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/middleware-sdk-ec2/tsconfig.types.json
+++ b/packages/middleware-sdk-ec2/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "declarationDir": "dist/types",
+    "declarationDir": "dist-types",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/middleware-sdk-glacier/package.json
+++ b/packages/middleware-sdk-glacier/package.json
@@ -6,12 +6,12 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
     "test": "jest"
   },
-  "main": "./dist/cjs/index.js",
-  "module": "./dist/es/index.js",
-  "types": "./dist/types/index.d.ts",
+  "main": "./dist-cjs/index.js",
+  "module": "./dist-es/index.js",
+  "types": "./dist-types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"
@@ -32,8 +32,8 @@
   },
   "typesVersions": {
     "<4.0": {
-      "dist/types/*": [
-        "dist/types/ts3.4/*"
+      "dist-types/*": [
+        "dist-types/ts3.4/*"
       ]
     }
   },

--- a/packages/middleware-sdk-glacier/tsconfig.cjs.json
+++ b/packages/middleware-sdk-glacier/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "outDir": "dist/cjs",
+    "outDir": "dist-cjs",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/middleware-sdk-glacier/tsconfig.es.json
+++ b/packages/middleware-sdk-glacier/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "outDir": "dist/es",
+    "outDir": "dist-es",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/middleware-sdk-glacier/tsconfig.types.json
+++ b/packages/middleware-sdk-glacier/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "declarationDir": "dist/types",
+    "declarationDir": "dist-types",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/middleware-sdk-machinelearning/package.json
+++ b/packages/middleware-sdk-machinelearning/package.json
@@ -6,12 +6,12 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
     "test": "jest"
   },
-  "main": "./dist/cjs/index.js",
-  "module": "./dist/es/index.js",
-  "types": "./dist/types/index.d.ts",
+  "main": "./dist-cjs/index.js",
+  "module": "./dist-es/index.js",
+  "types": "./dist-types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"
@@ -32,8 +32,8 @@
   },
   "typesVersions": {
     "<4.0": {
-      "dist/types/*": [
-        "dist/types/ts3.4/*"
+      "dist-types/*": [
+        "dist-types/ts3.4/*"
       ]
     }
   },

--- a/packages/middleware-sdk-machinelearning/tsconfig.cjs.json
+++ b/packages/middleware-sdk-machinelearning/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "outDir": "dist/cjs",
+    "outDir": "dist-cjs",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/middleware-sdk-machinelearning/tsconfig.es.json
+++ b/packages/middleware-sdk-machinelearning/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "outDir": "dist/es",
+    "outDir": "dist-es",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/middleware-sdk-machinelearning/tsconfig.types.json
+++ b/packages/middleware-sdk-machinelearning/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "declarationDir": "dist/types",
+    "declarationDir": "dist-types",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/middleware-sdk-rds/package.json
+++ b/packages/middleware-sdk-rds/package.json
@@ -6,12 +6,12 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
     "test": "jest"
   },
-  "main": "./dist/cjs/index.js",
-  "module": "./dist/es/index.js",
-  "types": "./dist/types/index.d.ts",
+  "main": "./dist-cjs/index.js",
+  "module": "./dist-es/index.js",
+  "types": "./dist-types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"
@@ -34,8 +34,8 @@
   },
   "typesVersions": {
     "<4.0": {
-      "dist/types/*": [
-        "dist/types/ts3.4/*"
+      "dist-types/*": [
+        "dist-types/ts3.4/*"
       ]
     }
   },

--- a/packages/middleware-sdk-rds/tsconfig.cjs.json
+++ b/packages/middleware-sdk-rds/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "outDir": "dist/cjs",
+    "outDir": "dist-cjs",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/middleware-sdk-rds/tsconfig.es.json
+++ b/packages/middleware-sdk-rds/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "outDir": "dist/es",
+    "outDir": "dist-es",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/middleware-sdk-rds/tsconfig.types.json
+++ b/packages/middleware-sdk-rds/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "declarationDir": "dist/types",
+    "declarationDir": "dist-types",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/middleware-sdk-route53/package.json
+++ b/packages/middleware-sdk-route53/package.json
@@ -6,12 +6,12 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
     "test": "jest"
   },
-  "main": "./dist/cjs/index.js",
-  "module": "./dist/es/index.js",
-  "types": "./dist/types/index.d.ts",
+  "main": "./dist-cjs/index.js",
+  "module": "./dist-es/index.js",
+  "types": "./dist-types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"
@@ -31,8 +31,8 @@
   },
   "typesVersions": {
     "<4.0": {
-      "dist/types/*": [
-        "dist/types/ts3.4/*"
+      "dist-types/*": [
+        "dist-types/ts3.4/*"
       ]
     }
   },

--- a/packages/middleware-sdk-route53/tsconfig.cjs.json
+++ b/packages/middleware-sdk-route53/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "outDir": "dist/cjs",
+    "outDir": "dist-cjs",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/middleware-sdk-route53/tsconfig.es.json
+++ b/packages/middleware-sdk-route53/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "outDir": "dist/es",
+    "outDir": "dist-es",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/middleware-sdk-route53/tsconfig.types.json
+++ b/packages/middleware-sdk-route53/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "declarationDir": "dist/types",
+    "declarationDir": "dist-types",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/middleware-sdk-s3-control/package.json
+++ b/packages/middleware-sdk-s3-control/package.json
@@ -6,12 +6,12 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
     "test": "jest"
   },
-  "main": "./dist/cjs/index.js",
-  "module": "./dist/es/index.js",
-  "types": "./dist/types/index.d.ts",
+  "main": "./dist-cjs/index.js",
+  "module": "./dist-es/index.js",
+  "types": "./dist-types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"
@@ -35,8 +35,8 @@
   },
   "typesVersions": {
     "<4.0": {
-      "dist/types/*": [
-        "dist/types/ts3.4/*"
+      "dist-types/*": [
+        "dist-types/ts3.4/*"
       ]
     }
   },

--- a/packages/middleware-sdk-s3-control/tsconfig.cjs.json
+++ b/packages/middleware-sdk-s3-control/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "outDir": "dist/cjs",
+    "outDir": "dist-cjs",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/middleware-sdk-s3-control/tsconfig.es.json
+++ b/packages/middleware-sdk-s3-control/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "outDir": "dist/es",
+    "outDir": "dist-es",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/middleware-sdk-s3-control/tsconfig.types.json
+++ b/packages/middleware-sdk-s3-control/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "declarationDir": "dist/types",
+    "declarationDir": "dist-types",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/middleware-sdk-s3/package.json
+++ b/packages/middleware-sdk-s3/package.json
@@ -6,12 +6,12 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
     "test": "jest"
   },
-  "main": "./dist/cjs/index.js",
-  "module": "./dist/es/index.js",
-  "types": "./dist/types/index.d.ts",
+  "main": "./dist-cjs/index.js",
+  "module": "./dist-es/index.js",
+  "types": "./dist-types/index.d.ts",
   "browser": {
     "@aws-sdk/signature-v4-crt": false
   },
@@ -44,8 +44,8 @@
   },
   "typesVersions": {
     "<4.0": {
-      "dist/types/*": [
-        "dist/types/ts3.4/*"
+      "dist-types/*": [
+        "dist-types/ts3.4/*"
       ]
     }
   },

--- a/packages/middleware-sdk-s3/tsconfig.cjs.json
+++ b/packages/middleware-sdk-s3/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "outDir": "dist/cjs",
+    "outDir": "dist-cjs",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/middleware-sdk-s3/tsconfig.es.json
+++ b/packages/middleware-sdk-s3/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "outDir": "dist/es",
+    "outDir": "dist-es",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/middleware-sdk-s3/tsconfig.types.json
+++ b/packages/middleware-sdk-s3/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "declarationDir": "dist/types",
+    "declarationDir": "dist-types",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/middleware-sdk-sqs/package.json
+++ b/packages/middleware-sdk-sqs/package.json
@@ -6,12 +6,12 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
     "test": "jest"
   },
-  "main": "./dist/cjs/index.js",
-  "module": "./dist/es/index.js",
-  "types": "./dist/types/index.d.ts",
+  "main": "./dist-cjs/index.js",
+  "module": "./dist-es/index.js",
+  "types": "./dist-types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"
@@ -32,8 +32,8 @@
   },
   "typesVersions": {
     "<4.0": {
-      "dist/types/*": [
-        "dist/types/ts3.4/*"
+      "dist-types/*": [
+        "dist-types/ts3.4/*"
       ]
     }
   },

--- a/packages/middleware-sdk-sqs/tsconfig.cjs.json
+++ b/packages/middleware-sdk-sqs/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "outDir": "dist/cjs",
+    "outDir": "dist-cjs",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/middleware-sdk-sqs/tsconfig.es.json
+++ b/packages/middleware-sdk-sqs/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "outDir": "dist/es",
+    "outDir": "dist-es",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/middleware-sdk-sqs/tsconfig.types.json
+++ b/packages/middleware-sdk-sqs/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "declarationDir": "dist/types",
+    "declarationDir": "dist-types",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/middleware-sdk-sts/package.json
+++ b/packages/middleware-sdk-sts/package.json
@@ -6,12 +6,12 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
     "test": "jest"
   },
-  "main": "./dist/cjs/index.js",
-  "module": "./dist/es/index.js",
-  "types": "./dist/types/index.d.ts",
+  "main": "./dist-cjs/index.js",
+  "module": "./dist-es/index.js",
+  "types": "./dist-types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"
@@ -35,8 +35,8 @@
   },
   "typesVersions": {
     "<4.0": {
-      "dist/types/*": [
-        "dist/types/ts3.4/*"
+      "dist-types/*": [
+        "dist-types/ts3.4/*"
       ]
     }
   },

--- a/packages/middleware-sdk-sts/tsconfig.cjs.json
+++ b/packages/middleware-sdk-sts/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "outDir": "dist/cjs",
+    "outDir": "dist-cjs",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/middleware-sdk-sts/tsconfig.es.json
+++ b/packages/middleware-sdk-sts/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "outDir": "dist/es",
+    "outDir": "dist-es",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/middleware-sdk-sts/tsconfig.types.json
+++ b/packages/middleware-sdk-sts/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "declarationDir": "dist/types",
+    "declarationDir": "dist-types",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/middleware-sdk-transcribe-streaming/package.json
+++ b/packages/middleware-sdk-transcribe-streaming/package.json
@@ -1,15 +1,15 @@
 {
   "name": "@aws-sdk/middleware-sdk-transcribe-streaming",
   "version": "3.34.0",
-  "main": "./dist/cjs/index.js",
-  "module": "./dist/es/index.js",
-  "types": "./dist/types/index.d.ts",
+  "main": "./dist-cjs/index.js",
+  "module": "./dist-es/index.js",
+  "types": "./dist-types/index.d.ts",
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
     "pretest": "yarn build",
     "test": "jest --passWithNoTests"
   },
@@ -40,8 +40,8 @@
   },
   "typesVersions": {
     "<4.0": {
-      "dist/types/*": [
-        "dist/types/ts3.4/*"
+      "dist-types/*": [
+        "dist-types/ts3.4/*"
       ]
     }
   },

--- a/packages/middleware-sdk-transcribe-streaming/tsconfig.cjs.json
+++ b/packages/middleware-sdk-transcribe-streaming/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "outDir": "dist/cjs",
+    "outDir": "dist-cjs",
     "rootDir": "src",
     "stripInternal": true
   },

--- a/packages/middleware-sdk-transcribe-streaming/tsconfig.es.json
+++ b/packages/middleware-sdk-transcribe-streaming/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "lib": ["es5", "es2015.promise", "es2015.collection", "DOM"],
-    "outDir": "dist/es",
+    "outDir": "dist-es",
     "rootDir": "src",
     "stripInternal": true
   },

--- a/packages/middleware-sdk-transcribe-streaming/tsconfig.types.json
+++ b/packages/middleware-sdk-transcribe-streaming/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "declarationDir": "dist/types",
+    "declarationDir": "dist-types",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/middleware-serde/package.json
+++ b/packages/middleware-serde/package.json
@@ -6,12 +6,12 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
     "test": "jest"
   },
-  "main": "./dist/cjs/index.js",
-  "module": "./dist/es/index.js",
-  "types": "./dist/types/index.d.ts",
+  "main": "./dist-cjs/index.js",
+  "module": "./dist-es/index.js",
+  "types": "./dist-types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"
@@ -31,8 +31,8 @@
   },
   "typesVersions": {
     "<4.0": {
-      "dist/types/*": [
-        "dist/types/ts3.4/*"
+      "dist-types/*": [
+        "dist-types/ts3.4/*"
       ]
     }
   },

--- a/packages/middleware-serde/tsconfig.cjs.json
+++ b/packages/middleware-serde/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "outDir": "dist/cjs",
+    "outDir": "dist-cjs",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/middleware-serde/tsconfig.es.json
+++ b/packages/middleware-serde/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "outDir": "dist/es",
+    "outDir": "dist-es",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/middleware-serde/tsconfig.types.json
+++ b/packages/middleware-serde/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "declarationDir": "dist/types",
+    "declarationDir": "dist-types",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/middleware-signing/package.json
+++ b/packages/middleware-signing/package.json
@@ -6,12 +6,12 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
     "test": "jest"
   },
-  "main": "./dist/cjs/index.js",
-  "module": "./dist/es/index.js",
-  "types": "./dist/types/index.d.ts",
+  "main": "./dist-cjs/index.js",
+  "module": "./dist-es/index.js",
+  "types": "./dist-types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"
@@ -34,8 +34,8 @@
   },
   "typesVersions": {
     "<4.0": {
-      "dist/types/*": [
-        "dist/types/ts3.4/*"
+      "dist-types/*": [
+        "dist-types/ts3.4/*"
       ]
     }
   },

--- a/packages/middleware-signing/tsconfig.cjs.json
+++ b/packages/middleware-signing/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "outDir": "dist/cjs",
+    "outDir": "dist-cjs",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/middleware-signing/tsconfig.es.json
+++ b/packages/middleware-signing/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "outDir": "dist/es",
+    "outDir": "dist-es",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/middleware-signing/tsconfig.types.json
+++ b/packages/middleware-signing/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "declarationDir": "dist/types",
+    "declarationDir": "dist-types",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/middleware-ssec/package.json
+++ b/packages/middleware-ssec/package.json
@@ -6,12 +6,12 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
     "test": "jest"
   },
-  "main": "./dist/cjs/index.js",
-  "module": "./dist/es/index.js",
-  "types": "./dist/types/index.d.ts",
+  "main": "./dist-cjs/index.js",
+  "module": "./dist-es/index.js",
+  "types": "./dist-types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"
@@ -31,8 +31,8 @@
   },
   "typesVersions": {
     "<4.0": {
-      "dist/types/*": [
-        "dist/types/ts3.4/*"
+      "dist-types/*": [
+        "dist-types/ts3.4/*"
       ]
     }
   },

--- a/packages/middleware-ssec/tsconfig.cjs.json
+++ b/packages/middleware-ssec/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "outDir": "dist/cjs",
+    "outDir": "dist-cjs",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/middleware-ssec/tsconfig.es.json
+++ b/packages/middleware-ssec/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "outDir": "dist/es",
+    "outDir": "dist-es",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/middleware-ssec/tsconfig.types.json
+++ b/packages/middleware-ssec/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "declarationDir": "dist/types",
+    "declarationDir": "dist-types",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/middleware-stack/package.json
+++ b/packages/middleware-stack/package.json
@@ -7,7 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
     "test": "jest"
   },
   "author": {
@@ -16,9 +16,9 @@
     "url": "https://aws.amazon.com/javascript/"
   },
   "license": "Apache-2.0",
-  "main": "./dist/cjs/index.js",
-  "module": "./dist/es/index.js",
-  "types": "./dist/types/index.d.ts",
+  "main": "./dist-cjs/index.js",
+  "module": "./dist-es/index.js",
+  "types": "./dist-types/index.d.ts",
   "dependencies": {
     "tslib": "^2.3.0"
   },
@@ -33,8 +33,8 @@
   },
   "typesVersions": {
     "<4.0": {
-      "dist/types/*": [
-        "dist/types/ts3.4/*"
+      "dist-types/*": [
+        "dist-types/ts3.4/*"
       ]
     }
   },

--- a/packages/middleware-stack/tsconfig.cjs.json
+++ b/packages/middleware-stack/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "outDir": "dist/cjs",
+    "outDir": "dist-cjs",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/middleware-stack/tsconfig.es.json
+++ b/packages/middleware-stack/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "lib": ["es5", "es2015.promise", "es2015.collection"],
-    "outDir": "dist/es",
+    "outDir": "dist-es",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/middleware-stack/tsconfig.types.json
+++ b/packages/middleware-stack/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "declarationDir": "dist/types",
+    "declarationDir": "dist-types",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/middleware-user-agent/package.json
+++ b/packages/middleware-user-agent/package.json
@@ -6,12 +6,12 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
     "test": "jest --passWithNoTests"
   },
-  "main": "./dist/cjs/index.js",
-  "module": "./dist/es/index.js",
-  "types": "./dist/types/index.d.ts",
+  "main": "./dist-cjs/index.js",
+  "module": "./dist-es/index.js",
+  "types": "./dist-types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"
@@ -33,8 +33,8 @@
   },
   "typesVersions": {
     "<4.0": {
-      "dist/types/*": [
-        "dist/types/ts3.4/*"
+      "dist-types/*": [
+        "dist-types/ts3.4/*"
       ]
     }
   },

--- a/packages/middleware-user-agent/tsconfig.cjs.json
+++ b/packages/middleware-user-agent/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "outDir": "dist/cjs",
+    "outDir": "dist-cjs",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/middleware-user-agent/tsconfig.es.json
+++ b/packages/middleware-user-agent/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "outDir": "dist/es",
+    "outDir": "dist-es",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/middleware-user-agent/tsconfig.types.json
+++ b/packages/middleware-user-agent/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "declarationDir": "dist/types",
+    "declarationDir": "dist-types",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/node-config-provider/package.json
+++ b/packages/node-config-provider/package.json
@@ -7,7 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
     "test": "jest --passWithNoTests"
   },
   "author": {
@@ -16,9 +16,9 @@
     "url": "https://aws.amazon.com/javascript/"
   },
   "license": "Apache-2.0",
-  "main": "./dist/cjs/index.js",
-  "module": "./dist/es/index.js",
-  "types": "./dist/types/index.d.ts",
+  "main": "./dist-cjs/index.js",
+  "module": "./dist-es/index.js",
+  "types": "./dist-types/index.d.ts",
   "dependencies": {
     "@aws-sdk/property-provider": "3.34.0",
     "@aws-sdk/shared-ini-file-loader": "3.34.0",
@@ -36,8 +36,8 @@
   },
   "typesVersions": {
     "<4.0": {
-      "dist/types/*": [
-        "dist/types/ts3.4/*"
+      "dist-types/*": [
+        "dist-types/ts3.4/*"
       ]
     }
   },

--- a/packages/node-config-provider/tsconfig.cjs.json
+++ b/packages/node-config-provider/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "outDir": "dist/cjs",
+    "outDir": "dist-cjs",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/node-config-provider/tsconfig.es.json
+++ b/packages/node-config-provider/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "lib": ["es5", "es2015.promise", "es2015.iterable"],
-    "outDir": "dist/es",
+    "outDir": "dist-es",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/node-config-provider/tsconfig.types.json
+++ b/packages/node-config-provider/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "declarationDir": "dist/types",
+    "declarationDir": "dist-types",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/node-http-handler/package.json
+++ b/packages/node-http-handler/package.json
@@ -7,7 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
     "test": "jest --coverage"
   },
   "author": {
@@ -16,9 +16,9 @@
     "url": "https://aws.amazon.com/javascript/"
   },
   "license": "Apache-2.0",
-  "main": "./dist/cjs/index.js",
-  "module": "./dist/es/index.js",
-  "types": "./dist/types/index.d.ts",
+  "main": "./dist-cjs/index.js",
+  "module": "./dist-es/index.js",
+  "types": "./dist-types/index.d.ts",
   "dependencies": {
     "@aws-sdk/abort-controller": "3.34.0",
     "@aws-sdk/protocol-http": "3.34.0",
@@ -43,8 +43,8 @@
   },
   "typesVersions": {
     "<4.0": {
-      "dist/types/*": [
-        "dist/types/ts3.4/*"
+      "dist-types/*": [
+        "dist-types/ts3.4/*"
       ]
     }
   },

--- a/packages/node-http-handler/tsconfig.cjs.json
+++ b/packages/node-http-handler/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "outDir": "dist/cjs",
+    "outDir": "dist-cjs",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/node-http-handler/tsconfig.es.json
+++ b/packages/node-http-handler/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "lib": ["es5", "es2015.promise", "es2015.iterable"],
-    "outDir": "dist/es",
+    "outDir": "dist-es",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/node-http-handler/tsconfig.types.json
+++ b/packages/node-http-handler/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "declarationDir": "dist/types",
+    "declarationDir": "dist-types",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/polly-request-presigner/package.json
+++ b/packages/polly-request-presigner/package.json
@@ -6,12 +6,12 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
     "test": "jest"
   },
-  "main": "./dist/cjs/index.js",
-  "module": "./dist/es/index.js",
-  "types": "./dist/types/index.d.ts",
+  "main": "./dist-cjs/index.js",
+  "module": "./dist-es/index.js",
+  "types": "./dist-types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"
@@ -38,8 +38,8 @@
   },
   "typesVersions": {
     "<4.0": {
-      "dist/types/*": [
-        "dist/types/ts3.4/*"
+      "dist-types/*": [
+        "dist-types/ts3.4/*"
       ]
     }
   },

--- a/packages/polly-request-presigner/tsconfig.cjs.json
+++ b/packages/polly-request-presigner/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "outDir": "dist/cjs",
+    "outDir": "dist-cjs",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/polly-request-presigner/tsconfig.es.json
+++ b/packages/polly-request-presigner/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown", "dom"],
-    "outDir": "dist/es",
+    "outDir": "dist-es",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/polly-request-presigner/tsconfig.types.json
+++ b/packages/polly-request-presigner/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "declarationDir": "dist/types",
+    "declarationDir": "dist-types",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/property-provider/package.json
+++ b/packages/property-provider/package.json
@@ -6,12 +6,12 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
     "test": "jest"
   },
-  "main": "./dist/cjs/index.js",
-  "module": "./dist/es/index.js",
-  "types": "./dist/types/index.d.ts",
+  "main": "./dist-cjs/index.js",
+  "module": "./dist-es/index.js",
+  "types": "./dist-types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"
@@ -31,8 +31,8 @@
   },
   "typesVersions": {
     "<4.0": {
-      "dist/types/*": [
-        "dist/types/ts3.4/*"
+      "dist-types/*": [
+        "dist-types/ts3.4/*"
       ]
     }
   },

--- a/packages/property-provider/tsconfig.cjs.json
+++ b/packages/property-provider/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "outDir": "dist/cjs",
+    "outDir": "dist-cjs",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/property-provider/tsconfig.es.json
+++ b/packages/property-provider/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "outDir": "dist/es",
+    "outDir": "dist-es",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/property-provider/tsconfig.types.json
+++ b/packages/property-provider/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "declarationDir": "dist/types",
+    "declarationDir": "dist-types",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/protocol-http/package.json
+++ b/packages/protocol-http/package.json
@@ -6,12 +6,12 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
     "test": "jest"
   },
-  "main": "./dist/cjs/index.js",
-  "module": "./dist/es/index.js",
-  "types": "./dist/types/index.d.ts",
+  "main": "./dist-cjs/index.js",
+  "module": "./dist-es/index.js",
+  "types": "./dist-types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "email": "",
@@ -32,8 +32,8 @@
   },
   "typesVersions": {
     "<4.0": {
-      "dist/types/*": [
-        "dist/types/ts3.4/*"
+      "dist-types/*": [
+        "dist-types/ts3.4/*"
       ]
     }
   },

--- a/packages/protocol-http/tsconfig.cjs.json
+++ b/packages/protocol-http/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "outDir": "dist/cjs",
+    "outDir": "dist-cjs",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/protocol-http/tsconfig.es.json
+++ b/packages/protocol-http/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "outDir": "dist/es",
+    "outDir": "dist-es",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/protocol-http/tsconfig.types.json
+++ b/packages/protocol-http/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "declarationDir": "dist/types",
+    "declarationDir": "dist-types",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/querystring-builder/package.json
+++ b/packages/querystring-builder/package.json
@@ -6,12 +6,12 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
     "test": "jest"
   },
-  "main": "./dist/cjs/index.js",
-  "module": "./dist/es/index.js",
-  "types": "./dist/types/index.d.ts",
+  "main": "./dist-cjs/index.js",
+  "module": "./dist-es/index.js",
+  "types": "./dist-types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"
@@ -32,8 +32,8 @@
   },
   "typesVersions": {
     "<4.0": {
-      "dist/types/*": [
-        "dist/types/ts3.4/*"
+      "dist-types/*": [
+        "dist-types/ts3.4/*"
       ]
     }
   },

--- a/packages/querystring-builder/tsconfig.cjs.json
+++ b/packages/querystring-builder/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "outDir": "dist/cjs",
+    "outDir": "dist-cjs",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/querystring-builder/tsconfig.es.json
+++ b/packages/querystring-builder/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "outDir": "dist/es",
+    "outDir": "dist-es",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/querystring-builder/tsconfig.types.json
+++ b/packages/querystring-builder/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "declarationDir": "dist/types",
+    "declarationDir": "dist-types",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/querystring-parser/package.json
+++ b/packages/querystring-parser/package.json
@@ -6,12 +6,12 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
     "test": "jest"
   },
-  "main": "./dist/cjs/index.js",
-  "module": "./dist/es/index.js",
-  "types": "./dist/types/index.d.ts",
+  "main": "./dist-cjs/index.js",
+  "module": "./dist-es/index.js",
+  "types": "./dist-types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"
@@ -31,8 +31,8 @@
   },
   "typesVersions": {
     "<4.0": {
-      "dist/types/*": [
-        "dist/types/ts3.4/*"
+      "dist-types/*": [
+        "dist-types/ts3.4/*"
       ]
     }
   },

--- a/packages/querystring-parser/tsconfig.cjs.json
+++ b/packages/querystring-parser/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "outDir": "dist/cjs",
+    "outDir": "dist-cjs",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/querystring-parser/tsconfig.es.json
+++ b/packages/querystring-parser/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "outDir": "dist/es",
+    "outDir": "dist-es",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/querystring-parser/tsconfig.types.json
+++ b/packages/querystring-parser/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "declarationDir": "dist/types",
+    "declarationDir": "dist-types",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/s3-presigned-post/package.json
+++ b/packages/s3-presigned-post/package.json
@@ -6,12 +6,12 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
     "test": "jest"
   },
-  "main": "./dist/cjs/index.js",
-  "module": "./dist/es/index.js",
-  "types": "./dist/types/index.d.ts",
+  "main": "./dist-cjs/index.js",
+  "module": "./dist-es/index.js",
+  "types": "./dist-types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"
@@ -38,8 +38,8 @@
   },
   "typesVersions": {
     "<4.0": {
-      "dist/types/*": [
-        "dist/types/ts3.4/*"
+      "dist-types/*": [
+        "dist-types/ts3.4/*"
       ]
     }
   },

--- a/packages/s3-presigned-post/tsconfig.cjs.json
+++ b/packages/s3-presigned-post/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "outDir": "dist/cjs",
+    "outDir": "dist-cjs",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/s3-presigned-post/tsconfig.es.json
+++ b/packages/s3-presigned-post/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown", "dom"],
-    "outDir": "dist/es",
+    "outDir": "dist-es",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/s3-presigned-post/tsconfig.types.json
+++ b/packages/s3-presigned-post/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "declarationDir": "dist/types",
+    "declarationDir": "dist-types",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/s3-request-presigner/package.json
+++ b/packages/s3-request-presigner/package.json
@@ -6,12 +6,12 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
     "test": "jest"
   },
-  "main": "./dist/cjs/index.js",
-  "module": "./dist/es/index.js",
-  "types": "./dist/types/index.d.ts",
+  "main": "./dist-cjs/index.js",
+  "module": "./dist-es/index.js",
+  "types": "./dist-types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"
@@ -40,8 +40,8 @@
   },
   "typesVersions": {
     "<4.0": {
-      "dist/types/*": [
-        "dist/types/ts3.4/*"
+      "dist-types/*": [
+        "dist-types/ts3.4/*"
       ]
     }
   },

--- a/packages/s3-request-presigner/tsconfig.cjs.json
+++ b/packages/s3-request-presigner/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "outDir": "dist/cjs",
+    "outDir": "dist-cjs",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/s3-request-presigner/tsconfig.es.json
+++ b/packages/s3-request-presigner/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown", "dom"],
-    "outDir": "dist/es",
+    "outDir": "dist-es",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/s3-request-presigner/tsconfig.types.json
+++ b/packages/s3-request-presigner/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "declarationDir": "dist/types",
+    "declarationDir": "dist-types",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/service-error-classification/package.json
+++ b/packages/service-error-classification/package.json
@@ -6,12 +6,12 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
     "test": "jest"
   },
-  "main": "./dist/cjs/index.js",
-  "module": "./dist/es/index.js",
-  "types": "./dist/types/index.d.ts",
+  "main": "./dist-cjs/index.js",
+  "module": "./dist-es/index.js",
+  "types": "./dist-types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"
@@ -28,8 +28,8 @@
   },
   "typesVersions": {
     "<4.0": {
-      "dist/types/*": [
-        "dist/types/ts3.4/*"
+      "dist-types/*": [
+        "dist-types/ts3.4/*"
       ]
     }
   },

--- a/packages/service-error-classification/tsconfig.cjs.json
+++ b/packages/service-error-classification/tsconfig.cjs.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "noUnusedLocals": true,
-    "outDir": "dist/cjs",
+    "outDir": "dist-cjs",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/service-error-classification/tsconfig.es.json
+++ b/packages/service-error-classification/tsconfig.es.json
@@ -3,7 +3,7 @@
     "baseUrl": ".",
     "lib": ["es5", "es2015.collection", "es2015.iterable"],
     "noUnusedLocals": true,
-    "outDir": "dist/es",
+    "outDir": "dist-es",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/service-error-classification/tsconfig.types.json
+++ b/packages/service-error-classification/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "declarationDir": "dist/types",
+    "declarationDir": "dist-types",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/sha256-tree-hash/package.json
+++ b/packages/sha256-tree-hash/package.json
@@ -6,12 +6,12 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
     "test": "jest"
   },
-  "main": "./dist/cjs/index.js",
-  "module": "./dist/es/index.js",
-  "types": "./dist/types/index.d.ts",
+  "main": "./dist-cjs/index.js",
+  "module": "./dist-es/index.js",
+  "types": "./dist-types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"
@@ -34,8 +34,8 @@
   },
   "typesVersions": {
     "<4.0": {
-      "dist/types/*": [
-        "dist/types/ts3.4/*"
+      "dist-types/*": [
+        "dist-types/ts3.4/*"
       ]
     }
   },

--- a/packages/sha256-tree-hash/tsconfig.cjs.json
+++ b/packages/sha256-tree-hash/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "outDir": "dist/cjs",
+    "outDir": "dist-cjs",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/sha256-tree-hash/tsconfig.es.json
+++ b/packages/sha256-tree-hash/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "outDir": "dist/es",
+    "outDir": "dist-es",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/sha256-tree-hash/tsconfig.types.json
+++ b/packages/sha256-tree-hash/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "declarationDir": "dist/types",
+    "declarationDir": "dist-types",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/shared-ini-file-loader/package.json
+++ b/packages/shared-ini-file-loader/package.json
@@ -15,7 +15,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
     "test": "jest"
   },
   "author": {
@@ -23,16 +23,16 @@
     "url": "https://aws.amazon.com/javascript/"
   },
   "license": "Apache-2.0",
-  "main": "./dist/cjs/index.js",
-  "module": "./dist/es/index.js",
-  "types": "./dist/types/index.d.ts",
+  "main": "./dist-cjs/index.js",
+  "module": "./dist-es/index.js",
+  "types": "./dist-types/index.d.ts",
   "engines": {
     "node": ">= 10.0.0"
   },
   "typesVersions": {
     "<4.0": {
-      "dist/types/*": [
-        "dist/types/ts3.4/*"
+      "dist-types/*": [
+        "dist-types/ts3.4/*"
       ]
     }
   },

--- a/packages/shared-ini-file-loader/tsconfig.cjs.json
+++ b/packages/shared-ini-file-loader/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "outDir": "dist/cjs",
+    "outDir": "dist-cjs",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/shared-ini-file-loader/tsconfig.es.json
+++ b/packages/shared-ini-file-loader/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "lib": ["es5", "es2015.promise", "es2015.collection"],
-    "outDir": "dist/es",
+    "outDir": "dist-es",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/shared-ini-file-loader/tsconfig.types.json
+++ b/packages/shared-ini-file-loader/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "declarationDir": "dist/types",
+    "declarationDir": "dist-types",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/signature-v4-crt/package.json
+++ b/packages/signature-v4-crt/package.json
@@ -2,15 +2,15 @@
   "name": "@aws-sdk/signature-v4-crt",
   "version": "3.34.0",
   "description": "A revision of AWS Signature V4 request signer based on AWS Common Runtime https://github.com/awslabs/aws-crt-nodejs",
-  "main": "./dist/cjs/index.js",
-  "module": "./dist/es/index.js",
-  "types": "./dist/types/index.d.ts",
+  "main": "./dist-cjs/index.js",
+  "module": "./dist-es/index.js",
+  "types": "./dist-types/index.d.ts",
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
     "test": "jest --coverage"
   },
   "author": {

--- a/packages/signature-v4-crt/tsconfig.cjs.json
+++ b/packages/signature-v4-crt/tsconfig.cjs.json
@@ -3,7 +3,7 @@
     "baseUrl": ".",
     "lib": ["es2016"],
     "noUnusedLocals": true,
-    "outDir": "dist/cjs",
+    "outDir": "dist-cjs",
     "rootDir": "src",
     "stripInternal": true
   },

--- a/packages/signature-v4-crt/tsconfig.es.json
+++ b/packages/signature-v4-crt/tsconfig.es.json
@@ -3,7 +3,7 @@
     "baseUrl": ".",
     "lib": ["es5", "es2015.promise", "es2015.collection"],
     "noUnusedLocals": true,
-    "outDir": "dist/es",
+    "outDir": "dist-es",
     "rootDir": "src",
     "stripInternal": true
   },

--- a/packages/signature-v4-crt/tsconfig.types.json
+++ b/packages/signature-v4-crt/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "declarationDir": "dist/types",
+    "declarationDir": "dist-types",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/signature-v4/package.json
+++ b/packages/signature-v4/package.json
@@ -2,15 +2,15 @@
   "name": "@aws-sdk/signature-v4",
   "version": "3.34.0",
   "description": "A standalone implementation of the AWS Signature V4 request signing algorithm",
-  "main": "./dist/cjs/index.js",
-  "module": "./dist/es/index.js",
-  "types": "./dist/types/index.d.ts",
+  "main": "./dist-cjs/index.js",
+  "module": "./dist-es/index.js",
+  "types": "./dist-types/index.d.ts",
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
     "pretest": "yarn build",
     "test": "jest --coverage"
   },
@@ -39,8 +39,8 @@
   },
   "typesVersions": {
     "<4.0": {
-      "dist/types/*": [
-        "dist/types/ts3.4/*"
+      "dist-types/*": [
+        "dist-types/ts3.4/*"
       ]
     }
   },

--- a/packages/signature-v4/tsconfig.cjs.json
+++ b/packages/signature-v4/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "outDir": "dist/cjs",
+    "outDir": "dist-cjs",
     "rootDir": "src",
     "stripInternal": true
   },

--- a/packages/signature-v4/tsconfig.es.json
+++ b/packages/signature-v4/tsconfig.es.json
@@ -3,7 +3,7 @@
     "baseUrl": ".",
     "lib": ["es5", "es2015.promise", "es2015.collection"],
     "noUnusedLocals": true,
-    "outDir": "dist/es",
+    "outDir": "dist-es",
     "rootDir": "src",
     "stripInternal": true
   },

--- a/packages/signature-v4/tsconfig.types.json
+++ b/packages/signature-v4/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "declarationDir": "dist/types",
+    "declarationDir": "dist-types",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/smithy-client/package.json
+++ b/packages/smithy-client/package.json
@@ -6,12 +6,12 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
     "test": "jest --passWithNoTests"
   },
-  "main": "./dist/cjs/index.js",
-  "module": "./dist/es/index.js",
-  "types": "./dist/types/index.d.ts",
+  "main": "./dist-cjs/index.js",
+  "module": "./dist-es/index.js",
+  "types": "./dist-types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"
@@ -32,8 +32,8 @@
   },
   "typesVersions": {
     "<4.0": {
-      "dist/types/*": [
-        "dist/types/ts3.4/*"
+      "dist-types/*": [
+        "dist-types/ts3.4/*"
       ]
     }
   },

--- a/packages/smithy-client/tsconfig.cjs.json
+++ b/packages/smithy-client/tsconfig.cjs.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "noUnusedLocals": true,
-    "outDir": "dist/cjs",
+    "outDir": "dist-cjs",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/smithy-client/tsconfig.es.json
+++ b/packages/smithy-client/tsconfig.es.json
@@ -3,7 +3,7 @@
     "baseUrl": ".",
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "noUnusedLocals": true,
-    "outDir": "dist/es",
+    "outDir": "dist-es",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/smithy-client/tsconfig.types.json
+++ b/packages/smithy-client/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "declarationDir": "dist/types",
+    "declarationDir": "dist-types",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,9 +1,9 @@
 {
   "name": "@aws-sdk/types",
   "version": "3.34.0",
-  "main": "./dist/cjs/index.js",
-  "module": "./dist/es/index.js",
-  "types": "./dist/types/index.d.ts",
+  "main": "./dist-cjs/index.js",
+  "module": "./dist-es/index.js",
+  "types": "./dist-types/index.d.ts",
   "description": "Types for the AWS SDK",
   "devDependencies": {
     "typescript": "~4.3.5"
@@ -13,7 +13,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
     "test": "exit 0"
   },
   "author": {
@@ -26,8 +26,8 @@
   },
   "typesVersions": {
     "<4.0": {
-      "dist/types/*": [
-        "dist/types/ts3.4/*"
+      "dist-types/*": [
+        "dist-types/ts3.4/*"
       ]
     }
   },

--- a/packages/types/tsconfig.cjs.json
+++ b/packages/types/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "outDir": "dist/cjs",
+    "outDir": "dist-cjs",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/types/tsconfig.es.json
+++ b/packages/types/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "outDir": "dist/es",
+    "outDir": "dist-es",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/types/tsconfig.types.json
+++ b/packages/types/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "declarationDir": "dist/types",
+    "declarationDir": "dist-types",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/url-parser/package.json
+++ b/packages/url-parser/package.json
@@ -6,12 +6,12 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
     "test": "jest"
   },
-  "main": "./dist/cjs/index.js",
-  "module": "./dist/es/index.js",
-  "types": "./dist/types/index.d.ts",
+  "main": "./dist-cjs/index.js",
+  "module": "./dist-es/index.js",
+  "types": "./dist-types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"
@@ -29,8 +29,8 @@
   },
   "typesVersions": {
     "<4.0": {
-      "dist/types/*": [
-        "dist/types/ts3.4/*"
+      "dist-types/*": [
+        "dist-types/ts3.4/*"
       ]
     }
   },

--- a/packages/url-parser/tsconfig.cjs.json
+++ b/packages/url-parser/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "outDir": "dist/cjs",
+    "outDir": "dist-cjs",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/url-parser/tsconfig.es.json
+++ b/packages/url-parser/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "outDir": "dist/es",
+    "outDir": "dist-es",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/url-parser/tsconfig.types.json
+++ b/packages/url-parser/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "declarationDir": "dist/types",
+    "declarationDir": "dist-types",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/util-arn-parser/package.json
+++ b/packages/util-arn-parser/package.json
@@ -2,14 +2,14 @@
   "name": "@aws-sdk/util-arn-parser",
   "version": "3.34.0",
   "description": "A parser to Amazon Resource Names",
-  "main": "./dist/cjs/index.js",
-  "module": "./dist/es/index.js",
+  "main": "./dist-cjs/index.js",
+  "module": "./dist-es/index.js",
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
     "test": "jest"
   },
   "author": {
@@ -26,14 +26,14 @@
     "jest": "^26.1.0",
     "typescript": "~4.3.5"
   },
-  "types": "./dist/types/index.d.ts",
+  "types": "./dist-types/index.d.ts",
   "engines": {
     "node": ">= 10.0.0"
   },
   "typesVersions": {
     "<4.0": {
-      "dist/types/*": [
-        "dist/types/ts3.4/*"
+      "dist-types/*": [
+        "dist-types/ts3.4/*"
       ]
     }
   },

--- a/packages/util-arn-parser/tsconfig.cjs.json
+++ b/packages/util-arn-parser/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "outDir": "dist/cjs",
+    "outDir": "dist-cjs",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/util-arn-parser/tsconfig.es.json
+++ b/packages/util-arn-parser/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "outDir": "dist/es",
+    "outDir": "dist-es",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/util-arn-parser/tsconfig.types.json
+++ b/packages/util-arn-parser/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "declarationDir": "dist/types",
+    "declarationDir": "dist-types",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/util-base64-browser/package.json
+++ b/packages/util-base64-browser/package.json
@@ -2,14 +2,14 @@
   "name": "@aws-sdk/util-base64-browser",
   "version": "3.34.0",
   "description": "A pure JS Base64 <-> UInt8Array converter",
-  "main": "./dist/cjs/index.js",
-  "module": "./dist/es/index.js",
+  "main": "./dist-cjs/index.js",
+  "module": "./dist-es/index.js",
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
     "test": "jest"
   },
   "author": {
@@ -26,11 +26,11 @@
     "jest": "^26.1.0",
     "typescript": "~4.3.5"
   },
-  "types": "./dist/types/index.d.ts",
+  "types": "./dist-types/index.d.ts",
   "typesVersions": {
     "<4.0": {
-      "dist/types/*": [
-        "dist/types/ts3.4/*"
+      "dist-types/*": [
+        "dist-types/ts3.4/*"
       ]
     }
   },

--- a/packages/util-base64-browser/tsconfig.cjs.json
+++ b/packages/util-base64-browser/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "outDir": "dist/cjs",
+    "outDir": "dist-cjs",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/util-base64-browser/tsconfig.es.json
+++ b/packages/util-base64-browser/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "lib": ["es5", "es2015.collection"],
-    "outDir": "dist/es",
+    "outDir": "dist-es",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/util-base64-browser/tsconfig.types.json
+++ b/packages/util-base64-browser/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "declarationDir": "dist/types",
+    "declarationDir": "dist-types",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/util-base64-node/package.json
+++ b/packages/util-base64-node/package.json
@@ -2,14 +2,14 @@
   "name": "@aws-sdk/util-base64-node",
   "version": "3.34.0",
   "description": "A Node.JS Base64 <-> UInt8Array converter",
-  "main": "./dist/cjs/index.js",
-  "module": "./dist/es/index.js",
+  "main": "./dist-cjs/index.js",
+  "module": "./dist-es/index.js",
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
     "test": "jest"
   },
   "author": {
@@ -27,14 +27,14 @@
     "jest": "^26.1.0",
     "typescript": "~4.3.5"
   },
-  "types": "./dist/types/index.d.ts",
+  "types": "./dist-types/index.d.ts",
   "engines": {
     "node": ">= 10.0.0"
   },
   "typesVersions": {
     "<4.0": {
-      "dist/types/*": [
-        "dist/types/ts3.4/*"
+      "dist-types/*": [
+        "dist-types/ts3.4/*"
       ]
     }
   },

--- a/packages/util-base64-node/tsconfig.cjs.json
+++ b/packages/util-base64-node/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "outDir": "dist/cjs",
+    "outDir": "dist-cjs",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/util-base64-node/tsconfig.es.json
+++ b/packages/util-base64-node/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "outDir": "dist/es",
+    "outDir": "dist-es",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/util-base64-node/tsconfig.types.json
+++ b/packages/util-base64-node/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "declarationDir": "dist/types",
+    "declarationDir": "dist-types",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/util-body-length-browser/package.json
+++ b/packages/util-body-length-browser/package.json
@@ -7,12 +7,12 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
     "test": "jest"
   },
-  "main": "./dist/cjs/index.js",
-  "module": "./dist/es/index.js",
-  "types": "./dist/types/index.d.ts",
+  "main": "./dist-cjs/index.js",
+  "module": "./dist-es/index.js",
+  "types": "./dist-types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"
@@ -28,8 +28,8 @@
   },
   "typesVersions": {
     "<4.0": {
-      "dist/types/*": [
-        "dist/types/ts3.4/*"
+      "dist-types/*": [
+        "dist-types/ts3.4/*"
       ]
     }
   },

--- a/packages/util-body-length-browser/tsconfig.cjs.json
+++ b/packages/util-body-length-browser/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "outDir": "dist/cjs",
+    "outDir": "dist-cjs",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/util-body-length-browser/tsconfig.es.json
+++ b/packages/util-body-length-browser/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown", "dom"],
-    "outDir": "dist/es",
+    "outDir": "dist-es",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/util-body-length-browser/tsconfig.types.json
+++ b/packages/util-body-length-browser/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "declarationDir": "dist/types",
+    "declarationDir": "dist-types",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/util-body-length-node/package.json
+++ b/packages/util-body-length-node/package.json
@@ -7,7 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
     "test": "jest"
   },
   "devDependencies": {
@@ -16,9 +16,9 @@
     "jest": "^26.1.0",
     "typescript": "~4.3.5"
   },
-  "main": "./dist/cjs/index.js",
-  "module": "./dist/es/index.js",
-  "types": "./dist/types/index.d.ts",
+  "main": "./dist-cjs/index.js",
+  "module": "./dist-es/index.js",
+  "types": "./dist-types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"
@@ -32,8 +32,8 @@
   },
   "typesVersions": {
     "<4.0": {
-      "dist/types/*": [
-        "dist/types/ts3.4/*"
+      "dist-types/*": [
+        "dist-types/ts3.4/*"
       ]
     }
   },

--- a/packages/util-body-length-node/tsconfig.cjs.json
+++ b/packages/util-body-length-node/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "outDir": "dist/cjs",
+    "outDir": "dist-cjs",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/util-body-length-node/tsconfig.es.json
+++ b/packages/util-body-length-node/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "outDir": "dist/es",
+    "outDir": "dist-es",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/util-body-length-node/tsconfig.types.json
+++ b/packages/util-body-length-node/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "declarationDir": "dist/types",
+    "declarationDir": "dist-types",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/util-buffer-from/package.json
+++ b/packages/util-buffer-from/package.json
@@ -6,7 +6,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
     "test": "jest"
   },
   "author": {
@@ -24,16 +24,16 @@
     "jest": "^26.1.0",
     "typescript": "~4.3.5"
   },
-  "main": "./dist/cjs/index.js",
-  "module": "./dist/es/index.js",
-  "types": "./dist/types/index.d.ts",
+  "main": "./dist-cjs/index.js",
+  "module": "./dist-es/index.js",
+  "types": "./dist-types/index.d.ts",
   "engines": {
     "node": ">= 10.0.0"
   },
   "typesVersions": {
     "<4.0": {
-      "dist/types/*": [
-        "dist/types/ts3.4/*"
+      "dist-types/*": [
+        "dist-types/ts3.4/*"
       ]
     }
   },

--- a/packages/util-buffer-from/tsconfig.cjs.json
+++ b/packages/util-buffer-from/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "outDir": "dist/cjs",
+    "outDir": "dist-cjs",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/util-buffer-from/tsconfig.es.json
+++ b/packages/util-buffer-from/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "lib": ["es5", "es2015.collection"],
-    "outDir": "dist/es",
+    "outDir": "dist-es",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/util-buffer-from/tsconfig.types.json
+++ b/packages/util-buffer-from/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "declarationDir": "dist/types",
+    "declarationDir": "dist-types",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/util-create-request/package.json
+++ b/packages/util-create-request/package.json
@@ -6,12 +6,12 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
     "test": "jest"
   },
-  "main": "./dist/cjs/index.js",
-  "module": "./dist/es/index.js",
-  "types": "./dist/types/index.d.ts",
+  "main": "./dist-cjs/index.js",
+  "module": "./dist-es/index.js",
+  "types": "./dist-types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"
@@ -35,8 +35,8 @@
   },
   "typesVersions": {
     "<4.0": {
-      "dist/types/*": [
-        "dist/types/ts3.4/*"
+      "dist-types/*": [
+        "dist-types/ts3.4/*"
       ]
     }
   },

--- a/packages/util-create-request/tsconfig.cjs.json
+++ b/packages/util-create-request/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "outDir": "dist/cjs",
+    "outDir": "dist-cjs",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/util-create-request/tsconfig.es.json
+++ b/packages/util-create-request/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "outDir": "dist/es",
+    "outDir": "dist-es",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/util-create-request/tsconfig.types.json
+++ b/packages/util-create-request/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "declarationDir": "dist/types",
+    "declarationDir": "dist-types",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/util-credentials/package.json
+++ b/packages/util-credentials/package.json
@@ -2,14 +2,14 @@
   "name": "@aws-sdk/util-credentials",
   "version": "3.34.0",
   "description": "Shared utilities for all credential providers.",
-  "main": "./dist/cjs/index.js",
-  "module": "./dist/es/index.js",
+  "main": "./dist-cjs/index.js",
+  "module": "./dist-es/index.js",
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
     "test": "jest"
   },
   "keywords": [
@@ -31,7 +31,7 @@
     "jest": "^26.1.0",
     "typescript": "~4.3.5"
   },
-  "types": "./dist/types/index.d.ts",
+  "types": "./dist-types/index.d.ts",
   "engines": {
     "node": ">= 10.0.0"
   },

--- a/packages/util-credentials/tsconfig.cjs.json
+++ b/packages/util-credentials/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "outDir": "dist/cjs",
+    "outDir": "dist-cjs",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/util-credentials/tsconfig.es.json
+++ b/packages/util-credentials/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "lib": ["es5", "es2015.promise", "es2015.collection"],
-    "outDir": "dist/es",
+    "outDir": "dist-es",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/util-credentials/tsconfig.types.json
+++ b/packages/util-credentials/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "declarationDir": "dist/types",
+    "declarationDir": "dist-types",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/util-dynamodb/package.json
+++ b/packages/util-dynamodb/package.json
@@ -6,12 +6,12 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
     "test": "jest"
   },
-  "main": "./dist/cjs/index.js",
-  "module": "./dist/es/index.js",
-  "types": "./dist/types/index.d.ts",
+  "main": "./dist-cjs/index.js",
+  "module": "./dist-es/index.js",
+  "types": "./dist-types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"
@@ -31,8 +31,8 @@
   },
   "typesVersions": {
     "<4.0": {
-      "dist/types/*": [
-        "dist/types/ts3.4/*"
+      "dist-types/*": [
+        "dist-types/ts3.4/*"
       ]
     }
   },

--- a/packages/util-dynamodb/tsconfig.cjs.json
+++ b/packages/util-dynamodb/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "outDir": "dist/cjs",
+    "outDir": "dist-cjs",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/util-dynamodb/tsconfig.es.json
+++ b/packages/util-dynamodb/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "outDir": "dist/es",
+    "outDir": "dist-es",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/util-dynamodb/tsconfig.types.json
+++ b/packages/util-dynamodb/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "declarationDir": "dist/types",
+    "declarationDir": "dist-types",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/util-format-url/package.json
+++ b/packages/util-format-url/package.json
@@ -6,12 +6,12 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
     "test": "jest"
   },
-  "main": "./dist/cjs/index.js",
-  "module": "./dist/es/index.js",
-  "types": "./dist/types/index.d.ts",
+  "main": "./dist-cjs/index.js",
+  "module": "./dist-es/index.js",
+  "types": "./dist-types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"
@@ -32,8 +32,8 @@
   },
   "typesVersions": {
     "<4.0": {
-      "dist/types/*": [
-        "dist/types/ts3.4/*"
+      "dist-types/*": [
+        "dist-types/ts3.4/*"
       ]
     }
   },

--- a/packages/util-format-url/tsconfig.cjs.json
+++ b/packages/util-format-url/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "outDir": "dist/cjs",
+    "outDir": "dist-cjs",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/util-format-url/tsconfig.es.json
+++ b/packages/util-format-url/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "outDir": "dist/es",
+    "outDir": "dist-es",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/util-format-url/tsconfig.types.json
+++ b/packages/util-format-url/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "declarationDir": "dist/types",
+    "declarationDir": "dist-types",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/util-hex-encoding/package.json
+++ b/packages/util-hex-encoding/package.json
@@ -7,7 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
     "test": "jest"
   },
   "author": {
@@ -15,8 +15,8 @@
     "url": "https://aws.amazon.com/javascript/"
   },
   "license": "Apache-2.0",
-  "main": "./dist/cjs/index.js",
-  "module": "./dist/es/index.js",
+  "main": "./dist-cjs/index.js",
+  "module": "./dist-es/index.js",
   "dependencies": {
     "tslib": "^2.3.0"
   },
@@ -25,14 +25,14 @@
     "jest": "^26.1.0",
     "typescript": "~4.3.5"
   },
-  "types": "./dist/types/index.d.ts",
+  "types": "./dist-types/index.d.ts",
   "engines": {
     "node": ">= 10.0.0"
   },
   "typesVersions": {
     "<4.0": {
-      "dist/types/*": [
-        "dist/types/ts3.4/*"
+      "dist-types/*": [
+        "dist-types/ts3.4/*"
       ]
     }
   },

--- a/packages/util-hex-encoding/tsconfig.cjs.json
+++ b/packages/util-hex-encoding/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "outDir": "dist/cjs",
+    "outDir": "dist-cjs",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/util-hex-encoding/tsconfig.es.json
+++ b/packages/util-hex-encoding/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "lib": ["es5", "es2015.promise", "es2015.collection"],
-    "outDir": "dist/es",
+    "outDir": "dist-es",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/util-hex-encoding/tsconfig.types.json
+++ b/packages/util-hex-encoding/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "declarationDir": "dist/types",
+    "declarationDir": "dist-types",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/util-locate-window/package.json
+++ b/packages/util-locate-window/package.json
@@ -6,7 +6,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
     "test": "jest"
   },
   "author": {
@@ -23,16 +23,16 @@
     "jest": "^26.1.0",
     "typescript": "~4.3.5"
   },
-  "main": "./dist/cjs/index.js",
-  "module": "./dist/es/index.js",
-  "types": "./dist/types/index.d.ts",
+  "main": "./dist-cjs/index.js",
+  "module": "./dist-es/index.js",
+  "types": "./dist-types/index.d.ts",
   "engines": {
     "node": ">= 10.0.0"
   },
   "typesVersions": {
     "<4.0": {
-      "dist/types/*": [
-        "dist/types/ts3.4/*"
+      "dist-types/*": [
+        "dist-types/ts3.4/*"
       ]
     }
   },

--- a/packages/util-locate-window/tsconfig.cjs.json
+++ b/packages/util-locate-window/tsconfig.cjs.json
@@ -4,7 +4,7 @@
     "noImplicitAny": true,
     "noImplicitThis": true,
     "noImplicitUseStrict": true,
-    "outDir": "dist/cjs",
+    "outDir": "dist-cjs",
     "rootDir": "src",
     "strict": false,
     "strictNullChecks": true

--- a/packages/util-locate-window/tsconfig.es.json
+++ b/packages/util-locate-window/tsconfig.es.json
@@ -5,7 +5,7 @@
     "noImplicitAny": true,
     "noImplicitThis": true,
     "noImplicitUseStrict": true,
-    "outDir": "dist/es",
+    "outDir": "dist-es",
     "rootDir": "src",
     "strict": false,
     "strictNullChecks": true

--- a/packages/util-locate-window/tsconfig.types.json
+++ b/packages/util-locate-window/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "declarationDir": "dist/types",
+    "declarationDir": "dist-types",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/util-uri-escape/package.json
+++ b/packages/util-uri-escape/package.json
@@ -6,12 +6,12 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
     "test": "jest"
   },
-  "main": "./dist/cjs/index.js",
-  "module": "./dist/es/index.js",
-  "types": "./dist/types/index.d.ts",
+  "main": "./dist-cjs/index.js",
+  "module": "./dist-es/index.js",
+  "types": "./dist-types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"
@@ -30,8 +30,8 @@
   },
   "typesVersions": {
     "<4.0": {
-      "dist/types/*": [
-        "dist/types/ts3.4/*"
+      "dist-types/*": [
+        "dist-types/ts3.4/*"
       ]
     }
   },

--- a/packages/util-uri-escape/tsconfig.cjs.json
+++ b/packages/util-uri-escape/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "outDir": "dist/cjs",
+    "outDir": "dist-cjs",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/util-uri-escape/tsconfig.es.json
+++ b/packages/util-uri-escape/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "outDir": "dist/es",
+    "outDir": "dist-es",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/util-uri-escape/tsconfig.types.json
+++ b/packages/util-uri-escape/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "declarationDir": "dist/types",
+    "declarationDir": "dist-types",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/util-user-agent-browser/package.json
+++ b/packages/util-user-agent-browser/package.json
@@ -6,18 +6,18 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
     "test": "jest"
   },
-  "main": "./dist/cjs/index.js",
-  "module": "./dist/es/index.js",
-  "types": "./dist/types/index.d.ts",
+  "main": "./dist-cjs/index.js",
+  "module": "./dist-es/index.js",
+  "types": "./dist-types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"
   },
   "license": "Apache-2.0",
-  "react-native": "dist/es/index.native.js",
+  "react-native": "dist-es/index.native.js",
   "dependencies": {
     "@aws-sdk/types": "3.34.0",
     "bowser": "^2.11.0",
@@ -31,8 +31,8 @@
   },
   "typesVersions": {
     "<4.0": {
-      "dist/types/*": [
-        "dist/types/ts3.4/*"
+      "dist-types/*": [
+        "dist-types/ts3.4/*"
       ]
     }
   },

--- a/packages/util-user-agent-browser/tsconfig.cjs.json
+++ b/packages/util-user-agent-browser/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "outDir": "dist/cjs",
+    "outDir": "dist-cjs",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/util-user-agent-browser/tsconfig.es.json
+++ b/packages/util-user-agent-browser/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "lib": ["es5", "es2015.collection", "dom"],
-    "outDir": "dist/es",
+    "outDir": "dist-es",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/util-user-agent-browser/tsconfig.types.json
+++ b/packages/util-user-agent-browser/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "declarationDir": "dist/types",
+    "declarationDir": "dist-types",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/util-user-agent-node/package.json
+++ b/packages/util-user-agent-node/package.json
@@ -6,12 +6,12 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
     "test": "jest"
   },
-  "main": "./dist/cjs/index.js",
-  "module": "./dist/es/index.js",
-  "types": "./dist/types/index.d.ts",
+  "main": "./dist-cjs/index.js",
+  "module": "./dist-es/index.js",
+  "types": "./dist-types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"
@@ -34,8 +34,8 @@
   },
   "typesVersions": {
     "<4.0": {
-      "dist/types/*": [
-        "dist/types/ts3.4/*"
+      "dist-types/*": [
+        "dist-types/ts3.4/*"
       ]
     }
   },

--- a/packages/util-user-agent-node/tsconfig.cjs.json
+++ b/packages/util-user-agent-node/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "outDir": "dist/cjs",
+    "outDir": "dist-cjs",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/util-user-agent-node/tsconfig.es.json
+++ b/packages/util-user-agent-node/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "outDir": "dist/es",
+    "outDir": "dist-es",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/util-user-agent-node/tsconfig.types.json
+++ b/packages/util-user-agent-node/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "declarationDir": "dist/types",
+    "declarationDir": "dist-types",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/util-utf8-browser/package.json
+++ b/packages/util-utf8-browser/package.json
@@ -2,14 +2,14 @@
   "name": "@aws-sdk/util-utf8-browser",
   "version": "3.34.0",
   "description": "A browser UTF-8 string <-> UInt8Array converter",
-  "main": "./dist/cjs/index.js",
-  "module": "./dist/es/index.js",
+  "main": "./dist-cjs/index.js",
+  "module": "./dist-es/index.js",
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
     "test": "jest"
   },
   "author": {
@@ -25,11 +25,11 @@
     "jest": "^26.1.0",
     "typescript": "~4.3.5"
   },
-  "types": "./dist/types/index.d.ts",
+  "types": "./dist-types/index.d.ts",
   "typesVersions": {
     "<4.0": {
-      "dist/types/*": [
-        "dist/types/ts3.4/*"
+      "dist-types/*": [
+        "dist-types/ts3.4/*"
       ]
     }
   },

--- a/packages/util-utf8-browser/tsconfig.cjs.json
+++ b/packages/util-utf8-browser/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "outDir": "dist/cjs",
+    "outDir": "dist-cjs",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/util-utf8-browser/tsconfig.es.json
+++ b/packages/util-utf8-browser/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "lib": ["es5", "es2015.collection"],
-    "outDir": "dist/es",
+    "outDir": "dist-es",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/util-utf8-browser/tsconfig.types.json
+++ b/packages/util-utf8-browser/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "declarationDir": "dist/types",
+    "declarationDir": "dist-types",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/util-utf8-node/package.json
+++ b/packages/util-utf8-node/package.json
@@ -2,14 +2,14 @@
   "name": "@aws-sdk/util-utf8-node",
   "version": "3.34.0",
   "description": "A Node.JS UTF-8 string <-> UInt8Array converter",
-  "main": "./dist/cjs/index.js",
-  "module": "./dist/es/index.js",
+  "main": "./dist-cjs/index.js",
+  "module": "./dist-es/index.js",
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
     "test": "jest"
   },
   "author": {
@@ -30,14 +30,14 @@
   "jest": {
     "testEnvironment": "node"
   },
-  "types": "./dist/types/index.d.ts",
+  "types": "./dist-types/index.d.ts",
   "engines": {
     "node": ">= 10.0.0"
   },
   "typesVersions": {
     "<4.0": {
-      "dist/types/*": [
-        "dist/types/ts3.4/*"
+      "dist-types/*": [
+        "dist-types/ts3.4/*"
       ]
     }
   },

--- a/packages/util-utf8-node/tsconfig.cjs.json
+++ b/packages/util-utf8-node/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "outDir": "dist/cjs",
+    "outDir": "dist-cjs",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/util-utf8-node/tsconfig.es.json
+++ b/packages/util-utf8-node/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "outDir": "dist/es",
+    "outDir": "dist-es",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/util-utf8-node/tsconfig.types.json
+++ b/packages/util-utf8-node/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "declarationDir": "dist/types",
+    "declarationDir": "dist-types",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/util-waiter/package.json
+++ b/packages/util-waiter/package.json
@@ -17,7 +17,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
     "test": "jest"
   },
   "author": {
@@ -25,16 +25,16 @@
     "url": "https://aws.amazon.com/javascript/"
   },
   "license": "Apache-2.0",
-  "main": "./dist/cjs/index.js",
-  "module": "./dist/es/index.js",
-  "types": "./dist/types/index.d.ts",
+  "main": "./dist-cjs/index.js",
+  "module": "./dist-es/index.js",
+  "types": "./dist-types/index.d.ts",
   "engines": {
     "node": ">= 10.0.0"
   },
   "typesVersions": {
     "<4.0": {
-      "dist/types/*": [
-        "dist/types/ts3.4/*"
+      "dist-types/*": [
+        "dist-types/ts3.4/*"
       ]
     }
   },

--- a/packages/util-waiter/tsconfig.cjs.json
+++ b/packages/util-waiter/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "outDir": "dist/cjs",
+    "outDir": "dist-cjs",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/util-waiter/tsconfig.es.json
+++ b/packages/util-waiter/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "lib": ["es5", "es2015.collection"],
-    "outDir": "dist/es",
+    "outDir": "dist-es",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/util-waiter/tsconfig.types.json
+++ b/packages/util-waiter/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "declarationDir": "dist/types",
+    "declarationDir": "dist-types",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",

--- a/packages/xml-builder/package.json
+++ b/packages/xml-builder/package.json
@@ -15,7 +15,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4",
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
     "test": "jest"
   },
   "author": {
@@ -23,16 +23,16 @@
     "url": "https://aws.amazon.com/javascript/"
   },
   "license": "Apache-2.0",
-  "main": "./dist/cjs/index.js",
-  "module": "./dist/es/index.js",
-  "types": "./dist/types/index.d.ts",
+  "main": "./dist-cjs/index.js",
+  "module": "./dist-es/index.js",
+  "types": "./dist-types/index.d.ts",
   "engines": {
     "node": ">= 10.0.0"
   },
   "typesVersions": {
     "<4.0": {
-      "dist/types/*": [
-        "dist/types/ts3.4/*"
+      "dist-types/*": [
+        "dist-types/ts3.4/*"
       ]
     }
   },

--- a/packages/xml-builder/tsconfig.cjs.json
+++ b/packages/xml-builder/tsconfig.cjs.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "outDir": "dist/cjs",
+    "outDir": "dist-cjs",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/xml-builder/tsconfig.es.json
+++ b/packages/xml-builder/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "lib": ["es5", "es2015.collection"],
-    "outDir": "dist/es",
+    "outDir": "dist-es",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.es.json",

--- a/packages/xml-builder/tsconfig.types.json
+++ b/packages/xml-builder/tsconfig.types.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "declarationDir": "dist/types",
+    "declarationDir": "dist-types",
     "rootDir": "src"
   },
   "extends": "../../tsconfig.types.json",


### PR DESCRIPTION
### Issue
Following-up standard used in clients, introduced in https://github.com/aws/aws-sdk-js-v3/pull/2845

### Description
Transpile files in dist-* folders in clients.

Done using shell script:
```
foreach parentDir ("lib" "packages")
  for dir in ./$parentDir/*; do (cd "$dir" && sed -i 's/dist\//dist-/g' ./package.json); done
  for dir in ./$parentDir/*; do (cd "$dir" && sed -i 's/dist\//dist-/g' ./tsconfig.*); done
end
```

### Testing
✅ CI is successful.

✅ Integration tests are successful.
  * `yarn test:integration`
  * `yarn test:integration-legacy`

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
