### PR TITLE
fix(scripts): overwrite test folder for protocol_tests

### DIFF
--- a/protocol_tests/aws-ec2/test/functional/ec2query.spec.ts
+++ b/protocol_tests/aws-ec2/test/functional/ec2query.spec.ts
@@ -1,4 +1,7 @@
-import { EC2ProtocolClient } from "../../src/EC2ProtocolClient";
+import { HttpHandler, HttpRequest, HttpResponse } from "@aws-sdk/protocol-http";
+import { HeaderBag, HttpHandlerOptions } from "@aws-sdk/types";
+import { Readable } from "stream";
+
 import { EmptyInputAndEmptyOutputCommand } from "../../src/commands/EmptyInputAndEmptyOutputCommand";
 import { EndpointOperationCommand } from "../../src/commands/EndpointOperationCommand";
 import { EndpointWithHostLabelOperationCommand } from "../../src/commands/EndpointWithHostLabelOperationCommand";
@@ -19,10 +22,8 @@ import { XmlEnumsCommand } from "../../src/commands/XmlEnumsCommand";
 import { XmlListsCommand } from "../../src/commands/XmlListsCommand";
 import { XmlNamespacesCommand } from "../../src/commands/XmlNamespacesCommand";
 import { XmlTimestampsCommand } from "../../src/commands/XmlTimestampsCommand";
+import { EC2ProtocolClient } from "../../src/EC2ProtocolClient";
 import { ComplexError, InvalidGreeting } from "../../src/models/models_0";
-import { HttpHandlerOptions, HeaderBag } from "@aws-sdk/types";
-import { HttpHandler, HttpRequest, HttpResponse } from "@aws-sdk/protocol-http";
-import { Readable } from "stream";
 
 /**
  * Throws an expected exception that contains the serialized request.
@@ -112,7 +113,7 @@ const compareParts = (expectedParts: comparableParts, generatedParts: comparable
  * properties that have defined values.
  */
 const equivalentContents = (expected: any, generated: any): boolean => {
-  let localExpected = expected;
+  const localExpected = expected;
 
   // Short circuit on equality.
   if (localExpected == generated) {
@@ -136,7 +137,7 @@ const equivalentContents = (expected: any, generated: any): boolean => {
   }
 
   // Compare properties directly.
-  for (var index = 0; index < expectedProperties.length; index++) {
+  for (let index = 0; index < expectedProperties.length; index++) {
     const propertyName = expectedProperties[index];
     if (!equivalentContents(localExpected[propertyName], generated[propertyName])) {
       return false;

--- a/protocol_tests/aws-json-10/test/functional/awsjson1_0.spec.ts
+++ b/protocol_tests/aws-json-10/test/functional/awsjson1_0.spec.ts
@@ -1,4 +1,8 @@
-import { JSONRPC10Client } from "../../src/JSONRPC10Client";
+import { HttpHandler, HttpRequest, HttpResponse } from "@aws-sdk/protocol-http";
+import { Encoder as __Encoder } from "@aws-sdk/types";
+import { HeaderBag, HttpHandlerOptions } from "@aws-sdk/types";
+import { Readable } from "stream";
+
 import { EmptyInputAndEmptyOutputCommand } from "../../src/commands/EmptyInputAndEmptyOutputCommand";
 import { EndpointOperationCommand } from "../../src/commands/EndpointOperationCommand";
 import { EndpointWithHostLabelOperationCommand } from "../../src/commands/EndpointWithHostLabelOperationCommand";
@@ -7,11 +11,8 @@ import { JsonUnionsCommand } from "../../src/commands/JsonUnionsCommand";
 import { NoInputAndNoOutputCommand } from "../../src/commands/NoInputAndNoOutputCommand";
 import { NoInputAndOutputCommand } from "../../src/commands/NoInputAndOutputCommand";
 import { SimpleScalarPropertiesCommand } from "../../src/commands/SimpleScalarPropertiesCommand";
+import { JSONRPC10Client } from "../../src/JSONRPC10Client";
 import { ComplexError, FooError, InvalidGreeting } from "../../src/models/models_0";
-import { Encoder as __Encoder } from "@aws-sdk/types";
-import { HttpHandlerOptions, HeaderBag } from "@aws-sdk/types";
-import { HttpHandler, HttpRequest, HttpResponse } from "@aws-sdk/protocol-http";
-import { Readable } from "stream";
 
 /**
  * Throws an expected exception that contains the serialized request.
@@ -101,7 +102,7 @@ const compareParts = (expectedParts: comparableParts, generatedParts: comparable
  * properties that have defined values.
  */
 const equivalentContents = (expected: any, generated: any): boolean => {
-  let localExpected = expected;
+  const localExpected = expected;
 
   // Short circuit on equality.
   if (localExpected == generated) {
@@ -125,7 +126,7 @@ const equivalentContents = (expected: any, generated: any): boolean => {
   }
 
   // Compare properties directly.
-  for (var index = 0; index < expectedProperties.length; index++) {
+  for (let index = 0; index < expectedProperties.length; index++) {
     const propertyName = expectedProperties[index];
     if (!equivalentContents(localExpected[propertyName], generated[propertyName])) {
       return false;

--- a/protocol_tests/aws-json/test/functional/awsjson1_1.spec.ts
+++ b/protocol_tests/aws-json/test/functional/awsjson1_1.spec.ts
@@ -1,4 +1,8 @@
-import { JsonProtocolClient } from "../../src/JsonProtocolClient";
+import { HttpHandler, HttpRequest, HttpResponse } from "@aws-sdk/protocol-http";
+import { Encoder as __Encoder } from "@aws-sdk/types";
+import { HeaderBag, HttpHandlerOptions } from "@aws-sdk/types";
+import { Readable } from "stream";
+
 import { EmptyOperationCommand } from "../../src/commands/EmptyOperationCommand";
 import { EndpointOperationCommand } from "../../src/commands/EndpointOperationCommand";
 import { EndpointWithHostLabelOperationCommand } from "../../src/commands/EndpointWithHostLabelOperationCommand";
@@ -10,11 +14,8 @@ import { NullOperationCommand } from "../../src/commands/NullOperationCommand";
 import { OperationWithOptionalInputOutputCommand } from "../../src/commands/OperationWithOptionalInputOutputCommand";
 import { PutAndGetInlineDocumentsCommand } from "../../src/commands/PutAndGetInlineDocumentsCommand";
 import { SimpleScalarPropertiesCommand } from "../../src/commands/SimpleScalarPropertiesCommand";
+import { JsonProtocolClient } from "../../src/JsonProtocolClient";
 import { ComplexError, FooError, InvalidGreeting } from "../../src/models/models_0";
-import { Encoder as __Encoder } from "@aws-sdk/types";
-import { HttpHandlerOptions, HeaderBag } from "@aws-sdk/types";
-import { HttpHandler, HttpRequest, HttpResponse } from "@aws-sdk/protocol-http";
-import { Readable } from "stream";
 
 /**
  * Throws an expected exception that contains the serialized request.
@@ -104,7 +105,7 @@ const compareParts = (expectedParts: comparableParts, generatedParts: comparable
  * properties that have defined values.
  */
 const equivalentContents = (expected: any, generated: any): boolean => {
-  let localExpected = expected;
+  const localExpected = expected;
 
   // Short circuit on equality.
   if (localExpected == generated) {
@@ -128,7 +129,7 @@ const equivalentContents = (expected: any, generated: any): boolean => {
   }
 
   // Compare properties directly.
-  for (var index = 0; index < expectedProperties.length; index++) {
+  for (let index = 0; index < expectedProperties.length; index++) {
     const propertyName = expectedProperties[index];
     if (!equivalentContents(localExpected[propertyName], generated[propertyName])) {
       return false;

--- a/protocol_tests/aws-query/test/functional/awsquery.spec.ts
+++ b/protocol_tests/aws-query/test/functional/awsquery.spec.ts
@@ -1,4 +1,7 @@
-import { QueryProtocolClient } from "../../src/QueryProtocolClient";
+import { HttpHandler, HttpRequest, HttpResponse } from "@aws-sdk/protocol-http";
+import { HeaderBag, HttpHandlerOptions } from "@aws-sdk/types";
+import { Readable } from "stream";
+
 import { EmptyInputAndEmptyOutputCommand } from "../../src/commands/EmptyInputAndEmptyOutputCommand";
 import { EndpointOperationCommand } from "../../src/commands/EndpointOperationCommand";
 import { EndpointWithHostLabelOperationCommand } from "../../src/commands/EndpointWithHostLabelOperationCommand";
@@ -28,9 +31,7 @@ import { XmlMapsXmlNameCommand } from "../../src/commands/XmlMapsXmlNameCommand"
 import { XmlNamespacesCommand } from "../../src/commands/XmlNamespacesCommand";
 import { XmlTimestampsCommand } from "../../src/commands/XmlTimestampsCommand";
 import { ComplexError, CustomCodeError, InvalidGreeting } from "../../src/models/models_0";
-import { HttpHandlerOptions, HeaderBag } from "@aws-sdk/types";
-import { HttpHandler, HttpRequest, HttpResponse } from "@aws-sdk/protocol-http";
-import { Readable } from "stream";
+import { QueryProtocolClient } from "../../src/QueryProtocolClient";
 
 /**
  * Throws an expected exception that contains the serialized request.
@@ -120,7 +121,7 @@ const compareParts = (expectedParts: comparableParts, generatedParts: comparable
  * properties that have defined values.
  */
 const equivalentContents = (expected: any, generated: any): boolean => {
-  let localExpected = expected;
+  const localExpected = expected;
 
   // Short circuit on equality.
   if (localExpected == generated) {
@@ -144,7 +145,7 @@ const equivalentContents = (expected: any, generated: any): boolean => {
   }
 
   // Compare properties directly.
-  for (var index = 0; index < expectedProperties.length; index++) {
+  for (let index = 0; index < expectedProperties.length; index++) {
     const propertyName = expectedProperties[index];
     if (!equivalentContents(localExpected[propertyName], generated[propertyName])) {
       return false;

--- a/protocol_tests/aws-restjson/test/functional/restjson1.spec.ts
+++ b/protocol_tests/aws-restjson/test/functional/restjson1.spec.ts
@@ -1,4 +1,9 @@
-import { RestJsonProtocolClient } from "../../src/RestJsonProtocolClient";
+import { HttpHandler, HttpRequest, HttpResponse } from "@aws-sdk/protocol-http";
+import { buildQueryString } from "@aws-sdk/querystring-builder";
+import { Encoder as __Encoder } from "@aws-sdk/types";
+import { HeaderBag, HttpHandlerOptions } from "@aws-sdk/types";
+import { Readable } from "stream";
+
 import { AllQueryStringTypesCommand } from "../../src/commands/AllQueryStringTypesCommand";
 import { ConstantAndVariableQueryStringCommand } from "../../src/commands/ConstantAndVariableQueryStringCommand";
 import { ConstantQueryStringCommand } from "../../src/commands/ConstantQueryStringCommand";
@@ -45,11 +50,7 @@ import { StreamingTraitsRequireLengthCommand } from "../../src/commands/Streamin
 import { StreamingTraitsWithMediaTypeCommand } from "../../src/commands/StreamingTraitsWithMediaTypeCommand";
 import { TimestampFormatHeadersCommand } from "../../src/commands/TimestampFormatHeadersCommand";
 import { ComplexError, FooError, InvalidGreeting } from "../../src/models/models_0";
-import { buildQueryString } from "@aws-sdk/querystring-builder";
-import { Encoder as __Encoder } from "@aws-sdk/types";
-import { HttpHandlerOptions, HeaderBag } from "@aws-sdk/types";
-import { HttpHandler, HttpRequest, HttpResponse } from "@aws-sdk/protocol-http";
-import { Readable } from "stream";
+import { RestJsonProtocolClient } from "../../src/RestJsonProtocolClient";
 
 /**
  * Throws an expected exception that contains the serialized request.
@@ -139,7 +140,7 @@ const compareParts = (expectedParts: comparableParts, generatedParts: comparable
  * properties that have defined values.
  */
 const equivalentContents = (expected: any, generated: any): boolean => {
-  let localExpected = expected;
+  const localExpected = expected;
 
   // Short circuit on equality.
   if (localExpected == generated) {
@@ -163,7 +164,7 @@ const equivalentContents = (expected: any, generated: any): boolean => {
   }
 
   // Compare properties directly.
-  for (var index = 0; index < expectedProperties.length; index++) {
+  for (let index = 0; index < expectedProperties.length; index++) {
     const propertyName = expectedProperties[index];
     if (!equivalentContents(localExpected[propertyName], generated[propertyName])) {
       return false;

--- a/protocol_tests/aws-restxml/test/functional/restxml.spec.ts
+++ b/protocol_tests/aws-restxml/test/functional/restxml.spec.ts
@@ -1,4 +1,11 @@
-import { RestXmlProtocolClient } from "../../src/RestXmlProtocolClient";
+import { HttpHandler, HttpRequest, HttpResponse } from "@aws-sdk/protocol-http";
+import { buildQueryString } from "@aws-sdk/querystring-builder";
+import { Encoder as __Encoder } from "@aws-sdk/types";
+import { HeaderBag, HttpHandlerOptions } from "@aws-sdk/types";
+import { decodeHTML } from "entities";
+import { parse as xmlParse } from "fast-xml-parser";
+import { Readable } from "stream";
+
 import { AllQueryStringTypesCommand } from "../../src/commands/AllQueryStringTypesCommand";
 import { BodyWithXmlNameCommand } from "../../src/commands/BodyWithXmlNameCommand";
 import { ConstantAndVariableQueryStringCommand } from "../../src/commands/ConstantAndVariableQueryStringCommand";
@@ -52,13 +59,7 @@ import { XmlNamespacesCommand } from "../../src/commands/XmlNamespacesCommand";
 import { XmlTimestampsCommand } from "../../src/commands/XmlTimestampsCommand";
 import { XmlUnionsCommand } from "../../src/commands/XmlUnionsCommand";
 import { ComplexError, InvalidGreeting } from "../../src/models/models_0";
-import { buildQueryString } from "@aws-sdk/querystring-builder";
-import { Encoder as __Encoder } from "@aws-sdk/types";
-import { decodeHTML } from "entities";
-import { parse as xmlParse } from "fast-xml-parser";
-import { HttpHandlerOptions, HeaderBag } from "@aws-sdk/types";
-import { HttpHandler, HttpRequest, HttpResponse } from "@aws-sdk/protocol-http";
-import { Readable } from "stream";
+import { RestXmlProtocolClient } from "../../src/RestXmlProtocolClient";
 
 /**
  * Throws an expected exception that contains the serialized request.
@@ -148,7 +149,7 @@ const compareParts = (expectedParts: comparableParts, generatedParts: comparable
  * properties that have defined values.
  */
 const equivalentContents = (expected: any, generated: any): boolean => {
-  let localExpected = expected;
+  const localExpected = expected;
 
   // Short circuit on equality.
   if (localExpected == generated) {
@@ -172,7 +173,7 @@ const equivalentContents = (expected: any, generated: any): boolean => {
   }
 
   // Compare properties directly.
-  for (var index = 0; index < expectedProperties.length; index++) {
+  for (let index = 0; index < expectedProperties.length; index++) {
     const propertyName = expectedProperties[index];
     if (!equivalentContents(localExpected[propertyName], generated[propertyName])) {
       return false;

--- a/scripts/generate-clients/copy-to-clients.js
+++ b/scripts/generate-clients/copy-to-clients.js
@@ -15,7 +15,7 @@ const getOverwritableDirectories = (subDirectories, packageName) => {
   return subDirectories.filter((subDirectory) => {
     return (
       overwritableDirectories.indexOf(subDirectory) >= 0 ||
-      (packageName.startsWith("aws-") && subDirectory === "test") ||
+      (packageName.startsWith("@aws-sdk/aws-") && subDirectory === "test") ||
       additionalGeneratedFiles[packageName]?.indexOf(subDirectory) >= 0
     );
   });


### PR DESCRIPTION
### Issue
In the [codegen PR](https://github.com/aws/aws-sdk-js-v3/pull/2844) to move source code from source folder to "src", there was an incorrect check for folder name for protocol_tests for overwriting `"test"` folder. It checked for folder name `aws-` instead of package name `@aws-sdk/aws-`.

This issue was noticed in https://github.com/aws/aws-sdk-js-v3/pull/2840

### Description
Check for full package name before overwriting the "test" folder.

### Testing
Verified that:
* `yarn test:protocols` is successful.
* Generating s3 client does not overwrite "test" folder in client-s3.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
