### PR TITLE
fix: eslint SSDK protocol tests

### DIFF
--- a/.esprintrc
+++ b/.esprintrc
@@ -1,7 +1,7 @@
 {
   "paths": [
-    "codegen/sdk-codegen/build/smithyprojections/sdk-codegen/*/typescript-codegen/**/*.ts",
-    "codegen/protocol-test-codegen/build/smithyprojections/protocol-test-codegen/*/typescript-codegen/**/*.ts"
+    "codegen/sdk-codegen/build/smithyprojections/sdk-codegen/*/typescript*codegen/**/*.ts",
+    "codegen/protocol-test-codegen/build/smithyprojections/protocol-test-codegen/*/typescript*codegen/**/*.ts"
   ],
   "ignored": []
 }

--- a/scripts/generate-clients/index.js
+++ b/scripts/generate-clients/index.js
@@ -46,6 +46,7 @@ const {
   try {
     if (serverOnly === true) {
       await generateProtocolTests();
+      await eslintFixCode();
       await prettifyCode(CODE_GEN_PROTOCOL_TESTS_OUTPUT_DIR);
       await copyServerTests(CODE_GEN_PROTOCOL_TESTS_OUTPUT_DIR, PROTOCOL_TESTS_CLIENTS_DIR);
 


### PR DESCRIPTION
### Issue
Follow-up to https://github.com/aws/aws-sdk-js-v3/pull/2846
The script was not linting SSDK protocol tests. This issue was noticed while moving source code to src folder in SSDK protocol tests in https://github.com/awslabs/smithy-typescript/pull/437

### Description
eslint SSDK protocol tests

### Testing
Verified that source code is linted in `protocol_tests/aws-restjson-server` after running `yarn generate-clients --server-artifacts`

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
