### PR TITLE
fix(client-cognito-identity): import client from new location in src

### DIFF
--- a/clients/client-cognito-identity/test/e2e/CognitoIdentity.ispec.ts
+++ b/clients/client-cognito-identity/test/e2e/CognitoIdentity.ispec.ts
@@ -4,7 +4,8 @@
  * in NodeJS, Chromium and Firefox. This test is written in mocha.
  */
 import { expect } from "chai";
-import { CognitoIdentity } from "../index";
+
+import { CognitoIdentity } from "../../src/index";
 // There will be default values of defaultRegion, credentials, and isBrowser variable in browser tests.
 // Define the values for Node.js tests
 const region: string | undefined = (globalThis as any).defaultRegion || process?.env?.AWS_SMOKE_TEST_REGION;


### PR DESCRIPTION
### Issue
Internal JS-2860

### Description
imports client from src location for client-cognito-identity tests.

Commit which fixed e2e tests in PR: [`928ce1c` (#2845)](https://github.com/aws/aws-sdk-js-v3/pull/2845/commits/928ce1c69e2f4d6ed3e8dc4a6ff06cdb663c7cb8)
Updating import for `test/e2e/CognitoIdentity.ispec.ts` was missed.

### Testing
The e2e tests for client-cognito-identity were successful!

```console
$ pwd
/home/trivikr/workspace/aws-sdk-js-v3/clients/client-cognito-identity

$ AWS_SMOKE_TEST_REGION=[Region] AWS_SMOKE_TEST_IDENTITY_POOL_ID=[IdentityPoolId] yarn test:e2e
...
Chrome Headless 94.0.4606.61 (Linux x86_64): Executed 1 of 1 SUCCESS (0.216 secs / 0.214 secs)
```

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
