### PR TITLE
feat(codegen): do not pull client versions from packageInfo

### DIFF
--- a/codegen/sdk-codegen/build.gradle.kts
+++ b/codegen/sdk-codegen/build.gradle.kts
@@ -79,13 +79,17 @@ tasks.register("generate-smithy-build") {
                     File("smithy-aws-typescript-codegen/src/main/resources/software/amazon/smithy/aws/typescript/codegen/package.json.template")
                             .readText()
             ).expectObjectNode()
+
+            val rootPackageVersion = Node.parse(File("../package.json").readText()).expectObjectNode()
+                    .expectStringMember("version").getValue()
+
             val projectionContents = Node.objectNodeBuilder()
                     .withMember("imports", Node.fromStrings("${models.getAbsolutePath()}${File.separator}${file.name}"))
                     .withMember("plugins", Node.objectNode()
                             .withMember("typescript-codegen", Node.objectNodeBuilder()
                                     .withMember("package", "@aws-sdk/client-" + sdkId.toLowerCase())
                                     // Note that this version is replaced by Lerna when publishing.
-                                    .withMember("packageVersion", "3.0.0")
+                                    .withMember("packageVersion", rootPackageVersion)
                                     .withMember("packageJson", manifestOverwrites)
                                     .withMember("packageDescription", "AWS SDK for JavaScript "
                                         + clientName + " Client for Node.js, Browser and React Native")

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddUserAgentDependency.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddUserAgentDependency.java
@@ -73,7 +73,6 @@ public class AddUserAgentDependency implements TypeScriptIntegration {
                             writer.addDependency(AwsDependency.AWS_SDK_UTIL_USER_AGENT_NODE.dependency);
                             writer.addImport("defaultUserAgent", "defaultUserAgent",
                                     AwsDependency.AWS_SDK_UTIL_USER_AGENT_NODE.packageName);
-                            writer.addDefaultImport("packageInfo", "./package.json");
                             writeDefaultUserAgentProvider(writer, settings, model);
                         }
                 );
@@ -83,7 +82,6 @@ public class AddUserAgentDependency implements TypeScriptIntegration {
                             writer.addDependency(AwsDependency.AWS_SDK_UTIL_USER_AGENT_BROWSER.dependency);
                             writer.addImport("defaultUserAgent", "defaultUserAgent",
                                     AwsDependency.AWS_SDK_UTIL_USER_AGENT_BROWSER.packageName);
-                            writer.addDefaultImport("packageInfo", "./package.json");
                             writeDefaultUserAgentProvider(writer, settings, model);
                         }
                 );
@@ -96,6 +94,6 @@ public class AddUserAgentDependency implements TypeScriptIntegration {
         writer.write("defaultUserAgent({"
                 // serviceId is optional in defaultUserAgent. serviceId exists only for AWS services
                 + (isAwsService(settings, model) ? "serviceId: clientSharedValues.serviceId, " : "")
-                + "clientVersion: packageInfo.version})");
+                + "clientVersion: $S})", settings.getPackageVersion());
     }
 }

--- a/codegen/smithy-aws-typescript-codegen/src/test/java/software/amazon/smithy/aws/typescript/codegen/AddUserAgentDependencyTest.java
+++ b/codegen/smithy-aws-typescript-codegen/src/test/java/software/amazon/smithy/aws/typescript/codegen/AddUserAgentDependencyTest.java
@@ -42,12 +42,15 @@ public class AddUserAgentDependencyTest {
 
         // Check config files
         assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/runtimeConfig.ts").get(), containsString("defaultUserAgent"));
-        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/runtimeConfig.ts").get(), containsString("packageInfo.version"));
+        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/runtimeConfig.ts").get(), containsString("clientVersion: \"1.0.0\""));
         assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/runtimeConfig.ts").get(), containsString("clientSharedValues.serviceId"));
+        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/runtimeConfig.ts").get(), not(containsString("import packageInfo")));
+
 
         assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/runtimeConfig.browser.ts").get(), containsString("defaultUserAgent"));
-        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/runtimeConfig.browser.ts").get(), containsString("packageInfo.version"));
+        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/runtimeConfig.browser.ts").get(), containsString("clientVersion: \"1.0.0\""));
         assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/runtimeConfig.browser.ts").get(), containsString("clientSharedValues.serviceId"));
+        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/runtimeConfig.browser.ts").get(), not(containsString("import packageInfo")));
 
         // Check the config resolution and middleware plugin
         assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/NotSameClient.ts").get(), containsString("resolveUserAgentConfig"));
@@ -83,12 +86,14 @@ public class AddUserAgentDependencyTest {
 
         // Check config files
         assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/runtimeConfig.ts").get(), containsString("defaultUserAgent"));
-        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/runtimeConfig.ts").get(), containsString("packageInfo.version"));
+        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/runtimeConfig.ts").get(), containsString("clientVersion: \"1.0.0\""));
         assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/runtimeConfig.ts").get(), not(containsString("ClientSharedValues.serviceId")));
+        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/runtimeConfig.ts").get(), not(containsString("import packageInfo")));
 
         assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/runtimeConfig.browser.ts").get(), containsString("defaultUserAgent"));
-        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/runtimeConfig.browser.ts").get(), containsString("packageInfo.version"));
+        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/runtimeConfig.browser.ts").get(), containsString("clientVersion: \"1.0.0\""));
         assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/runtimeConfig.browser.ts").get(), not(containsString("ClientSharedValues.serviceId")));
+        assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/runtimeConfig.browser.ts").get(), not(containsString("import packageInfo")));
 
         // Check the config resolution and middleware plugin
         assertThat(manifest.getFileString(CodegenUtils.SOURCE_FOLDER + "/ExampleServiceClient.ts").get(), containsString("resolveUserAgentConfig"));


### PR DESCRIPTION
### Description
To avoid having to @ts-ignore importing packageInfo from package.json,
write the version contained in the typescript settings into the
UserAgent provider's arguments. This removes the need to postprocess
clients after they are generated.

### Testing
I generated clients locally, as well as a white-label client that failed without manual postprocessing.

### Additional context
This is just a demonstration of how we could drive versioning through updates to the central package.json, instead of lerna, since we generate a smithy-build that we can inject a version into before generation. 

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
