### PR TITLE
fix(client-documentation-generator): read files from src folder

### DIFF
--- a/packages/client-documentation-generator/src/sdk-client-rename-project.ts
+++ b/packages/client-documentation-generator/src/sdk-client-rename-project.ts
@@ -23,7 +23,7 @@ export class SdkClientRenameProjectPlugin extends RendererComponent {
         sourceFile.fileName.endsWith("/package.json")
       )?.[0]?.fullFileName;
       const { name } = metadataDir || JSON.parse(readFileSync(metadataDir).toString());
-      const serviceIdReflection = clientDirectory.files
+      const serviceIdReflection = clientDirectory.directories.src.files
         ?.filter((sourceFile) => sourceFile.fileName.endsWith("/runtimeConfig.shared.ts"))?.[0]
         .reflections.filter((reflection) => reflection.name === "serviceId")?.[0];
       this.projectName = serviceIdReflection /* serviceIdReflection.defaultValue looks like '"S3"' */

--- a/packages/client-documentation-generator/src/sdk-client-toc-plugin.ts
+++ b/packages/client-documentation-generator/src/sdk-client-toc-plugin.ts
@@ -167,6 +167,8 @@ export class SdkClientTocPlugin extends RendererComponent {
       projectModel = projectModel.parent as ProjectReflection;
     }
     const clientsDirectory = getCurrentClientDirectory({ project: projectModel as ProjectReflection });
-    return dirname(clientsDirectory?.files.find((file) => file.name.endsWith("Client.ts")).fullFileName);
+    return dirname(
+      clientsDirectory?.directories.src.files.find((file) => file.name.endsWith("Client.ts")).fullFileName
+    );
   }
 }

--- a/packages/client-documentation-generator/src/sdk-client-toc-plugin.ts
+++ b/packages/client-documentation-generator/src/sdk-client-toc-plugin.ts
@@ -168,7 +168,7 @@ export class SdkClientTocPlugin extends RendererComponent {
     }
     const clientsDirectory = getCurrentClientDirectory({ project: projectModel as ProjectReflection });
     return dirname(
-      clientsDirectory?.directories.src.files.find((file) => file.name.endsWith("Client.ts")).fullFileName
+      dirname(clientsDirectory?.directories.src.files.find((file) => file.name.endsWith("Client.ts")).fullFileName)
     );
   }
 }

--- a/packages/client-documentation-generator/src/utils.ts
+++ b/packages/client-documentation-generator/src/utils.ts
@@ -2,7 +2,5 @@ import { ProjectReflection, SourceDirectory } from "typedoc/dist/lib/models";
 
 export const getCurrentClientDirectory = (event: { project: ProjectReflection }): SourceDirectory => {
   const clientsDirectory = event.project.directory.directories["clients"].directories;
-  return Object.values(clientsDirectory).filter((directory) =>
-    directory?.files.find((file) => file.name.endsWith("Client.ts"))
-  )[0];
+  return Object.values(clientsDirectory).filter((directory) => directory?.directories?.src)[0];
 };


### PR DESCRIPTION
### Issue
Internal JS-2862

### Description
Fixes doc generation after source code for clients was moved to src folder in https://github.com/aws/aws-sdk-js-v3/pull/2845

### Testing
Verified that `build:docs` command succeeds for all clients:
```
$ ./node_modules/.bin/lerna run --scope '@aws-sdk/client-*' build:docs
```

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
