### PR TITLE
fix(client-opsworks): intermittent integ tests failures

### DIFF
--- a/features/opsworks/step_definitions/opsworks.js
+++ b/features/opsworks/step_definitions/opsworks.js
@@ -3,8 +3,8 @@ const { OpsWorks } = require("../../../clients/client-opsworks");
 const { Before, Given, Then } = require("cucumber");
 
 Before({ tags: "@opsworks" }, function (scenario, callback) {
-  this.iam = new IAM({});
-  this.service = new OpsWorks({});
+  this.iam = new IAM({ region: "us-west-2" });
+  this.service = new OpsWorks({ region: "us-west-2" });
   callback();
 });
 


### PR DESCRIPTION
### Issue
Internal JS-2867
Refs: https://github.com/aws/aws-sdk-js/pull/3839

### Description
Explicitly setting region for OpsWorks integration tests, as they're failing intermittently.

### Testing
Integration test for OpsWorks is successful
```console
$ yarn test:integration-legacy -t @opsworks
yarn run v1.22.11
$ cucumber-js --fail-fast -t @opsworks
..................

2 scenarios (2 passed)
14 steps (14 passed)
0m01.326s
Done in 4.93s.
```

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
