### PR TITLE
feat(codegen): test non-AWS client builds

### DIFF
--- a/.github/workflows/generic-client-tests.yml
+++ b/.github/workflows/generic-client-tests.yml
@@ -1,0 +1,40 @@
+name: generic-client-tests
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-java@v1
+        with:
+          java-version: '11'
+
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '14'
+          cache: 'yarn'
+
+      - name: build and publish smithy-typescript
+        run: |
+          git clone --depth 1 https://github.com/awslabs/smithy-typescript.git
+          cd smithy-typescript
+          ./gradlew clean build publishToMavenLocal
+          cd ..
+
+      - name: build codegen and generate generic client
+        run: |
+          cd codegen
+          ./gradlew clean smithy-aws-typescript-codegen:build generic-client-test-codegen:build
+
+      - name: build generic client
+        run: |
+          cd codegen/generic-client-test-codegen/build/smithyprojections/generic-client-test-codegen/aws-echo-service/typescript-codegen/
+          yarn install && yarn build

--- a/codegen/generic-client-test-codegen/build.gradle.kts
+++ b/codegen/generic-client-test-codegen/build.gradle.kts
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+import software.amazon.smithy.gradle.tasks.SmithyBuild
+
+plugins {
+    id("software.amazon.smithy") version "0.5.3"
+}
+
+dependencies {
+    implementation("software.amazon.smithy:smithy-aws-protocol-tests:[1.11.0, 1.12.0[")
+    implementation(project(":smithy-aws-typescript-codegen"))
+}
+
+// This project doesn't produce a JAR.
+tasks["jar"].enabled = false
+
+// Run the SmithyBuild task manually since this project needs the built JAR
+// from smithy-aws-typescript-codegen.
+tasks["smithyBuildJar"].enabled = false
+
+tasks.create<SmithyBuild>("buildSdk") {
+    addRuntimeClasspath = true
+}
+
+// Run the `buildSdk` automatically.
+tasks["build"].finalizedBy(tasks["buildSdk"])

--- a/codegen/generic-client-test-codegen/model/echo.smithy
+++ b/codegen/generic-client-test-codegen/model/echo.smithy
@@ -1,0 +1,51 @@
+$version: "1.0"
+
+namespace aws.test.generic
+
+use aws.protocols#restJson1
+
+@restJson1
+service EchoService {
+    version: "2018-05-10",
+    operations: [Echo, Length],
+}
+
+@http(code: 200, method: "POST", uri: "/echo",)
+operation Echo {
+    input: EchoInput,
+    output: EchoOutput,
+    errors: [PalindromeException],
+}
+
+@readonly
+@http(code: 200, method: "GET", uri: "/length/{string}")
+operation Length {
+    input: LengthInput,
+    output: LengthOutput,
+    errors: [PalindromeException],
+}
+
+structure EchoInput {
+    string: String,
+}
+
+structure EchoOutput {
+    string: String,
+}
+
+structure LengthInput {
+    @required
+    @httpLabel
+    string: String,
+}
+
+structure LengthOutput {
+    length: Integer,
+}
+
+/// For some reason, this service does not like palindromes!
+@httpError(400)
+@error("client")
+structure PalindromeException {
+    message: String,
+}

--- a/codegen/generic-client-test-codegen/smithy-build.json
+++ b/codegen/generic-client-test-codegen/smithy-build.json
@@ -1,0 +1,30 @@
+{
+  "version": "1.0",
+  "imports": ["model/echo.smithy"],
+  "projections": {
+    "aws-echo-service": {
+      "transforms": [
+        {
+          "name": "includeServices",
+          "args": {
+            "services": ["aws.test.generic#EchoService"]
+          }
+        }
+      ],
+      "plugins": {
+        "typescript-codegen": {
+          "package": "@aws-sdk/aws-echo-service",
+          "packageVersion": "1.0.0-alpha.1",
+          "packageJson": {
+            "author": {
+              "name": "AWS SDK for JavaScript Team",
+              "url": "https://aws.amazon.com/javascript/"
+            },
+            "license": "Apache-2.0"
+          },
+          "private": true
+        }
+      }
+    }
+  }
+}

--- a/codegen/settings.gradle.kts
+++ b/codegen/settings.gradle.kts
@@ -17,3 +17,4 @@ rootProject.name = "codegen"
 include(":smithy-aws-typescript-codegen")
 include(":sdk-codegen")
 include(":protocol-test-codegen")
+include(":generic-client-test-codegen")


### PR DESCRIPTION
### Description
Generate a non-AWS client and add a GitHub action that verifies that it will compile.

### Testing
Ran the tests manually locally, and in this PR.

~Test failing due to a non-`@ts-ignore`d import: https://github.com/aws/aws-sdk-js-v3/pull/2876/checks?check_run_id=3820762025~
~They should pass once rebased upon a merged https://github.com/aws/aws-sdk-js-v3/pull/2875~

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
