### PR TITLE
fix: correct typo in module READMEs

### DIFF
--- a/clients/client-accessanalyzer/README.md
+++ b/clients/client-accessanalyzer/README.md
@@ -19,7 +19,7 @@ call programmatically. For general information about IAM Access Analyzer, see <a
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-accessanalyzer
+To install this package, simply type add or install @aws-sdk/client-accessanalyzer
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-accessanalyzer`

--- a/clients/client-account/README.md
+++ b/clients/client-account/README.md
@@ -11,7 +11,7 @@ AWS SDK for JavaScript Account Client for Node.js, Browser and React Native.
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-account
+To install this package, simply type add or install @aws-sdk/client-account
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-account`

--- a/clients/client-acm-pca/README.md
+++ b/clients/client-acm-pca/README.md
@@ -28,7 +28,7 @@ console.</p>
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-acm-pca
+To install this package, simply type add or install @aws-sdk/client-acm-pca
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-acm-pca`

--- a/clients/client-acm/README.md
+++ b/clients/client-acm/README.md
@@ -14,7 +14,7 @@ and applications. For more information about using ACM, see the <a href="https:/
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-acm
+To install this package, simply type add or install @aws-sdk/client-acm
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-acm`

--- a/clients/client-alexa-for-business/README.md
+++ b/clients/client-alexa-for-business/README.md
@@ -18,7 +18,7 @@ as shared devices in their organization. </p>
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-alexa-for-business
+To install this package, simply type add or install @aws-sdk/client-alexa-for-business
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-alexa-for-business`

--- a/clients/client-amp/README.md
+++ b/clients/client-amp/README.md
@@ -11,7 +11,7 @@ Amazon Managed Service for Prometheus
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-amp
+To install this package, simply type add or install @aws-sdk/client-amp
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-amp`

--- a/clients/client-amplify/README.md
+++ b/clients/client-amplify/README.md
@@ -16,7 +16,7 @@ for client app development. For more information, see the <a href="https://docs.
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-amplify
+To install this package, simply type add or install @aws-sdk/client-amplify
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-amplify`

--- a/clients/client-amplifybackend/README.md
+++ b/clients/client-amplifybackend/README.md
@@ -11,7 +11,7 @@ AWS SDK for JavaScript AmplifyBackend Client for Node.js, Browser and React Nati
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-amplifybackend
+To install this package, simply type add or install @aws-sdk/client-amplifybackend
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-amplifybackend`

--- a/clients/client-api-gateway/README.md
+++ b/clients/client-api-gateway/README.md
@@ -13,7 +13,7 @@ AWS SDK for JavaScript APIGateway Client for Node.js, Browser and React Native.
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-api-gateway
+To install this package, simply type add or install @aws-sdk/client-api-gateway
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-api-gateway`

--- a/clients/client-apigatewaymanagementapi/README.md
+++ b/clients/client-apigatewaymanagementapi/README.md
@@ -11,7 +11,7 @@ AWS SDK for JavaScript ApiGatewayManagementApi Client for Node.js, Browser and R
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-apigatewaymanagementapi
+To install this package, simply type add or install @aws-sdk/client-apigatewaymanagementapi
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-apigatewaymanagementapi`

--- a/clients/client-apigatewayv2/README.md
+++ b/clients/client-apigatewayv2/README.md
@@ -11,7 +11,7 @@ AWS SDK for JavaScript ApiGatewayV2 Client for Node.js, Browser and React Native
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-apigatewayv2
+To install this package, simply type add or install @aws-sdk/client-apigatewayv2
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-apigatewayv2`

--- a/clients/client-app-mesh/README.md
+++ b/clients/client-app-mesh/README.md
@@ -23,7 +23,7 @@ for Services and Pods</a> in the Kubernetes documentation.</p>
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-app-mesh
+To install this package, simply type add or install @aws-sdk/client-app-mesh
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-app-mesh`

--- a/clients/client-appconfig/README.md
+++ b/clients/client-appconfig/README.md
@@ -60,7 +60,7 @@ system.</p>
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-appconfig
+To install this package, simply type add or install @aws-sdk/client-appconfig
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-appconfig`

--- a/clients/client-appflow/README.md
+++ b/clients/client-appflow/README.md
@@ -49,7 +49,7 @@ profile using Amazon AppFlow API operations. For example, Salesforce users can r
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-appflow
+To install this package, simply type add or install @aws-sdk/client-appflow
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-appflow`

--- a/clients/client-appintegrations/README.md
+++ b/clients/client-appintegrations/README.md
@@ -15,7 +15,7 @@ in the <i>Amazon Connect Administrator Guide</i>.</p>
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-appintegrations
+To install this package, simply type add or install @aws-sdk/client-appintegrations
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-appintegrations`

--- a/clients/client-application-auto-scaling/README.md
+++ b/clients/client-application-auto-scaling/README.md
@@ -83,7 +83,7 @@ Guide</a>.</p>
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-application-auto-scaling
+To install this package, simply type add or install @aws-sdk/client-application-auto-scaling
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-application-auto-scaling`

--- a/clients/client-application-discovery-service/README.md
+++ b/clients/client-application-discovery-service/README.md
@@ -136,7 +136,7 @@ collected data before it is shared with the service.</p>
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-application-discovery-service
+To install this package, simply type add or install @aws-sdk/client-application-discovery-service
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-application-discovery-service`

--- a/clients/client-application-insights/README.md
+++ b/clients/client-application-insights/README.md
@@ -24,7 +24,7 @@ analysis on impactful metrics and log errors. </p>
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-application-insights
+To install this package, simply type add or install @aws-sdk/client-application-insights
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-application-insights`

--- a/clients/client-applicationcostprofiler/README.md
+++ b/clients/client-applicationcostprofiler/README.md
@@ -16,7 +16,7 @@ Profiler User Guide</a>.</p>
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-applicationcostprofiler
+To install this package, simply type add or install @aws-sdk/client-applicationcostprofiler
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-applicationcostprofiler`

--- a/clients/client-apprunner/README.md
+++ b/clients/client-apprunner/README.md
@@ -28,7 +28,7 @@ endpoints and quotas</a> in the <i>Amazon Web Services General Reference</i>.</p
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-apprunner
+To install this package, simply type add or install @aws-sdk/client-apprunner
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-apprunner`

--- a/clients/client-appstream/README.md
+++ b/clients/client-appstream/README.md
@@ -32,7 +32,7 @@ AWS SDK for JavaScript AppStream Client for Node.js, Browser and React Native.
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-appstream
+To install this package, simply type add or install @aws-sdk/client-appstream
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-appstream`

--- a/clients/client-appsync/README.md
+++ b/clients/client-appsync/README.md
@@ -12,7 +12,7 @@ sources using GraphQL from your application.</p>
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-appsync
+To install this package, simply type add or install @aws-sdk/client-appsync
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-appsync`

--- a/clients/client-athena/README.md
+++ b/clients/client-athena/README.md
@@ -24,7 +24,7 @@ Guide</i>.</p>
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-athena
+To install this package, simply type add or install @aws-sdk/client-athena
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-athena`

--- a/clients/client-auditmanager/README.md
+++ b/clients/client-auditmanager/README.md
@@ -41,7 +41,7 @@ to support internal audits with unique requirements. </p>
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-auditmanager
+To install this package, simply type add or install @aws-sdk/client-auditmanager
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-auditmanager`

--- a/clients/client-auto-scaling-plans/README.md
+++ b/clients/client-auto-scaling-plans/README.md
@@ -44,7 +44,7 @@ permissions for AWS Auto Scaling actions, see the <a href="https://docs.aws.amaz
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-auto-scaling-plans
+To install this package, simply type add or install @aws-sdk/client-auto-scaling-plans
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-auto-scaling-plans`

--- a/clients/client-auto-scaling/README.md
+++ b/clients/client-auto-scaling/README.md
@@ -18,7 +18,7 @@ IAM users required permissions for Amazon EC2 Auto Scaling resources</a> in the
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-auto-scaling
+To install this package, simply type add or install @aws-sdk/client-auto-scaling
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-auto-scaling`

--- a/clients/client-backup/README.md
+++ b/clients/client-backup/README.md
@@ -16,7 +16,7 @@ auditing.</p>
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-backup
+To install this package, simply type add or install @aws-sdk/client-backup
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-backup`

--- a/clients/client-batch/README.md
+++ b/clients/client-batch/README.md
@@ -22,7 +22,7 @@ your time and energy on analyzing results and solving your specific problems. </
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-batch
+To install this package, simply type add or install @aws-sdk/client-batch
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-batch`

--- a/clients/client-braket/README.md
+++ b/clients/client-braket/README.md
@@ -11,7 +11,7 @@ AWS SDK for JavaScript Braket Client for Node.js, Browser and React Native.
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-braket
+To install this package, simply type add or install @aws-sdk/client-braket
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-braket`

--- a/clients/client-budgets/README.md
+++ b/clients/client-budgets/README.md
@@ -53,7 +53,7 @@ AWS SDK for JavaScript Budgets Client for Node.js, Browser and React Native.
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-budgets
+To install this package, simply type add or install @aws-sdk/client-budgets
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-budgets`

--- a/clients/client-chime-sdk-identity/README.md
+++ b/clients/client-chime-sdk-identity/README.md
@@ -14,7 +14,7 @@ identity APIs, refer to <a href="https://docs.aws.amazon.com/chime/latest/APIRef
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-chime-sdk-identity
+To install this package, simply type add or install @aws-sdk/client-chime-sdk-identity
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-chime-sdk-identity`

--- a/clients/client-chime-sdk-messaging/README.md
+++ b/clients/client-chime-sdk-messaging/README.md
@@ -15,7 +15,7 @@ APIs, see <a href="https://docs.aws.amazon.com/chime/latest/APIReference/API_Ope
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-chime-sdk-messaging
+To install this package, simply type add or install @aws-sdk/client-chime-sdk-messaging
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-chime-sdk-messaging`

--- a/clients/client-chime/README.md
+++ b/clients/client-chime/README.md
@@ -50,7 +50,7 @@ in the <i>Amazon Chime Administration Guide</i>.</p>
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-chime
+To install this package, simply type add or install @aws-sdk/client-chime
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-chime`

--- a/clients/client-cloud9/README.md
+++ b/clients/client-cloud9/README.md
@@ -78,7 +78,7 @@ environment member for an environment.</p>
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-cloud9
+To install this package, simply type add or install @aws-sdk/client-cloud9
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-cloud9`

--- a/clients/client-cloudcontrol/README.md
+++ b/clients/client-cloudcontrol/README.md
@@ -17,7 +17,7 @@ Guide</a>.</p>
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-cloudcontrol
+To install this package, simply type add or install @aws-sdk/client-cloudcontrol
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-cloudcontrol`

--- a/clients/client-clouddirectory/README.md
+++ b/clients/client-clouddirectory/README.md
@@ -17,7 +17,7 @@ Service</a> and the <a href="https://docs.aws.amazon.com/clouddirectory/latest/d
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-clouddirectory
+To install this package, simply type add or install @aws-sdk/client-clouddirectory
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-clouddirectory`

--- a/clients/client-cloudformation/README.md
+++ b/clients/client-cloudformation/README.md
@@ -28,7 +28,7 @@ documentation at <a href="https://docs.aws.amazon.com/">
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-cloudformation
+To install this package, simply type add or install @aws-sdk/client-cloudformation
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-cloudformation`

--- a/clients/client-cloudfront/README.md
+++ b/clients/client-cloudfront/README.md
@@ -15,7 +15,7 @@ CloudFront API actions, data types, and errors. For detailed information about C
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-cloudfront
+To install this package, simply type add or install @aws-sdk/client-cloudfront
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-cloudfront`

--- a/clients/client-cloudhsm-v2/README.md
+++ b/clients/client-cloudhsm-v2/README.md
@@ -12,7 +12,7 @@ CloudHSM User Guide</a>.</p>
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-cloudhsm-v2
+To install this package, simply type add or install @aws-sdk/client-cloudhsm-v2
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-cloudhsm-v2`

--- a/clients/client-cloudhsm/README.md
+++ b/clients/client-cloudhsm/README.md
@@ -22,7 +22,7 @@ Reference</a>.</p>
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-cloudhsm
+To install this package, simply type add or install @aws-sdk/client-cloudhsm
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-cloudhsm`

--- a/clients/client-cloudsearch-domain/README.md
+++ b/clients/client-cloudsearch-domain/README.md
@@ -14,7 +14,7 @@ AWS SDK for JavaScript CloudSearchDomain Client for Node.js, Browser and React N
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-cloudsearch-domain
+To install this package, simply type add or install @aws-sdk/client-cloudsearch-domain
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-cloudsearch-domain`

--- a/clients/client-cloudsearch/README.md
+++ b/clients/client-cloudsearch/README.md
@@ -18,7 +18,7 @@ see <a href="http://docs.aws.amazon.com/general/latest/gr/rande.html#cloudsearch
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-cloudsearch
+To install this package, simply type add or install @aws-sdk/client-cloudsearch
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-cloudsearch`

--- a/clients/client-cloudtrail/README.md
+++ b/clients/client-cloudtrail/README.md
@@ -27,7 +27,7 @@ Guide</a> for information about the data that is included with each Amazon Web S
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-cloudtrail
+To install this package, simply type add or install @aws-sdk/client-cloudtrail
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-cloudtrail`

--- a/clients/client-cloudwatch-events/README.md
+++ b/clients/client-cloudwatch-events/README.md
@@ -31,7 +31,7 @@ Guide</a>.</p>
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-cloudwatch-events
+To install this package, simply type add or install @aws-sdk/client-cloudwatch-events
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-cloudwatch-events`

--- a/clients/client-cloudwatch-logs/README.md
+++ b/clients/client-cloudwatch-logs/README.md
@@ -44,7 +44,7 @@ and into the log service. You can then access the raw log data when you need it.
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-cloudwatch-logs
+To install this package, simply type add or install @aws-sdk/client-cloudwatch-logs
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-cloudwatch-logs`

--- a/clients/client-cloudwatch/README.md
+++ b/clients/client-cloudwatch/README.md
@@ -25,7 +25,7 @@ utilization, application performance, and operational health.</p>
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-cloudwatch
+To install this package, simply type add or install @aws-sdk/client-cloudwatch
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-cloudwatch`

--- a/clients/client-codeartifact/README.md
+++ b/clients/client-codeartifact/README.md
@@ -264,7 +264,7 @@ that specifies permissions to access it. </p>
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-codeartifact
+To install this package, simply type add or install @aws-sdk/client-codeartifact
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-codeartifact`

--- a/clients/client-codebuild/README.md
+++ b/clients/client-codebuild/README.md
@@ -22,7 +22,7 @@ Guide</a>.</i>
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-codebuild
+To install this package, simply type add or install @aws-sdk/client-codebuild
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-codebuild`

--- a/clients/client-codecommit/README.md
+++ b/clients/client-codecommit/README.md
@@ -402,7 +402,7 @@ by sending data to the trigger target.</p>
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-codecommit
+To install this package, simply type add or install @aws-sdk/client-codecommit
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-codecommit`

--- a/clients/client-codedeploy/README.md
+++ b/clients/client-codedeploy/README.md
@@ -111,7 +111,7 @@ Developer Forum</a>
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-codedeploy
+To install this package, simply type add or install @aws-sdk/client-codedeploy
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-codedeploy`

--- a/clients/client-codeguru-reviewer/README.md
+++ b/clients/client-codeguru-reviewer/README.md
@@ -26,7 +26,7 @@ VPC endpoints (Amazon Web Services PrivateLink)</a> in the <i>Amazon CodeGuru Re
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-codeguru-reviewer
+To install this package, simply type add or install @aws-sdk/client-codeguru-reviewer
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-codeguru-reviewer`

--- a/clients/client-codeguruprofiler/README.md
+++ b/clients/client-codeguruprofiler/README.md
@@ -33,7 +33,7 @@ the <i>Amazon CodeGuru Profiler User Guide</i>.
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-codeguruprofiler
+To install this package, simply type add or install @aws-sdk/client-codeguruprofiler
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-codeguruprofiler`

--- a/clients/client-codepipeline/README.md
+++ b/clients/client-codepipeline/README.md
@@ -206,7 +206,7 @@ success.</p>
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-codepipeline
+To install this package, simply type add or install @aws-sdk/client-codepipeline
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-codepipeline`

--- a/clients/client-codestar-connections/README.md
+++ b/clients/client-codestar-connections/README.md
@@ -91,7 +91,7 @@ Guide</a>.</p>
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-codestar-connections
+To install this package, simply type add or install @aws-sdk/client-codestar-connections
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-codestar-connections`

--- a/clients/client-codestar-notifications/README.md
+++ b/clients/client-codestar-notifications/README.md
@@ -92,7 +92,7 @@ your account. </p>
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-codestar-notifications
+To install this package, simply type add or install @aws-sdk/client-codestar-notifications
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-codestar-notifications`

--- a/clients/client-codestar/README.md
+++ b/clients/client-codestar/README.md
@@ -101,7 +101,7 @@ all projects.</p>
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-codestar
+To install this package, simply type add or install @aws-sdk/client-codestar
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-codestar`

--- a/clients/client-cognito-identity-provider/README.md
+++ b/clients/client-cognito-identity-provider/README.md
@@ -17,7 +17,7 @@ Documentation</a>.</p>
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-cognito-identity-provider
+To install this package, simply type add or install @aws-sdk/client-cognito-identity-provider
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-cognito-identity-provider`

--- a/clients/client-cognito-identity/README.md
+++ b/clients/client-cognito-identity/README.md
@@ -25,7 +25,7 @@ see <a href="https://docs.aws.amazon.com/cognito/latest/developerguide/authentic
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-cognito-identity
+To install this package, simply type add or install @aws-sdk/client-cognito-identity
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-cognito-identity`

--- a/clients/client-cognito-sync/README.md
+++ b/clients/client-cognito-sync/README.md
@@ -24,7 +24,7 @@ make API calls via the AWS Mobile SDK. To learn more, see the <a href="http://do
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-cognito-sync
+To install this package, simply type add or install @aws-sdk/client-cognito-sync
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-cognito-sync`

--- a/clients/client-comprehend/README.md
+++ b/clients/client-comprehend/README.md
@@ -14,7 +14,7 @@ more.</p>
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-comprehend
+To install this package, simply type add or install @aws-sdk/client-comprehend
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-comprehend`

--- a/clients/client-comprehendmedical/README.md
+++ b/clients/client-comprehendmedical/README.md
@@ -12,7 +12,7 @@ to gain insight in your documents. </p>
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-comprehendmedical
+To install this package, simply type add or install @aws-sdk/client-comprehendmedical
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-comprehendmedical`

--- a/clients/client-compute-optimizer/README.md
+++ b/clients/client-compute-optimizer/README.md
@@ -21,7 +21,7 @@ service, see the <a href="https://docs.aws.amazon.com/compute-optimizer/latest/u
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-compute-optimizer
+To install this package, simply type add or install @aws-sdk/client-compute-optimizer
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-compute-optimizer`

--- a/clients/client-config-service/README.md
+++ b/clients/client-config-service/README.md
@@ -33,7 +33,7 @@ Guide</i>.</p>
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-config-service
+To install this package, simply type add or install @aws-sdk/client-config-service
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-config-service`

--- a/clients/client-connect-contact-lens/README.md
+++ b/clients/client-connect-contact-lens/README.md
@@ -17,7 +17,7 @@ Contact Lens</a> in the <i>Amazon Connect Administrator Guide</i>. </p>
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-connect-contact-lens
+To install this package, simply type add or install @aws-sdk/client-connect-contact-lens
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-connect-contact-lens`

--- a/clients/client-connect/README.md
+++ b/clients/client-connect/README.md
@@ -26,7 +26,7 @@ Endpoints</a>.</p>
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-connect
+To install this package, simply type add or install @aws-sdk/client-connect
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-connect`

--- a/clients/client-connectparticipant/README.md
+++ b/clients/client-connectparticipant/README.md
@@ -16,7 +16,7 @@ customers.</p>
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-connectparticipant
+To install this package, simply type add or install @aws-sdk/client-connectparticipant
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-connectparticipant`

--- a/clients/client-cost-and-usage-report-service/README.md
+++ b/clients/client-cost-and-usage-report-service/README.md
@@ -28,7 +28,7 @@ AWS Cost and Usage API.</p>
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-cost-and-usage-report-service
+To install this package, simply type add or install @aws-sdk/client-cost-and-usage-report-service
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-cost-and-usage-report-service`

--- a/clients/client-cost-explorer/README.md
+++ b/clients/client-cost-explorer/README.md
@@ -26,7 +26,7 @@ Management Pricing</a>.</p>
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-cost-explorer
+To install this package, simply type add or install @aws-sdk/client-cost-explorer
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-cost-explorer`

--- a/clients/client-customer-profiles/README.md
+++ b/clients/client-customer-profiles/README.md
@@ -21,7 +21,7 @@ center.</p>
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-customer-profiles
+To install this package, simply type add or install @aws-sdk/client-customer-profiles
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-customer-profiles`

--- a/clients/client-data-pipeline/README.md
+++ b/clients/client-data-pipeline/README.md
@@ -27,7 +27,7 @@ When the task is done, the task runner reports the final success or failure of t
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-data-pipeline
+To install this package, simply type add or install @aws-sdk/client-data-pipeline
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-data-pipeline`

--- a/clients/client-database-migration-service/README.md
+++ b/clients/client-database-migration-service/README.md
@@ -21,7 +21,7 @@ in the <i>Database Migration Service User Guide.</i>
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-database-migration-service
+To install this package, simply type add or install @aws-sdk/client-database-migration-service
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-database-migration-service`

--- a/clients/client-databrew/README.md
+++ b/clients/client-databrew/README.md
@@ -14,7 +14,7 @@ data and perform one-click data transformations, with no coding required.</p>
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-databrew
+To install this package, simply type add or install @aws-sdk/client-databrew
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-databrew`

--- a/clients/client-dataexchange/README.md
+++ b/clients/client-dataexchange/README.md
@@ -11,7 +11,7 @@ AWS SDK for JavaScript DataExchange Client for Node.js, Browser and React Native
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-dataexchange
+To install this package, simply type add or install @aws-sdk/client-dataexchange
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-dataexchange`

--- a/clients/client-datasync/README.md
+++ b/clients/client-datasync/README.md
@@ -17,7 +17,7 @@ programming interface that you can use to manage DataSync.</p>
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-datasync
+To install this package, simply type add or install @aws-sdk/client-datasync
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-datasync`

--- a/clients/client-dax/README.md
+++ b/clients/client-dax/README.md
@@ -16,7 +16,7 @@ significant improvements in read performance.</p>
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-dax
+To install this package, simply type add or install @aws-sdk/client-dax
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-dax`

--- a/clients/client-detective/README.md
+++ b/clients/client-detective/README.md
@@ -56,7 +56,7 @@ Detective, the administrator account manages the accounts in their behavior grap
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-detective
+To install this package, simply type add or install @aws-sdk/client-detective
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-detective`

--- a/clients/client-device-farm/README.md
+++ b/clients/client-device-farm/README.md
@@ -25,7 +25,7 @@ devices in the cloud. For more information, see the <a href="https://docs.aws.am
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-device-farm
+To install this package, simply type add or install @aws-sdk/client-device-farm
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-device-farm`

--- a/clients/client-devops-guru/README.md
+++ b/clients/client-devops-guru/README.md
@@ -26,7 +26,7 @@ learn about DevOps Guru concepts, see <a href="https://docs.aws.amazon.com/devop
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-devops-guru
+To install this package, simply type add or install @aws-sdk/client-devops-guru
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-devops-guru`

--- a/clients/client-direct-connect/README.md
+++ b/clients/client-direct-connect/README.md
@@ -16,7 +16,7 @@ Amazon Web Services resources in the China Regions can only be accessed through 
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-direct-connect
+To install this package, simply type add or install @aws-sdk/client-direct-connect
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-direct-connect`

--- a/clients/client-directory-service/README.md
+++ b/clients/client-directory-service/README.md
@@ -25,7 +25,7 @@ Services</a>.</p>
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-directory-service
+To install this package, simply type add or install @aws-sdk/client-directory-service
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-directory-service`

--- a/clients/client-dlm/README.md
+++ b/clients/client-dlm/README.md
@@ -18,7 +18,7 @@ Snapshot Lifecycle</a> in the <i>Amazon EC2 User Guide</i>.</p>
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-dlm
+To install this package, simply type add or install @aws-sdk/client-dlm
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-dlm`

--- a/clients/client-docdb/README.md
+++ b/clients/client-docdb/README.md
@@ -11,7 +11,7 @@ AWS SDK for JavaScript DocDB Client for Node.js, Browser and React Native.
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-docdb
+To install this package, simply type add or install @aws-sdk/client-docdb
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-docdb`

--- a/clients/client-dynamodb-streams/README.md
+++ b/clients/client-dynamodb-streams/README.md
@@ -16,7 +16,7 @@ Guide.</p>
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-dynamodb-streams
+To install this package, simply type add or install @aws-sdk/client-dynamodb-streams
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-dynamodb-streams`

--- a/clients/client-dynamodb/README.md
+++ b/clients/client-dynamodb/README.md
@@ -28,7 +28,7 @@ built-in high availability and data durability. </p>
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-dynamodb
+To install this package, simply type add or install @aws-sdk/client-dynamodb
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-dynamodb`

--- a/clients/client-ebs/README.md
+++ b/clients/client-ebs/README.md
@@ -29,7 +29,7 @@ the <i>Amazon Web Services General Reference</i>.</p>
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-ebs
+To install this package, simply type add or install @aws-sdk/client-ebs
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-ebs`

--- a/clients/client-ec2-instance-connect/README.md
+++ b/clients/client-ec2-instance-connect/README.md
@@ -13,7 +13,7 @@ instances.</p>
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-ec2-instance-connect
+To install this package, simply type add or install @aws-sdk/client-ec2-instance-connect
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-ec2-instance-connect`

--- a/clients/client-ec2/README.md
+++ b/clients/client-ec2/README.md
@@ -37,7 +37,7 @@ and reliable storage volumes that can be attached to any running instance and us
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-ec2
+To install this package, simply type add or install @aws-sdk/client-ec2
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-ec2`

--- a/clients/client-ecr-public/README.md
+++ b/clients/client-ecr-public/README.md
@@ -18,7 +18,7 @@ API for private repositories, see <a href="https://docs.aws.amazon.com/AmazonECR
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-ecr-public
+To install this package, simply type add or install @aws-sdk/client-ecr-public
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-ecr-public`

--- a/clients/client-ecr/README.md
+++ b/clients/client-ecr/README.md
@@ -20,7 +20,7 @@ repositories and images.</p>
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-ecr
+To install this package, simply type add or install @aws-sdk/client-ecr
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-ecr`

--- a/clients/client-ecs/README.md
+++ b/clients/client-ecs/README.md
@@ -24,7 +24,7 @@ systems or worry about scaling your management infrastructure.</p>
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-ecs
+To install this package, simply type add or install @aws-sdk/client-ecs
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-ecs`

--- a/clients/client-efs/README.md
+++ b/clients/client-efs/README.md
@@ -16,7 +16,7 @@ storage they need, when they need it. For more information, see the <a href="htt
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-efs
+To install this package, simply type add or install @aws-sdk/client-efs
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-efs`

--- a/clients/client-eks/README.md
+++ b/clients/client-eks/README.md
@@ -20,7 +20,7 @@ code modification required.</p>
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-eks
+To install this package, simply type add or install @aws-sdk/client-eks
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-eks`

--- a/clients/client-elastic-beanstalk/README.md
+++ b/clients/client-elastic-beanstalk/README.md
@@ -24,7 +24,7 @@ Glossary</i>.</p>
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-elastic-beanstalk
+To install this package, simply type add or install @aws-sdk/client-elastic-beanstalk
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-elastic-beanstalk`

--- a/clients/client-elastic-inference/README.md
+++ b/clients/client-elastic-inference/README.md
@@ -13,7 +13,7 @@ Elastic Inference public APIs.
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-elastic-inference
+To install this package, simply type add or install @aws-sdk/client-elastic-inference
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-elastic-inference`

--- a/clients/client-elastic-load-balancing-v2/README.md
+++ b/clients/client-elastic-load-balancing-v2/README.md
@@ -43,7 +43,7 @@ most one time. If you repeat an operation, it succeeds.</p>
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-elastic-load-balancing-v2
+To install this package, simply type add or install @aws-sdk/client-elastic-load-balancing-v2
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-elastic-load-balancing-v2`

--- a/clients/client-elastic-load-balancing/README.md
+++ b/clients/client-elastic-load-balancing/README.md
@@ -31,7 +31,7 @@ response code.</p>
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-elastic-load-balancing
+To install this package, simply type add or install @aws-sdk/client-elastic-load-balancing
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-elastic-load-balancing`

--- a/clients/client-elastic-transcoder/README.md
+++ b/clients/client-elastic-transcoder/README.md
@@ -13,7 +13,7 @@ AWS SDK for JavaScript ElasticTranscoder Client for Node.js, Browser and React N
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-elastic-transcoder
+To install this package, simply type add or install @aws-sdk/client-elastic-transcoder
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-elastic-transcoder`

--- a/clients/client-elasticache/README.md
+++ b/clients/client-elasticache/README.md
@@ -21,7 +21,7 @@ associated with their cache and can receive alarms if a part of their cache runs
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-elasticache
+To install this package, simply type add or install @aws-sdk/client-elasticache
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-elasticache`

--- a/clients/client-elasticsearch-service/README.md
+++ b/clients/client-elasticsearch-service/README.md
@@ -18,7 +18,7 @@ see <a href="http://docs.aws.amazon.com/general/latest/gr/rande.html#elasticsear
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-elasticsearch-service
+To install this package, simply type add or install @aws-sdk/client-elasticsearch-service
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-elasticsearch-service`

--- a/clients/client-emr-containers/README.md
+++ b/clients/client-emr-containers/README.md
@@ -32,7 +32,7 @@ information, see <a href="https://docs.aws.amazon.com/emr/latest/EMR-on-EKS-Deve
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-emr-containers
+To install this package, simply type add or install @aws-sdk/client-emr-containers
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-emr-containers`

--- a/clients/client-emr/README.md
+++ b/clients/client-emr/README.md
@@ -14,7 +14,7 @@ simulation, and data warehouse management.</p>
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-emr
+To install this package, simply type add or install @aws-sdk/client-emr
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-emr`

--- a/clients/client-eventbridge/README.md
+++ b/clients/client-eventbridge/README.md
@@ -31,7 +31,7 @@ Guide</a>.</p>
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-eventbridge
+To install this package, simply type add or install @aws-sdk/client-eventbridge
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-eventbridge`

--- a/clients/client-finspace-data/README.md
+++ b/clients/client-finspace-data/README.md
@@ -11,7 +11,7 @@ AWS SDK for JavaScript FinspaceData Client for Node.js, Browser and React Native
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-finspace-data
+To install this package, simply type add or install @aws-sdk/client-finspace-data
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-finspace-data`

--- a/clients/client-finspace/README.md
+++ b/clients/client-finspace/README.md
@@ -12,7 +12,7 @@ environments. </p>
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-finspace
+To install this package, simply type add or install @aws-sdk/client-finspace
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-finspace`

--- a/clients/client-firehose/README.md
+++ b/clients/client-firehose/README.md
@@ -15,7 +15,7 @@ Elasticsearch Service (Amazon ES), Amazon Redshift, and Splunk.</p>
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-firehose
+To install this package, simply type add or install @aws-sdk/client-firehose
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-firehose`

--- a/clients/client-fis/README.md
+++ b/clients/client-fis/README.md
@@ -12,7 +12,7 @@ experiments on your AWS workloads. For more information, see the <a href="https:
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-fis
+To install this package, simply type add or install @aws-sdk/client-fis
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-fis`

--- a/clients/client-fms/README.md
+++ b/clients/client-fms/README.md
@@ -17,7 +17,7 @@ types, and errors. For detailed information about Firewall Manager features, see
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-fms
+To install this package, simply type add or install @aws-sdk/client-fms
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-fms`

--- a/clients/client-forecast/README.md
+++ b/clients/client-forecast/README.md
@@ -11,7 +11,7 @@ AWS SDK for JavaScript Forecast Client for Node.js, Browser and React Native.
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-forecast
+To install this package, simply type add or install @aws-sdk/client-forecast
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-forecast`

--- a/clients/client-forecastquery/README.md
+++ b/clients/client-forecastquery/README.md
@@ -11,7 +11,7 @@ AWS SDK for JavaScript Forecastquery Client for Node.js, Browser and React Nativ
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-forecastquery
+To install this package, simply type add or install @aws-sdk/client-forecastquery
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-forecastquery`

--- a/clients/client-frauddetector/README.md
+++ b/clients/client-frauddetector/README.md
@@ -13,7 +13,7 @@ more information about Amazon Fraud Detector features, see the <a href="https://
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-frauddetector
+To install this package, simply type add or install @aws-sdk/client-frauddetector
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-frauddetector`

--- a/clients/client-fsx/README.md
+++ b/clients/client-fsx/README.md
@@ -12,7 +12,7 @@ application administrators to launch and use shared file storage.</p>
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-fsx
+To install this package, simply type add or install @aws-sdk/client-fsx
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-fsx`

--- a/clients/client-gamelift/README.md
+++ b/clients/client-gamelift/README.md
@@ -69,7 +69,7 @@ and resources</a>
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-gamelift
+To install this package, simply type add or install @aws-sdk/client-gamelift
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-gamelift`

--- a/clients/client-glacier/README.md
+++ b/clients/client-glacier/README.md
@@ -48,7 +48,7 @@ retrieving the job output, and deleting archives.</p>
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-glacier
+To install this package, simply type add or install @aws-sdk/client-glacier
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-glacier`

--- a/clients/client-global-accelerator/README.md
+++ b/clients/client-global-accelerator/README.md
@@ -159,7 +159,7 @@ or many EC2 instances.</p>
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-global-accelerator
+To install this package, simply type add or install @aws-sdk/client-global-accelerator
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-global-accelerator`

--- a/clients/client-glue/README.md
+++ b/clients/client-glue/README.md
@@ -13,7 +13,7 @@ AWS SDK for JavaScript Glue Client for Node.js, Browser and React Native.
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-glue
+To install this package, simply type add or install @aws-sdk/client-glue
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-glue`

--- a/clients/client-grafana/README.md
+++ b/clients/client-grafana/README.md
@@ -17,7 +17,7 @@ build, package, or deploy any hardware to run Grafana servers.  </p>
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-grafana
+To install this package, simply type add or install @aws-sdk/client-grafana
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-grafana`

--- a/clients/client-greengrass/README.md
+++ b/clients/client-greengrass/README.md
@@ -11,7 +11,7 @@ AWS IoT Greengrass seamlessly extends AWS onto physical devices so they can act 
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-greengrass
+To install this package, simply type add or install @aws-sdk/client-greengrass
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-greengrass`

--- a/clients/client-greengrassv2/README.md
+++ b/clients/client-greengrassv2/README.md
@@ -21,7 +21,7 @@ the <i>IoT Greengrass V2 Developer Guide</i>.</p>
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-greengrassv2
+To install this package, simply type add or install @aws-sdk/client-greengrassv2
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-greengrassv2`

--- a/clients/client-groundstation/README.md
+++ b/clients/client-groundstation/README.md
@@ -14,7 +14,7 @@ to build or manage your own ground station infrastructure.</p>
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-groundstation
+To install this package, simply type add or install @aws-sdk/client-groundstation
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-groundstation`

--- a/clients/client-guardduty/README.md
+++ b/clients/client-guardduty/README.md
@@ -27,7 +27,7 @@ GuardDuty User Guide</a>
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-guardduty
+To install this package, simply type add or install @aws-sdk/client-guardduty
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-guardduty`

--- a/clients/client-health/README.md
+++ b/clients/client-health/README.md
@@ -60,7 +60,7 @@ organization, you might receive several page results. Specify the
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-health
+To install this package, simply type add or install @aws-sdk/client-health
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-health`

--- a/clients/client-healthlake/README.md
+++ b/clients/client-healthlake/README.md
@@ -12,7 +12,7 @@ transform, query, and analyze their FHIR-formatted data in a consistent fashion 
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-healthlake
+To install this package, simply type add or install @aws-sdk/client-healthlake
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-healthlake`

--- a/clients/client-honeycode/README.md
+++ b/clients/client-honeycode/README.md
@@ -15,7 +15,7 @@ resources, and even your team.
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-honeycode
+To install this package, simply type add or install @aws-sdk/client-honeycode
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-honeycode`

--- a/clients/client-iam/README.md
+++ b/clients/client-iam/README.md
@@ -16,7 +16,7 @@ applications can access. For more information about IAM, see <a href="http://aws
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-iam
+To install this package, simply type add or install @aws-sdk/client-iam
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-iam`

--- a/clients/client-identitystore/README.md
+++ b/clients/client-identitystore/README.md
@@ -13,7 +13,7 @@ Guide</a>.</p>
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-identitystore
+To install this package, simply type add or install @aws-sdk/client-identitystore
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-identitystore`

--- a/clients/client-imagebuilder/README.md
+++ b/clients/client-imagebuilder/README.md
@@ -14,7 +14,7 @@ IT standards.</p>
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-imagebuilder
+To install this package, simply type add or install @aws-sdk/client-imagebuilder
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-imagebuilder`

--- a/clients/client-inspector/README.md
+++ b/clients/client-inspector/README.md
@@ -15,7 +15,7 @@ Guide</a>.</p>
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-inspector
+To install this package, simply type add or install @aws-sdk/client-inspector
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-inspector`

--- a/clients/client-iot-1click-devices-service/README.md
+++ b/clients/client-iot-1click-devices-service/README.md
@@ -13,7 +13,7 @@ protocols.</p>
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-iot-1click-devices-service
+To install this package, simply type add or install @aws-sdk/client-iot-1click-devices-service
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-iot-1click-devices-service`

--- a/clients/client-iot-1click-projects/README.md
+++ b/clients/client-iot-1click-projects/README.md
@@ -11,7 +11,7 @@ AWS SDK for JavaScript IoT1ClickProjects Client for Node.js, Browser and React N
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-iot-1click-projects
+To install this package, simply type add or install @aws-sdk/client-iot-1click-projects
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-iot-1click-projects`

--- a/clients/client-iot-data-plane/README.md
+++ b/clients/client-iot-data-plane/README.md
@@ -22,7 +22,7 @@ to sign requests is: <i>iotdevicegateway</i>.</p>
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-iot-data-plane
+To install this package, simply type add or install @aws-sdk/client-iot-data-plane
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-iot-data-plane`

--- a/clients/client-iot-events-data/README.md
+++ b/clients/client-iot-events-data/README.md
@@ -15,7 +15,7 @@ detectors, list detectors, and view or update a detector's status.</p>
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-iot-events-data
+To install this package, simply type add or install @aws-sdk/client-iot-events-data
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-iot-events-data`

--- a/clients/client-iot-events/README.md
+++ b/clients/client-iot-events/README.md
@@ -13,7 +13,7 @@ update, and delete inputs and detector models, and to list their versions.</p>
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-iot-events
+To install this package, simply type add or install @aws-sdk/client-iot-events
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-iot-events`

--- a/clients/client-iot-jobs-data-plane/README.md
+++ b/clients/client-iot-jobs-data-plane/README.md
@@ -21,7 +21,7 @@ for all the targets of the job</p>
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-iot-jobs-data-plane
+To install this package, simply type add or install @aws-sdk/client-iot-jobs-data-plane
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-iot-jobs-data-plane`

--- a/clients/client-iot-wireless/README.md
+++ b/clients/client-iot-wireless/README.md
@@ -11,7 +11,7 @@ AWS SDK for JavaScript IoTWireless Client for Node.js, Browser and React Native.
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-iot-wireless
+To install this package, simply type add or install @aws-sdk/client-iot-wireless
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-iot-wireless`

--- a/clients/client-iot/README.md
+++ b/clients/client-iot/README.md
@@ -27,7 +27,7 @@ Guide</a>.</p>
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-iot
+To install this package, simply type add or install @aws-sdk/client-iot
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-iot`

--- a/clients/client-iotanalytics/README.md
+++ b/clients/client-iotanalytics/README.md
@@ -29,7 +29,7 @@ are at risk of abandoning their wearable devices.</p>
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-iotanalytics
+To install this package, simply type add or install @aws-sdk/client-iotanalytics
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-iotanalytics`

--- a/clients/client-iotdeviceadvisor/README.md
+++ b/clients/client-iotdeviceadvisor/README.md
@@ -11,7 +11,7 @@ AWS SDK for JavaScript IotDeviceAdvisor Client for Node.js, Browser and React Na
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-iotdeviceadvisor
+To install this package, simply type add or install @aws-sdk/client-iotdeviceadvisor
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-iotdeviceadvisor`

--- a/clients/client-iotfleethub/README.md
+++ b/clients/client-iotfleethub/README.md
@@ -14,7 +14,7 @@ AWS SDK for JavaScript IoTFleetHub Client for Node.js, Browser and React Native.
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-iotfleethub
+To install this package, simply type add or install @aws-sdk/client-iotfleethub
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-iotfleethub`

--- a/clients/client-iotsecuretunneling/README.md
+++ b/clients/client-iotsecuretunneling/README.md
@@ -16,7 +16,7 @@ deployed in the field.</p>
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-iotsecuretunneling
+To install this package, simply type add or install @aws-sdk/client-iotsecuretunneling
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-iotsecuretunneling`

--- a/clients/client-iotsitewise/README.md
+++ b/clients/client-iotsitewise/README.md
@@ -12,7 +12,7 @@ AWS SDK for JavaScript IoTSiteWise Client for Node.js, Browser and React Native.
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-iotsitewise
+To install this package, simply type add or install @aws-sdk/client-iotsitewise
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-iotsitewise`

--- a/clients/client-iotthingsgraph/README.md
+++ b/clients/client-iotthingsgraph/README.md
@@ -16,7 +16,7 @@ and defining how they interact at an abstract level.</p>
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-iotthingsgraph
+To install this package, simply type add or install @aws-sdk/client-iotthingsgraph
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-iotthingsgraph`

--- a/clients/client-ivs/README.md
+++ b/clients/client-ivs/README.md
@@ -366,7 +366,7 @@ specified ARN.</p>
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-ivs
+To install this package, simply type add or install @aws-sdk/client-ivs
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-ivs`

--- a/clients/client-kafka/README.md
+++ b/clients/client-kafka/README.md
@@ -11,7 +11,7 @@ AWS SDK for JavaScript Kafka Client for Node.js, Browser and React Native.
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-kafka
+To install this package, simply type add or install @aws-sdk/client-kafka
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-kafka`

--- a/clients/client-kafkaconnect/README.md
+++ b/clients/client-kafkaconnect/README.md
@@ -11,7 +11,7 @@ AWS SDK for JavaScript KafkaConnect Client for Node.js, Browser and React Native
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-kafkaconnect
+To install this package, simply type add or install @aws-sdk/client-kafkaconnect
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-kafkaconnect`

--- a/clients/client-kendra/README.md
+++ b/clients/client-kendra/README.md
@@ -11,7 +11,7 @@ AWS SDK for JavaScript Kendra Client for Node.js, Browser and React Native.
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-kendra
+To install this package, simply type add or install @aws-sdk/client-kendra
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-kendra`

--- a/clients/client-kinesis-analytics-v2/README.md
+++ b/clients/client-kinesis-analytics-v2/README.md
@@ -13,7 +13,7 @@ series analytics, feed real-time dashboards, and create real-time metrics.</p>
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-kinesis-analytics-v2
+To install this package, simply type add or install @aws-sdk/client-kinesis-analytics-v2
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-kinesis-analytics-v2`

--- a/clients/client-kinesis-analytics/README.md
+++ b/clients/client-kinesis-analytics/README.md
@@ -21,7 +21,7 @@ The Amazon Kinesis Analytics Developer Guide provides additional information.
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-kinesis-analytics
+To install this package, simply type add or install @aws-sdk/client-kinesis-analytics
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-kinesis-analytics`

--- a/clients/client-kinesis-video-archived-media/README.md
+++ b/clients/client-kinesis-video-archived-media/README.md
@@ -11,7 +11,7 @@ AWS SDK for JavaScript KinesisVideoArchivedMedia Client for Node.js, Browser and
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-kinesis-video-archived-media
+To install this package, simply type add or install @aws-sdk/client-kinesis-video-archived-media
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-kinesis-video-archived-media`

--- a/clients/client-kinesis-video-media/README.md
+++ b/clients/client-kinesis-video-media/README.md
@@ -11,7 +11,7 @@ AWS SDK for JavaScript KinesisVideoMedia Client for Node.js, Browser and React N
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-kinesis-video-media
+To install this package, simply type add or install @aws-sdk/client-kinesis-video-media
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-kinesis-video-media`

--- a/clients/client-kinesis-video-signaling/README.md
+++ b/clients/client-kinesis-video-signaling/README.md
@@ -13,7 +13,7 @@ establish peer-to-peer connection in webRTC technology.</p>
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-kinesis-video-signaling
+To install this package, simply type add or install @aws-sdk/client-kinesis-video-signaling
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-kinesis-video-signaling`

--- a/clients/client-kinesis-video/README.md
+++ b/clients/client-kinesis-video/README.md
@@ -11,7 +11,7 @@ AWS SDK for JavaScript KinesisVideo Client for Node.js, Browser and React Native
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-kinesis-video
+To install this package, simply type add or install @aws-sdk/client-kinesis-video
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-kinesis-video`

--- a/clients/client-kinesis/README.md
+++ b/clients/client-kinesis/README.md
@@ -14,7 +14,7 @@ real-time processing of streaming big data.</p>
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-kinesis
+To install this package, simply type add or install @aws-sdk/client-kinesis
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-kinesis`

--- a/clients/client-kms/README.md
+++ b/clients/client-kms/README.md
@@ -101,7 +101,7 @@ keys and assigning policies, by using the console.</p>
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-kms
+To install this package, simply type add or install @aws-sdk/client-kms
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-kms`

--- a/clients/client-lakeformation/README.md
+++ b/clients/client-lakeformation/README.md
@@ -13,7 +13,7 @@ AWS SDK for JavaScript LakeFormation Client for Node.js, Browser and React Nativ
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-lakeformation
+To install this package, simply type add or install @aws-sdk/client-lakeformation
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-lakeformation`

--- a/clients/client-lambda/README.md
+++ b/clients/client-lambda/README.md
@@ -18,7 +18,7 @@ Lambda</a>, and for information about how the service works, see <a href="https:
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-lambda
+To install this package, simply type add or install @aws-sdk/client-lambda
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-lambda`

--- a/clients/client-lex-model-building-service/README.md
+++ b/clients/client-lex-model-building-service/README.md
@@ -15,7 +15,7 @@ bots for new and existing client applications. </p>
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-lex-model-building-service
+To install this package, simply type add or install @aws-sdk/client-lex-model-building-service
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-lex-model-building-service`

--- a/clients/client-lex-models-v2/README.md
+++ b/clients/client-lex-models-v2/README.md
@@ -11,7 +11,7 @@ AWS SDK for JavaScript LexModelsV2 Client for Node.js, Browser and React Native.
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-lex-models-v2
+To install this package, simply type add or install @aws-sdk/client-lex-models-v2
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-lex-models-v2`

--- a/clients/client-lex-runtime-service/README.md
+++ b/clients/client-lex-runtime-service/README.md
@@ -22,7 +22,7 @@ API, . </p>
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-lex-runtime-service
+To install this package, simply type add or install @aws-sdk/client-lex-runtime-service
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-lex-runtime-service`

--- a/clients/client-lex-runtime-v2/README.md
+++ b/clients/client-lex-runtime-v2/README.md
@@ -11,7 +11,7 @@ AWS SDK for JavaScript LexRuntimeV2 Client for Node.js, Browser and React Native
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-lex-runtime-v2
+To install this package, simply type add or install @aws-sdk/client-lex-runtime-v2
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-lex-runtime-v2`

--- a/clients/client-license-manager/README.md
+++ b/clients/client-license-manager/README.md
@@ -12,7 +12,7 @@ Amazon Web Services accounts and on-premises servers.</p>
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-license-manager
+To install this package, simply type add or install @aws-sdk/client-license-manager
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-license-manager`

--- a/clients/client-lightsail/README.md
+++ b/clients/client-lightsail/README.md
@@ -25,7 +25,7 @@ Quotas</a> in the <i>AWS General Reference</i>.</p>
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-lightsail
+To install this package, simply type add or install @aws-sdk/client-lightsail
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-lightsail`

--- a/clients/client-location/README.md
+++ b/clients/client-location/README.md
@@ -11,7 +11,7 @@ Suite of geospatial services including Maps, Places, Routes, Tracking, and Geofe
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-location
+To install this package, simply type add or install @aws-sdk/client-location
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-location`

--- a/clients/client-lookoutequipment/README.md
+++ b/clients/client-lookoutequipment/README.md
@@ -12,7 +12,7 @@ anomalies in machines from sensor data for use in predictive maintenance. </p>
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-lookoutequipment
+To install this package, simply type add or install @aws-sdk/client-lookoutequipment
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-lookoutequipment`

--- a/clients/client-lookoutmetrics/README.md
+++ b/clients/client-lookoutmetrics/README.md
@@ -13,7 +13,7 @@ Lookout for Metrics Developer Guide</a>.</p>
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-lookoutmetrics
+To install this package, simply type add or install @aws-sdk/client-lookoutmetrics
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-lookoutmetrics`

--- a/clients/client-lookoutvision/README.md
+++ b/clients/client-lookoutvision/README.md
@@ -17,7 +17,7 @@ on printed circuit boards.</p>
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-lookoutvision
+To install this package, simply type add or install @aws-sdk/client-lookoutvision
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-lookoutvision`

--- a/clients/client-machine-learning/README.md
+++ b/clients/client-machine-learning/README.md
@@ -12,7 +12,7 @@ exposed by Amazon Machine Learning
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-machine-learning
+To install this package, simply type add or install @aws-sdk/client-machine-learning
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-machine-learning`

--- a/clients/client-macie/README.md
+++ b/clients/client-macie/README.md
@@ -18,7 +18,7 @@ Classic User Guide</a>. </p>
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-macie
+To install this package, simply type add or install @aws-sdk/client-macie
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-macie`

--- a/clients/client-macie2/README.md
+++ b/clients/client-macie2/README.md
@@ -11,7 +11,7 @@ AWS SDK for JavaScript Macie2 Client for Node.js, Browser and React Native.
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-macie2
+To install this package, simply type add or install @aws-sdk/client-macie2
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-macie2`

--- a/clients/client-managedblockchain/README.md
+++ b/clients/client-managedblockchain/README.md
@@ -14,7 +14,7 @@ AWS SDK for JavaScript ManagedBlockchain Client for Node.js, Browser and React N
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-managedblockchain
+To install this package, simply type add or install @aws-sdk/client-managedblockchain
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-managedblockchain`

--- a/clients/client-marketplace-catalog/README.md
+++ b/clients/client-marketplace-catalog/README.md
@@ -17,7 +17,7 @@ Marketplace.</p>
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-marketplace-catalog
+To install this package, simply type add or install @aws-sdk/client-marketplace-catalog
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-marketplace-catalog`

--- a/clients/client-marketplace-commerce-analytics/README.md
+++ b/clients/client-marketplace-commerce-analytics/README.md
@@ -11,7 +11,7 @@ Provides AWS Marketplace business intelligence data on-demand.
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-marketplace-commerce-analytics
+To install this package, simply type add or install @aws-sdk/client-marketplace-commerce-analytics
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-marketplace-commerce-analytics`

--- a/clients/client-marketplace-entitlement-service/README.md
+++ b/clients/client-marketplace-entitlement-service/README.md
@@ -28,7 +28,7 @@ product.</p>
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-marketplace-entitlement-service
+To install this package, simply type add or install @aws-sdk/client-marketplace-entitlement-service
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-marketplace-entitlement-service`

--- a/clients/client-marketplace-metering/README.md
+++ b/clients/client-marketplace-metering/README.md
@@ -68,7 +68,7 @@ records over time. For more information, see the <i>
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-marketplace-metering
+To install this package, simply type add or install @aws-sdk/client-marketplace-metering
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-marketplace-metering`

--- a/clients/client-mediaconnect/README.md
+++ b/clients/client-mediaconnect/README.md
@@ -11,7 +11,7 @@ API for AWS Elemental MediaConnect
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-mediaconnect
+To install this package, simply type add or install @aws-sdk/client-mediaconnect
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-mediaconnect`

--- a/clients/client-mediaconvert/README.md
+++ b/clients/client-mediaconvert/README.md
@@ -11,7 +11,7 @@ AWS Elemental MediaConvert
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-mediaconvert
+To install this package, simply type add or install @aws-sdk/client-mediaconvert
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-mediaconvert`

--- a/clients/client-medialive/README.md
+++ b/clients/client-medialive/README.md
@@ -11,7 +11,7 @@ API for AWS Elemental MediaLive
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-medialive
+To install this package, simply type add or install @aws-sdk/client-medialive
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-medialive`

--- a/clients/client-mediapackage-vod/README.md
+++ b/clients/client-mediapackage-vod/README.md
@@ -11,7 +11,7 @@ AWS Elemental MediaPackage VOD
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-mediapackage-vod
+To install this package, simply type add or install @aws-sdk/client-mediapackage-vod
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-mediapackage-vod`

--- a/clients/client-mediapackage/README.md
+++ b/clients/client-mediapackage/README.md
@@ -11,7 +11,7 @@ AWS Elemental MediaPackage
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-mediapackage
+To install this package, simply type add or install @aws-sdk/client-mediapackage
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-mediapackage`

--- a/clients/client-mediastore-data/README.md
+++ b/clients/client-mediastore-data/README.md
@@ -13,7 +13,7 @@ MediaStore.</p>
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-mediastore-data
+To install this package, simply type add or install @aws-sdk/client-mediastore-data
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-mediastore-data`

--- a/clients/client-mediastore/README.md
+++ b/clients/client-mediastore/README.md
@@ -12,7 +12,7 @@ You use a container endpoint to create, read, and delete objects. </p>
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-mediastore
+To install this package, simply type add or install @aws-sdk/client-mediastore
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-mediastore`

--- a/clients/client-mediatailor/README.md
+++ b/clients/client-mediatailor/README.md
@@ -11,7 +11,7 @@ AWS SDK for JavaScript MediaTailor Client for Node.js, Browser and React Native.
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-mediatailor
+To install this package, simply type add or install @aws-sdk/client-mediatailor
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-mediatailor`

--- a/clients/client-memorydb/README.md
+++ b/clients/client-memorydb/README.md
@@ -13,7 +13,7 @@ MemoryDB stores the entire database in-memory, enabling low latency and high thr
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-memorydb
+To install this package, simply type add or install @aws-sdk/client-memorydb
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-memorydb`

--- a/clients/client-mgn/README.md
+++ b/clients/client-mgn/README.md
@@ -11,7 +11,7 @@ AWS SDK for JavaScript Mgn Client for Node.js, Browser and React Native.
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-mgn
+To install this package, simply type add or install @aws-sdk/client-mgn
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-mgn`

--- a/clients/client-migration-hub/README.md
+++ b/clients/client-migration-hub/README.md
@@ -16,7 +16,7 @@ must make the API calls while in your home region.</p>
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-migration-hub
+To install this package, simply type add or install @aws-sdk/client-migration-hub
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-migration-hub`

--- a/clients/client-migrationhub-config/README.md
+++ b/clients/client-migrationhub-config/README.md
@@ -36,7 +36,7 @@ API reference. </p>
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-migrationhub-config
+To install this package, simply type add or install @aws-sdk/client-migrationhub-config
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-migrationhub-config`

--- a/clients/client-mobile/README.md
+++ b/clients/client-mobile/README.md
@@ -15,7 +15,7 @@ with the necessary SDKs, constants, tools and samples to make use of those resou
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-mobile
+To install this package, simply type add or install @aws-sdk/client-mobile
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-mobile`

--- a/clients/client-mq/README.md
+++ b/clients/client-mq/README.md
@@ -11,7 +11,7 @@ AWS SDK for JavaScript Mq Client for Node.js, Browser and React Native.
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-mq
+To install this package, simply type add or install @aws-sdk/client-mq
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-mq`

--- a/clients/client-mturk/README.md
+++ b/clients/client-mturk/README.md
@@ -11,7 +11,7 @@ AWS SDK for JavaScript MTurk Client for Node.js, Browser and React Native.
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-mturk
+To install this package, simply type add or install @aws-sdk/client-mturk
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-mturk`

--- a/clients/client-mwaa/README.md
+++ b/clients/client-mwaa/README.md
@@ -13,7 +13,7 @@ AWS SDK for JavaScript MWAA Client for Node.js, Browser and React Native.
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-mwaa
+To install this package, simply type add or install @aws-sdk/client-mwaa
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-mwaa`

--- a/clients/client-neptune/README.md
+++ b/clients/client-neptune/README.md
@@ -29,7 +29,7 @@ following some related topics from the user guide.</p>
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-neptune
+To install this package, simply type add or install @aws-sdk/client-neptune
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-neptune`

--- a/clients/client-network-firewall/README.md
+++ b/clients/client-network-firewall/README.md
@@ -88,7 +88,7 @@ endpoints.</p>
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-network-firewall
+To install this package, simply type add or install @aws-sdk/client-network-firewall
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-network-firewall`

--- a/clients/client-networkmanager/README.md
+++ b/clients/client-networkmanager/README.md
@@ -13,7 +13,7 @@ AWS and on-premises networks that are built around transit gateways.</p>
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-networkmanager
+To install this package, simply type add or install @aws-sdk/client-networkmanager
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-networkmanager`

--- a/clients/client-nimble/README.md
+++ b/clients/client-nimble/README.md
@@ -9,7 +9,7 @@ AWS SDK for JavaScript Nimble Client for Node.js, Browser and React Native.
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-nimble
+To install this package, simply type add or install @aws-sdk/client-nimble
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-nimble`

--- a/clients/client-opensearch/README.md
+++ b/clients/client-opensearch/README.md
@@ -23,7 +23,7 @@ see <a href="http://docs.aws.amazon.com/general/latest/gr/rande.html#service-reg
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-opensearch
+To install this package, simply type add or install @aws-sdk/client-opensearch
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-opensearch`

--- a/clients/client-opsworks/README.md
+++ b/clients/client-opsworks/README.md
@@ -126,7 +126,7 @@ see <a href="https://docs.aws.amazon.com/opsworks/latest/userguide/workingcookbo
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-opsworks
+To install this package, simply type add or install @aws-sdk/client-opsworks
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-opsworks`

--- a/clients/client-opsworkscm/README.md
+++ b/clients/client-opsworkscm/README.md
@@ -99,7 +99,7 @@ can only be accessed or managed within the endpoint in which they are created.</
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-opsworkscm
+To install this package, simply type add or install @aws-sdk/client-opsworkscm
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-opsworkscm`

--- a/clients/client-organizations/README.md
+++ b/clients/client-organizations/README.md
@@ -81,7 +81,7 @@ To learn more about AWS CloudTrail, including how to turn it on and find your lo
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-organizations
+To install this package, simply type add or install @aws-sdk/client-organizations
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-organizations`

--- a/clients/client-outposts/README.md
+++ b/clients/client-outposts/README.md
@@ -15,7 +15,7 @@ latency and local data processing needs.</p>
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-outposts
+To install this package, simply type add or install @aws-sdk/client-outposts
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-outposts`

--- a/clients/client-personalize-events/README.md
+++ b/clients/client-personalize-events/README.md
@@ -13,7 +13,7 @@ it for model training either alone or combined with historical data. For more in
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-personalize-events
+To install this package, simply type add or install @aws-sdk/client-personalize-events
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-personalize-events`

--- a/clients/client-personalize-runtime/README.md
+++ b/clients/client-personalize-runtime/README.md
@@ -11,7 +11,7 @@ AWS SDK for JavaScript PersonalizeRuntime Client for Node.js, Browser and React 
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-personalize-runtime
+To install this package, simply type add or install @aws-sdk/client-personalize-runtime
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-personalize-runtime`

--- a/clients/client-personalize/README.md
+++ b/clients/client-personalize/README.md
@@ -12,7 +12,7 @@ recommendations to customers.</p>
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-personalize
+To install this package, simply type add or install @aws-sdk/client-personalize
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-personalize`

--- a/clients/client-pi/README.md
+++ b/clients/client-pi/README.md
@@ -32,7 +32,7 @@ SQL, Wait event, User, and Host.</p>
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-pi
+To install this package, simply type add or install @aws-sdk/client-pi
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-pi`

--- a/clients/client-pinpoint-email/README.md
+++ b/clients/client-pinpoint-email/README.md
@@ -40,7 +40,7 @@ available in each Region, see <a href="http://aws.amazon.com/about-aws/global-in
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-pinpoint-email
+To install this package, simply type add or install @aws-sdk/client-pinpoint-email
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-pinpoint-email`

--- a/clients/client-pinpoint-sms-voice/README.md
+++ b/clients/client-pinpoint-sms-voice/README.md
@@ -11,7 +11,7 @@ Pinpoint SMS and Voice Messaging public facing APIs
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-pinpoint-sms-voice
+To install this package, simply type add or install @aws-sdk/client-pinpoint-sms-voice
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-pinpoint-sms-voice`

--- a/clients/client-pinpoint/README.md
+++ b/clients/client-pinpoint/README.md
@@ -11,7 +11,7 @@ AWS SDK for JavaScript Pinpoint Client for Node.js, Browser and React Native.
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-pinpoint
+To install this package, simply type add or install @aws-sdk/client-pinpoint
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-pinpoint`

--- a/clients/client-polly/README.md
+++ b/clients/client-polly/README.md
@@ -16,7 +16,7 @@ the best results for your application domain.</p>
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-polly
+To install this package, simply type add or install @aws-sdk/client-polly
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-polly`

--- a/clients/client-pricing/README.md
+++ b/clients/client-pricing/README.md
@@ -34,7 +34,7 @@ an <code>AmazonEC2</code> instance, with a <code>Provisioned IOPS</code>
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-pricing
+To install this package, simply type add or install @aws-sdk/client-pricing
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-pricing`

--- a/clients/client-proton/README.md
+++ b/clients/client-proton/README.md
@@ -131,7 +131,7 @@ succeeds without performing any further actions other than returning the origina
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-proton
+To install this package, simply type add or install @aws-sdk/client-proton
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-proton`

--- a/clients/client-qldb-session/README.md
+++ b/clients/client-qldb-session/README.md
@@ -31,7 +31,7 @@ QLDB shell</a>.</p>
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-qldb-session
+To install this package, simply type add or install @aws-sdk/client-qldb-session
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-qldb-session`

--- a/clients/client-qldb/README.md
+++ b/clients/client-qldb/README.md
@@ -11,7 +11,7 @@ AWS SDK for JavaScript QLDB Client for Node.js, Browser and React Native.
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-qldb
+To install this package, simply type add or install @aws-sdk/client-qldb
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-qldb`

--- a/clients/client-quicksight/README.md
+++ b/clients/client-quicksight/README.md
@@ -16,7 +16,7 @@ you can use to manage Amazon QuickSight. </p>
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-quicksight
+To install this package, simply type add or install @aws-sdk/client-quicksight
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-quicksight`

--- a/clients/client-ram/README.md
+++ b/clients/client-ram/README.md
@@ -33,7 +33,7 @@ Guide</a>
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-ram
+To install this package, simply type add or install @aws-sdk/client-ram
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-ram`

--- a/clients/client-rds-data/README.md
+++ b/clients/client-rds-data/README.md
@@ -17,7 +17,7 @@ Serverless</a> in the <i>Amazon Aurora User Guide</i>.</p>
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-rds-data
+To install this package, simply type add or install @aws-sdk/client-rds-data
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-rds-data`

--- a/clients/client-rds/README.md
+++ b/clients/client-rds/README.md
@@ -68,7 +68,7 @@ from the user guide.</p>
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-rds
+To install this package, simply type add or install @aws-sdk/client-rds
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-rds`

--- a/clients/client-redshift-data/README.md
+++ b/clients/client-redshift-data/README.md
@@ -15,7 +15,7 @@ can run SQL statements, which are committed if the statement succeeds. </p>
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-redshift-data
+To install this package, simply type add or install @aws-sdk/client-redshift-data
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-redshift-data`

--- a/clients/client-redshift/README.md
+++ b/clients/client-redshift/README.md
@@ -33,7 +33,7 @@ build, query, and maintain the databases that make up your data warehouse. </p>
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-redshift
+To install this package, simply type add or install @aws-sdk/client-redshift
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-redshift`

--- a/clients/client-rekognition/README.md
+++ b/clients/client-rekognition/README.md
@@ -11,7 +11,7 @@ AWS SDK for JavaScript Rekognition Client for Node.js, Browser and React Native.
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-rekognition
+To install this package, simply type add or install @aws-sdk/client-rekognition
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-rekognition`

--- a/clients/client-resource-groups-tagging-api/README.md
+++ b/clients/client-resource-groups-tagging-api/README.md
@@ -11,7 +11,7 @@ AWS SDK for JavaScript ResourceGroupsTaggingAPI Client for Node.js, Browser and 
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-resource-groups-tagging-api
+To install this package, simply type add or install @aws-sdk/client-resource-groups-tagging-api
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-resource-groups-tagging-api`

--- a/clients/client-resource-groups/README.md
+++ b/clients/client-resource-groups/README.md
@@ -46,7 +46,7 @@ results</p>
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-resource-groups
+To install this package, simply type add or install @aws-sdk/client-resource-groups
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-resource-groups`

--- a/clients/client-robomaker/README.md
+++ b/clients/client-robomaker/README.md
@@ -11,7 +11,7 @@ AWS SDK for JavaScript RoboMaker Client for Node.js, Browser and React Native.
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-robomaker
+To install this package, simply type add or install @aws-sdk/client-robomaker
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-robomaker`

--- a/clients/client-route-53-domains/README.md
+++ b/clients/client-route-53-domains/README.md
@@ -11,7 +11,7 @@ AWS SDK for JavaScript Route53Domains Client for Node.js, Browser and React Nati
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-route-53-domains
+To install this package, simply type add or install @aws-sdk/client-route-53-domains
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-route-53-domains`

--- a/clients/client-route-53/README.md
+++ b/clients/client-route-53/README.md
@@ -11,7 +11,7 @@ AWS SDK for JavaScript Route53 Client for Node.js, Browser and React Native.
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-route-53
+To install this package, simply type add or install @aws-sdk/client-route-53
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-route-53`

--- a/clients/client-route53-recovery-cluster/README.md
+++ b/clients/client-route53-recovery-cluster/README.md
@@ -32,7 +32,7 @@ see the <a href="r53recovery/latest/dg/">Amazon Route 53 Application Recovery Co
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-route53-recovery-cluster
+To install this package, simply type add or install @aws-sdk/client-route53-recovery-cluster
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-route53-recovery-cluster`

--- a/clients/client-route53-recovery-control-config/README.md
+++ b/clients/client-route53-recovery-control-config/README.md
@@ -11,7 +11,7 @@ AWS SDK for JavaScript Route53RecoveryControlConfig Client for Node.js, Browser 
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-route53-recovery-control-config
+To install this package, simply type add or install @aws-sdk/client-route53-recovery-control-config
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-route53-recovery-control-config`

--- a/clients/client-route53-recovery-readiness/README.md
+++ b/clients/client-route53-recovery-readiness/README.md
@@ -11,7 +11,7 @@ AWS Route53 Recovery Readiness
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-route53-recovery-readiness
+To install this package, simply type add or install @aws-sdk/client-route53-recovery-readiness
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-route53-recovery-readiness`

--- a/clients/client-route53resolver/README.md
+++ b/clients/client-route53resolver/README.md
@@ -43,7 +43,7 @@ network to your VPCs (inbound queries), or both.</p>
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-route53resolver
+To install this package, simply type add or install @aws-sdk/client-route53resolver
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-route53resolver`

--- a/clients/client-s3-control/README.md
+++ b/clients/client-s3-control/README.md
@@ -14,7 +14,7 @@ Amazon Web Services S3 Control provides access to Amazon S3 control plane action
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-s3-control
+To install this package, simply type add or install @aws-sdk/client-s3-control
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-s3-control`

--- a/clients/client-s3/README.md
+++ b/clients/client-s3/README.md
@@ -11,7 +11,7 @@ AWS SDK for JavaScript S3 Client for Node.js, Browser and React Native.
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-s3
+To install this package, simply type add or install @aws-sdk/client-s3
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-s3`

--- a/clients/client-s3outposts/README.md
+++ b/clients/client-s3outposts/README.md
@@ -11,7 +11,7 @@ AWS SDK for JavaScript S3Outposts Client for Node.js, Browser and React Native.
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-s3outposts
+To install this package, simply type add or install @aws-sdk/client-s3outposts
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-s3outposts`

--- a/clients/client-sagemaker-a2i-runtime/README.md
+++ b/clients/client-sagemaker-a2i-runtime/README.md
@@ -36,7 +36,7 @@ Amazon A2I</a> in the Amazon SageMaker Developer Guide.</p>
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-sagemaker-a2i-runtime
+To install this package, simply type add or install @aws-sdk/client-sagemaker-a2i-runtime
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-sagemaker-a2i-runtime`

--- a/clients/client-sagemaker-edge/README.md
+++ b/clients/client-sagemaker-edge/README.md
@@ -11,7 +11,7 @@ AWS SDK for JavaScript SagemakerEdge Client for Node.js, Browser and React Nativ
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-sagemaker-edge
+To install this package, simply type add or install @aws-sdk/client-sagemaker-edge
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-sagemaker-edge`

--- a/clients/client-sagemaker-featurestore-runtime/README.md
+++ b/clients/client-sagemaker-featurestore-runtime/README.md
@@ -37,7 +37,7 @@ store.</p>
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-sagemaker-featurestore-runtime
+To install this package, simply type add or install @aws-sdk/client-sagemaker-featurestore-runtime
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-sagemaker-featurestore-runtime`

--- a/clients/client-sagemaker-runtime/README.md
+++ b/clients/client-sagemaker-runtime/README.md
@@ -11,7 +11,7 @@ AWS SDK for JavaScript SageMakerRuntime Client for Node.js, Browser and React Na
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-sagemaker-runtime
+To install this package, simply type add or install @aws-sdk/client-sagemaker-runtime
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-sagemaker-runtime`

--- a/clients/client-sagemaker/README.md
+++ b/clients/client-sagemaker/README.md
@@ -26,7 +26,7 @@ Runtime API Reference</a>
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-sagemaker
+To install this package, simply type add or install @aws-sdk/client-sagemaker
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-sagemaker`

--- a/clients/client-savingsplans/README.md
+++ b/clients/client-savingsplans/README.md
@@ -14,7 +14,7 @@ more information, see the <a href="https://docs.aws.amazon.com/savingsplans/late
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-savingsplans
+To install this package, simply type add or install @aws-sdk/client-savingsplans
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-savingsplans`

--- a/clients/client-schemas/README.md
+++ b/clients/client-schemas/README.md
@@ -11,7 +11,7 @@ AWS SDK for JavaScript Schemas Client for Node.js, Browser and React Native.
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-schemas
+To install this package, simply type add or install @aws-sdk/client-schemas
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-schemas`

--- a/clients/client-secrets-manager/README.md
+++ b/clients/client-secrets-manager/README.md
@@ -67,7 +67,7 @@ To learn more about CloudTrail, including enabling it and find your log files, s
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-secrets-manager
+To install this package, simply type add or install @aws-sdk/client-secrets-manager
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-secrets-manager`

--- a/clients/client-securityhub/README.md
+++ b/clients/client-securityhub/README.md
@@ -53,7 +53,7 @@ second. <code>BurstLimit</code> of 5 requests per second.</p>
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-securityhub
+To install this package, simply type add or install @aws-sdk/client-securityhub
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-securityhub`

--- a/clients/client-serverlessapplicationrepository/README.md
+++ b/clients/client-serverlessapplicationrepository/README.md
@@ -30,7 +30,7 @@ developers, and publish new versions of applications. </p>
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-serverlessapplicationrepository
+To install this package, simply type add or install @aws-sdk/client-serverlessapplicationrepository
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-serverlessapplicationrepository`

--- a/clients/client-service-catalog-appregistry/README.md
+++ b/clients/client-service-catalog-appregistry/README.md
@@ -11,7 +11,7 @@ AWS SDK for JavaScript ServiceCatalogAppRegistry Client for Node.js, Browser and
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-service-catalog-appregistry
+To install this package, simply type add or install @aws-sdk/client-service-catalog-appregistry
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-service-catalog-appregistry`

--- a/clients/client-service-catalog/README.md
+++ b/clients/client-service-catalog/README.md
@@ -18,7 +18,7 @@ Concepts</a>.</p>
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-service-catalog
+To install this package, simply type add or install @aws-sdk/client-service-catalog
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-service-catalog`

--- a/clients/client-service-quotas/README.md
+++ b/clients/client-service-quotas/README.md
@@ -13,7 +13,7 @@ create in your AWS account. For more information, see the <a href="https://docs.
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-service-quotas
+To install this package, simply type add or install @aws-sdk/client-service-quotas
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-service-quotas`

--- a/clients/client-servicediscovery/README.md
+++ b/clients/client-servicediscovery/README.md
@@ -17,7 +17,7 @@ that contains up to eight healthy records. </p>
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-servicediscovery
+To install this package, simply type add or install @aws-sdk/client-servicediscovery
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-servicediscovery`

--- a/clients/client-ses/README.md
+++ b/clients/client-ses/README.md
@@ -20,7 +20,7 @@ Guide</a>.</p>
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-ses
+To install this package, simply type add or install @aws-sdk/client-ses
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-ses`

--- a/clients/client-sesv2/README.md
+++ b/clients/client-sesv2/README.md
@@ -18,7 +18,7 @@ and code samples that demonstrate how to use Amazon SES API v2 features programm
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-sesv2
+To install this package, simply type add or install @aws-sdk/client-sesv2
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-sesv2`

--- a/clients/client-sfn/README.md
+++ b/clients/client-sfn/README.md
@@ -27,7 +27,7 @@ For more information about Step Functions, see the <i>
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-sfn
+To install this package, simply type add or install @aws-sdk/client-sfn
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-sfn`

--- a/clients/client-shield/README.md
+++ b/clients/client-shield/README.md
@@ -15,7 +15,7 @@ data types, and errors. For detailed information about WAF and Shield Advanced f
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-shield
+To install this package, simply type add or install @aws-sdk/client-shield
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-shield`

--- a/clients/client-signer/README.md
+++ b/clients/client-signer/README.md
@@ -27,7 +27,7 @@ sign updates in Amazon FreeRTOS and AWS IoT Device Management. </p>
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-signer
+To install this package, simply type add or install @aws-sdk/client-signer
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-signer`

--- a/clients/client-sms/README.md
+++ b/clients/client-sms/README.md
@@ -28,7 +28,7 @@ product page</a>
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-sms
+To install this package, simply type add or install @aws-sdk/client-sms
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-sms`

--- a/clients/client-snow-device-management/README.md
+++ b/clients/client-snow-device-management/README.md
@@ -11,7 +11,7 @@ AWS SDK for JavaScript SnowDeviceManagement Client for Node.js, Browser and Reac
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-snow-device-management
+To install this package, simply type add or install @aws-sdk/client-snow-device-management
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-snow-device-management`

--- a/clients/client-snowball/README.md
+++ b/clients/client-snowball/README.md
@@ -17,7 +17,7 @@ information, see the <a href="https://docs.aws.amazon.com/AWSImportExport/latest
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-snowball
+To install this package, simply type add or install @aws-sdk/client-snowball
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-snowball`

--- a/clients/client-sns/README.md
+++ b/clients/client-sns/README.md
@@ -24,7 +24,7 @@ responses. For a list of available SDKs, go to <a href="http://aws.amazon.com/to
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-sns
+To install this package, simply type add or install @aws-sdk/client-sns
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-sns`

--- a/clients/client-sqs/README.md
+++ b/clients/client-sqs/README.md
@@ -79,7 +79,7 @@ access management</a> in the <i>Amazon SQS Developer Guide.</i>
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-sqs
+To install this package, simply type add or install @aws-sdk/client-sqs
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-sqs`

--- a/clients/client-ssm-contacts/README.md
+++ b/clients/client-ssm-contacts/README.md
@@ -18,7 +18,7 @@ and enables responder team escalation. </p>
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-ssm-contacts
+To install this package, simply type add or install @aws-sdk/client-ssm-contacts
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-ssm-contacts`

--- a/clients/client-ssm-incidents/README.md
+++ b/clients/client-ssm-incidents/README.md
@@ -18,7 +18,7 @@ escalation. </p>
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-ssm-incidents
+To install this package, simply type add or install @aws-sdk/client-ssm-incidents
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-ssm-incidents`

--- a/clients/client-ssm/README.md
+++ b/clients/client-ssm/README.md
@@ -42,7 +42,7 @@ Reference</a>.</p>
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-ssm
+To install this package, simply type add or install @aws-sdk/client-ssm
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-ssm`

--- a/clients/client-sso-admin/README.md
+++ b/clients/client-sso-admin/README.md
@@ -18,7 +18,7 @@ Reference</a>.</p>
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-sso-admin
+To install this package, simply type add or install @aws-sdk/client-sso-admin
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-sso-admin`

--- a/clients/client-sso-oidc/README.md
+++ b/clients/client-sso-oidc/README.md
@@ -28,7 +28,7 @@ information about the AWS SDKs, including how to download and install them, see 
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-sso-oidc
+To install this package, simply type add or install @aws-sdk/client-sso-oidc
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-sso-oidc`

--- a/clients/client-sso/README.md
+++ b/clients/client-sso/README.md
@@ -26,7 +26,7 @@ information about the AWS SDKs, including how to download and install them, see 
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-sso
+To install this package, simply type add or install @aws-sdk/client-sso
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-sso`

--- a/clients/client-storage-gateway/README.md
+++ b/clients/client-storage-gateway/README.md
@@ -82,7 +82,7 @@ Heads-up – Longer Storage Gateway volume and snapshot IDs coming in
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-storage-gateway
+To install this package, simply type add or install @aws-sdk/client-storage-gateway
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-storage-gateway`

--- a/clients/client-sts/README.md
+++ b/clients/client-sts/README.md
@@ -16,7 +16,7 @@ more information about using this service, see <a href="https://docs.aws.amazon.
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-sts
+To install this package, simply type add or install @aws-sdk/client-sts
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-sts`

--- a/clients/client-support/README.md
+++ b/clients/client-support/README.md
@@ -85,7 +85,7 @@ how to call Trusted Advisor for results of checks on your resources.</p>
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-support
+To install this package, simply type add or install @aws-sdk/client-support
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-support`

--- a/clients/client-swf/README.md
+++ b/clients/client-swf/README.md
@@ -26,7 +26,7 @@ programming model, see the <i>
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-swf
+To install this package, simply type add or install @aws-sdk/client-swf
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-swf`

--- a/clients/client-synthetics/README.md
+++ b/clients/client-synthetics/README.md
@@ -27,7 +27,7 @@ Considerations for Synthetics Canaries</a>.</p>
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-synthetics
+To install this package, simply type add or install @aws-sdk/client-synthetics
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-synthetics`

--- a/clients/client-textract/README.md
+++ b/clients/client-textract/README.md
@@ -13,7 +13,7 @@ Amazon Textract.</p>
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-textract
+To install this package, simply type add or install @aws-sdk/client-textract
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-textract`

--- a/clients/client-timestream-query/README.md
+++ b/clients/client-timestream-query/README.md
@@ -13,7 +13,7 @@ AWS SDK for JavaScript TimestreamQuery Client for Node.js, Browser and React Nat
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-timestream-query
+To install this package, simply type add or install @aws-sdk/client-timestream-query
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-timestream-query`

--- a/clients/client-timestream-write/README.md
+++ b/clients/client-timestream-write/README.md
@@ -11,7 +11,7 @@ AWS SDK for JavaScript TimestreamWrite Client for Node.js, Browser and React Nat
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-timestream-write
+To install this package, simply type add or install @aws-sdk/client-timestream-write
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-timestream-write`

--- a/clients/client-transcribe-streaming/README.md
+++ b/clients/client-transcribe-streaming/README.md
@@ -11,7 +11,7 @@ AWS SDK for JavaScript TranscribeStreaming Client for Node.js, Browser and React
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-transcribe-streaming
+To install this package, simply type add or install @aws-sdk/client-transcribe-streaming
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-transcribe-streaming`

--- a/clients/client-transcribe/README.md
+++ b/clients/client-transcribe/README.md
@@ -11,7 +11,7 @@ AWS SDK for JavaScript Transcribe Client for Node.js, Browser and React Native.
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-transcribe
+To install this package, simply type add or install @aws-sdk/client-transcribe
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-transcribe`

--- a/clients/client-transfer/README.md
+++ b/clients/client-transfer/README.md
@@ -19,7 +19,7 @@ infrastructure to buy and set up.</p>
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-transfer
+To install this package, simply type add or install @aws-sdk/client-transfer
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-transfer`

--- a/clients/client-translate/README.md
+++ b/clients/client-translate/README.md
@@ -12,7 +12,7 @@ languages.</p>
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-translate
+To install this package, simply type add or install @aws-sdk/client-translate
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-translate`

--- a/clients/client-voice-id/README.md
+++ b/clients/client-voice-id/README.md
@@ -13,7 +13,7 @@ describes the APIs used for this service.
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-voice-id
+To install this package, simply type add or install @aws-sdk/client-voice-id
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-voice-id`

--- a/clients/client-waf-regional/README.md
+++ b/clients/client-waf-regional/README.md
@@ -21,7 +21,7 @@ WAF Classic</a> in the developer guide.</p>
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-waf-regional
+To install this package, simply type add or install @aws-sdk/client-waf-regional
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-waf-regional`

--- a/clients/client-waf/README.md
+++ b/clients/client-waf/README.md
@@ -21,7 +21,7 @@ data types, and errors. For detailed information about AWS WAF Classic features 
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-waf
+To install this package, simply type add or install @aws-sdk/client-waf
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-waf`

--- a/clients/client-wafv2/README.md
+++ b/clients/client-wafv2/README.md
@@ -70,7 +70,7 @@ maximum cost of a rule group when you use it.</p>
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-wafv2
+To install this package, simply type add or install @aws-sdk/client-wafv2
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-wafv2`

--- a/clients/client-wellarchitected/README.md
+++ b/clients/client-wellarchitected/README.md
@@ -17,7 +17,7 @@ about the AWS Well-Architected Tool, see the
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-wellarchitected
+To install this package, simply type add or install @aws-sdk/client-wellarchitected
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-wellarchitected`

--- a/clients/client-wisdom/README.md
+++ b/clients/client-wisdom/README.md
@@ -15,7 +15,7 @@ can manually manage content by uploading custom files and control their lifecycl
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-wisdom
+To install this package, simply type add or install @aws-sdk/client-wisdom
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-wisdom`

--- a/clients/client-workdocs/README.md
+++ b/clients/client-workdocs/README.md
@@ -43,7 +43,7 @@ using the IAM model.</p>
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-workdocs
+To install this package, simply type add or install @aws-sdk/client-workdocs
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-workdocs`

--- a/clients/client-worklink/README.md
+++ b/clients/client-worklink/README.md
@@ -17,7 +17,7 @@ mobile devices.</p>
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-worklink
+To install this package, simply type add or install @aws-sdk/client-worklink
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-worklink`

--- a/clients/client-workmail/README.md
+++ b/clients/client-workmail/README.md
@@ -46,7 +46,7 @@ model.</p>
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-workmail
+To install this package, simply type add or install @aws-sdk/client-workmail
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-workmail`

--- a/clients/client-workmailmessageflow/README.md
+++ b/clients/client-workmailmessageflow/README.md
@@ -15,7 +15,7 @@ WorkMail organization.</p>
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-workmailmessageflow
+To install this package, simply type add or install @aws-sdk/client-workmailmessageflow
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-workmailmessageflow`

--- a/clients/client-workspaces/README.md
+++ b/clients/client-workspaces/README.md
@@ -14,7 +14,7 @@ Amazon Linux desktops for your users.</p>
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-workspaces
+To install this package, simply type add or install @aws-sdk/client-workspaces
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-workspaces`

--- a/clients/client-xray/README.md
+++ b/clients/client-xray/README.md
@@ -12,7 +12,7 @@ and other data created by processing those traces.</p>
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/client-xray
+To install this package, simply type add or install @aws-sdk/client-xray
 using your favorite package manager:
 
 - `npm install @aws-sdk/client-xray`

--- a/codegen/smithy-aws-typescript-codegen/src/main/resources/software/amazon/smithy/aws/typescript/codegen/README.md.template
+++ b/codegen/smithy-aws-typescript-codegen/src/main/resources/software/amazon/smithy/aws/typescript/codegen/README.md.template
@@ -10,7 +10,7 @@ AWS SDK for JavaScript ${serviceId} Client for Node.js, Browser and React Native
 ${documentation}
 
 ## Installing
-To install the this package, simply type add or install ${packageName}
+To install this package, simply type add or install ${packageName}
 using your favorite package manager: 
 - `npm install ${packageName}`
 - `yarn add ${packageName}`

--- a/protocol_tests/aws-ec2/README.md
+++ b/protocol_tests/aws-ec2/README.md
@@ -11,7 +11,7 @@ An EC2 query service that sends query requests and XML responses.
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/aws-ec2
+To install this package, simply type add or install @aws-sdk/aws-ec2
 using your favorite package manager:
 
 - `npm install @aws-sdk/aws-ec2`

--- a/protocol_tests/aws-json-10/README.md
+++ b/protocol_tests/aws-json-10/README.md
@@ -9,7 +9,7 @@ AWS SDK for JavaScript JSONRPC10 Client for Node.js, Browser and React Native.
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/aws-json-10
+To install this package, simply type add or install @aws-sdk/aws-json-10
 using your favorite package manager:
 
 - `npm install @aws-sdk/aws-json-10`

--- a/protocol_tests/aws-json/README.md
+++ b/protocol_tests/aws-json/README.md
@@ -9,7 +9,7 @@ AWS SDK for JavaScript JsonProtocol Client for Node.js, Browser and React Native
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/aws-json
+To install this package, simply type add or install @aws-sdk/aws-json
 using your favorite package manager:
 
 - `npm install @aws-sdk/aws-json`

--- a/protocol_tests/aws-query/README.md
+++ b/protocol_tests/aws-query/README.md
@@ -11,7 +11,7 @@ A query service that sends query requests and XML responses.
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/aws-query
+To install this package, simply type add or install @aws-sdk/aws-query
 using your favorite package manager:
 
 - `npm install @aws-sdk/aws-query`

--- a/protocol_tests/aws-restjson/README.md
+++ b/protocol_tests/aws-restjson/README.md
@@ -11,7 +11,7 @@ A REST JSON service that sends JSON requests and responses.
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/aws-restjson
+To install this package, simply type add or install @aws-sdk/aws-restjson
 using your favorite package manager:
 
 - `npm install @aws-sdk/aws-restjson`

--- a/protocol_tests/aws-restxml/README.md
+++ b/protocol_tests/aws-restxml/README.md
@@ -11,7 +11,7 @@ A REST XML service that sends XML requests and responses.
 
 ## Installing
 
-To install the this package, simply type add or install @aws-sdk/aws-restxml
+To install this package, simply type add or install @aws-sdk/aws-restxml
 using your favorite package manager:
 
 - `npm install @aws-sdk/aws-restxml`


### PR DESCRIPTION
### Issue
None

### Description
Correct a typo in the module READMEs: "the this module" -> "this module"

### Testing
Doc-only change

### Additional context


---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
