### PR TITLE
feat(codegen): enable SSDK validation protocol tests

### DIFF
--- a/codegen/protocol-test-codegen/smithy-build.json
+++ b/codegen/protocol-test-codegen/smithy-build.json
@@ -126,6 +126,22 @@
         }
       }
     },
+    "aws-restjson-validation": {
+      "transforms": [
+        {
+          "name": "includeServices",
+          "args": {
+            "services": ["aws.protocoltests.restjson.validation#RestJsonValidation"]
+          }
+        }
+      ],
+      "plugins": {
+        "typescript-ssdk-codegen": {
+          "package": "@aws-sdk/aws-restjson-validation-server",
+          "packageVersion": "1.0.0-alpha.1"
+        }
+      }
+    },
     "aws-restxml": {
       "transforms": [
         {

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsProtocolUtils.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsProtocolUtils.java
@@ -327,6 +327,16 @@ final class AwsProtocolUtils {
             return true;
         }
 
+        //TODO: reenable when the SSDK uses RE2 and not built-in regex for pattern constraints
+        if (testCase.getId().equals("RestJsonMalformedPatternReDOSString")) {
+            return true;
+        }
+        //TODO: broken in Smithy 1.12.0, remove after next Smithy release
+        if (testCase.getId().equals("RestJsonMalformedLengthBlobOverride_case1")
+            || testCase.getId().equals("RestJsonMalformedRequiredQueryNoValue")) {
+            return true;
+        }
+
         return false;
     }
 }


### PR DESCRIPTION
### Description
As a separate set of models from malformed request tests, Smithy publishes
malformed request tests for built-in validation, which exercises how the SSDK
rejects requests that do not obey the modeled constraints (such as length,
pattern, etc).

### Testing
Ran `yarn generate-clients -s && yarn test:server-protocols` locally with https://github.com/awslabs/smithy-typescript/pull/450 and https://github.com/awslabs/smithy-typescript/pull/449 checked out and linked locally.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
