### PR TITLE
fix(scripts): do not destructure function parameter

### DIFF
--- a/scripts/downlevel-dts/downlevelWorkspace.mjs
+++ b/scripts/downlevel-dts/downlevelWorkspace.mjs
@@ -48,7 +48,6 @@ export const downlevelWorkspace = async (workspacesDir, workspaceName) => {
       }
     }
   } catch (error) {
-    throw error;
     // downlevelDir is not present, do nothing.
   }
 };

--- a/scripts/downlevel-dts/getAllFiles.mjs
+++ b/scripts/downlevel-dts/getAllFiles.mjs
@@ -7,10 +7,10 @@ export const getAllFiles = async (dirPath, arrayOfFiles = []) => {
 
   for (const file of files) {
     const filePath = join(dirPath, file);
-    const { isDirectory } = await stat(filePath);
-    if (isDirectory()) {
+    const stats = await stat(filePath);
+    if (stats.isDirectory()) {
       const filesInDirectory = await getAllFiles(filePath, arrayOfFiles);
-      arrayOfFiles.push(filesInDirectory);
+      arrayOfFiles.concat(filesInDirectory);
     } else {
       arrayOfFiles.push(filePath);
     }


### PR DESCRIPTION
### Issue
Fixes: https://github.com/aws/aws-sdk-js-v3/issues/2890

### Description
Stores output of `fsPromises.stat` in a variable before calling `.isDirectory()` on it.

This changes sum of unpacked npm publish sizes for all packages from **456.40 MB** to **411.28 MB** (reduction of `~10%`).

<details>
<summary>Code used for measuring npm unpacked publish size</summary>

```js
const { readdirSync, readFileSync, statSync } = require("fs");
const { join } = require("path");
const { spawnSync } = require("child_process");

const { packages } = JSON.parse(readFileSync(join(process.cwd(), "package.json"))).workspaces;

const getAllFiles = (dirPath, arrayOfFiles) => {
  files = readdirSync(dirPath);

  arrayOfFiles = arrayOfFiles || [];

  files.forEach((file) => {
    if (statSync(dirPath + "/" + file).isDirectory()) {
      arrayOfFiles = getAllFiles(dirPath + "/" + file, arrayOfFiles);
    } else {
      arrayOfFiles.push(join(dirPath, "/", file));
    }
  });

  return arrayOfFiles;
};

let totalSizeInMB = 0;

spawnSync("git", ["clean", "-dfx"]);
spawnSync("yarn");
spawnSync("yarn", ["build:all"]);
spawnSync("yarn", ["downlevel-dts"]);

const packageNameColLength = 50;
const sizeColLength = 15;
const packageSizeList = [];

packages
  .map((dir) => dir.replace("/*", ""))
  .forEach((workspacesDir) => {
    // Process each workspace in workspace directory
    readdirSync(join(process.cwd(), workspacesDir), { withFileTypes: true })
      .filter((dirent) => dirent.isDirectory())
      .map((dirent) => dirent.name)
      .forEach((workspaceDir) => {
        if (workspaceDir.startsWith("aws-")) {
          return;
        }
        try {
          // npm pack posts debug messages to stderr
          // Refs: https://github.com/npm/npm/issues/118#issuecomment-325440
          const { stderr } = spawnSync("npm", ["pack", "--dry-run"], {
            cwd: join(process.cwd(), workspacesDir, workspaceDir),
          });
          const packageName = `@aws-sdk/${workspaceDir}`;
          const unpackedSize = stderr
            .toString()
            .match(/unpacked size: ([^\n]*)/)[1]
            .trim();
          packageSizeList.push({ packageName, unpackedSize });
          const [size, unit] = unpackedSize.split(" ");
          totalSizeInMB += size / (unit === "kB" ? 1024 : 1);
        } catch (error) {
          console.log(`${workspaceDir}: ${error}`);
        }
      });
  });

console.log(`Total size: ${totalSizeInMB.toFixed(2)} MB\n`);

console.log(`| ${"Package name".padEnd(packageNameColLength)} | ${"Unpacked size".padEnd(sizeColLength)} |`);
console.log(`|-${"-".padEnd(packageNameColLength, "-")}-|-${"-".padEnd(sizeColLength, "-")}-|`);
packageSizeList.forEach(({ packageName, unpackedSize }) =>
  console.log(`| ${packageName.padEnd(packageNameColLength)} | ${unpackedSize.padEnd(sizeColLength)} |`)
);
```

</details>

<details>
<summary>Before</summary>

```md
Total size: 456.40 MB

| Package name                                    | Unpacked size |
| ----------------------------------------------- | ------------- |
| @aws-sdk/client-accessanalyzer                  | 1.3 MB        |
| @aws-sdk/client-account                         | 194.9 kB      |
| @aws-sdk/client-acm                             | 763.4 kB      |
| @aws-sdk/client-acm-pca                         | 1.2 MB        |
| @aws-sdk/client-alexa-for-business              | 2.8 MB        |
| @aws-sdk/client-amp                             | 676.7 kB      |
| @aws-sdk/client-amplify                         | 1.3 MB        |
| @aws-sdk/client-amplifybackend                  | 996.1 kB      |
| @aws-sdk/client-api-gateway                     | 4.2 MB        |
| @aws-sdk/client-apigatewaymanagementapi         | 239.8 kB      |
| @aws-sdk/client-apigatewayv2                    | 2.6 MB        |
| @aws-sdk/client-app-mesh                        | 2.1 MB        |
| @aws-sdk/client-appconfig                       | 1.2 MB        |
| @aws-sdk/client-appflow                         | 1.2 MB        |
| @aws-sdk/client-appintegrations                 | 590.2 kB      |
| @aws-sdk/client-application-auto-scaling        | 989.4 kB      |
| @aws-sdk/client-application-discovery-service   | 1.1 MB        |
| @aws-sdk/client-application-insights            | 1.0 MB        |
| @aws-sdk/client-applicationcostprofiler         | 300.5 kB      |
| @aws-sdk/client-apprunner                       | 884.7 kB      |
| @aws-sdk/client-appstream                       | 1.8 MB        |
| @aws-sdk/client-appsync                         | 1.5 MB        |
| @aws-sdk/client-athena                          | 1.3 MB        |
| @aws-sdk/client-auditmanager                    | 1.9 MB        |
| @aws-sdk/client-auto-scaling                    | 2.6 MB        |
| @aws-sdk/client-auto-scaling-plans              | 504.3 kB      |
| @aws-sdk/client-backup                          | 2.6 MB        |
| @aws-sdk/client-batch                           | 1.2 MB        |
| @aws-sdk/client-braket                          | 408.1 kB      |
| @aws-sdk/client-budgets                         | 1.0 MB        |
| @aws-sdk/client-chime                           | 6.8 MB        |
| @aws-sdk/client-chime-sdk-identity              | 664.9 kB      |
| @aws-sdk/client-chime-sdk-messaging             | 1.2 MB        |
| @aws-sdk/client-cloud9                          | 635.1 kB      |
| @aws-sdk/client-cloudcontrol                    | 521.7 kB      |
| @aws-sdk/client-clouddirectory                  | 2.9 MB        |
| @aws-sdk/client-cloudformation                  | 3.2 MB        |
| @aws-sdk/client-cloudfront                      | 4.2 MB        |
| @aws-sdk/client-cloudhsm                        | 771.1 kB      |
| @aws-sdk/client-cloudhsm-v2                     | 665.0 kB      |
| @aws-sdk/client-cloudsearch                     | 1.1 MB        |
| @aws-sdk/client-cloudsearch-domain              | 345.4 kB      |
| @aws-sdk/client-cloudtrail                      | 1.1 MB        |
| @aws-sdk/client-cloudwatch                      | 1.6 MB        |
| @aws-sdk/client-cloudwatch-events               | 1.9 MB        |
| @aws-sdk/client-cloudwatch-logs                 | 1.5 MB        |
| @aws-sdk/client-codeartifact                    | 1.5 MB        |
| @aws-sdk/client-codebuild                       | 2.0 MB        |
| @aws-sdk/client-codecommit                      | 4.2 MB        |
| @aws-sdk/client-codedeploy                      | 2.4 MB        |
| @aws-sdk/client-codeguru-reviewer               | 845.2 kB      |
| @aws-sdk/client-codeguruprofiler                | 1.0 MB        |
| @aws-sdk/client-codepipeline                    | 1.8 MB        |
| @aws-sdk/client-codestar                        | 736.5 kB      |
| @aws-sdk/client-codestar-connections            | 491.0 kB      |
| @aws-sdk/client-codestar-notifications          | 602.1 kB      |
| @aws-sdk/client-cognito-identity                | 976.8 kB      |
| @aws-sdk/client-cognito-identity-provider       | 4.3 MB        |
| @aws-sdk/client-cognito-sync                    | 872.9 kB      |
| @aws-sdk/client-comprehend                      | 2.6 MB        |
| @aws-sdk/client-comprehendmedical               | 890.3 kB      |
| @aws-sdk/client-compute-optimizer               | 1.1 MB        |
| @aws-sdk/client-config-service                  | 3.7 MB        |
| @aws-sdk/client-connect                         | 3.9 MB        |
| @aws-sdk/client-connect-contact-lens            | 178.1 kB      |
| @aws-sdk/client-connectparticipant              | 458.2 kB      |
| @aws-sdk/client-cost-and-usage-report-service   | 307.8 kB      |
| @aws-sdk/client-cost-explorer                   | 1.7 MB        |
| @aws-sdk/client-customer-profiles               | 1.2 MB        |
| @aws-sdk/client-data-pipeline                   | 923.1 kB      |
| @aws-sdk/client-database-migration-service      | 2.8 MB        |
| @aws-sdk/client-databrew                        | 1.5 MB        |
| @aws-sdk/client-dataexchange                    | 1.1 MB        |
| @aws-sdk/client-datasync                        | 1.3 MB        |
| @aws-sdk/client-dax                             | 916.7 kB      |
| @aws-sdk/client-detective                       | 615.0 kB      |
| @aws-sdk/client-device-farm                     | 2.8 MB        |
| @aws-sdk/client-devops-guru                     | 1.1 MB        |
| @aws-sdk/client-direct-connect                  | 2.0 MB        |
| @aws-sdk/client-directory-service               | 2.3 MB        |
| @aws-sdk/client-dlm                             | 501.7 kB      |
| @aws-sdk/client-docdb                           | 2.4 MB        |
| @aws-sdk/client-dynamodb                        | 2.9 MB        |
| @aws-sdk/client-dynamodb-streams                | 370.9 kB      |
| @aws-sdk/client-ebs                             | 433.3 kB      |
| @aws-sdk/client-ec2                             | 18.6 MB       |
| @aws-sdk/client-ec2-instance-connect            | 246.8 kB      |
| @aws-sdk/client-ecr                             | 1.5 MB        |
| @aws-sdk/client-ecr-public                      | 934.6 kB      |
| @aws-sdk/client-ecs                             | 3.0 MB        |
| @aws-sdk/client-efs                             | 1.3 MB        |
| @aws-sdk/client-eks                             | 1.7 MB        |
| @aws-sdk/client-elastic-beanstalk               | 1.9 MB        |
| @aws-sdk/client-elastic-inference               | 358.6 kB      |
| @aws-sdk/client-elastic-load-balancing          | 1.3 MB        |
| @aws-sdk/client-elastic-load-balancing-v2       | 1.7 MB        |
| @aws-sdk/client-elastic-transcoder              | 1.2 MB        |
| @aws-sdk/client-elasticache                     | 3.4 MB        |
| @aws-sdk/client-elasticsearch-service           | 1.8 MB        |
| @aws-sdk/client-emr                             | 2.2 MB        |
| @aws-sdk/client-emr-containers                  | 630.1 kB      |
| @aws-sdk/client-eventbridge                     | 1.9 MB        |
| @aws-sdk/client-finspace                        | 339.1 kB      |
| @aws-sdk/client-finspace-data                   | 213.1 kB      |
| @aws-sdk/client-firehose                        | 1.1 MB        |
| @aws-sdk/client-fis                             | 579.4 kB      |
| @aws-sdk/client-fms                             | 1.2 MB        |
| @aws-sdk/client-forecast                        | 1.6 MB        |
| @aws-sdk/client-forecastquery                   | 212.8 kB      |
| @aws-sdk/client-frauddetector                   | 2.0 MB        |
| @aws-sdk/client-fsx                             | 1.7 MB        |
| @aws-sdk/client-gamelift                        | 4.6 MB        |
| @aws-sdk/client-glacier                         | 1.6 MB        |
| @aws-sdk/client-global-accelerator              | 1.8 MB        |
| @aws-sdk/client-glue                            | 5.8 MB        |
| @aws-sdk/client-grafana                         | 580.9 kB      |
| @aws-sdk/client-greengrass                      | 2.8 MB        |
| @aws-sdk/client-greengrassv2                    | 1.1 MB        |
| @aws-sdk/client-groundstation                   | 1.0 MB        |
| @aws-sdk/client-guardduty                       | 2.0 MB        |
| @aws-sdk/client-health                          | 787.2 kB      |
| @aws-sdk/client-healthlake                      | 541.1 kB      |
| @aws-sdk/client-honeycode                       | 701.3 kB      |
| @aws-sdk/client-iam                             | 5.8 MB        |
| @aws-sdk/client-identitystore                   | 260.3 kB      |
| @aws-sdk/client-imagebuilder                    | 2.1 MB        |
| @aws-sdk/client-inspector                       | 1.5 MB        |
| @aws-sdk/client-iot                             | 8.6 MB        |
| @aws-sdk/client-iot-1click-devices-service      | 516.7 kB      |
| @aws-sdk/client-iot-1click-projects             | 652.5 kB      |
| @aws-sdk/client-iot-data-plane                  | 402.7 kB      |
| @aws-sdk/client-iot-events                      | 1.3 MB        |
| @aws-sdk/client-iot-events-data                 | 600.7 kB      |
| @aws-sdk/client-iot-jobs-data-plane             | 333.5 kB      |
| @aws-sdk/client-iot-wireless                    | 2.0 MB        |
| @aws-sdk/client-iotanalytics                    | 1.5 MB        |
| @aws-sdk/client-iotdeviceadvisor                | 508.7 kB      |
| @aws-sdk/client-iotfleethub                     | 345.1 kB      |
| @aws-sdk/client-iotsecuretunneling              | 362.0 kB      |
| @aws-sdk/client-iotsitewise                     | 2.5 MB        |
| @aws-sdk/client-iotthingsgraph                  | 1.3 MB        |
| @aws-sdk/client-ivs                             | 1.0 MB        |
| @aws-sdk/client-kafka                           | 1.3 MB        |
| @aws-sdk/client-kafkaconnect                    | 633.2 kB      |
| @aws-sdk/client-kendra                          | 2.2 MB        |
| @aws-sdk/client-kinesis                         | 1.3 MB        |
| @aws-sdk/client-kinesis-analytics               | 1.1 MB        |
| @aws-sdk/client-kinesis-analytics-v2            | 1.7 MB        |
| @aws-sdk/client-kinesis-video                   | 812.9 kB      |
| @aws-sdk/client-kinesis-video-archived-media    | 604.6 kB      |
| @aws-sdk/client-kinesis-video-media             | 226.9 kB      |
| @aws-sdk/client-kinesis-video-signaling         | 218.6 kB      |
| @aws-sdk/client-kms                             | 2.7 MB        |
| @aws-sdk/client-lakeformation                   | 958.4 kB      |
| @aws-sdk/client-lambda                          | 2.6 MB        |
| @aws-sdk/client-lex-model-building-service      | 2.0 MB        |
| @aws-sdk/client-lex-models-v2                   | 2.7 MB        |
| @aws-sdk/client-lex-runtime-service             | 578.9 kB      |
| @aws-sdk/client-lex-runtime-v2                  | 592.9 kB      |
| @aws-sdk/client-license-manager                 | 1.9 MB        |
| @aws-sdk/client-lightsail                       | 5.9 MB        |
| @aws-sdk/client-location                        | 2.0 MB        |
| @aws-sdk/client-lookoutequipment                | 890.9 kB      |
| @aws-sdk/client-lookoutmetrics                  | 1.0 MB        |
| @aws-sdk/client-lookoutvision                   | 818.5 kB      |
| @aws-sdk/client-machine-learning                | 1.3 MB        |
| @aws-sdk/client-macie                           | 392.1 kB      |
| @aws-sdk/client-macie2                          | 2.5 MB        |
| @aws-sdk/client-managedblockchain               | 1.1 MB        |
| @aws-sdk/client-marketplace-catalog             | 425.8 kB      |
| @aws-sdk/client-marketplace-commerce-analytics  | 251.4 kB      |
| @aws-sdk/client-marketplace-entitlement-service | 227.5 kB      |
| @aws-sdk/client-marketplace-metering            | 406.0 kB      |
| @aws-sdk/client-mediaconnect                    | 1.3 MB        |
| @aws-sdk/client-mediaconvert                    | 2.9 MB        |
| @aws-sdk/client-medialive                       | 3.5 MB        |
| @aws-sdk/client-mediapackage                    | 928.2 kB      |
| @aws-sdk/client-mediapackage-vod                | 786.3 kB      |
| @aws-sdk/client-mediastore                      | 755.7 kB      |
| @aws-sdk/client-mediastore-data                 | 331.2 kB      |
| @aws-sdk/client-mediatailor                     | 1.2 MB        |
| @aws-sdk/client-memorydb                        | 1.4 MB        |
| @aws-sdk/client-mgn                             | 1.0 MB        |
| @aws-sdk/client-migration-hub                   | 838.0 kB      |
| @aws-sdk/client-migrationhub-config             | 290.0 kB      |
| @aws-sdk/client-mobile                          | 474.3 kB      |
| @aws-sdk/client-mq                              | 945.6 kB      |
| @aws-sdk/client-mturk                           | 1.5 MB        |
| @aws-sdk/client-mwaa                            | 505.6 kB      |
| @aws-sdk/client-neptune                         | 2.9 MB        |
| @aws-sdk/client-network-firewall                | 1.4 MB        |
| @aws-sdk/client-networkmanager                  | 1.4 MB        |
| @aws-sdk/client-nimble                          | 1.7 MB        |
| @aws-sdk/client-opensearch                      | 1.7 MB        |
| @aws-sdk/client-opsworks                        | 2.7 MB        |
| @aws-sdk/client-opsworkscm                      | 878.0 kB      |
| @aws-sdk/client-organizations                   | 2.6 MB        |
| @aws-sdk/client-outposts                        | 495.0 kB      |
| @aws-sdk/client-personalize                     | 1.8 MB        |
| @aws-sdk/client-personalize-events              | 255.2 kB      |
| @aws-sdk/client-personalize-runtime             | 237.6 kB      |
| @aws-sdk/client-pi                              | 338.3 kB      |
| @aws-sdk/client-pinpoint                        | 4.8 MB        |
| @aws-sdk/client-pinpoint-email                  | 1.7 MB        |
| @aws-sdk/client-pinpoint-sms-voice              | 446.0 kB      |
| @aws-sdk/client-polly                           | 542.1 kB      |
| @aws-sdk/client-pricing                         | 307.4 kB      |
| @aws-sdk/client-proton                          | 2.0 MB        |
| @aws-sdk/client-qldb                            | 856.4 kB      |
| @aws-sdk/client-qldb-session                    | 272.5 kB      |
| @aws-sdk/client-quicksight                      | 4.9 MB        |
| @aws-sdk/client-ram                             | 1.1 MB        |
| @aws-sdk/client-rds                             | 6.7 MB        |
| @aws-sdk/client-rds-data                        | 484.5 kB      |
| @aws-sdk/client-redshift                        | 4.9 MB        |
| @aws-sdk/client-redshift-data                   | 521.4 kB      |
| @aws-sdk/client-rekognition                     | 2.6 MB        |
| @aws-sdk/client-resource-groups                 | 812.0 kB      |
| @aws-sdk/client-resource-groups-tagging-api     | 516.4 kB      |
| @aws-sdk/client-robomaker                       | 2.3 MB        |
| @aws-sdk/client-route-53                        | 3.0 MB        |
| @aws-sdk/client-route-53-domains                | 1.2 MB        |
| @aws-sdk/client-route53-recovery-cluster        | 228.5 kB      |
| @aws-sdk/client-route53-recovery-control-config | 824.8 kB      |
| @aws-sdk/client-route53-recovery-readiness      | 1.1 MB        |
| @aws-sdk/client-route53resolver                 | 2.4 MB        |
| @aws-sdk/client-s3                              | 5.3 MB        |
| @aws-sdk/client-s3-control                      | 2.7 MB        |
| @aws-sdk/client-s3outposts                      | 222.9 kB      |
| @aws-sdk/client-sagemaker                       | 9.7 MB        |
| @aws-sdk/client-sagemaker-a2i-runtime           | 358.4 kB      |
| @aws-sdk/client-sagemaker-edge                  | 154.9 kB      |
| @aws-sdk/client-sagemaker-featurestore-runtime  | 250.9 kB      |
| @aws-sdk/client-sagemaker-runtime               | 257.9 kB      |
| @aws-sdk/client-savingsplans                    | 480.7 kB      |
| @aws-sdk/client-schemas                         | 1.1 MB        |
| @aws-sdk/client-secrets-manager                 | 1.2 MB        |
| @aws-sdk/client-securityhub                     | 4.2 MB        |
| @aws-sdk/client-serverlessapplicationrepository | 758.5 kB      |
| @aws-sdk/client-service-catalog                 | 3.1 MB        |
| @aws-sdk/client-service-catalog-appregistry     | 778.4 kB      |
| @aws-sdk/client-service-quotas                  | 874.1 kB      |
| @aws-sdk/client-servicediscovery                | 1.2 MB        |
| @aws-sdk/client-ses                             | 2.7 MB        |
| @aws-sdk/client-sesv2                           | 3.1 MB        |
| @aws-sdk/client-sfn                             | 1.1 MB        |
| @aws-sdk/client-shield                          | 1.2 MB        |
| @aws-sdk/client-signer                          | 815.3 kB      |
| @aws-sdk/client-sms                             | 1.3 MB        |
| @aws-sdk/client-snow-device-management          | 561.6 kB      |
| @aws-sdk/client-snowball                        | 1.1 MB        |
| @aws-sdk/client-sns                             | 1.6 MB        |
| @aws-sdk/client-sqs                             | 1.1 MB        |
| @aws-sdk/client-ssm                             | 6.2 MB        |
| @aws-sdk/client-ssm-contacts                    | 960.5 kB      |
| @aws-sdk/client-ssm-incidents                   | 1.1 MB        |
| @aws-sdk/client-sso                             | 292.8 kB      |
| @aws-sdk/client-sso-admin                       | 1.2 MB        |
| @aws-sdk/client-sso-oidc                        | 306.2 kB      |
| @aws-sdk/client-storage-gateway                 | 3.2 MB        |
| @aws-sdk/client-sts                             | 784.5 kB      |
| @aws-sdk/client-support                         | 777.5 kB      |
| @aws-sdk/client-swf                             | 2.2 MB        |
| @aws-sdk/client-synthetics                      | 630.7 kB      |
| @aws-sdk/client-textract                        | 604.8 kB      |
| @aws-sdk/client-timestream-query                | 244.7 kB      |
| @aws-sdk/client-timestream-write                | 627.8 kB      |
| @aws-sdk/client-transcribe                      | 1.6 MB        |
| @aws-sdk/client-transcribe-streaming            | 412.1 kB      |
| @aws-sdk/client-transfer                        | 1.4 MB        |
| @aws-sdk/client-translate                       | 698.0 kB      |
| @aws-sdk/client-voice-id                        | 845.1 kB      |
| @aws-sdk/client-waf                             | 3.4 MB        |
| @aws-sdk/client-waf-regional                    | 3.6 MB        |
| @aws-sdk/client-wafv2                           | 2.2 MB        |
| @aws-sdk/client-wellarchitected                 | 1.3 MB        |
| @aws-sdk/client-wisdom                          | 1.1 MB        |
| @aws-sdk/client-workdocs                        | 1.6 MB        |
| @aws-sdk/client-worklink                        | 1.2 MB        |
| @aws-sdk/client-workmail                        | 2.0 MB        |
| @aws-sdk/client-workmailmessageflow             | 226.1 kB      |
| @aws-sdk/client-workspaces                      | 1.9 MB        |
| @aws-sdk/client-xray                            | 1.2 MB        |
| @aws-sdk/lib-dynamodb                           | 200.6 kB      |
| @aws-sdk/lib-storage                            | 70.7 kB       |
| @aws-sdk/abort-controller                       | 41.5 kB       |
| @aws-sdk/body-checksum-browser                  | 34.4 kB       |
| @aws-sdk/body-checksum-node                     | 35.1 kB       |
| @aws-sdk/chunked-blob-reader                    | 30.2 kB       |
| @aws-sdk/chunked-blob-reader-native             | 25.1 kB       |
| @aws-sdk/chunked-stream-reader-node             | 35.8 kB       |
| @aws-sdk/client-documentation-generator         | 61.4 kB       |
| @aws-sdk/config-resolver                        | 99.6 kB       |
| @aws-sdk/core-packages-documentation-generator  | 30.7 kB       |
| @aws-sdk/credential-provider-cognito-identity   | 122.3 kB      |
| @aws-sdk/credential-provider-env                | 46.0 kB       |
| @aws-sdk/credential-provider-imds               | 81.0 kB       |
| @aws-sdk/credential-provider-ini                | 61.6 kB       |
| @aws-sdk/credential-provider-node               | 61.8 kB       |
| @aws-sdk/credential-provider-process            | 46.8 kB       |
| @aws-sdk/credential-provider-sso                | 35.2 kB       |
| @aws-sdk/credential-provider-web-identity       | 42.0 kB       |
| @aws-sdk/credential-providers                   | 99.4 kB       |
| @aws-sdk/endpoint-cache                         | 23.8 kB       |
| @aws-sdk/eventstream-handler-node               | 37.6 kB       |
| @aws-sdk/eventstream-marshaller                 | 93.0 kB       |
| @aws-sdk/eventstream-serde-browser              | 40.6 kB       |
| @aws-sdk/eventstream-serde-config-resolver      | 29.2 kB       |
| @aws-sdk/eventstream-serde-node                 | 41.1 kB       |
| @aws-sdk/eventstream-serde-universal            | 52.5 kB       |
| @aws-sdk/fetch-http-handler                     | 71.4 kB       |
| @aws-sdk/hash-blob-browser                      | 52.1 kB       |
| @aws-sdk/hash-node                              | 41.3 kB       |
| @aws-sdk/hash-stream-node                       | 48.9 kB       |
| @aws-sdk/invalid-dependency                     | 25.9 kB       |
| @aws-sdk/is-array-buffer                        | 28.8 kB       |
| @aws-sdk/karma-credential-loader                | 39.6 kB       |
| @aws-sdk/md5-js                                 | 57.7 kB       |
| @aws-sdk/middleware-apply-body-checksum         | 48.3 kB       |
| @aws-sdk/middleware-bucket-endpoint             | 112.2 kB      |
| @aws-sdk/middleware-content-length              | 59.2 kB       |
| @aws-sdk/middleware-endpoint-discovery          | 49.2 kB       |
| @aws-sdk/middleware-eventstream                 | 33.0 kB       |
| @aws-sdk/middleware-expect-continue             | 50.8 kB       |
| @aws-sdk/middleware-header-default              | 43.6 kB       |
| @aws-sdk/middleware-host-header                 | 38.6 kB       |
| @aws-sdk/middleware-location-constraint         | 45.4 kB       |
| @aws-sdk/middleware-logger                      | 27.1 kB       |
| @aws-sdk/middleware-retry                       | 107.7 kB      |
| @aws-sdk/middleware-sdk-api-gateway             | 53.2 kB       |
| @aws-sdk/middleware-sdk-ec2                     | 46.4 kB       |
| @aws-sdk/middleware-sdk-glacier                 | 62.0 kB       |
| @aws-sdk/middleware-sdk-machinelearning         | 37.3 kB       |
| @aws-sdk/middleware-sdk-rds                     | 50.7 kB       |
| @aws-sdk/middleware-sdk-route53                 | 42.2 kB       |
| @aws-sdk/middleware-sdk-s3                      | 56.8 kB       |
| @aws-sdk/middleware-sdk-s3-control              | 66.3 kB       |
| @aws-sdk/middleware-sdk-sqs                     | 45.2 kB       |
| @aws-sdk/middleware-sdk-sts                     | 20.6 kB       |
| @aws-sdk/middleware-sdk-transcribe-streaming    | 58.0 kB       |
| @aws-sdk/middleware-serde                       | 50.3 kB       |
| @aws-sdk/middleware-signing                     | 81.2 kB       |
| @aws-sdk/middleware-ssec                        | 36.6 kB       |
| @aws-sdk/middleware-stack                       | 71.9 kB       |
| @aws-sdk/middleware-user-agent                  | 56.3 kB       |
| @aws-sdk/node-config-provider                   | 35.5 kB       |
| @aws-sdk/node-http-handler                      | 109.4 kB      |
| @aws-sdk/polly-request-presigner                | 36.4 kB       |
| @aws-sdk/property-provider                      | 57.2 kB       |
| @aws-sdk/protocol-http                          | 54.8 kB       |
| @aws-sdk/querystring-builder                    | 41.7 kB       |
| @aws-sdk/querystring-parser                     | 40.3 kB       |
| @aws-sdk/s3-presigned-post                      | 38.1 kB       |
| @aws-sdk/s3-request-presigner                   | 80.1 kB       |
| @aws-sdk/service-error-classification           | 37.1 kB       |
| @aws-sdk/sha256-tree-hash                       | 51.2 kB       |
| @aws-sdk/shared-ini-file-loader                 | 43.4 kB       |
| @aws-sdk/signature-v4                           | 189.0 kB      |
| @aws-sdk/signature-v4-crt                       | 83.5 kB       |
| @aws-sdk/smithy-client                          | 133.4 kB      |
| @aws-sdk/types                                  | 179.4 kB      |
| @aws-sdk/url-parser                             | 18.9 kB       |
| @aws-sdk/util-arn-parser                        | 22.9 kB       |
| @aws-sdk/util-base64-browser                    | 35.4 kB       |
| @aws-sdk/util-base64-node                       | 32.9 kB       |
| @aws-sdk/util-body-length-browser               | 30.6 kB       |
| @aws-sdk/util-body-length-node                  | 30.5 kB       |
| @aws-sdk/util-buffer-from                       | 32.2 kB       |
| @aws-sdk/util-create-request                    | 63.4 kB       |
| @aws-sdk/util-credentials                       | 18.7 kB       |
| @aws-sdk/util-dynamodb                          | 57.2 kB       |
| @aws-sdk/util-format-url                        | 45.2 kB       |
| @aws-sdk/util-hex-encoding                      | 31.0 kB       |
| @aws-sdk/util-locate-window                     | 29.1 kB       |
| @aws-sdk/util-uri-escape                        | 32.2 kB       |
| @aws-sdk/util-user-agent-browser                | 58.1 kB       |
| @aws-sdk/util-user-agent-node                   | 56.4 kB       |
| @aws-sdk/util-utf8-browser                      | 35.4 kB       |
| @aws-sdk/util-utf8-node                         | 31.6 kB       |
| @aws-sdk/util-waiter                            | 36.8 kB       |
| @aws-sdk/xml-builder                            | 37.9 kB       |

```

</details>

<details>
<summary>After</summary>

```md
Total size: 411.28 MB

| Package name                                    | Unpacked size |
| ----------------------------------------------- | ------------- |
| @aws-sdk/client-accessanalyzer                  | 1.2 MB        |
| @aws-sdk/client-account                         | 179.8 kB      |
| @aws-sdk/client-acm                             | 687.2 kB      |
| @aws-sdk/client-acm-pca                         | 1.1 MB        |
| @aws-sdk/client-alexa-for-business              | 2.7 MB        |
| @aws-sdk/client-amp                             | 643.5 kB      |
| @aws-sdk/client-amplify                         | 1.3 MB        |
| @aws-sdk/client-amplifybackend                  | 939.5 kB      |
| @aws-sdk/client-api-gateway                     | 3.9 MB        |
| @aws-sdk/client-apigatewaymanagementapi         | 231.8 kB      |
| @aws-sdk/client-apigatewayv2                    | 2.3 MB        |
| @aws-sdk/client-app-mesh                        | 1.9 MB        |
| @aws-sdk/client-appconfig                       | 1.2 MB        |
| @aws-sdk/client-appflow                         | 1.1 MB        |
| @aws-sdk/client-appintegrations                 | 556.4 kB      |
| @aws-sdk/client-application-auto-scaling        | 767.8 kB      |
| @aws-sdk/client-application-discovery-service   | 1.0 MB        |
| @aws-sdk/client-application-insights            | 944.3 kB      |
| @aws-sdk/client-applicationcostprofiler         | 284.4 kB      |
| @aws-sdk/client-apprunner                       | 804.1 kB      |
| @aws-sdk/client-appstream                       | 1.6 MB        |
| @aws-sdk/client-appsync                         | 1.4 MB        |
| @aws-sdk/client-athena                          | 1.2 MB        |
| @aws-sdk/client-auditmanager                    | 1.7 MB        |
| @aws-sdk/client-auto-scaling                    | 2.3 MB        |
| @aws-sdk/client-auto-scaling-plans              | 451.6 kB      |
| @aws-sdk/client-backup                          | 2.3 MB        |
| @aws-sdk/client-batch                           | 986.7 kB      |
| @aws-sdk/client-braket                          | 390.1 kB      |
| @aws-sdk/client-budgets                         | 937.3 kB      |
| @aws-sdk/client-chime                           | 6.4 MB        |
| @aws-sdk/client-chime-sdk-identity              | 632.6 kB      |
| @aws-sdk/client-chime-sdk-messaging             | 1.2 MB        |
| @aws-sdk/client-cloud9                          | 592.3 kB      |
| @aws-sdk/client-cloudcontrol                    | 471.3 kB      |
| @aws-sdk/client-clouddirectory                  | 2.7 MB        |
| @aws-sdk/client-cloudformation                  | 2.7 MB        |
| @aws-sdk/client-cloudfront                      | 3.7 MB        |
| @aws-sdk/client-cloudhsm                        | 694.7 kB      |
| @aws-sdk/client-cloudhsm-v2                     | 624.4 kB      |
| @aws-sdk/client-cloudsearch                     | 1.0 MB        |
| @aws-sdk/client-cloudsearch-domain              | 297.2 kB      |
| @aws-sdk/client-cloudtrail                      | 980.6 kB      |
| @aws-sdk/client-cloudwatch                      | 1.4 MB        |
| @aws-sdk/client-cloudwatch-events               | 1.8 MB        |
| @aws-sdk/client-cloudwatch-logs                 | 1.4 MB        |
| @aws-sdk/client-codeartifact                    | 1.3 MB        |
| @aws-sdk/client-codebuild                       | 1.7 MB        |
| @aws-sdk/client-codecommit                      | 3.9 MB        |
| @aws-sdk/client-codedeploy                      | 2.2 MB        |
| @aws-sdk/client-codeguru-reviewer               | 752.6 kB      |
| @aws-sdk/client-codeguruprofiler                | 937.1 kB      |
| @aws-sdk/client-codepipeline                    | 1.6 MB        |
| @aws-sdk/client-codestar                        | 684.1 kB      |
| @aws-sdk/client-codestar-connections            | 455.6 kB      |
| @aws-sdk/client-codestar-notifications          | 563.3 kB      |
| @aws-sdk/client-cognito-identity                | 904.3 kB      |
| @aws-sdk/client-cognito-identity-provider       | 3.9 MB        |
| @aws-sdk/client-cognito-sync                    | 782.9 kB      |
| @aws-sdk/client-comprehend                      | 2.3 MB        |
| @aws-sdk/client-comprehendmedical               | 825.9 kB      |
| @aws-sdk/client-compute-optimizer               | 950.1 kB      |
| @aws-sdk/client-config-service                  | 3.4 MB        |
| @aws-sdk/client-connect                         | 3.7 MB        |
| @aws-sdk/client-connect-contact-lens            | 168.6 kB      |
| @aws-sdk/client-connectparticipant              | 431.5 kB      |
| @aws-sdk/client-cost-and-usage-report-service   | 294.4 kB      |
| @aws-sdk/client-cost-explorer                   | 1.4 MB        |
| @aws-sdk/client-customer-profiles               | 1.2 MB        |
| @aws-sdk/client-data-pipeline                   | 804.0 kB      |
| @aws-sdk/client-database-migration-service      | 2.5 MB        |
| @aws-sdk/client-databrew                        | 1.4 MB        |
| @aws-sdk/client-dataexchange                    | 1.1 MB        |
| @aws-sdk/client-datasync                        | 1.2 MB        |
| @aws-sdk/client-dax                             | 853.5 kB      |
| @aws-sdk/client-detective                       | 566.6 kB      |
| @aws-sdk/client-device-farm                     | 2.5 MB        |
| @aws-sdk/client-devops-guru                     | 964.5 kB      |
| @aws-sdk/client-direct-connect                  | 1.8 MB        |
| @aws-sdk/client-directory-service               | 2.1 MB        |
| @aws-sdk/client-dlm                             | 469.8 kB      |
| @aws-sdk/client-docdb                           | 2.1 MB        |
| @aws-sdk/client-dynamodb                        | 2.4 MB        |
| @aws-sdk/client-dynamodb-streams                | 336.2 kB      |
| @aws-sdk/client-ebs                             | 403.9 kB      |
| @aws-sdk/client-ec2                             | 16.5 MB       |
| @aws-sdk/client-ec2-instance-connect            | 237.0 kB      |
| @aws-sdk/client-ecr                             | 1.3 MB        |
| @aws-sdk/client-ecr-public                      | 858.1 kB      |
| @aws-sdk/client-ecs                             | 2.5 MB        |
| @aws-sdk/client-efs                             | 1.1 MB        |
| @aws-sdk/client-eks                             | 1.5 MB        |
| @aws-sdk/client-elastic-beanstalk               | 1.7 MB        |
| @aws-sdk/client-elastic-inference               | 341.1 kB      |
| @aws-sdk/client-elastic-load-balancing          | 1.2 MB        |
| @aws-sdk/client-elastic-load-balancing-v2       | 1.5 MB        |
| @aws-sdk/client-elastic-transcoder              | 993.7 kB      |
| @aws-sdk/client-elasticache                     | 3.0 MB        |
| @aws-sdk/client-elasticsearch-service           | 1.7 MB        |
| @aws-sdk/client-emr                             | 1.9 MB        |
| @aws-sdk/client-emr-containers                  | 589.0 kB      |
| @aws-sdk/client-eventbridge                     | 1.7 MB        |
| @aws-sdk/client-finspace                        | 321.6 kB      |
| @aws-sdk/client-finspace-data                   | 199.5 kB      |
| @aws-sdk/client-firehose                        | 919.4 kB      |
| @aws-sdk/client-fis                             | 544.9 kB      |
| @aws-sdk/client-fms                             | 1.1 MB        |
| @aws-sdk/client-forecast                        | 1.4 MB        |
| @aws-sdk/client-forecastquery                   | 204.3 kB      |
| @aws-sdk/client-frauddetector                   | 1.9 MB        |
| @aws-sdk/client-fsx                             | 1.5 MB        |
| @aws-sdk/client-gamelift                        | 3.8 MB        |
| @aws-sdk/client-glacier                         | 1.4 MB        |
| @aws-sdk/client-global-accelerator              | 1.7 MB        |
| @aws-sdk/client-glue                            | 5.3 MB        |
| @aws-sdk/client-grafana                         | 532.3 kB      |
| @aws-sdk/client-greengrass                      | 2.6 MB        |
| @aws-sdk/client-greengrassv2                    | 1.0 MB        |
| @aws-sdk/client-groundstation                   | 954.6 kB      |
| @aws-sdk/client-guardduty                       | 1.9 MB        |
| @aws-sdk/client-health                          | 687.8 kB      |
| @aws-sdk/client-healthlake                      | 508.3 kB      |
| @aws-sdk/client-honeycode                       | 636.8 kB      |
| @aws-sdk/client-iam                             | 5.1 MB        |
| @aws-sdk/client-identitystore                   | 241.2 kB      |
| @aws-sdk/client-imagebuilder                    | 2.0 MB        |
| @aws-sdk/client-inspector                       | 1.4 MB        |
| @aws-sdk/client-iot                             | 8.0 MB        |
| @aws-sdk/client-iot-1click-devices-service      | 490.9 kB      |
| @aws-sdk/client-iot-1click-projects             | 621.6 kB      |
| @aws-sdk/client-iot-data-plane                  | 378.0 kB      |
| @aws-sdk/client-iot-events                      | 1.2 MB        |
| @aws-sdk/client-iot-events-data                 | 559.3 kB      |
| @aws-sdk/client-iot-jobs-data-plane             | 315.6 kB      |
| @aws-sdk/client-iot-wireless                    | 1.9 MB        |
| @aws-sdk/client-iotanalytics                    | 1.4 MB        |
| @aws-sdk/client-iotdeviceadvisor                | 481.9 kB      |
| @aws-sdk/client-iotfleethub                     | 326.1 kB      |
| @aws-sdk/client-iotsecuretunneling              | 345.3 kB      |
| @aws-sdk/client-iotsitewise                     | 2.3 MB        |
| @aws-sdk/client-iotthingsgraph                  | 1.2 MB        |
| @aws-sdk/client-ivs                             | 914.7 kB      |
| @aws-sdk/client-kafka                           | 1.2 MB        |
| @aws-sdk/client-kafkaconnect                    | 592.5 kB      |
| @aws-sdk/client-kendra                          | 2.0 MB        |
| @aws-sdk/client-kinesis                         | 1.1 MB        |
| @aws-sdk/client-kinesis-analytics               | 970.6 kB      |
| @aws-sdk/client-kinesis-analytics-v2            | 1.5 MB        |
| @aws-sdk/client-kinesis-video                   | 754.2 kB      |
| @aws-sdk/client-kinesis-video-archived-media    | 488.5 kB      |
| @aws-sdk/client-kinesis-video-media             | 208.6 kB      |
| @aws-sdk/client-kinesis-video-signaling         | 207.2 kB      |
| @aws-sdk/client-kms                             | 2.2 MB        |
| @aws-sdk/client-lakeformation                   | 896.2 kB      |
| @aws-sdk/client-lambda                          | 2.4 MB        |
| @aws-sdk/client-lex-model-building-service      | 1.7 MB        |
| @aws-sdk/client-lex-models-v2                   | 2.4 MB        |
| @aws-sdk/client-lex-runtime-service             | 485.8 kB      |
| @aws-sdk/client-lex-runtime-v2                  | 506.8 kB      |
| @aws-sdk/client-license-manager                 | 1.8 MB        |
| @aws-sdk/client-lightsail                       | 5.2 MB        |
| @aws-sdk/client-location                        | 1.8 MB        |
| @aws-sdk/client-lookoutequipment                | 823.7 kB      |
| @aws-sdk/client-lookoutmetrics                  | 979.5 kB      |
| @aws-sdk/client-lookoutvision                   | 753.0 kB      |
| @aws-sdk/client-machine-learning                | 1.2 MB        |
| @aws-sdk/client-macie                           | 370.0 kB      |
| @aws-sdk/client-macie2                          | 2.2 MB        |
| @aws-sdk/client-managedblockchain               | 1.0 MB        |
| @aws-sdk/client-marketplace-catalog             | 397.8 kB      |
| @aws-sdk/client-marketplace-commerce-analytics  | 231.1 kB      |
| @aws-sdk/client-marketplace-entitlement-service | 217.2 kB      |
| @aws-sdk/client-marketplace-metering            | 372.0 kB      |
| @aws-sdk/client-mediaconnect                    | 1.2 MB        |
| @aws-sdk/client-mediaconvert                    | 2.4 MB        |
| @aws-sdk/client-medialive                       | 3.2 MB        |
| @aws-sdk/client-mediapackage                    | 869.5 kB      |
| @aws-sdk/client-mediapackage-vod                | 747.0 kB      |
| @aws-sdk/client-mediastore                      | 694.4 kB      |
| @aws-sdk/client-mediastore-data                 | 311.6 kB      |
| @aws-sdk/client-mediatailor                     | 1.1 MB        |
| @aws-sdk/client-memorydb                        | 1.3 MB        |
| @aws-sdk/client-mgn                             | 954.4 kB      |
| @aws-sdk/client-migration-hub                   | 780.3 kB      |
| @aws-sdk/client-migrationhub-config             | 276.0 kB      |
| @aws-sdk/client-mobile                          | 447.9 kB      |
| @aws-sdk/client-mq                              | 879.3 kB      |
| @aws-sdk/client-mturk                           | 1.3 MB        |
| @aws-sdk/client-mwaa                            | 460.9 kB      |
| @aws-sdk/client-neptune                         | 2.6 MB        |
| @aws-sdk/client-network-firewall                | 1.2 MB        |
| @aws-sdk/client-networkmanager                  | 1.3 MB        |
| @aws-sdk/client-nimble                          | 1.6 MB        |
| @aws-sdk/client-opensearch                      | 1.6 MB        |
| @aws-sdk/client-opsworks                        | 2.3 MB        |
| @aws-sdk/client-opsworkscm                      | 778.1 kB      |
| @aws-sdk/client-organizations                   | 2.2 MB        |
| @aws-sdk/client-outposts                        | 473.6 kB      |
| @aws-sdk/client-personalize                     | 1.6 MB        |
| @aws-sdk/client-personalize-events              | 242.2 kB      |
| @aws-sdk/client-personalize-runtime             | 225.5 kB      |
| @aws-sdk/client-pi                              | 300.3 kB      |
| @aws-sdk/client-pinpoint                        | 4.4 MB        |
| @aws-sdk/client-pinpoint-email                  | 1.6 MB        |
| @aws-sdk/client-pinpoint-sms-voice              | 425.3 kB      |
| @aws-sdk/client-polly                           | 500.4 kB      |
| @aws-sdk/client-pricing                         | 290.3 kB      |
| @aws-sdk/client-proton                          | 1.8 MB        |
| @aws-sdk/client-qldb                            | 777.7 kB      |
| @aws-sdk/client-qldb-session                    | 255.2 kB      |
| @aws-sdk/client-quicksight                      | 4.6 MB        |
| @aws-sdk/client-ram                             | 1.1 MB        |
| @aws-sdk/client-rds                             | 5.8 MB        |
| @aws-sdk/client-rds-data                        | 455.2 kB      |
| @aws-sdk/client-redshift                        | 4.4 MB        |
| @aws-sdk/client-redshift-data                   | 469.4 kB      |
| @aws-sdk/client-rekognition                     | 2.3 MB        |
| @aws-sdk/client-resource-groups                 | 730.5 kB      |
| @aws-sdk/client-resource-groups-tagging-api     | 463.6 kB      |
| @aws-sdk/client-robomaker                       | 2.1 MB        |
| @aws-sdk/client-route-53                        | 2.5 MB        |
| @aws-sdk/client-route-53-domains                | 1.0 MB        |
| @aws-sdk/client-route53-recovery-cluster        | 212.2 kB      |
| @aws-sdk/client-route53-recovery-control-config | 771.6 kB      |
| @aws-sdk/client-route53-recovery-readiness      | 1.1 MB        |
| @aws-sdk/client-route53resolver                 | 2.2 MB        |
| @aws-sdk/client-s3                              | 4.2 MB        |
| @aws-sdk/client-s3-control                      | 2.4 MB        |
| @aws-sdk/client-s3outposts                      | 206.9 kB      |
| @aws-sdk/client-sagemaker                       | 8.5 MB        |
| @aws-sdk/client-sagemaker-a2i-runtime           | 338.7 kB      |
| @aws-sdk/client-sagemaker-edge                  | 147.9 kB      |
| @aws-sdk/client-sagemaker-featurestore-runtime  | 234.3 kB      |
| @aws-sdk/client-sagemaker-runtime               | 238.4 kB      |
| @aws-sdk/client-savingsplans                    | 458.6 kB      |
| @aws-sdk/client-schemas                         | 1.1 MB        |
| @aws-sdk/client-secrets-manager                 | 1.0 MB        |
| @aws-sdk/client-securityhub                     | 3.8 MB        |
| @aws-sdk/client-serverlessapplicationrepository | 697.6 kB      |
| @aws-sdk/client-service-catalog                 | 2.8 MB        |
| @aws-sdk/client-service-catalog-appregistry     | 731.6 kB      |
| @aws-sdk/client-service-quotas                  | 833.6 kB      |
| @aws-sdk/client-servicediscovery                | 1.1 MB        |
| @aws-sdk/client-ses                             | 2.4 MB        |
| @aws-sdk/client-sesv2                           | 2.8 MB        |
| @aws-sdk/client-sfn                             | 988.3 kB      |
| @aws-sdk/client-shield                          | 1.1 MB        |
| @aws-sdk/client-signer                          | 761.4 kB      |
| @aws-sdk/client-sms                             | 1.3 MB        |
| @aws-sdk/client-snow-device-management          | 528.2 kB      |
| @aws-sdk/client-snowball                        | 949.2 kB      |
| @aws-sdk/client-sns                             | 1.4 MB        |
| @aws-sdk/client-sqs                             | 877.7 kB      |
| @aws-sdk/client-ssm                             | 5.5 MB        |
| @aws-sdk/client-ssm-contacts                    | 902.8 kB      |
| @aws-sdk/client-ssm-incidents                   | 1.1 MB        |
| @aws-sdk/client-sso                             | 278.3 kB      |
| @aws-sdk/client-sso-admin                       | 1.1 MB        |
| @aws-sdk/client-sso-oidc                        | 290.3 kB      |
| @aws-sdk/client-storage-gateway                 | 2.8 MB        |
| @aws-sdk/client-sts                             | 607.4 kB      |
| @aws-sdk/client-support                         | 676.1 kB      |
| @aws-sdk/client-swf                             | 1.8 MB        |
| @aws-sdk/client-synthetics                      | 564.0 kB      |
| @aws-sdk/client-textract                        | 532.0 kB      |
| @aws-sdk/client-timestream-query                | 227.9 kB      |
| @aws-sdk/client-timestream-write                | 578.5 kB      |
| @aws-sdk/client-transcribe                      | 1.5 MB        |
| @aws-sdk/client-transcribe-streaming            | 379.0 kB      |
| @aws-sdk/client-transfer                        | 1.2 MB        |
| @aws-sdk/client-translate                       | 649.2 kB      |
| @aws-sdk/client-voice-id                        | 783.2 kB      |
| @aws-sdk/client-waf                             | 2.9 MB        |
| @aws-sdk/client-waf-regional                    | 3.0 MB        |
| @aws-sdk/client-wafv2                           | 1.9 MB        |
| @aws-sdk/client-wellarchitected                 | 1.2 MB        |
| @aws-sdk/client-wisdom                          | 1.1 MB        |
| @aws-sdk/client-workdocs                        | 1.5 MB        |
| @aws-sdk/client-worklink                        | 1.1 MB        |
| @aws-sdk/client-workmail                        | 1.9 MB        |
| @aws-sdk/client-workmailmessageflow             | 214.4 kB      |
| @aws-sdk/client-workspaces                      | 1.8 MB        |
| @aws-sdk/client-xray                            | 1.1 MB        |
| @aws-sdk/lib-dynamodb                           | 184.8 kB      |
| @aws-sdk/lib-storage                            | 69.4 kB       |
| @aws-sdk/abort-controller                       | 41.4 kB       |
| @aws-sdk/body-checksum-browser                  | 34.4 kB       |
| @aws-sdk/body-checksum-node                     | 35.1 kB       |
| @aws-sdk/chunked-blob-reader                    | 30.2 kB       |
| @aws-sdk/chunked-blob-reader-native             | 25.1 kB       |
| @aws-sdk/chunked-stream-reader-node             | 35.8 kB       |
| @aws-sdk/client-documentation-generator         | 60.6 kB       |
| @aws-sdk/config-resolver                        | 98.4 kB       |
| @aws-sdk/core-packages-documentation-generator  | 30.4 kB       |
| @aws-sdk/credential-provider-cognito-identity   | 119.4 kB      |
| @aws-sdk/credential-provider-env                | 45.7 kB       |
| @aws-sdk/credential-provider-imds               | 79.8 kB       |
| @aws-sdk/credential-provider-ini                | 60.0 kB       |
| @aws-sdk/credential-provider-node               | 59.9 kB       |
| @aws-sdk/credential-provider-process            | 46.6 kB       |
| @aws-sdk/credential-provider-sso                | 34.5 kB       |
| @aws-sdk/credential-provider-web-identity       | 34.2 kB       |
| @aws-sdk/credential-providers                   | 82.4 kB       |
| @aws-sdk/endpoint-cache                         | 22.8 kB       |
| @aws-sdk/eventstream-handler-node               | 37.2 kB       |
| @aws-sdk/eventstream-marshaller                 | 91.8 kB       |
| @aws-sdk/eventstream-serde-browser              | 39.0 kB       |
| @aws-sdk/eventstream-serde-config-resolver      | 29.1 kB       |
| @aws-sdk/eventstream-serde-node                 | 40.7 kB       |
| @aws-sdk/eventstream-serde-universal            | 52.4 kB       |
| @aws-sdk/fetch-http-handler                     | 71.2 kB       |
| @aws-sdk/hash-blob-browser                      | 52.1 kB       |
| @aws-sdk/hash-node                              | 41.3 kB       |
| @aws-sdk/hash-stream-node                       | 48.8 kB       |
| @aws-sdk/invalid-dependency                     | 25.9 kB       |
| @aws-sdk/is-array-buffer                        | 28.8 kB       |
| @aws-sdk/karma-credential-loader                | 39.6 kB       |
| @aws-sdk/md5-js                                 | 57.7 kB       |
| @aws-sdk/middleware-apply-body-checksum         | 47.9 kB       |
| @aws-sdk/middleware-bucket-endpoint             | 108.6 kB      |
| @aws-sdk/middleware-content-length              | 59.2 kB       |
| @aws-sdk/middleware-endpoint-discovery          | 47.8 kB       |
| @aws-sdk/middleware-eventstream                 | 32.8 kB       |
| @aws-sdk/middleware-expect-continue             | 50.8 kB       |
| @aws-sdk/middleware-header-default              | 43.6 kB       |
| @aws-sdk/middleware-host-header                 | 38.5 kB       |
| @aws-sdk/middleware-location-constraint         | 45.0 kB       |
| @aws-sdk/middleware-logger                      | 27.1 kB       |
| @aws-sdk/middleware-retry                       | 104.1 kB      |
| @aws-sdk/middleware-sdk-api-gateway             | 53.2 kB       |
| @aws-sdk/middleware-sdk-ec2                     | 46.4 kB       |
| @aws-sdk/middleware-sdk-glacier                 | 62.0 kB       |
| @aws-sdk/middleware-sdk-machinelearning         | 37.3 kB       |
| @aws-sdk/middleware-sdk-rds                     | 50.6 kB       |
| @aws-sdk/middleware-sdk-route53                 | 42.2 kB       |
| @aws-sdk/middleware-sdk-s3                      | 55.9 kB       |
| @aws-sdk/middleware-sdk-s3-control              | 64.7 kB       |
| @aws-sdk/middleware-sdk-sqs                     | 45.2 kB       |
| @aws-sdk/middleware-sdk-sts                     | 20.2 kB       |
| @aws-sdk/middleware-sdk-transcribe-streaming    | 56.9 kB       |
| @aws-sdk/middleware-serde                       | 50.3 kB       |
| @aws-sdk/middleware-signing                     | 79.3 kB       |
| @aws-sdk/middleware-ssec                        | 36.6 kB       |
| @aws-sdk/middleware-stack                       | 71.9 kB       |
| @aws-sdk/middleware-user-agent                  | 55.4 kB       |
| @aws-sdk/node-config-provider                   | 34.5 kB       |
| @aws-sdk/node-http-handler                      | 107.6 kB      |
| @aws-sdk/polly-request-presigner                | 36.0 kB       |
| @aws-sdk/property-provider                      | 54.1 kB       |
| @aws-sdk/protocol-http                          | 54.8 kB       |
| @aws-sdk/querystring-builder                    | 41.7 kB       |
| @aws-sdk/querystring-parser                     | 40.3 kB       |
| @aws-sdk/s3-presigned-post                      | 38.0 kB       |
| @aws-sdk/s3-request-presigner                   | 80.1 kB       |
| @aws-sdk/service-error-classification           | 36.7 kB       |
| @aws-sdk/sha256-tree-hash                       | 50.6 kB       |
| @aws-sdk/shared-ini-file-loader                 | 42.9 kB       |
| @aws-sdk/signature-v4                           | 186.9 kB      |
| @aws-sdk/signature-v4-crt                       | 81.8 kB       |
| @aws-sdk/smithy-client                          | 122.9 kB      |
| @aws-sdk/types                                  | 155.6 kB      |
| @aws-sdk/url-parser                             | 18.9 kB       |
| @aws-sdk/util-arn-parser                        | 22.7 kB       |
| @aws-sdk/util-base64-browser                    | 35.0 kB       |
| @aws-sdk/util-base64-node                       | 32.6 kB       |
| @aws-sdk/util-body-length-browser               | 30.6 kB       |
| @aws-sdk/util-body-length-node                  | 30.5 kB       |
| @aws-sdk/util-buffer-from                       | 32.2 kB       |
| @aws-sdk/util-create-request                    | 63.4 kB       |
| @aws-sdk/util-credentials                       | 18.3 kB       |
| @aws-sdk/util-dynamodb                          | 55.3 kB       |
| @aws-sdk/util-format-url                        | 45.2 kB       |
| @aws-sdk/util-hex-encoding                      | 30.8 kB       |
| @aws-sdk/util-locate-window                     | 28.9 kB       |
| @aws-sdk/util-uri-escape                        | 32.2 kB       |
| @aws-sdk/util-user-agent-browser                | 57.8 kB       |
| @aws-sdk/util-user-agent-node                   | 56.3 kB       |
| @aws-sdk/util-utf8-browser                      | 34.8 kB       |
| @aws-sdk/util-utf8-node                         | 31.6 kB       |
| @aws-sdk/util-waiter                            | 35.8 kB       |
| @aws-sdk/xml-builder                            | 37.7 kB       |

```

</details>

### Testing
Verified that comments are removed from downlevel-dts files:

<details>
<summary>Before: comments are present in downlevel-dts</summary>

```console
$ pwd
/home/trivikr/workspace/aws-sdk-js-v3/clients/client-sts

$ tail dist-types/ts3.4/STS.d.ts
     *          temporary credentials have the same permissions as the IAM user. </p>
     *          <p>For more information about using <code>GetSessionToken</code> to create temporary
     *          credentials, go to <a href="https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_request.html#api_getsessiontoken">Temporary
     *             Credentials for Users in Untrusted Environments</a> in the
     *             <i>IAM User Guide</i>. </p>
     */
    getSessionToken(args: GetSessionTokenCommandInput, options?: __HttpHandlerOptions): Promise<GetSessionTokenCommandOutput>;
    getSessionToken(args: GetSessionTokenCommandInput, cb: (err: any, data?: GetSessionTokenCommandOutput) => void): void;
    getSessionToken(args: GetSessionTokenCommandInput, options: __HttpHandlerOptions, cb: (err: any, data?: GetSessionTokenCommandOutput) => void): void;
}
```

</details>

<details>
<summary>After: comments are not present in downlevel-dts files</summary>

```console
$ pwd
/home/trivikr/workspace/aws-sdk-js-v3/clients/client-sts

$ tail dist-types/ts3.4/STS.d.ts
    getCallerIdentity(args: GetCallerIdentityCommandInput, options: __HttpHandlerOptions, cb: (err: any, data?: GetCallerIdentityCommandOutput) => void): void;
    
    getFederationToken(args: GetFederationTokenCommandInput, options?: __HttpHandlerOptions): Promise<GetFederationTokenCommandOutput>;
    getFederationToken(args: GetFederationTokenCommandInput, cb: (err: any, data?: GetFederationTokenCommandOutput) => void): void;
    getFederationToken(args: GetFederationTokenCommandInput, options: __HttpHandlerOptions, cb: (err: any, data?: GetFederationTokenCommandOutput) => void): void;
    
    getSessionToken(args: GetSessionTokenCommandInput, options?: __HttpHandlerOptions): Promise<GetSessionTokenCommandOutput>;
    getSessionToken(args: GetSessionTokenCommandInput, cb: (err: any, data?: GetSessionTokenCommandOutput) => void): void;
    getSessionToken(args: GetSessionTokenCommandInput, options: __HttpHandlerOptions, cb: (err: any, data?: GetSessionTokenCommandOutput) => void): void;
}
```

</details>

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
