### PR TITLE
fix(clients): emitDeclarationOnly in tsconfig.types.json

### DIFF
--- a/clients/client-accessanalyzer/tsconfig.types.json
+++ b/clients/client-accessanalyzer/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-account/tsconfig.types.json
+++ b/clients/client-account/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-acm-pca/tsconfig.types.json
+++ b/clients/client-acm-pca/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-acm/tsconfig.types.json
+++ b/clients/client-acm/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-alexa-for-business/tsconfig.types.json
+++ b/clients/client-alexa-for-business/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-amp/tsconfig.types.json
+++ b/clients/client-amp/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-amplify/tsconfig.types.json
+++ b/clients/client-amplify/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-amplifybackend/tsconfig.types.json
+++ b/clients/client-amplifybackend/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-api-gateway/tsconfig.types.json
+++ b/clients/client-api-gateway/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-apigatewaymanagementapi/tsconfig.types.json
+++ b/clients/client-apigatewaymanagementapi/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-apigatewayv2/tsconfig.types.json
+++ b/clients/client-apigatewayv2/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-app-mesh/tsconfig.types.json
+++ b/clients/client-app-mesh/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-appconfig/tsconfig.types.json
+++ b/clients/client-appconfig/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-appflow/tsconfig.types.json
+++ b/clients/client-appflow/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-appintegrations/tsconfig.types.json
+++ b/clients/client-appintegrations/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-application-auto-scaling/tsconfig.types.json
+++ b/clients/client-application-auto-scaling/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-application-discovery-service/tsconfig.types.json
+++ b/clients/client-application-discovery-service/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-application-insights/tsconfig.types.json
+++ b/clients/client-application-insights/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-applicationcostprofiler/tsconfig.types.json
+++ b/clients/client-applicationcostprofiler/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-apprunner/tsconfig.types.json
+++ b/clients/client-apprunner/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-appstream/tsconfig.types.json
+++ b/clients/client-appstream/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-appsync/tsconfig.types.json
+++ b/clients/client-appsync/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-athena/tsconfig.types.json
+++ b/clients/client-athena/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-auditmanager/tsconfig.types.json
+++ b/clients/client-auditmanager/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-auto-scaling-plans/tsconfig.types.json
+++ b/clients/client-auto-scaling-plans/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-auto-scaling/tsconfig.types.json
+++ b/clients/client-auto-scaling/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-backup/tsconfig.types.json
+++ b/clients/client-backup/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-batch/tsconfig.types.json
+++ b/clients/client-batch/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-braket/tsconfig.types.json
+++ b/clients/client-braket/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-budgets/tsconfig.types.json
+++ b/clients/client-budgets/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-chime-sdk-identity/tsconfig.types.json
+++ b/clients/client-chime-sdk-identity/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-chime-sdk-messaging/tsconfig.types.json
+++ b/clients/client-chime-sdk-messaging/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-chime/tsconfig.types.json
+++ b/clients/client-chime/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-cloud9/tsconfig.types.json
+++ b/clients/client-cloud9/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-cloudcontrol/tsconfig.types.json
+++ b/clients/client-cloudcontrol/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-clouddirectory/tsconfig.types.json
+++ b/clients/client-clouddirectory/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-cloudformation/tsconfig.types.json
+++ b/clients/client-cloudformation/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-cloudfront/tsconfig.types.json
+++ b/clients/client-cloudfront/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-cloudhsm-v2/tsconfig.types.json
+++ b/clients/client-cloudhsm-v2/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-cloudhsm/tsconfig.types.json
+++ b/clients/client-cloudhsm/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-cloudsearch-domain/tsconfig.types.json
+++ b/clients/client-cloudsearch-domain/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-cloudsearch/tsconfig.types.json
+++ b/clients/client-cloudsearch/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-cloudtrail/tsconfig.types.json
+++ b/clients/client-cloudtrail/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-cloudwatch-events/tsconfig.types.json
+++ b/clients/client-cloudwatch-events/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-cloudwatch-logs/tsconfig.types.json
+++ b/clients/client-cloudwatch-logs/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-cloudwatch/tsconfig.types.json
+++ b/clients/client-cloudwatch/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-codeartifact/tsconfig.types.json
+++ b/clients/client-codeartifact/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-codebuild/tsconfig.types.json
+++ b/clients/client-codebuild/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-codecommit/tsconfig.types.json
+++ b/clients/client-codecommit/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-codedeploy/tsconfig.types.json
+++ b/clients/client-codedeploy/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-codeguru-reviewer/tsconfig.types.json
+++ b/clients/client-codeguru-reviewer/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-codeguruprofiler/tsconfig.types.json
+++ b/clients/client-codeguruprofiler/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-codepipeline/tsconfig.types.json
+++ b/clients/client-codepipeline/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-codestar-connections/tsconfig.types.json
+++ b/clients/client-codestar-connections/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-codestar-notifications/tsconfig.types.json
+++ b/clients/client-codestar-notifications/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-codestar/tsconfig.types.json
+++ b/clients/client-codestar/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-cognito-identity-provider/tsconfig.types.json
+++ b/clients/client-cognito-identity-provider/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-cognito-identity/tsconfig.types.json
+++ b/clients/client-cognito-identity/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-cognito-sync/tsconfig.types.json
+++ b/clients/client-cognito-sync/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-comprehend/tsconfig.types.json
+++ b/clients/client-comprehend/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-comprehendmedical/tsconfig.types.json
+++ b/clients/client-comprehendmedical/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-compute-optimizer/tsconfig.types.json
+++ b/clients/client-compute-optimizer/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-config-service/tsconfig.types.json
+++ b/clients/client-config-service/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-connect-contact-lens/tsconfig.types.json
+++ b/clients/client-connect-contact-lens/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-connect/tsconfig.types.json
+++ b/clients/client-connect/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-connectparticipant/tsconfig.types.json
+++ b/clients/client-connectparticipant/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-cost-and-usage-report-service/tsconfig.types.json
+++ b/clients/client-cost-and-usage-report-service/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-cost-explorer/tsconfig.types.json
+++ b/clients/client-cost-explorer/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-customer-profiles/tsconfig.types.json
+++ b/clients/client-customer-profiles/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-data-pipeline/tsconfig.types.json
+++ b/clients/client-data-pipeline/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-database-migration-service/tsconfig.types.json
+++ b/clients/client-database-migration-service/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-databrew/tsconfig.types.json
+++ b/clients/client-databrew/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-dataexchange/tsconfig.types.json
+++ b/clients/client-dataexchange/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-datasync/tsconfig.types.json
+++ b/clients/client-datasync/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-dax/tsconfig.types.json
+++ b/clients/client-dax/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-detective/tsconfig.types.json
+++ b/clients/client-detective/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-device-farm/tsconfig.types.json
+++ b/clients/client-device-farm/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-devops-guru/tsconfig.types.json
+++ b/clients/client-devops-guru/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-direct-connect/tsconfig.types.json
+++ b/clients/client-direct-connect/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-directory-service/tsconfig.types.json
+++ b/clients/client-directory-service/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-dlm/tsconfig.types.json
+++ b/clients/client-dlm/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-docdb/tsconfig.types.json
+++ b/clients/client-docdb/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-dynamodb-streams/tsconfig.types.json
+++ b/clients/client-dynamodb-streams/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-dynamodb/tsconfig.types.json
+++ b/clients/client-dynamodb/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-ebs/tsconfig.types.json
+++ b/clients/client-ebs/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-ec2-instance-connect/tsconfig.types.json
+++ b/clients/client-ec2-instance-connect/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-ec2/tsconfig.types.json
+++ b/clients/client-ec2/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-ecr-public/tsconfig.types.json
+++ b/clients/client-ecr-public/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-ecr/tsconfig.types.json
+++ b/clients/client-ecr/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-ecs/tsconfig.types.json
+++ b/clients/client-ecs/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-efs/tsconfig.types.json
+++ b/clients/client-efs/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-eks/tsconfig.types.json
+++ b/clients/client-eks/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-elastic-beanstalk/tsconfig.types.json
+++ b/clients/client-elastic-beanstalk/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-elastic-inference/tsconfig.types.json
+++ b/clients/client-elastic-inference/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-elastic-load-balancing-v2/tsconfig.types.json
+++ b/clients/client-elastic-load-balancing-v2/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-elastic-load-balancing/tsconfig.types.json
+++ b/clients/client-elastic-load-balancing/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-elastic-transcoder/tsconfig.types.json
+++ b/clients/client-elastic-transcoder/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-elasticache/tsconfig.types.json
+++ b/clients/client-elasticache/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-elasticsearch-service/tsconfig.types.json
+++ b/clients/client-elasticsearch-service/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-emr-containers/tsconfig.types.json
+++ b/clients/client-emr-containers/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-emr/tsconfig.types.json
+++ b/clients/client-emr/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-eventbridge/tsconfig.types.json
+++ b/clients/client-eventbridge/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-finspace-data/tsconfig.types.json
+++ b/clients/client-finspace-data/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-finspace/tsconfig.types.json
+++ b/clients/client-finspace/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-firehose/tsconfig.types.json
+++ b/clients/client-firehose/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-fis/tsconfig.types.json
+++ b/clients/client-fis/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-fms/tsconfig.types.json
+++ b/clients/client-fms/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-forecast/tsconfig.types.json
+++ b/clients/client-forecast/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-forecastquery/tsconfig.types.json
+++ b/clients/client-forecastquery/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-frauddetector/tsconfig.types.json
+++ b/clients/client-frauddetector/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-fsx/tsconfig.types.json
+++ b/clients/client-fsx/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-gamelift/tsconfig.types.json
+++ b/clients/client-gamelift/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-glacier/tsconfig.types.json
+++ b/clients/client-glacier/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-global-accelerator/tsconfig.types.json
+++ b/clients/client-global-accelerator/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-glue/tsconfig.types.json
+++ b/clients/client-glue/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-grafana/tsconfig.types.json
+++ b/clients/client-grafana/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-greengrass/tsconfig.types.json
+++ b/clients/client-greengrass/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-greengrassv2/tsconfig.types.json
+++ b/clients/client-greengrassv2/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-groundstation/tsconfig.types.json
+++ b/clients/client-groundstation/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-guardduty/tsconfig.types.json
+++ b/clients/client-guardduty/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-health/tsconfig.types.json
+++ b/clients/client-health/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-healthlake/tsconfig.types.json
+++ b/clients/client-healthlake/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-honeycode/tsconfig.types.json
+++ b/clients/client-honeycode/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-iam/tsconfig.types.json
+++ b/clients/client-iam/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-identitystore/tsconfig.types.json
+++ b/clients/client-identitystore/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-imagebuilder/tsconfig.types.json
+++ b/clients/client-imagebuilder/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-inspector/tsconfig.types.json
+++ b/clients/client-inspector/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-iot-1click-devices-service/tsconfig.types.json
+++ b/clients/client-iot-1click-devices-service/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-iot-1click-projects/tsconfig.types.json
+++ b/clients/client-iot-1click-projects/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-iot-data-plane/tsconfig.types.json
+++ b/clients/client-iot-data-plane/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-iot-events-data/tsconfig.types.json
+++ b/clients/client-iot-events-data/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-iot-events/tsconfig.types.json
+++ b/clients/client-iot-events/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-iot-jobs-data-plane/tsconfig.types.json
+++ b/clients/client-iot-jobs-data-plane/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-iot-wireless/tsconfig.types.json
+++ b/clients/client-iot-wireless/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-iot/tsconfig.types.json
+++ b/clients/client-iot/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-iotanalytics/tsconfig.types.json
+++ b/clients/client-iotanalytics/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-iotdeviceadvisor/tsconfig.types.json
+++ b/clients/client-iotdeviceadvisor/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-iotfleethub/tsconfig.types.json
+++ b/clients/client-iotfleethub/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-iotsecuretunneling/tsconfig.types.json
+++ b/clients/client-iotsecuretunneling/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-iotsitewise/tsconfig.types.json
+++ b/clients/client-iotsitewise/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-iotthingsgraph/tsconfig.types.json
+++ b/clients/client-iotthingsgraph/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-ivs/tsconfig.types.json
+++ b/clients/client-ivs/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-kafka/tsconfig.types.json
+++ b/clients/client-kafka/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-kafkaconnect/tsconfig.types.json
+++ b/clients/client-kafkaconnect/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-kendra/tsconfig.types.json
+++ b/clients/client-kendra/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-kinesis-analytics-v2/tsconfig.types.json
+++ b/clients/client-kinesis-analytics-v2/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-kinesis-analytics/tsconfig.types.json
+++ b/clients/client-kinesis-analytics/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-kinesis-video-archived-media/tsconfig.types.json
+++ b/clients/client-kinesis-video-archived-media/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-kinesis-video-media/tsconfig.types.json
+++ b/clients/client-kinesis-video-media/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-kinesis-video-signaling/tsconfig.types.json
+++ b/clients/client-kinesis-video-signaling/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-kinesis-video/tsconfig.types.json
+++ b/clients/client-kinesis-video/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-kinesis/tsconfig.types.json
+++ b/clients/client-kinesis/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-kms/tsconfig.types.json
+++ b/clients/client-kms/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-lakeformation/tsconfig.types.json
+++ b/clients/client-lakeformation/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-lambda/tsconfig.types.json
+++ b/clients/client-lambda/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-lex-model-building-service/tsconfig.types.json
+++ b/clients/client-lex-model-building-service/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-lex-models-v2/tsconfig.types.json
+++ b/clients/client-lex-models-v2/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-lex-runtime-service/tsconfig.types.json
+++ b/clients/client-lex-runtime-service/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-lex-runtime-v2/tsconfig.types.json
+++ b/clients/client-lex-runtime-v2/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-license-manager/tsconfig.types.json
+++ b/clients/client-license-manager/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-lightsail/tsconfig.types.json
+++ b/clients/client-lightsail/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-location/tsconfig.types.json
+++ b/clients/client-location/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-lookoutequipment/tsconfig.types.json
+++ b/clients/client-lookoutequipment/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-lookoutmetrics/tsconfig.types.json
+++ b/clients/client-lookoutmetrics/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-lookoutvision/tsconfig.types.json
+++ b/clients/client-lookoutvision/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-machine-learning/tsconfig.types.json
+++ b/clients/client-machine-learning/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-macie/tsconfig.types.json
+++ b/clients/client-macie/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-macie2/tsconfig.types.json
+++ b/clients/client-macie2/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-managedblockchain/tsconfig.types.json
+++ b/clients/client-managedblockchain/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-marketplace-catalog/tsconfig.types.json
+++ b/clients/client-marketplace-catalog/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-marketplace-commerce-analytics/tsconfig.types.json
+++ b/clients/client-marketplace-commerce-analytics/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-marketplace-entitlement-service/tsconfig.types.json
+++ b/clients/client-marketplace-entitlement-service/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-marketplace-metering/tsconfig.types.json
+++ b/clients/client-marketplace-metering/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-mediaconnect/tsconfig.types.json
+++ b/clients/client-mediaconnect/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-mediaconvert/tsconfig.types.json
+++ b/clients/client-mediaconvert/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-medialive/tsconfig.types.json
+++ b/clients/client-medialive/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-mediapackage-vod/tsconfig.types.json
+++ b/clients/client-mediapackage-vod/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-mediapackage/tsconfig.types.json
+++ b/clients/client-mediapackage/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-mediastore-data/tsconfig.types.json
+++ b/clients/client-mediastore-data/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-mediastore/tsconfig.types.json
+++ b/clients/client-mediastore/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-mediatailor/tsconfig.types.json
+++ b/clients/client-mediatailor/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-memorydb/tsconfig.types.json
+++ b/clients/client-memorydb/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-mgn/tsconfig.types.json
+++ b/clients/client-mgn/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-migration-hub/tsconfig.types.json
+++ b/clients/client-migration-hub/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-migrationhub-config/tsconfig.types.json
+++ b/clients/client-migrationhub-config/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-mobile/tsconfig.types.json
+++ b/clients/client-mobile/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-mq/tsconfig.types.json
+++ b/clients/client-mq/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-mturk/tsconfig.types.json
+++ b/clients/client-mturk/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-mwaa/tsconfig.types.json
+++ b/clients/client-mwaa/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-neptune/tsconfig.types.json
+++ b/clients/client-neptune/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-network-firewall/tsconfig.types.json
+++ b/clients/client-network-firewall/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-networkmanager/tsconfig.types.json
+++ b/clients/client-networkmanager/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-nimble/tsconfig.types.json
+++ b/clients/client-nimble/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-opensearch/tsconfig.types.json
+++ b/clients/client-opensearch/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-opsworks/tsconfig.types.json
+++ b/clients/client-opsworks/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-opsworkscm/tsconfig.types.json
+++ b/clients/client-opsworkscm/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-organizations/tsconfig.types.json
+++ b/clients/client-organizations/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-outposts/tsconfig.types.json
+++ b/clients/client-outposts/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-personalize-events/tsconfig.types.json
+++ b/clients/client-personalize-events/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-personalize-runtime/tsconfig.types.json
+++ b/clients/client-personalize-runtime/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-personalize/tsconfig.types.json
+++ b/clients/client-personalize/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-pi/tsconfig.types.json
+++ b/clients/client-pi/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-pinpoint-email/tsconfig.types.json
+++ b/clients/client-pinpoint-email/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-pinpoint-sms-voice/tsconfig.types.json
+++ b/clients/client-pinpoint-sms-voice/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-pinpoint/tsconfig.types.json
+++ b/clients/client-pinpoint/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-polly/tsconfig.types.json
+++ b/clients/client-polly/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-pricing/tsconfig.types.json
+++ b/clients/client-pricing/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-proton/tsconfig.types.json
+++ b/clients/client-proton/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-qldb-session/tsconfig.types.json
+++ b/clients/client-qldb-session/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-qldb/tsconfig.types.json
+++ b/clients/client-qldb/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-quicksight/tsconfig.types.json
+++ b/clients/client-quicksight/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-ram/tsconfig.types.json
+++ b/clients/client-ram/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-rds-data/tsconfig.types.json
+++ b/clients/client-rds-data/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-rds/tsconfig.types.json
+++ b/clients/client-rds/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-redshift-data/tsconfig.types.json
+++ b/clients/client-redshift-data/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-redshift/tsconfig.types.json
+++ b/clients/client-redshift/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-rekognition/tsconfig.types.json
+++ b/clients/client-rekognition/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-resource-groups-tagging-api/tsconfig.types.json
+++ b/clients/client-resource-groups-tagging-api/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-resource-groups/tsconfig.types.json
+++ b/clients/client-resource-groups/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-robomaker/tsconfig.types.json
+++ b/clients/client-robomaker/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-route-53-domains/tsconfig.types.json
+++ b/clients/client-route-53-domains/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-route-53/tsconfig.types.json
+++ b/clients/client-route-53/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-route53-recovery-cluster/tsconfig.types.json
+++ b/clients/client-route53-recovery-cluster/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-route53-recovery-control-config/tsconfig.types.json
+++ b/clients/client-route53-recovery-control-config/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-route53-recovery-readiness/tsconfig.types.json
+++ b/clients/client-route53-recovery-readiness/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-route53resolver/tsconfig.types.json
+++ b/clients/client-route53resolver/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-s3-control/tsconfig.types.json
+++ b/clients/client-s3-control/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-s3/tsconfig.types.json
+++ b/clients/client-s3/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-s3outposts/tsconfig.types.json
+++ b/clients/client-s3outposts/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-sagemaker-a2i-runtime/tsconfig.types.json
+++ b/clients/client-sagemaker-a2i-runtime/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-sagemaker-edge/tsconfig.types.json
+++ b/clients/client-sagemaker-edge/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-sagemaker-featurestore-runtime/tsconfig.types.json
+++ b/clients/client-sagemaker-featurestore-runtime/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-sagemaker-runtime/tsconfig.types.json
+++ b/clients/client-sagemaker-runtime/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-sagemaker/tsconfig.types.json
+++ b/clients/client-sagemaker/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-savingsplans/tsconfig.types.json
+++ b/clients/client-savingsplans/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-schemas/tsconfig.types.json
+++ b/clients/client-schemas/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-secrets-manager/tsconfig.types.json
+++ b/clients/client-secrets-manager/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-securityhub/tsconfig.types.json
+++ b/clients/client-securityhub/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-serverlessapplicationrepository/tsconfig.types.json
+++ b/clients/client-serverlessapplicationrepository/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-service-catalog-appregistry/tsconfig.types.json
+++ b/clients/client-service-catalog-appregistry/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-service-catalog/tsconfig.types.json
+++ b/clients/client-service-catalog/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-service-quotas/tsconfig.types.json
+++ b/clients/client-service-quotas/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-servicediscovery/tsconfig.types.json
+++ b/clients/client-servicediscovery/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-ses/tsconfig.types.json
+++ b/clients/client-ses/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-sesv2/tsconfig.types.json
+++ b/clients/client-sesv2/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-sfn/tsconfig.types.json
+++ b/clients/client-sfn/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-shield/tsconfig.types.json
+++ b/clients/client-shield/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-signer/tsconfig.types.json
+++ b/clients/client-signer/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-sms/tsconfig.types.json
+++ b/clients/client-sms/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-snow-device-management/tsconfig.types.json
+++ b/clients/client-snow-device-management/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-snowball/tsconfig.types.json
+++ b/clients/client-snowball/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-sns/tsconfig.types.json
+++ b/clients/client-sns/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-sqs/tsconfig.types.json
+++ b/clients/client-sqs/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-ssm-contacts/tsconfig.types.json
+++ b/clients/client-ssm-contacts/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-ssm-incidents/tsconfig.types.json
+++ b/clients/client-ssm-incidents/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-ssm/tsconfig.types.json
+++ b/clients/client-ssm/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-sso-admin/tsconfig.types.json
+++ b/clients/client-sso-admin/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-sso-oidc/tsconfig.types.json
+++ b/clients/client-sso-oidc/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-sso/tsconfig.types.json
+++ b/clients/client-sso/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-storage-gateway/tsconfig.types.json
+++ b/clients/client-storage-gateway/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-sts/tsconfig.types.json
+++ b/clients/client-sts/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-support/tsconfig.types.json
+++ b/clients/client-support/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-swf/tsconfig.types.json
+++ b/clients/client-swf/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-synthetics/tsconfig.types.json
+++ b/clients/client-synthetics/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-textract/tsconfig.types.json
+++ b/clients/client-textract/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-timestream-query/tsconfig.types.json
+++ b/clients/client-timestream-query/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-timestream-write/tsconfig.types.json
+++ b/clients/client-timestream-write/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-transcribe-streaming/tsconfig.types.json
+++ b/clients/client-transcribe-streaming/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-transcribe/tsconfig.types.json
+++ b/clients/client-transcribe/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-transfer/tsconfig.types.json
+++ b/clients/client-transfer/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-translate/tsconfig.types.json
+++ b/clients/client-translate/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-voice-id/tsconfig.types.json
+++ b/clients/client-voice-id/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-waf-regional/tsconfig.types.json
+++ b/clients/client-waf-regional/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-waf/tsconfig.types.json
+++ b/clients/client-waf/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-wafv2/tsconfig.types.json
+++ b/clients/client-wafv2/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-wellarchitected/tsconfig.types.json
+++ b/clients/client-wellarchitected/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-wisdom/tsconfig.types.json
+++ b/clients/client-wisdom/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-workdocs/tsconfig.types.json
+++ b/clients/client-workdocs/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-worklink/tsconfig.types.json
+++ b/clients/client-worklink/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-workmail/tsconfig.types.json
+++ b/clients/client-workmail/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-workmailmessageflow/tsconfig.types.json
+++ b/clients/client-workmailmessageflow/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-workspaces/tsconfig.types.json
+++ b/clients/client-workspaces/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/clients/client-xray/tsconfig.types.json
+++ b/clients/client-xray/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }


### PR DESCRIPTION
### Issue
Fixes: https://github.com/aws/aws-sdk-js-v3/issues/2892

### Description
Adds emitDeclarationOnly in tsconfig.types.json

This reduces sum of unpacked npm publish sizes for all clients from **406.25 MB** to **389.15 MB** (reduction of `~4%`).

<details>
<summary>Code used for measuring npm unpacked publish size</summary>

```js
const { readdirSync, readFileSync, statSync } = require("fs");
const { join } = require("path");
const { spawnSync } = require("child_process");

const { packages } = JSON.parse(readFileSync(join(process.cwd(), "package.json"))).workspaces;

const getAllFiles = (dirPath, arrayOfFiles) => {
  files = readdirSync(dirPath);

  arrayOfFiles = arrayOfFiles || [];

  files.forEach((file) => {
    if (statSync(dirPath + "/" + file).isDirectory()) {
      arrayOfFiles = getAllFiles(dirPath + "/" + file, arrayOfFiles);
    } else {
      arrayOfFiles.push(join(dirPath, "/", file));
    }
  });

  return arrayOfFiles;
};

let totalSizeInMB = 0;

spawnSync("git", ["clean", "-dfx"]);
spawnSync("yarn");
spawnSync("yarn", ["build:all"]);
spawnSync("yarn", ["downlevel-dts"]);

const packageNameColLength = 50;
const sizeColLength = 15;
const packageSizeList = [];

packages
  .map((dir) => dir.replace("/*", ""))
  .forEach((workspacesDir) => {
    // Process each workspace in workspace directory
    readdirSync(join(process.cwd(), workspacesDir), { withFileTypes: true })
      .filter((dirent) => dirent.isDirectory())
      .map((dirent) => dirent.name)
      .forEach((workspaceDir) => {
        if (!workspaceDir.startsWith("client-")) {
          return;
        }
        try {
          // npm pack posts debug messages to stderr
          // Refs: https://github.com/npm/npm/issues/118#issuecomment-325440
          const { stderr } = spawnSync("npm", ["pack", "--dry-run"], {
            cwd: join(process.cwd(), workspacesDir, workspaceDir),
          });
          const packageName = `@aws-sdk/${workspaceDir}`;
          const unpackedSize = stderr
            .toString()
            .match(/unpacked size: ([^\n]*)/)[1]
            .trim();
          packageSizeList.push({ packageName, unpackedSize });
          const [size, unit] = unpackedSize.split(" ");
          totalSizeInMB += size / (unit === "kB" ? 1024 : 1);
        } catch (error) {
          console.log(`${workspaceDir}: ${error}`);
        }
      });
  });

console.log(`Total size: ${totalSizeInMB.toFixed(2)} MB\n`);

console.log(`| ${"Package name".padEnd(packageNameColLength)} | ${"Unpacked size".padEnd(sizeColLength)} |`);
console.log(`|-${"-".padEnd(packageNameColLength, "-")}-|-${"-".padEnd(sizeColLength, "-")}-|`);
packageSizeList.forEach(({ packageName, unpackedSize }) =>
  console.log(`| ${packageName.padEnd(packageNameColLength)} | ${unpackedSize.padEnd(sizeColLength)} |`)
);

```

</details>

<details>
<summary>Before</summary>

```md
Total size: 406.25 MB

| Package name                                    | Unpacked size |
| ----------------------------------------------- | ------------- |
| @aws-sdk/client-accessanalyzer                  | 1.2 MB        |
| @aws-sdk/client-account                         | 179.8 kB      |
| @aws-sdk/client-acm                             | 687.2 kB      |
| @aws-sdk/client-acm-pca                         | 1.1 MB        |
| @aws-sdk/client-alexa-for-business              | 2.7 MB        |
| @aws-sdk/client-amp                             | 643.5 kB      |
| @aws-sdk/client-amplify                         | 1.3 MB        |
| @aws-sdk/client-amplifybackend                  | 939.5 kB      |
| @aws-sdk/client-api-gateway                     | 3.9 MB        |
| @aws-sdk/client-apigatewaymanagementapi         | 231.8 kB      |
| @aws-sdk/client-apigatewayv2                    | 2.3 MB        |
| @aws-sdk/client-app-mesh                        | 1.9 MB        |
| @aws-sdk/client-appconfig                       | 1.2 MB        |
| @aws-sdk/client-appflow                         | 1.1 MB        |
| @aws-sdk/client-appintegrations                 | 556.4 kB      |
| @aws-sdk/client-application-auto-scaling        | 767.8 kB      |
| @aws-sdk/client-application-discovery-service   | 1.0 MB        |
| @aws-sdk/client-application-insights            | 944.3 kB      |
| @aws-sdk/client-applicationcostprofiler         | 284.4 kB      |
| @aws-sdk/client-apprunner                       | 804.1 kB      |
| @aws-sdk/client-appstream                       | 1.6 MB        |
| @aws-sdk/client-appsync                         | 1.4 MB        |
| @aws-sdk/client-athena                          | 1.2 MB        |
| @aws-sdk/client-auditmanager                    | 1.7 MB        |
| @aws-sdk/client-auto-scaling                    | 2.3 MB        |
| @aws-sdk/client-auto-scaling-plans              | 451.6 kB      |
| @aws-sdk/client-backup                          | 2.3 MB        |
| @aws-sdk/client-batch                           | 986.7 kB      |
| @aws-sdk/client-braket                          | 390.1 kB      |
| @aws-sdk/client-budgets                         | 937.3 kB      |
| @aws-sdk/client-chime                           | 6.4 MB        |
| @aws-sdk/client-chime-sdk-identity              | 632.6 kB      |
| @aws-sdk/client-chime-sdk-messaging             | 1.2 MB        |
| @aws-sdk/client-cloud9                          | 592.3 kB      |
| @aws-sdk/client-cloudcontrol                    | 471.3 kB      |
| @aws-sdk/client-clouddirectory                  | 2.7 MB        |
| @aws-sdk/client-cloudformation                  | 2.7 MB        |
| @aws-sdk/client-cloudfront                      | 3.7 MB        |
| @aws-sdk/client-cloudhsm                        | 694.7 kB      |
| @aws-sdk/client-cloudhsm-v2                     | 624.4 kB      |
| @aws-sdk/client-cloudsearch                     | 1.0 MB        |
| @aws-sdk/client-cloudsearch-domain              | 297.2 kB      |
| @aws-sdk/client-cloudtrail                      | 980.6 kB      |
| @aws-sdk/client-cloudwatch                      | 1.4 MB        |
| @aws-sdk/client-cloudwatch-events               | 1.8 MB        |
| @aws-sdk/client-cloudwatch-logs                 | 1.4 MB        |
| @aws-sdk/client-codeartifact                    | 1.3 MB        |
| @aws-sdk/client-codebuild                       | 1.7 MB        |
| @aws-sdk/client-codecommit                      | 3.9 MB        |
| @aws-sdk/client-codedeploy                      | 2.2 MB        |
| @aws-sdk/client-codeguru-reviewer               | 752.6 kB      |
| @aws-sdk/client-codeguruprofiler                | 937.1 kB      |
| @aws-sdk/client-codepipeline                    | 1.6 MB        |
| @aws-sdk/client-codestar                        | 684.1 kB      |
| @aws-sdk/client-codestar-connections            | 455.6 kB      |
| @aws-sdk/client-codestar-notifications          | 563.3 kB      |
| @aws-sdk/client-cognito-identity                | 904.3 kB      |
| @aws-sdk/client-cognito-identity-provider       | 3.9 MB        |
| @aws-sdk/client-cognito-sync                    | 782.9 kB      |
| @aws-sdk/client-comprehend                      | 2.3 MB        |
| @aws-sdk/client-comprehendmedical               | 825.9 kB      |
| @aws-sdk/client-compute-optimizer               | 950.1 kB      |
| @aws-sdk/client-config-service                  | 3.4 MB        |
| @aws-sdk/client-connect                         | 3.7 MB        |
| @aws-sdk/client-connect-contact-lens            | 168.6 kB      |
| @aws-sdk/client-connectparticipant              | 431.5 kB      |
| @aws-sdk/client-cost-and-usage-report-service   | 294.4 kB      |
| @aws-sdk/client-cost-explorer                   | 1.4 MB        |
| @aws-sdk/client-customer-profiles               | 1.2 MB        |
| @aws-sdk/client-data-pipeline                   | 804.0 kB      |
| @aws-sdk/client-database-migration-service      | 2.5 MB        |
| @aws-sdk/client-databrew                        | 1.4 MB        |
| @aws-sdk/client-dataexchange                    | 1.1 MB        |
| @aws-sdk/client-datasync                        | 1.2 MB        |
| @aws-sdk/client-dax                             | 853.5 kB      |
| @aws-sdk/client-detective                       | 566.6 kB      |
| @aws-sdk/client-device-farm                     | 2.5 MB        |
| @aws-sdk/client-devops-guru                     | 964.5 kB      |
| @aws-sdk/client-direct-connect                  | 1.8 MB        |
| @aws-sdk/client-directory-service               | 2.1 MB        |
| @aws-sdk/client-dlm                             | 469.8 kB      |
| @aws-sdk/client-docdb                           | 2.1 MB        |
| @aws-sdk/client-dynamodb                        | 2.4 MB        |
| @aws-sdk/client-dynamodb-streams                | 336.2 kB      |
| @aws-sdk/client-ebs                             | 403.9 kB      |
| @aws-sdk/client-ec2                             | 16.5 MB       |
| @aws-sdk/client-ec2-instance-connect            | 237.0 kB      |
| @aws-sdk/client-ecr                             | 1.3 MB        |
| @aws-sdk/client-ecr-public                      | 858.1 kB      |
| @aws-sdk/client-ecs                             | 2.5 MB        |
| @aws-sdk/client-efs                             | 1.1 MB        |
| @aws-sdk/client-eks                             | 1.5 MB        |
| @aws-sdk/client-elastic-beanstalk               | 1.7 MB        |
| @aws-sdk/client-elastic-inference               | 341.1 kB      |
| @aws-sdk/client-elastic-load-balancing          | 1.2 MB        |
| @aws-sdk/client-elastic-load-balancing-v2       | 1.5 MB        |
| @aws-sdk/client-elastic-transcoder              | 993.7 kB      |
| @aws-sdk/client-elasticache                     | 3.0 MB        |
| @aws-sdk/client-elasticsearch-service           | 1.7 MB        |
| @aws-sdk/client-emr                             | 1.9 MB        |
| @aws-sdk/client-emr-containers                  | 589.0 kB      |
| @aws-sdk/client-eventbridge                     | 1.7 MB        |
| @aws-sdk/client-finspace                        | 321.6 kB      |
| @aws-sdk/client-finspace-data                   | 199.5 kB      |
| @aws-sdk/client-firehose                        | 919.4 kB      |
| @aws-sdk/client-fis                             | 544.9 kB      |
| @aws-sdk/client-fms                             | 1.1 MB        |
| @aws-sdk/client-forecast                        | 1.4 MB        |
| @aws-sdk/client-forecastquery                   | 204.3 kB      |
| @aws-sdk/client-frauddetector                   | 1.9 MB        |
| @aws-sdk/client-fsx                             | 1.5 MB        |
| @aws-sdk/client-gamelift                        | 3.8 MB        |
| @aws-sdk/client-glacier                         | 1.4 MB        |
| @aws-sdk/client-global-accelerator              | 1.7 MB        |
| @aws-sdk/client-glue                            | 5.3 MB        |
| @aws-sdk/client-grafana                         | 532.3 kB      |
| @aws-sdk/client-greengrass                      | 2.6 MB        |
| @aws-sdk/client-greengrassv2                    | 1.0 MB        |
| @aws-sdk/client-groundstation                   | 954.6 kB      |
| @aws-sdk/client-guardduty                       | 1.9 MB        |
| @aws-sdk/client-health                          | 687.8 kB      |
| @aws-sdk/client-healthlake                      | 508.3 kB      |
| @aws-sdk/client-honeycode                       | 636.8 kB      |
| @aws-sdk/client-iam                             | 5.1 MB        |
| @aws-sdk/client-identitystore                   | 241.2 kB      |
| @aws-sdk/client-imagebuilder                    | 2.0 MB        |
| @aws-sdk/client-inspector                       | 1.4 MB        |
| @aws-sdk/client-iot                             | 8.0 MB        |
| @aws-sdk/client-iot-1click-devices-service      | 490.9 kB      |
| @aws-sdk/client-iot-1click-projects             | 621.6 kB      |
| @aws-sdk/client-iot-data-plane                  | 378.0 kB      |
| @aws-sdk/client-iot-events                      | 1.2 MB        |
| @aws-sdk/client-iot-events-data                 | 559.3 kB      |
| @aws-sdk/client-iot-jobs-data-plane             | 315.6 kB      |
| @aws-sdk/client-iot-wireless                    | 1.9 MB        |
| @aws-sdk/client-iotanalytics                    | 1.4 MB        |
| @aws-sdk/client-iotdeviceadvisor                | 481.9 kB      |
| @aws-sdk/client-iotfleethub                     | 326.1 kB      |
| @aws-sdk/client-iotsecuretunneling              | 345.3 kB      |
| @aws-sdk/client-iotsitewise                     | 2.3 MB        |
| @aws-sdk/client-iotthingsgraph                  | 1.2 MB        |
| @aws-sdk/client-ivs                             | 914.7 kB      |
| @aws-sdk/client-kafka                           | 1.2 MB        |
| @aws-sdk/client-kafkaconnect                    | 592.5 kB      |
| @aws-sdk/client-kendra                          | 2.0 MB        |
| @aws-sdk/client-kinesis                         | 1.1 MB        |
| @aws-sdk/client-kinesis-analytics               | 970.6 kB      |
| @aws-sdk/client-kinesis-analytics-v2            | 1.5 MB        |
| @aws-sdk/client-kinesis-video                   | 754.2 kB      |
| @aws-sdk/client-kinesis-video-archived-media    | 488.5 kB      |
| @aws-sdk/client-kinesis-video-media             | 208.6 kB      |
| @aws-sdk/client-kinesis-video-signaling         | 207.2 kB      |
| @aws-sdk/client-kms                             | 2.2 MB        |
| @aws-sdk/client-lakeformation                   | 896.2 kB      |
| @aws-sdk/client-lambda                          | 2.4 MB        |
| @aws-sdk/client-lex-model-building-service      | 1.7 MB        |
| @aws-sdk/client-lex-models-v2                   | 2.4 MB        |
| @aws-sdk/client-lex-runtime-service             | 485.8 kB      |
| @aws-sdk/client-lex-runtime-v2                  | 506.8 kB      |
| @aws-sdk/client-license-manager                 | 1.8 MB        |
| @aws-sdk/client-lightsail                       | 5.2 MB        |
| @aws-sdk/client-location                        | 1.8 MB        |
| @aws-sdk/client-lookoutequipment                | 823.7 kB      |
| @aws-sdk/client-lookoutmetrics                  | 979.5 kB      |
| @aws-sdk/client-lookoutvision                   | 753.0 kB      |
| @aws-sdk/client-machine-learning                | 1.2 MB        |
| @aws-sdk/client-macie                           | 370.0 kB      |
| @aws-sdk/client-macie2                          | 2.2 MB        |
| @aws-sdk/client-managedblockchain               | 1.0 MB        |
| @aws-sdk/client-marketplace-catalog             | 397.8 kB      |
| @aws-sdk/client-marketplace-commerce-analytics  | 231.1 kB      |
| @aws-sdk/client-marketplace-entitlement-service | 217.2 kB      |
| @aws-sdk/client-marketplace-metering            | 372.0 kB      |
| @aws-sdk/client-mediaconnect                    | 1.2 MB        |
| @aws-sdk/client-mediaconvert                    | 2.4 MB        |
| @aws-sdk/client-medialive                       | 3.2 MB        |
| @aws-sdk/client-mediapackage                    | 869.5 kB      |
| @aws-sdk/client-mediapackage-vod                | 747.0 kB      |
| @aws-sdk/client-mediastore                      | 694.4 kB      |
| @aws-sdk/client-mediastore-data                 | 311.6 kB      |
| @aws-sdk/client-mediatailor                     | 1.1 MB        |
| @aws-sdk/client-memorydb                        | 1.3 MB        |
| @aws-sdk/client-mgn                             | 954.4 kB      |
| @aws-sdk/client-migration-hub                   | 780.3 kB      |
| @aws-sdk/client-migrationhub-config             | 276.0 kB      |
| @aws-sdk/client-mobile                          | 447.9 kB      |
| @aws-sdk/client-mq                              | 879.3 kB      |
| @aws-sdk/client-mturk                           | 1.3 MB        |
| @aws-sdk/client-mwaa                            | 460.9 kB      |
| @aws-sdk/client-neptune                         | 2.6 MB        |
| @aws-sdk/client-network-firewall                | 1.2 MB        |
| @aws-sdk/client-networkmanager                  | 1.3 MB        |
| @aws-sdk/client-nimble                          | 1.6 MB        |
| @aws-sdk/client-opensearch                      | 1.6 MB        |
| @aws-sdk/client-opsworks                        | 2.3 MB        |
| @aws-sdk/client-opsworkscm                      | 778.1 kB      |
| @aws-sdk/client-organizations                   | 2.2 MB        |
| @aws-sdk/client-outposts                        | 473.6 kB      |
| @aws-sdk/client-personalize                     | 1.6 MB        |
| @aws-sdk/client-personalize-events              | 242.2 kB      |
| @aws-sdk/client-personalize-runtime             | 225.5 kB      |
| @aws-sdk/client-pi                              | 300.3 kB      |
| @aws-sdk/client-pinpoint                        | 4.4 MB        |
| @aws-sdk/client-pinpoint-email                  | 1.6 MB        |
| @aws-sdk/client-pinpoint-sms-voice              | 425.3 kB      |
| @aws-sdk/client-polly                           | 500.4 kB      |
| @aws-sdk/client-pricing                         | 290.3 kB      |
| @aws-sdk/client-proton                          | 1.8 MB        |
| @aws-sdk/client-qldb                            | 777.7 kB      |
| @aws-sdk/client-qldb-session                    | 255.2 kB      |
| @aws-sdk/client-quicksight                      | 4.6 MB        |
| @aws-sdk/client-ram                             | 1.1 MB        |
| @aws-sdk/client-rds                             | 5.8 MB        |
| @aws-sdk/client-rds-data                        | 455.2 kB      |
| @aws-sdk/client-redshift                        | 4.4 MB        |
| @aws-sdk/client-redshift-data                   | 469.4 kB      |
| @aws-sdk/client-rekognition                     | 2.3 MB        |
| @aws-sdk/client-resource-groups                 | 730.5 kB      |
| @aws-sdk/client-resource-groups-tagging-api     | 463.6 kB      |
| @aws-sdk/client-robomaker                       | 2.1 MB        |
| @aws-sdk/client-route-53                        | 2.5 MB        |
| @aws-sdk/client-route-53-domains                | 1.0 MB        |
| @aws-sdk/client-route53-recovery-cluster        | 212.2 kB      |
| @aws-sdk/client-route53-recovery-control-config | 771.6 kB      |
| @aws-sdk/client-route53-recovery-readiness      | 1.1 MB        |
| @aws-sdk/client-route53resolver                 | 2.2 MB        |
| @aws-sdk/client-s3                              | 4.2 MB        |
| @aws-sdk/client-s3-control                      | 2.4 MB        |
| @aws-sdk/client-s3outposts                      | 206.9 kB      |
| @aws-sdk/client-sagemaker                       | 8.5 MB        |
| @aws-sdk/client-sagemaker-a2i-runtime           | 338.7 kB      |
| @aws-sdk/client-sagemaker-edge                  | 147.9 kB      |
| @aws-sdk/client-sagemaker-featurestore-runtime  | 234.3 kB      |
| @aws-sdk/client-sagemaker-runtime               | 238.4 kB      |
| @aws-sdk/client-savingsplans                    | 458.6 kB      |
| @aws-sdk/client-schemas                         | 1.1 MB        |
| @aws-sdk/client-secrets-manager                 | 1.0 MB        |
| @aws-sdk/client-securityhub                     | 3.8 MB        |
| @aws-sdk/client-serverlessapplicationrepository | 697.6 kB      |
| @aws-sdk/client-service-catalog                 | 2.8 MB        |
| @aws-sdk/client-service-catalog-appregistry     | 731.6 kB      |
| @aws-sdk/client-service-quotas                  | 833.6 kB      |
| @aws-sdk/client-servicediscovery                | 1.1 MB        |
| @aws-sdk/client-ses                             | 2.4 MB        |
| @aws-sdk/client-sesv2                           | 2.8 MB        |
| @aws-sdk/client-sfn                             | 988.3 kB      |
| @aws-sdk/client-shield                          | 1.1 MB        |
| @aws-sdk/client-signer                          | 761.4 kB      |
| @aws-sdk/client-sms                             | 1.3 MB        |
| @aws-sdk/client-snow-device-management          | 528.2 kB      |
| @aws-sdk/client-snowball                        | 949.2 kB      |
| @aws-sdk/client-sns                             | 1.4 MB        |
| @aws-sdk/client-sqs                             | 877.7 kB      |
| @aws-sdk/client-ssm                             | 5.5 MB        |
| @aws-sdk/client-ssm-contacts                    | 902.8 kB      |
| @aws-sdk/client-ssm-incidents                   | 1.1 MB        |
| @aws-sdk/client-sso                             | 278.3 kB      |
| @aws-sdk/client-sso-admin                       | 1.1 MB        |
| @aws-sdk/client-sso-oidc                        | 290.3 kB      |
| @aws-sdk/client-storage-gateway                 | 2.8 MB        |
| @aws-sdk/client-sts                             | 607.4 kB      |
| @aws-sdk/client-support                         | 676.1 kB      |
| @aws-sdk/client-swf                             | 1.8 MB        |
| @aws-sdk/client-synthetics                      | 564.0 kB      |
| @aws-sdk/client-textract                        | 532.0 kB      |
| @aws-sdk/client-timestream-query                | 227.9 kB      |
| @aws-sdk/client-timestream-write                | 578.5 kB      |
| @aws-sdk/client-transcribe                      | 1.5 MB        |
| @aws-sdk/client-transcribe-streaming            | 379.0 kB      |
| @aws-sdk/client-transfer                        | 1.2 MB        |
| @aws-sdk/client-translate                       | 649.2 kB      |
| @aws-sdk/client-voice-id                        | 783.2 kB      |
| @aws-sdk/client-waf                             | 2.9 MB        |
| @aws-sdk/client-waf-regional                    | 3.0 MB        |
| @aws-sdk/client-wafv2                           | 1.9 MB        |
| @aws-sdk/client-wellarchitected                 | 1.2 MB        |
| @aws-sdk/client-wisdom                          | 1.1 MB        |
| @aws-sdk/client-workdocs                        | 1.5 MB        |
| @aws-sdk/client-worklink                        | 1.1 MB        |
| @aws-sdk/client-workmail                        | 1.9 MB        |
| @aws-sdk/client-workmailmessageflow             | 214.4 kB      |
| @aws-sdk/client-workspaces                      | 1.8 MB        |
| @aws-sdk/client-xray                            | 1.1 MB        |
| @aws-sdk/client-documentation-generator         | 60.6 kB       |

```

</details>

<details>
<summary>After</summary>

```md
Total size: 389.15 MB

| Package name                                    | Unpacked size |
| ----------------------------------------------- | ------------- |
| @aws-sdk/client-accessanalyzer                  | 1.1 MB        |
| @aws-sdk/client-account                         | 174.7 kB      |
| @aws-sdk/client-acm                             | 657.4 kB      |
| @aws-sdk/client-acm-pca                         | 1.0 MB        |
| @aws-sdk/client-alexa-for-business              | 2.5 MB        |
| @aws-sdk/client-amp                             | 621.9 kB      |
| @aws-sdk/client-amplify                         | 1.2 MB        |
| @aws-sdk/client-amplifybackend                  | 910.3 kB      |
| @aws-sdk/client-api-gateway                     | 3.8 MB        |
| @aws-sdk/client-apigatewaymanagementapi         | 226.7 kB      |
| @aws-sdk/client-apigatewayv2                    | 2.3 MB        |
| @aws-sdk/client-app-mesh                        | 1.9 MB        |
| @aws-sdk/client-appconfig                       | 1.1 MB        |
| @aws-sdk/client-appflow                         | 1.1 MB        |
| @aws-sdk/client-appintegrations                 | 534.4 kB      |
| @aws-sdk/client-application-auto-scaling        | 738.0 kB      |
| @aws-sdk/client-application-discovery-service   | 979.2 kB      |
| @aws-sdk/client-application-insights            | 906.9 kB      |
| @aws-sdk/client-applicationcostprofiler         | 274.6 kB      |
| @aws-sdk/client-apprunner                       | 769.0 kB      |
| @aws-sdk/client-appstream                       | 1.6 MB        |
| @aws-sdk/client-appsync                         | 1.4 MB        |
| @aws-sdk/client-athena                          | 1.1 MB        |
| @aws-sdk/client-auditmanager                    | 1.7 MB        |
| @aws-sdk/client-auto-scaling                    | 2.2 MB        |
| @aws-sdk/client-auto-scaling-plans              | 439.5 kB      |
| @aws-sdk/client-backup                          | 2.2 MB        |
| @aws-sdk/client-batch                           | 953.9 kB      |
| @aws-sdk/client-braket                          | 379.0 kB      |
| @aws-sdk/client-budgets                         | 903.1 kB      |
| @aws-sdk/client-chime                           | 6.2 MB        |
| @aws-sdk/client-chime-sdk-identity              | 610.5 kB      |
| @aws-sdk/client-chime-sdk-messaging             | 1.1 MB        |
| @aws-sdk/client-cloud9                          | 570.6 kB      |
| @aws-sdk/client-cloudcontrol                    | 454.0 kB      |
| @aws-sdk/client-clouddirectory                  | 2.6 MB        |
| @aws-sdk/client-cloudformation                  | 2.6 MB        |
| @aws-sdk/client-cloudfront                      | 3.5 MB        |
| @aws-sdk/client-cloudhsm                        | 651.4 kB      |
| @aws-sdk/client-cloudhsm-v2                     | 603.8 kB      |
| @aws-sdk/client-cloudsearch                     | 988.2 kB      |
| @aws-sdk/client-cloudsearch-domain              | 287.3 kB      |
| @aws-sdk/client-cloudtrail                      | 945.3 kB      |
| @aws-sdk/client-cloudwatch                      | 1.3 MB        |
| @aws-sdk/client-cloudwatch-events               | 1.7 MB        |
| @aws-sdk/client-cloudwatch-logs                 | 1.3 MB        |
| @aws-sdk/client-codeartifact                    | 1.3 MB        |
| @aws-sdk/client-codebuild                       | 1.6 MB        |
| @aws-sdk/client-codecommit                      | 3.7 MB        |
| @aws-sdk/client-codedeploy                      | 2.1 MB        |
| @aws-sdk/client-codeguru-reviewer               | 726.6 kB      |
| @aws-sdk/client-codeguruprofiler                | 895.9 kB      |
| @aws-sdk/client-codepipeline                    | 1.5 MB        |
| @aws-sdk/client-codestar                        | 654.9 kB      |
| @aws-sdk/client-codestar-connections            | 431.7 kB      |
| @aws-sdk/client-codestar-notifications          | 539.2 kB      |
| @aws-sdk/client-cognito-identity                | 865.9 kB      |
| @aws-sdk/client-cognito-identity-provider       | 3.7 MB        |
| @aws-sdk/client-cognito-sync                    | 738.1 kB      |
| @aws-sdk/client-comprehend                      | 2.2 MB        |
| @aws-sdk/client-comprehendmedical               | 797.3 kB      |
| @aws-sdk/client-compute-optimizer               | 921.6 kB      |
| @aws-sdk/client-config-service                  | 3.2 MB        |
| @aws-sdk/client-connect                         | 3.5 MB        |
| @aws-sdk/client-connect-contact-lens            | 164.6 kB      |
| @aws-sdk/client-connectparticipant              | 417.7 kB      |
| @aws-sdk/client-cost-and-usage-report-service   | 286.8 kB      |
| @aws-sdk/client-cost-explorer                   | 1.4 MB        |
| @aws-sdk/client-customer-profiles               | 1.1 MB        |
| @aws-sdk/client-data-pipeline                   | 746.7 kB      |
| @aws-sdk/client-database-migration-service      | 2.4 MB        |
| @aws-sdk/client-databrew                        | 1.3 MB        |
| @aws-sdk/client-dataexchange                    | 1.0 MB        |
| @aws-sdk/client-datasync                        | 1.1 MB        |
| @aws-sdk/client-dax                             | 825.3 kB      |
| @aws-sdk/client-detective                       | 538.8 kB      |
| @aws-sdk/client-device-farm                     | 2.4 MB        |
| @aws-sdk/client-devops-guru                     | 929.8 kB      |
| @aws-sdk/client-direct-connect                  | 1.7 MB        |
| @aws-sdk/client-directory-service               | 2.0 MB        |
| @aws-sdk/client-dlm                             | 458.5 kB      |
| @aws-sdk/client-docdb                           | 2.1 MB        |
| @aws-sdk/client-dynamodb                        | 2.3 MB        |
| @aws-sdk/client-dynamodb-streams                | 327.6 kB      |
| @aws-sdk/client-ebs                             | 391.2 kB      |
| @aws-sdk/client-ec2                             | 15.7 MB       |
| @aws-sdk/client-ec2-instance-connect            | 232.5 kB      |
| @aws-sdk/client-ecr                             | 1.3 MB        |
| @aws-sdk/client-ecr-public                      | 823.9 kB      |
| @aws-sdk/client-ecs                             | 2.4 MB        |
| @aws-sdk/client-efs                             | 1.1 MB        |
| @aws-sdk/client-eks                             | 1.4 MB        |
| @aws-sdk/client-elastic-beanstalk               | 1.7 MB        |
| @aws-sdk/client-elastic-inference               | 332.6 kB      |
| @aws-sdk/client-elastic-load-balancing          | 1.1 MB        |
| @aws-sdk/client-elastic-load-balancing-v2       | 1.5 MB        |
| @aws-sdk/client-elastic-transcoder              | 967.3 kB      |
| @aws-sdk/client-elasticache                     | 2.9 MB        |
| @aws-sdk/client-elasticsearch-service           | 1.6 MB        |
| @aws-sdk/client-emr                             | 1.9 MB        |
| @aws-sdk/client-emr-containers                  | 564.1 kB      |
| @aws-sdk/client-eventbridge                     | 1.7 MB        |
| @aws-sdk/client-finspace                        | 312.0 kB      |
| @aws-sdk/client-finspace-data                   | 194.9 kB      |
| @aws-sdk/client-firehose                        | 880.0 kB      |
| @aws-sdk/client-fis                             | 526.6 kB      |
| @aws-sdk/client-fms                             | 1.1 MB        |
| @aws-sdk/client-forecast                        | 1.3 MB        |
| @aws-sdk/client-forecastquery                   | 201.1 kB      |
| @aws-sdk/client-frauddetector                   | 1.8 MB        |
| @aws-sdk/client-fsx                             | 1.4 MB        |
| @aws-sdk/client-gamelift                        | 3.5 MB        |
| @aws-sdk/client-glacier                         | 1.3 MB        |
| @aws-sdk/client-global-accelerator              | 1.6 MB        |
| @aws-sdk/client-glue                            | 5.1 MB        |
| @aws-sdk/client-grafana                         | 512.8 kB      |
| @aws-sdk/client-greengrass                      | 2.5 MB        |
| @aws-sdk/client-greengrassv2                    | 974.2 kB      |
| @aws-sdk/client-groundstation                   | 922.8 kB      |
| @aws-sdk/client-guardduty                       | 1.8 MB        |
| @aws-sdk/client-health                          | 647.2 kB      |
| @aws-sdk/client-healthlake                      | 491.6 kB      |
| @aws-sdk/client-honeycode                       | 617.3 kB      |
| @aws-sdk/client-iam                             | 4.8 MB        |
| @aws-sdk/client-identitystore                   | 234.3 kB      |
| @aws-sdk/client-imagebuilder                    | 1.9 MB        |
| @aws-sdk/client-inspector                       | 1.3 MB        |
| @aws-sdk/client-iot                             | 7.7 MB        |
| @aws-sdk/client-iot-1click-devices-service      | 473.3 kB      |
| @aws-sdk/client-iot-1click-projects             | 601.1 kB      |
| @aws-sdk/client-iot-data-plane                  | 363.6 kB      |
| @aws-sdk/client-iot-events                      | 1.1 MB        |
| @aws-sdk/client-iot-events-data                 | 543.4 kB      |
| @aws-sdk/client-iot-jobs-data-plane             | 307.7 kB      |
| @aws-sdk/client-iot-wireless                    | 1.8 MB        |
| @aws-sdk/client-iotanalytics                    | 1.3 MB        |
| @aws-sdk/client-iotdeviceadvisor                | 464.4 kB      |
| @aws-sdk/client-iotfleethub                     | 314.4 kB      |
| @aws-sdk/client-iotsecuretunneling              | 335.3 kB      |
| @aws-sdk/client-iotsitewise                     | 2.2 MB        |
| @aws-sdk/client-iotthingsgraph                  | 1.2 MB        |
| @aws-sdk/client-ivs                             | 850.0 kB      |
| @aws-sdk/client-kafka                           | 1.2 MB        |
| @aws-sdk/client-kafkaconnect                    | 577.0 kB      |
| @aws-sdk/client-kendra                          | 1.9 MB        |
| @aws-sdk/client-kinesis                         | 1.1 MB        |
| @aws-sdk/client-kinesis-analytics               | 924.1 kB      |
| @aws-sdk/client-kinesis-analytics-v2            | 1.4 MB        |
| @aws-sdk/client-kinesis-video                   | 723.5 kB      |
| @aws-sdk/client-kinesis-video-archived-media    | 450.4 kB      |
| @aws-sdk/client-kinesis-video-media             | 203.6 kB      |
| @aws-sdk/client-kinesis-video-signaling         | 201.7 kB      |
| @aws-sdk/client-kms                             | 2.0 MB        |
| @aws-sdk/client-lakeformation                   | 864.0 kB      |
| @aws-sdk/client-lambda                          | 2.3 MB        |
| @aws-sdk/client-lex-model-building-service      | 1.7 MB        |
| @aws-sdk/client-lex-models-v2                   | 2.4 MB        |
| @aws-sdk/client-lex-runtime-service             | 468.9 kB      |
| @aws-sdk/client-lex-runtime-v2                  | 493.8 kB      |
| @aws-sdk/client-license-manager                 | 1.7 MB        |
| @aws-sdk/client-lightsail                       | 4.9 MB        |
| @aws-sdk/client-location                        | 1.8 MB        |
| @aws-sdk/client-lookoutequipment                | 793.3 kB      |
| @aws-sdk/client-lookoutmetrics                  | 946.4 kB      |
| @aws-sdk/client-lookoutvision                   | 721.3 kB      |
| @aws-sdk/client-machine-learning                | 1.1 MB        |
| @aws-sdk/client-macie                           | 358.4 kB      |
| @aws-sdk/client-macie2                          | 2.2 MB        |
| @aws-sdk/client-managedblockchain               | 967.2 kB      |
| @aws-sdk/client-marketplace-catalog             | 386.6 kB      |
| @aws-sdk/client-marketplace-commerce-analytics  | 226.1 kB      |
| @aws-sdk/client-marketplace-entitlement-service | 213.4 kB      |
| @aws-sdk/client-marketplace-metering            | 354.9 kB      |
| @aws-sdk/client-mediaconnect                    | 1.2 MB        |
| @aws-sdk/client-mediaconvert                    | 2.4 MB        |
| @aws-sdk/client-medialive                       | 3.2 MB        |
| @aws-sdk/client-mediapackage                    | 849.1 kB      |
| @aws-sdk/client-mediapackage-vod                | 725.8 kB      |
| @aws-sdk/client-mediastore                      | 664.8 kB      |
| @aws-sdk/client-mediastore-data                 | 304.4 kB      |
| @aws-sdk/client-mediatailor                     | 1.1 MB        |
| @aws-sdk/client-memorydb                        | 1.2 MB        |
| @aws-sdk/client-mgn                             | 922.2 kB      |
| @aws-sdk/client-migration-hub                   | 749.8 kB      |
| @aws-sdk/client-migrationhub-config             | 268.4 kB      |
| @aws-sdk/client-mobile                          | 436.1 kB      |
| @aws-sdk/client-mq                              | 853.2 kB      |
| @aws-sdk/client-mturk                           | 1.3 MB        |
| @aws-sdk/client-mwaa                            | 447.0 kB      |
| @aws-sdk/client-neptune                         | 2.5 MB        |
| @aws-sdk/client-network-firewall                | 1.2 MB        |
| @aws-sdk/client-networkmanager                  | 1.3 MB        |
| @aws-sdk/client-nimble                          | 1.6 MB        |
| @aws-sdk/client-opensearch                      | 1.5 MB        |
| @aws-sdk/client-opsworks                        | 2.2 MB        |
| @aws-sdk/client-opsworkscm                      | 735.9 kB      |
| @aws-sdk/client-organizations                   | 2.1 MB        |
| @aws-sdk/client-outposts                        | 459.3 kB      |
| @aws-sdk/client-personalize                     | 1.5 MB        |
| @aws-sdk/client-personalize-events              | 237.0 kB      |
| @aws-sdk/client-personalize-runtime             | 221.4 kB      |
| @aws-sdk/client-pi                              | 291.6 kB      |
| @aws-sdk/client-pinpoint                        | 4.3 MB        |
| @aws-sdk/client-pinpoint-email                  | 1.5 MB        |
| @aws-sdk/client-pinpoint-sms-voice              | 414.1 kB      |
| @aws-sdk/client-polly                           | 484.7 kB      |
| @aws-sdk/client-pricing                         | 281.0 kB      |
| @aws-sdk/client-proton                          | 1.7 MB        |
| @aws-sdk/client-qldb                            | 748.1 kB      |
| @aws-sdk/client-qldb-session                    | 248.4 kB      |
| @aws-sdk/client-quicksight                      | 4.4 MB        |
| @aws-sdk/client-ram                             | 1.0 MB        |
| @aws-sdk/client-rds                             | 5.6 MB        |
| @aws-sdk/client-rds-data                        | 444.5 kB      |
| @aws-sdk/client-redshift                        | 4.2 MB        |
| @aws-sdk/client-redshift-data                   | 450.4 kB      |
| @aws-sdk/client-rekognition                     | 2.2 MB        |
| @aws-sdk/client-resource-groups                 | 697.8 kB      |
| @aws-sdk/client-resource-groups-tagging-api     | 445.4 kB      |
| @aws-sdk/client-robomaker                       | 2.0 MB        |
| @aws-sdk/client-route-53                        | 2.4 MB        |
| @aws-sdk/client-route-53-domains                | 997.0 kB      |
| @aws-sdk/client-route53-recovery-cluster        | 201.7 kB      |
| @aws-sdk/client-route53-recovery-control-config | 740.3 kB      |
| @aws-sdk/client-route53-recovery-readiness      | 1.0 MB        |
| @aws-sdk/client-route53resolver                 | 2.1 MB        |
| @aws-sdk/client-s3                              | 3.9 MB        |
| @aws-sdk/client-s3-control                      | 2.2 MB        |
| @aws-sdk/client-s3outposts                      | 199.1 kB      |
| @aws-sdk/client-sagemaker                       | 8.2 MB        |
| @aws-sdk/client-sagemaker-a2i-runtime           | 326.7 kB      |
| @aws-sdk/client-sagemaker-edge                  | 144.7 kB      |
| @aws-sdk/client-sagemaker-featurestore-runtime  | 225.1 kB      |
| @aws-sdk/client-sagemaker-runtime               | 232.3 kB      |
| @aws-sdk/client-savingsplans                    | 446.5 kB      |
| @aws-sdk/client-schemas                         | 1.1 MB        |
| @aws-sdk/client-secrets-manager                 | 950.5 kB      |
| @aws-sdk/client-securityhub                     | 3.7 MB        |
| @aws-sdk/client-serverlessapplicationrepository | 674.6 kB      |
| @aws-sdk/client-service-catalog                 | 2.7 MB        |
| @aws-sdk/client-service-catalog-appregistry     | 702.2 kB      |
| @aws-sdk/client-service-quotas                  | 807.0 kB      |
| @aws-sdk/client-servicediscovery                | 1.0 MB        |
| @aws-sdk/client-ses                             | 2.2 MB        |
| @aws-sdk/client-sesv2                           | 2.7 MB        |
| @aws-sdk/client-sfn                             | 946.8 kB      |
| @aws-sdk/client-shield                          | 1.1 MB        |
| @aws-sdk/client-signer                          | 734.0 kB      |
| @aws-sdk/client-sms                             | 1.2 MB        |
| @aws-sdk/client-snow-device-management          | 510.4 kB      |
| @aws-sdk/client-snowball                        | 908.8 kB      |
| @aws-sdk/client-sns                             | 1.4 MB        |
| @aws-sdk/client-sqs                             | 820.3 kB      |
| @aws-sdk/client-ssm                             | 5.3 MB        |
| @aws-sdk/client-ssm-contacts                    | 868.0 kB      |
| @aws-sdk/client-ssm-incidents                   | 1.0 MB        |
| @aws-sdk/client-sso                             | 270.1 kB      |
| @aws-sdk/client-sso-admin                       | 1.1 MB        |
| @aws-sdk/client-sso-oidc                        | 282.8 kB      |
| @aws-sdk/client-storage-gateway                 | 2.6 MB        |
| @aws-sdk/client-sts                             | 546.3 kB      |
| @aws-sdk/client-support                         | 630.9 kB      |
| @aws-sdk/client-swf                             | 1.7 MB        |
| @aws-sdk/client-synthetics                      | 539.2 kB      |
| @aws-sdk/client-textract                        | 510.3 kB      |
| @aws-sdk/client-timestream-query                | 221.6 kB      |
| @aws-sdk/client-timestream-write                | 552.7 kB      |
| @aws-sdk/client-transcribe                      | 1.4 MB        |
| @aws-sdk/client-transcribe-streaming            | 374.1 kB      |
| @aws-sdk/client-transfer                        | 1.2 MB        |
| @aws-sdk/client-translate                       | 629.3 kB      |
| @aws-sdk/client-voice-id                        | 756.9 kB      |
| @aws-sdk/client-waf                             | 2.7 MB        |
| @aws-sdk/client-waf-regional                    | 2.8 MB        |
| @aws-sdk/client-wafv2                           | 1.8 MB        |
| @aws-sdk/client-wellarchitected                 | 1.1 MB        |
| @aws-sdk/client-wisdom                          | 1.0 MB        |
| @aws-sdk/client-workdocs                        | 1.5 MB        |
| @aws-sdk/client-worklink                        | 1.1 MB        |
| @aws-sdk/client-workmail                        | 1.8 MB        |
| @aws-sdk/client-workmailmessageflow             | 209.8 kB      |
| @aws-sdk/client-workspaces                      | 1.7 MB        |
| @aws-sdk/client-xray                            | 1.1 MB        |
| @aws-sdk/client-documentation-generator         | 60.6 kB       |

```

</details>


### Testing
Verified that comments are not present in files in `dist-cjs`

```console
$ pwd
/home/trivikr/workspace/aws-sdk-js-v3/clients/client-sts

$ tail dist-cjs/STSClient.js 
        this.middlewareStack.use(middleware_content_length_1.getContentLengthPlugin(this.config));
        this.middlewareStack.use(middleware_host_header_1.getHostHeaderPlugin(this.config));
        this.middlewareStack.use(middleware_logger_1.getLoggerPlugin(this.config));
        this.middlewareStack.use(middleware_user_agent_1.getUserAgentPlugin(this.config));
    }
    destroy() {
        super.destroy();
    }
}
exports.STSClient = STSClient;

$ tail dist-es/STSClient.js
        _this.middlewareStack.use(getLoggerPlugin(_this.config));
        _this.middlewareStack.use(getUserAgentPlugin(_this.config));
        return _this;
    }
    STSClient.prototype.destroy = function () {
        _super.prototype.destroy.call(this);
    };
    return STSClient;
}(__Client));
export { STSClient };
```

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
