### PR TITLE
feat(lib-dynamodb): add pagination for query and scan

### DIFF
--- a/lib/lib-dynamodb/src/index.ts
+++ b/lib/lib-dynamodb/src/index.ts
@@ -13,3 +13,6 @@ export * from "./commands/TransactWriteCommand";
 export * from "./commands/UpdateCommand";
 export * from "./DynamoDBDocumentClient";
 export * from "./DynamoDBDocument";
+export * from "./pagination/Interfaces";
+export * from "./pagination/QueryPaginator";
+export * from "./pagination/ScanPaginator";

--- a/lib/lib-dynamodb/src/pagination/Interfaces.ts
+++ b/lib/lib-dynamodb/src/pagination/Interfaces.ts
@@ -1,0 +1,8 @@
+import { PaginationConfiguration } from "@aws-sdk/types";
+
+import { DynamoDBDocument } from "../DynamoDBDocument";
+import { DynamoDBDocumentClient } from "../DynamoDBDocumentClient";
+
+export interface DynamoDBDocumentPaginationConfiguration extends PaginationConfiguration {
+  client: DynamoDBDocument | DynamoDBDocumentClient;
+}

--- a/lib/lib-dynamodb/src/pagination/QueryPaginator.ts
+++ b/lib/lib-dynamodb/src/pagination/QueryPaginator.ts
@@ -1,0 +1,55 @@
+import { Paginator } from "@aws-sdk/types";
+
+import { QueryCommand, QueryCommandInput, QueryCommandOutput } from "../commands/QueryCommand";
+import { DynamoDBDocument } from "../DynamoDBDocument";
+import { DynamoDBDocumentClient } from "../DynamoDBDocumentClient";
+import { DynamoDBDocumentPaginationConfiguration } from "./Interfaces";
+
+/**
+ * @private
+ */
+const makePagedClientRequest = async (
+  client: DynamoDBDocumentClient,
+  input: QueryCommandInput,
+  ...args: any
+): Promise<QueryCommandOutput> => {
+  // @ts-ignore
+  return await client.send(new QueryCommand(input), ...args);
+};
+/**
+ * @private
+ */
+const makePagedRequest = async (
+  client: DynamoDBDocument,
+  input: QueryCommandInput,
+  ...args: any
+): Promise<QueryCommandOutput> => {
+  // @ts-ignore
+  return await client.query(input, ...args);
+};
+export async function* paginateQuery(
+  config: DynamoDBDocumentPaginationConfiguration,
+  input: QueryCommandInput,
+  ...additionalArguments: any
+): Paginator<QueryCommandOutput> {
+  // ToDo: replace with actual type instead of typeof input.ExclusiveStartKey
+  let token: typeof input.ExclusiveStartKey | undefined = config.startingToken || undefined;
+  let hasNext = true;
+  let page: QueryCommandOutput;
+  while (hasNext) {
+    input.ExclusiveStartKey = token;
+    input["Limit"] = config.pageSize;
+    if (config.client instanceof DynamoDBDocument) {
+      page = await makePagedRequest(config.client, input, ...additionalArguments);
+    } else if (config.client instanceof DynamoDBDocumentClient) {
+      page = await makePagedClientRequest(config.client, input, ...additionalArguments);
+    } else {
+      throw new Error("Invalid client, expected DynamoDB | DynamoDBClient");
+    }
+    yield page;
+    token = page.LastEvaluatedKey;
+    hasNext = !!token;
+  }
+  // @ts-ignore
+  return undefined;
+}

--- a/lib/lib-dynamodb/src/pagination/ScanPaginator.ts
+++ b/lib/lib-dynamodb/src/pagination/ScanPaginator.ts
@@ -1,0 +1,55 @@
+import { Paginator } from "@aws-sdk/types";
+
+import { ScanCommand, ScanCommandInput, ScanCommandOutput } from "../commands/ScanCommand";
+import { DynamoDBDocument } from "../DynamoDBDocument";
+import { DynamoDBDocumentClient } from "../DynamoDBDocumentClient";
+import { DynamoDBDocumentPaginationConfiguration } from "./Interfaces";
+
+/**
+ * @private
+ */
+const makePagedClientRequest = async (
+  client: DynamoDBDocumentClient,
+  input: ScanCommandInput,
+  ...args: any
+): Promise<ScanCommandOutput> => {
+  // @ts-ignore
+  return await client.send(new ScanCommand(input), ...args);
+};
+/**
+ * @private
+ */
+const makePagedRequest = async (
+  client: DynamoDBDocument,
+  input: ScanCommandInput,
+  ...args: any
+): Promise<ScanCommandOutput> => {
+  // @ts-ignore
+  return await client.scan(input, ...args);
+};
+export async function* paginateScan(
+  config: DynamoDBDocumentPaginationConfiguration,
+  input: ScanCommandInput,
+  ...additionalArguments: any
+): Paginator<ScanCommandOutput> {
+  // ToDo: replace with actual type instead of typeof input.ExclusiveStartKey
+  let token: typeof input.ExclusiveStartKey | undefined = config.startingToken || undefined;
+  let hasNext = true;
+  let page: ScanCommandOutput;
+  while (hasNext) {
+    input.ExclusiveStartKey = token;
+    input["Limit"] = config.pageSize;
+    if (config.client instanceof DynamoDBDocument) {
+      page = await makePagedRequest(config.client, input, ...additionalArguments);
+    } else if (config.client instanceof DynamoDBDocumentClient) {
+      page = await makePagedClientRequest(config.client, input, ...additionalArguments);
+    } else {
+      throw new Error("Invalid client, expected DynamoDB | DynamoDBClient");
+    }
+    yield page;
+    token = page.LastEvaluatedKey;
+    hasNext = !!token;
+  }
+  // @ts-ignore
+  return undefined;
+}


### PR DESCRIPTION
### Issue
N/A

### Description
Analogous to the implementation in @aws-sdk/client-dynamodb, pagination would also be immensely helpful in @aws-sdk/lib-dynamodb. The two relevant commands are query and scan. The implementation is the same as in @aws-sdk/client-dynamodb except that the clients and commands point their @aws-sdk/lib-dynamodb counterparts.

### Testing
Build locally and executed both new functions.


---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
