### PR TITLE
docs(credential-provider-node): correct example code for EKS IAM roles

### DIFF
--- a/packages/credential-provider-node/README.md
+++ b/packages/credential-provider-node/README.md
@@ -39,7 +39,7 @@ const { defaultProvider } = require("@aws-sdk/credential-provider-node");
 const { S3Client, GetObjectCommand } = require("@aws-sdk/client-s3");
 
 const provider = defaultProvider({
-  roleAssumerWithWebIdentity: getDefaultRoleAssumerWithWebIdentity,
+  roleAssumerWithWebIdentity: getDefaultRoleAssumerWithWebIdentity(),
 });
 
 const client = new S3Client({ credentialDefaultProvider: provider });


### PR DESCRIPTION
### Issue
N/A

### Description
The example code for EKS roles in the `credential-provider-node` README currently passes the `getDefaultRoleAssumerWithWebIdentity` function itself as the `roleAssumerWithWebIdentity` when setting up the default credentials provider. Instead, it should be calling this function and passing the returned value (also a function).

### Testing
The current example code does not work as intended. By instead calling the `getDefaultRoleAssumerWithWebIdentity` and passing its returned value as `roleAssumerWithWebIdentity`, I was able to get a working example going.

### Additional context
N/A

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
