### PR TITLE
Speed ssdk tests

### DIFF
--- a/.github/workflows/server-protocol-tests.yml
+++ b/.github/workflows/server-protocol-tests.yml
@@ -45,7 +45,7 @@ jobs:
 
       - name: generate protocol tests
         run: |
-          yarn generate-clients --server-artifacts
+          yarn generate-clients --server-artifacts --skip-formatting
 
       # there are new dependencies as a result of generating server protocol tests
       - name: install dependencies again

--- a/.github/workflows/server-protocol-tests.yml
+++ b/.github/workflows/server-protocol-tests.yml
@@ -22,11 +22,16 @@ jobs:
           node-version: '14'
           cache: 'yarn'
 
+      - uses: actions/checkout@v2
+        with:
+          repository: awslabs/smithy-typescript
+          path: smithy-typescript
+          fetch-depth: 1
+
       - name: build and publish smithy-typescript
         run: |
-          git clone --depth 1 https://github.com/awslabs/smithy-typescript.git
           cd smithy-typescript
-          ./gradlew clean build publishToMavenLocal
+          ./gradlew clean :smithy-typescript-codegen:publishToMavenLocal
           cd smithy-typescript-ssdk-libs
           yarn install
           yarn build

--- a/scripts/generate-clients/index.js
+++ b/scripts/generate-clients/index.js
@@ -21,6 +21,7 @@ const {
   output: clientsDir,
   noProtocolTest,
   s: serverOnly,
+  skipFormatting,
 } = yargs
   .alias("m", "models")
   .string("m")
@@ -40,14 +41,18 @@ const {
   .boolean("s")
   .describe("s", "Generate server artifacts instead of client ones")
   .conflicts("s", ["m", "g", "n"])
+  .boolean("skipFormatting")
+  .describe("skipFormatting", "Skip running prettier and eslint fix on generated code")
   .help().argv;
 
 (async () => {
   try {
     if (serverOnly === true) {
       await generateProtocolTests();
-      await eslintFixCode();
-      await prettifyCode(CODE_GEN_PROTOCOL_TESTS_OUTPUT_DIR);
+      if (!skipFormatting) {
+        await eslintFixCode();
+        await prettifyCode(CODE_GEN_PROTOCOL_TESTS_OUTPUT_DIR);
+      }
       await copyServerTests(CODE_GEN_PROTOCOL_TESTS_OUTPUT_DIR, PROTOCOL_TESTS_CLIENTS_DIR);
 
       emptyDirSync(CODE_GEN_PROTOCOL_TESTS_OUTPUT_DIR);
@@ -60,9 +65,11 @@ const {
     await generateClients(models || globs);
     if (!noProtocolTest) await generateProtocolTests();
 
-    await eslintFixCode();
-    await prettifyCode(CODE_GEN_SDK_OUTPUT_DIR);
-    if (!noProtocolTest) await prettifyCode(CODE_GEN_PROTOCOL_TESTS_OUTPUT_DIR);
+    if (!skipFormatting) {
+      await eslintFixCode();
+      await prettifyCode(CODE_GEN_SDK_OUTPUT_DIR);
+      if (!noProtocolTest) await prettifyCode(CODE_GEN_PROTOCOL_TESTS_OUTPUT_DIR);
+    }
 
     await copyToClients(CODE_GEN_SDK_OUTPUT_DIR, clientsDir);
     if (!noProtocolTest) await copyToClients(CODE_GEN_PROTOCOL_TESTS_OUTPUT_DIR, PROTOCOL_TESTS_CLIENTS_DIR);


### PR DESCRIPTION
### Issue

n/a

### Description

This does a few things to try to speed up server protocol test CI:

* Uses github actions to checkout smithy-typescript instead of manually invoking git (maybe doesn't matter, but I can't imagine it hurts)
* Skips running tests / building other sub-projects of smithy-typescript aside from what is needed
* Omits code formatting on the generated code during ci

### Testing

The ci should continue to pass

### Additional context

The only other thing we could do is move this off of github actions so we can get better hardware to run tsc, which takes up the vast majority of the build time.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
