### PR TITLE
fix(dependencies): move production deps to dependencies

### DIFF
--- a/packages/config-resolver/package.json
+++ b/packages/config-resolver/package.json
@@ -18,12 +18,12 @@
   },
   "license": "Apache-2.0",
   "devDependencies": {
-    "@aws-sdk/node-config-provider": "3.38.0",
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
     "typescript": "~4.3.5"
   },
   "dependencies": {
+    "@aws-sdk/node-config-provider": "3.38.0",
     "@aws-sdk/signature-v4": "3.38.0",
     "@aws-sdk/types": "3.38.0",
     "tslib": "^2.3.0"

--- a/packages/middleware-bucket-endpoint/package.json
+++ b/packages/middleware-bucket-endpoint/package.json
@@ -21,11 +21,11 @@
     "@aws-sdk/protocol-http": "3.38.0",
     "@aws-sdk/types": "3.38.0",
     "@aws-sdk/util-arn-parser": "3.37.0",
+    "@aws-sdk/node-config-provider": "3.38.0",
     "tslib": "^2.3.0"
   },
   "devDependencies": {
     "@aws-sdk/middleware-stack": "3.38.0",
-    "@aws-sdk/node-config-provider": "3.38.0",
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
     "typescript": "~4.3.5"

--- a/packages/middleware-retry/package.json
+++ b/packages/middleware-retry/package.json
@@ -20,12 +20,12 @@
   "dependencies": {
     "@aws-sdk/protocol-http": "3.38.0",
     "@aws-sdk/service-error-classification": "3.38.0",
+    "@aws-sdk/node-config-provider": "3.38.0",
     "@aws-sdk/types": "3.38.0",
     "tslib": "^2.3.0",
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@aws-sdk/node-config-provider": "3.38.0",
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
     "typescript": "~4.3.5"


### PR DESCRIPTION
Having them only in devDependencies doesn't work because they are
imported in production code

Right now, we are overriding these in our yarnrc, but it would be nice to fix it for everyone

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
