### PR TITLE
chore(dependency): bump aws crypto helpers dependency to 2.0.0

### DIFF
--- a/clients/client-accessanalyzer/package.json
+++ b/clients/client-accessanalyzer/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-account/package.json
+++ b/clients/client-account/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.1.0",
-    "@aws-crypto/sha256-js": "^1.1.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-acm-pca/package.json
+++ b/clients/client-acm-pca/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-acm/package.json
+++ b/clients/client-acm/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-alexa-for-business/package.json
+++ b/clients/client-alexa-for-business/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-amp/package.json
+++ b/clients/client-amp/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.1.0",
-    "@aws-crypto/sha256-js": "^1.1.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-amplify/package.json
+++ b/clients/client-amplify/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-amplifybackend/package.json
+++ b/clients/client-amplifybackend/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-api-gateway/package.json
+++ b/clients/client-api-gateway/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-apigatewaymanagementapi/package.json
+++ b/clients/client-apigatewaymanagementapi/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-apigatewayv2/package.json
+++ b/clients/client-apigatewayv2/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-app-mesh/package.json
+++ b/clients/client-app-mesh/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-appconfig/package.json
+++ b/clients/client-appconfig/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-appflow/package.json
+++ b/clients/client-appflow/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-appintegrations/package.json
+++ b/clients/client-appintegrations/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-application-auto-scaling/package.json
+++ b/clients/client-application-auto-scaling/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-application-discovery-service/package.json
+++ b/clients/client-application-discovery-service/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-application-insights/package.json
+++ b/clients/client-application-insights/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-applicationcostprofiler/package.json
+++ b/clients/client-applicationcostprofiler/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.1.0",
-    "@aws-crypto/sha256-js": "^1.1.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-apprunner/package.json
+++ b/clients/client-apprunner/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.1.0",
-    "@aws-crypto/sha256-js": "^1.1.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-appstream/package.json
+++ b/clients/client-appstream/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-appsync/package.json
+++ b/clients/client-appsync/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-athena/package.json
+++ b/clients/client-athena/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-auditmanager/package.json
+++ b/clients/client-auditmanager/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-auto-scaling-plans/package.json
+++ b/clients/client-auto-scaling-plans/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-auto-scaling/package.json
+++ b/clients/client-auto-scaling/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-backup/package.json
+++ b/clients/client-backup/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-batch/package.json
+++ b/clients/client-batch/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-braket/package.json
+++ b/clients/client-braket/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-budgets/package.json
+++ b/clients/client-budgets/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-chime-sdk-identity/package.json
+++ b/clients/client-chime-sdk-identity/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.1.0",
-    "@aws-crypto/sha256-js": "^1.1.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-chime-sdk-messaging/package.json
+++ b/clients/client-chime-sdk-messaging/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.1.0",
-    "@aws-crypto/sha256-js": "^1.1.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-chime/package.json
+++ b/clients/client-chime/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-cloud9/package.json
+++ b/clients/client-cloud9/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-cloudcontrol/package.json
+++ b/clients/client-cloudcontrol/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.1.0",
-    "@aws-crypto/sha256-js": "^1.1.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-clouddirectory/package.json
+++ b/clients/client-clouddirectory/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-cloudformation/package.json
+++ b/clients/client-cloudformation/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-cloudfront/package.json
+++ b/clients/client-cloudfront/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-cloudhsm-v2/package.json
+++ b/clients/client-cloudhsm-v2/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-cloudhsm/package.json
+++ b/clients/client-cloudhsm/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-cloudsearch-domain/package.json
+++ b/clients/client-cloudsearch-domain/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-cloudsearch/package.json
+++ b/clients/client-cloudsearch/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-cloudtrail/package.json
+++ b/clients/client-cloudtrail/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-cloudwatch-events/package.json
+++ b/clients/client-cloudwatch-events/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-cloudwatch-logs/package.json
+++ b/clients/client-cloudwatch-logs/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-cloudwatch/package.json
+++ b/clients/client-cloudwatch/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-codeartifact/package.json
+++ b/clients/client-codeartifact/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-codebuild/package.json
+++ b/clients/client-codebuild/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-codecommit/package.json
+++ b/clients/client-codecommit/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-codedeploy/package.json
+++ b/clients/client-codedeploy/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-codeguru-reviewer/package.json
+++ b/clients/client-codeguru-reviewer/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-codeguruprofiler/package.json
+++ b/clients/client-codeguruprofiler/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-codepipeline/package.json
+++ b/clients/client-codepipeline/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-codestar-connections/package.json
+++ b/clients/client-codestar-connections/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-codestar-notifications/package.json
+++ b/clients/client-codestar-notifications/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-codestar/package.json
+++ b/clients/client-codestar/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-cognito-identity-provider/package.json
+++ b/clients/client-cognito-identity-provider/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-cognito-identity/package.json
+++ b/clients/client-cognito-identity/package.json
@@ -20,8 +20,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-cognito-sync/package.json
+++ b/clients/client-cognito-sync/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-comprehend/package.json
+++ b/clients/client-comprehend/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-comprehendmedical/package.json
+++ b/clients/client-comprehendmedical/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-compute-optimizer/package.json
+++ b/clients/client-compute-optimizer/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-config-service/package.json
+++ b/clients/client-config-service/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-connect-contact-lens/package.json
+++ b/clients/client-connect-contact-lens/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-connect/package.json
+++ b/clients/client-connect/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-connectparticipant/package.json
+++ b/clients/client-connectparticipant/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-cost-and-usage-report-service/package.json
+++ b/clients/client-cost-and-usage-report-service/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-cost-explorer/package.json
+++ b/clients/client-cost-explorer/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-customer-profiles/package.json
+++ b/clients/client-customer-profiles/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-data-pipeline/package.json
+++ b/clients/client-data-pipeline/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-database-migration-service/package.json
+++ b/clients/client-database-migration-service/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-databrew/package.json
+++ b/clients/client-databrew/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-dataexchange/package.json
+++ b/clients/client-dataexchange/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-datasync/package.json
+++ b/clients/client-datasync/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-dax/package.json
+++ b/clients/client-dax/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-detective/package.json
+++ b/clients/client-detective/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-device-farm/package.json
+++ b/clients/client-device-farm/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-devops-guru/package.json
+++ b/clients/client-devops-guru/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-direct-connect/package.json
+++ b/clients/client-direct-connect/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-directory-service/package.json
+++ b/clients/client-directory-service/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-dlm/package.json
+++ b/clients/client-dlm/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-docdb/package.json
+++ b/clients/client-docdb/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-dynamodb-streams/package.json
+++ b/clients/client-dynamodb-streams/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-dynamodb/package.json
+++ b/clients/client-dynamodb/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-ebs/package.json
+++ b/clients/client-ebs/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-ec2-instance-connect/package.json
+++ b/clients/client-ec2-instance-connect/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-ec2/package.json
+++ b/clients/client-ec2/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-ecr-public/package.json
+++ b/clients/client-ecr-public/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-ecr/package.json
+++ b/clients/client-ecr/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-ecs/package.json
+++ b/clients/client-ecs/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-efs/package.json
+++ b/clients/client-efs/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-eks/package.json
+++ b/clients/client-eks/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-elastic-beanstalk/package.json
+++ b/clients/client-elastic-beanstalk/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-elastic-inference/package.json
+++ b/clients/client-elastic-inference/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-elastic-load-balancing-v2/package.json
+++ b/clients/client-elastic-load-balancing-v2/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-elastic-load-balancing/package.json
+++ b/clients/client-elastic-load-balancing/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-elastic-transcoder/package.json
+++ b/clients/client-elastic-transcoder/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-elasticache/package.json
+++ b/clients/client-elasticache/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-elasticsearch-service/package.json
+++ b/clients/client-elasticsearch-service/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-emr-containers/package.json
+++ b/clients/client-emr-containers/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-emr/package.json
+++ b/clients/client-emr/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-eventbridge/package.json
+++ b/clients/client-eventbridge/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-finspace-data/package.json
+++ b/clients/client-finspace-data/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.1.0",
-    "@aws-crypto/sha256-js": "^1.1.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-finspace/package.json
+++ b/clients/client-finspace/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.1.0",
-    "@aws-crypto/sha256-js": "^1.1.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-firehose/package.json
+++ b/clients/client-firehose/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-fis/package.json
+++ b/clients/client-fis/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.1.0",
-    "@aws-crypto/sha256-js": "^1.1.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-fms/package.json
+++ b/clients/client-fms/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-forecast/package.json
+++ b/clients/client-forecast/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-forecastquery/package.json
+++ b/clients/client-forecastquery/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-frauddetector/package.json
+++ b/clients/client-frauddetector/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-fsx/package.json
+++ b/clients/client-fsx/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-gamelift/package.json
+++ b/clients/client-gamelift/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-glacier/package.json
+++ b/clients/client-glacier/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/body-checksum-browser": "3.38.0",
     "@aws-sdk/body-checksum-node": "3.38.0",
     "@aws-sdk/client-sts": "3.38.0",

--- a/clients/client-global-accelerator/package.json
+++ b/clients/client-global-accelerator/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-glue/package.json
+++ b/clients/client-glue/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-grafana/package.json
+++ b/clients/client-grafana/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.1.0",
-    "@aws-crypto/sha256-js": "^1.1.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-greengrass/package.json
+++ b/clients/client-greengrass/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-greengrassv2/package.json
+++ b/clients/client-greengrassv2/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.1.0",
-    "@aws-crypto/sha256-js": "^1.1.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-groundstation/package.json
+++ b/clients/client-groundstation/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-guardduty/package.json
+++ b/clients/client-guardduty/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-health/package.json
+++ b/clients/client-health/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-healthlake/package.json
+++ b/clients/client-healthlake/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-honeycode/package.json
+++ b/clients/client-honeycode/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-iam/package.json
+++ b/clients/client-iam/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-identitystore/package.json
+++ b/clients/client-identitystore/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-imagebuilder/package.json
+++ b/clients/client-imagebuilder/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-inspector/package.json
+++ b/clients/client-inspector/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-iot-1click-devices-service/package.json
+++ b/clients/client-iot-1click-devices-service/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-iot-1click-projects/package.json
+++ b/clients/client-iot-1click-projects/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-iot-data-plane/package.json
+++ b/clients/client-iot-data-plane/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-iot-events-data/package.json
+++ b/clients/client-iot-events-data/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-iot-events/package.json
+++ b/clients/client-iot-events/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-iot-jobs-data-plane/package.json
+++ b/clients/client-iot-jobs-data-plane/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-iot-wireless/package.json
+++ b/clients/client-iot-wireless/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.1.0",
-    "@aws-crypto/sha256-js": "^1.1.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-iot/package.json
+++ b/clients/client-iot/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-iotanalytics/package.json
+++ b/clients/client-iotanalytics/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-iotdeviceadvisor/package.json
+++ b/clients/client-iotdeviceadvisor/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.1.0",
-    "@aws-crypto/sha256-js": "^1.1.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-iotfleethub/package.json
+++ b/clients/client-iotfleethub/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.1.0",
-    "@aws-crypto/sha256-js": "^1.1.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-iotsecuretunneling/package.json
+++ b/clients/client-iotsecuretunneling/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-iotsitewise/package.json
+++ b/clients/client-iotsitewise/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-iotthingsgraph/package.json
+++ b/clients/client-iotthingsgraph/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-ivs/package.json
+++ b/clients/client-ivs/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-kafka/package.json
+++ b/clients/client-kafka/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-kafkaconnect/package.json
+++ b/clients/client-kafkaconnect/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.1.0",
-    "@aws-crypto/sha256-js": "^1.1.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-kendra/package.json
+++ b/clients/client-kendra/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-kinesis-analytics-v2/package.json
+++ b/clients/client-kinesis-analytics-v2/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-kinesis-analytics/package.json
+++ b/clients/client-kinesis-analytics/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-kinesis-video-archived-media/package.json
+++ b/clients/client-kinesis-video-archived-media/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-kinesis-video-media/package.json
+++ b/clients/client-kinesis-video-media/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-kinesis-video-signaling/package.json
+++ b/clients/client-kinesis-video-signaling/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-kinesis-video/package.json
+++ b/clients/client-kinesis-video/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-kinesis/package.json
+++ b/clients/client-kinesis/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-kms/package.json
+++ b/clients/client-kms/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-lakeformation/package.json
+++ b/clients/client-lakeformation/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-lambda/package.json
+++ b/clients/client-lambda/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-lex-model-building-service/package.json
+++ b/clients/client-lex-model-building-service/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-lex-models-v2/package.json
+++ b/clients/client-lex-models-v2/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.1.0",
-    "@aws-crypto/sha256-js": "^1.1.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-lex-runtime-service/package.json
+++ b/clients/client-lex-runtime-service/package.json
@@ -20,8 +20,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-lex-runtime-v2/package.json
+++ b/clients/client-lex-runtime-v2/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.1.0",
-    "@aws-crypto/sha256-js": "^1.1.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-license-manager/package.json
+++ b/clients/client-license-manager/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-lightsail/package.json
+++ b/clients/client-lightsail/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-location/package.json
+++ b/clients/client-location/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.1.0",
-    "@aws-crypto/sha256-js": "^1.1.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-lookoutequipment/package.json
+++ b/clients/client-lookoutequipment/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.1.0",
-    "@aws-crypto/sha256-js": "^1.1.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-lookoutmetrics/package.json
+++ b/clients/client-lookoutmetrics/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.1.0",
-    "@aws-crypto/sha256-js": "^1.1.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-lookoutvision/package.json
+++ b/clients/client-lookoutvision/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-machine-learning/package.json
+++ b/clients/client-machine-learning/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-macie/package.json
+++ b/clients/client-macie/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-macie2/package.json
+++ b/clients/client-macie2/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-managedblockchain/package.json
+++ b/clients/client-managedblockchain/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-marketplace-catalog/package.json
+++ b/clients/client-marketplace-catalog/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-marketplace-commerce-analytics/package.json
+++ b/clients/client-marketplace-commerce-analytics/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-marketplace-entitlement-service/package.json
+++ b/clients/client-marketplace-entitlement-service/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-marketplace-metering/package.json
+++ b/clients/client-marketplace-metering/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-mediaconnect/package.json
+++ b/clients/client-mediaconnect/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-mediaconvert/package.json
+++ b/clients/client-mediaconvert/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-medialive/package.json
+++ b/clients/client-medialive/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-mediapackage-vod/package.json
+++ b/clients/client-mediapackage-vod/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-mediapackage/package.json
+++ b/clients/client-mediapackage/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-mediastore-data/package.json
+++ b/clients/client-mediastore-data/package.json
@@ -20,8 +20,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-mediastore/package.json
+++ b/clients/client-mediastore/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-mediatailor/package.json
+++ b/clients/client-mediatailor/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-memorydb/package.json
+++ b/clients/client-memorydb/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.1.0",
-    "@aws-crypto/sha256-js": "^1.1.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-mgn/package.json
+++ b/clients/client-mgn/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.1.0",
-    "@aws-crypto/sha256-js": "^1.1.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-migration-hub/package.json
+++ b/clients/client-migration-hub/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-migrationhub-config/package.json
+++ b/clients/client-migrationhub-config/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-mobile/package.json
+++ b/clients/client-mobile/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-mq/package.json
+++ b/clients/client-mq/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-mturk/package.json
+++ b/clients/client-mturk/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-mwaa/package.json
+++ b/clients/client-mwaa/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.1.0",
-    "@aws-crypto/sha256-js": "^1.1.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-neptune/package.json
+++ b/clients/client-neptune/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-network-firewall/package.json
+++ b/clients/client-network-firewall/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-networkmanager/package.json
+++ b/clients/client-networkmanager/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-nimble/package.json
+++ b/clients/client-nimble/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.1.0",
-    "@aws-crypto/sha256-js": "^1.1.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-opensearch/package.json
+++ b/clients/client-opensearch/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.1.0",
-    "@aws-crypto/sha256-js": "^1.1.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-opsworks/package.json
+++ b/clients/client-opsworks/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-opsworkscm/package.json
+++ b/clients/client-opsworkscm/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-organizations/package.json
+++ b/clients/client-organizations/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-outposts/package.json
+++ b/clients/client-outposts/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-panorama/package.json
+++ b/clients/client-panorama/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.1.0",
-    "@aws-crypto/sha256-js": "^1.1.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-personalize-events/package.json
+++ b/clients/client-personalize-events/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-personalize-runtime/package.json
+++ b/clients/client-personalize-runtime/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-personalize/package.json
+++ b/clients/client-personalize/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-pi/package.json
+++ b/clients/client-pi/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-pinpoint-email/package.json
+++ b/clients/client-pinpoint-email/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-pinpoint-sms-voice/package.json
+++ b/clients/client-pinpoint-sms-voice/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-pinpoint/package.json
+++ b/clients/client-pinpoint/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-polly/package.json
+++ b/clients/client-polly/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-pricing/package.json
+++ b/clients/client-pricing/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-proton/package.json
+++ b/clients/client-proton/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.1.0",
-    "@aws-crypto/sha256-js": "^1.1.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-qldb-session/package.json
+++ b/clients/client-qldb-session/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-qldb/package.json
+++ b/clients/client-qldb/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-quicksight/package.json
+++ b/clients/client-quicksight/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-ram/package.json
+++ b/clients/client-ram/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-rds-data/package.json
+++ b/clients/client-rds-data/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-rds/package.json
+++ b/clients/client-rds/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-redshift-data/package.json
+++ b/clients/client-redshift-data/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-redshift/package.json
+++ b/clients/client-redshift/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-rekognition/package.json
+++ b/clients/client-rekognition/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-resource-groups-tagging-api/package.json
+++ b/clients/client-resource-groups-tagging-api/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-resource-groups/package.json
+++ b/clients/client-resource-groups/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-robomaker/package.json
+++ b/clients/client-robomaker/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-route-53-domains/package.json
+++ b/clients/client-route-53-domains/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-route-53/package.json
+++ b/clients/client-route-53/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-route53-recovery-cluster/package.json
+++ b/clients/client-route53-recovery-cluster/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.1.0",
-    "@aws-crypto/sha256-js": "^1.1.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-route53-recovery-control-config/package.json
+++ b/clients/client-route53-recovery-control-config/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.1.0",
-    "@aws-crypto/sha256-js": "^1.1.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-route53-recovery-readiness/package.json
+++ b/clients/client-route53-recovery-readiness/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.1.0",
-    "@aws-crypto/sha256-js": "^1.1.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-route53resolver/package.json
+++ b/clients/client-route53resolver/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-s3-control/package.json
+++ b/clients/client-s3-control/package.json
@@ -20,8 +20,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-s3/package.json
+++ b/clients/client-s3/package.json
@@ -21,8 +21,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-s3outposts/package.json
+++ b/clients/client-s3outposts/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-sagemaker-a2i-runtime/package.json
+++ b/clients/client-sagemaker-a2i-runtime/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-sagemaker-edge/package.json
+++ b/clients/client-sagemaker-edge/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-sagemaker-featurestore-runtime/package.json
+++ b/clients/client-sagemaker-featurestore-runtime/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-sagemaker-runtime/package.json
+++ b/clients/client-sagemaker-runtime/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-sagemaker/package.json
+++ b/clients/client-sagemaker/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-savingsplans/package.json
+++ b/clients/client-savingsplans/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-schemas/package.json
+++ b/clients/client-schemas/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-secrets-manager/package.json
+++ b/clients/client-secrets-manager/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-securityhub/package.json
+++ b/clients/client-securityhub/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-serverlessapplicationrepository/package.json
+++ b/clients/client-serverlessapplicationrepository/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-service-catalog-appregistry/package.json
+++ b/clients/client-service-catalog-appregistry/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-service-catalog/package.json
+++ b/clients/client-service-catalog/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-service-quotas/package.json
+++ b/clients/client-service-quotas/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-servicediscovery/package.json
+++ b/clients/client-servicediscovery/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-ses/package.json
+++ b/clients/client-ses/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-sesv2/package.json
+++ b/clients/client-sesv2/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-sfn/package.json
+++ b/clients/client-sfn/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-shield/package.json
+++ b/clients/client-shield/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-signer/package.json
+++ b/clients/client-signer/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-sms/package.json
+++ b/clients/client-sms/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-snow-device-management/package.json
+++ b/clients/client-snow-device-management/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.1.0",
-    "@aws-crypto/sha256-js": "^1.1.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-snowball/package.json
+++ b/clients/client-snowball/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-sns/package.json
+++ b/clients/client-sns/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-sqs/package.json
+++ b/clients/client-sqs/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-ssm-contacts/package.json
+++ b/clients/client-ssm-contacts/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.1.0",
-    "@aws-crypto/sha256-js": "^1.1.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-ssm-incidents/package.json
+++ b/clients/client-ssm-incidents/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.1.0",
-    "@aws-crypto/sha256-js": "^1.1.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-ssm/package.json
+++ b/clients/client-ssm/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-sso-admin/package.json
+++ b/clients/client-sso-admin/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-sso-oidc/package.json
+++ b/clients/client-sso-oidc/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/fetch-http-handler": "3.38.0",
     "@aws-sdk/hash-node": "3.38.0",

--- a/clients/client-sso/package.json
+++ b/clients/client-sso/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/fetch-http-handler": "3.38.0",
     "@aws-sdk/hash-node": "3.38.0",

--- a/clients/client-storage-gateway/package.json
+++ b/clients/client-storage-gateway/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-sts/package.json
+++ b/clients/client-sts/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",
     "@aws-sdk/fetch-http-handler": "3.38.0",

--- a/clients/client-support/package.json
+++ b/clients/client-support/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-swf/package.json
+++ b/clients/client-swf/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-synthetics/package.json
+++ b/clients/client-synthetics/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-textract/package.json
+++ b/clients/client-textract/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-timestream-query/package.json
+++ b/clients/client-timestream-query/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-timestream-write/package.json
+++ b/clients/client-timestream-write/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-transcribe-streaming/package.json
+++ b/clients/client-transcribe-streaming/package.json
@@ -21,8 +21,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-transcribe/package.json
+++ b/clients/client-transcribe/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-transfer/package.json
+++ b/clients/client-transfer/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-translate/package.json
+++ b/clients/client-translate/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-voice-id/package.json
+++ b/clients/client-voice-id/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.1.0",
-    "@aws-crypto/sha256-js": "^1.1.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-waf-regional/package.json
+++ b/clients/client-waf-regional/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-waf/package.json
+++ b/clients/client-waf/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-wafv2/package.json
+++ b/clients/client-wafv2/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-wellarchitected/package.json
+++ b/clients/client-wellarchitected/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.1.0",
-    "@aws-crypto/sha256-js": "^1.1.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-wisdom/package.json
+++ b/clients/client-wisdom/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.1.0",
-    "@aws-crypto/sha256-js": "^1.1.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-workdocs/package.json
+++ b/clients/client-workdocs/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-worklink/package.json
+++ b/clients/client-worklink/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-workmail/package.json
+++ b/clients/client-workmail/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-workmailmessageflow/package.json
+++ b/clients/client-workmailmessageflow/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-workspaces/package.json
+++ b/clients/client-workspaces/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/clients/client-xray/package.json
+++ b/clients/client-xray/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/packages/body-checksum-browser/package.json
+++ b/packages/body-checksum-browser/package.json
@@ -26,7 +26,7 @@
     "tslib": "^2.3.0"
   },
   "devDependencies": {
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/util-utf8-browser": "3.37.0",
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",

--- a/packages/body-checksum-node/package.json
+++ b/packages/body-checksum-node/package.json
@@ -27,7 +27,7 @@
     "tslib": "^2.3.0"
   },
   "devDependencies": {
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/util-utf8-node": "3.37.0",
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",

--- a/packages/eventstream-marshaller/package.json
+++ b/packages/eventstream-marshaller/package.json
@@ -18,7 +18,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "@aws-crypto/crc32": "^1.0.0",
+    "@aws-crypto/crc32": "2.0.0",
     "@aws-sdk/types": "3.38.0",
     "@aws-sdk/util-hex-encoding": "3.37.0",
     "tslib": "^2.3.0"

--- a/packages/hash-blob-browser/package.json
+++ b/packages/hash-blob-browser/package.json
@@ -24,7 +24,7 @@
     "tslib": "^2.3.0"
   },
   "devDependencies": {
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/util-hex-encoding": "3.37.0",
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",

--- a/packages/hash-stream-node/package.json
+++ b/packages/hash-stream-node/package.json
@@ -22,7 +22,7 @@
     "tslib": "^2.3.0"
   },
   "devDependencies": {
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/util-hex-encoding": "3.37.0",
     "@types/jest": "^26.0.4",
     "@types/node": "^10.0.0",

--- a/packages/sha256-tree-hash/package.json
+++ b/packages/sha256-tree-hash/package.json
@@ -22,7 +22,7 @@
     "tslib": "^2.3.0"
   },
   "devDependencies": {
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/util-hex-encoding": "3.37.0",
     "@aws-sdk/util-utf8-node": "3.37.0",
     "@types/jest": "^26.0.4",

--- a/packages/signature-v4-crt/package.json
+++ b/packages/signature-v4-crt/package.json
@@ -28,7 +28,7 @@
     "tslib": "^2.3.0"
   },
   "devDependencies": {
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/protocol-http": "3.38.0",
     "@aws-sdk/types": "3.38.0",
     "@aws-sdk/util-buffer-from": "3.37.0",

--- a/packages/signature-v4/package.json
+++ b/packages/signature-v4/package.json
@@ -27,7 +27,7 @@
     "tslib": "^2.3.0"
   },
   "devDependencies": {
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/protocol-http": "3.38.0",
     "@aws-sdk/util-buffer-from": "3.37.0",
     "@types/jest": "^26.0.4",

--- a/protocol_tests/aws-ec2/package.json
+++ b/protocol_tests/aws-ec2/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/fetch-http-handler": "3.38.0",
     "@aws-sdk/hash-node": "3.38.0",

--- a/protocol_tests/aws-json-10/package.json
+++ b/protocol_tests/aws-json-10/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.1.0",
-    "@aws-crypto/sha256-js": "^1.1.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/fetch-http-handler": "3.38.0",
     "@aws-sdk/hash-node": "3.38.0",

--- a/protocol_tests/aws-json/package.json
+++ b/protocol_tests/aws-json/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/client-sts": "3.38.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/credential-provider-node": "3.38.0",

--- a/protocol_tests/aws-query/package.json
+++ b/protocol_tests/aws-query/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/fetch-http-handler": "3.38.0",
     "@aws-sdk/hash-node": "3.38.0",

--- a/protocol_tests/aws-restjson/package.json
+++ b/protocol_tests/aws-restjson/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/fetch-http-handler": "3.38.0",
     "@aws-sdk/hash-blob-browser": "3.38.0",

--- a/protocol_tests/aws-restxml/package.json
+++ b/protocol_tests/aws-restxml/package.json
@@ -19,8 +19,8 @@
   "module": "./dist-es/index.js",
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0",
-    "@aws-crypto/sha256-js": "^1.0.0",
+    "@aws-crypto/sha256-browser": "2.0.0",
+    "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/config-resolver": "3.38.0",
     "@aws-sdk/fetch-http-handler": "3.38.0",
     "@aws-sdk/hash-node": "3.38.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,47 +2,59 @@
 # yarn lockfile v1
 
 
-"@aws-crypto/crc32@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@aws-crypto/crc32/-/crc32-1.0.0.tgz#6a0164fd92bb365860ba6afb5dfef449701eb8ca"
-  integrity sha512-wr4EyCv3ZfLH3Sg7FErV6e/cLhpk9rUP/l5322y8PRgpQsItdieaLbtE4aDOR+dxl8U7BG9FIwWXH4TleTDZ9A==
+"@aws-crypto/crc32@2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@aws-crypto/crc32/-/crc32-2.0.0.tgz#4ad432a3c03ec3087c5540ff6e41e6565d2dc153"
+  integrity sha512-TvE1r2CUueyXOuHdEigYjIZVesInd9KN+K/TFFNfkkxRThiNxO6i4ZqqAVMoEjAamZZ1AA8WXJkjCz7YShHPQA==
+  dependencies:
+    "@aws-crypto/util" "^2.0.0"
+    "@aws-sdk/types" "^3.1.0"
+    tslib "^1.11.1"
+
+"@aws-crypto/ie11-detection@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@aws-crypto/ie11-detection/-/ie11-detection-2.0.0.tgz#bb6c2facf8f03457e949dcf0921477397ffa4c6e"
+  integrity sha512-pkVXf/dq6PITJ0jzYZ69VhL8VFOFoPZLZqtU/12SGnzYuJOOGNfF41q9GxdI1yqC8R13Rq3jOLKDFpUJFT5eTA==
   dependencies:
     tslib "^1.11.1"
 
-"@aws-crypto/ie11-detection@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@aws-crypto/ie11-detection/-/ie11-detection-1.0.0.tgz#d3a6af29ba7f15458f79c41d1cd8cac3925e726a"
-  integrity sha512-kCKVhCF1oDxFYgQrxXmIrS5oaWulkvRcPz+QBDMsUr2crbF4VGgGT6+uQhSwJFdUAQ2A//Vq+uT83eJrkzFgXA==
+"@aws-crypto/sha256-browser@2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@aws-crypto/sha256-browser/-/sha256-browser-2.0.0.tgz#741c9024df55ec59b51e5b1f5d806a4852699fb5"
+  integrity sha512-rYXOQ8BFOaqMEHJrLHul/25ckWH6GTJtdLSajhlqGMx0PmSueAuvboCuZCTqEKlxR8CQOwRarxYMZZSYlhRA1A==
   dependencies:
-    tslib "^1.11.1"
-
-"@aws-crypto/sha256-browser@^1.0.0", "@aws-crypto/sha256-browser@^1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@aws-crypto/sha256-browser/-/sha256-browser-1.1.0.tgz#20092cc6c08d8f04db0ed57b6f05cff150384f77"
-  integrity sha512-VIpuLRDonMAHgomrsm/zKbeXTnxpr4aHDQmS4pF+NcpvBp64l675yjGA9hyUYs/QJwBjUl8WqMjh9tIRgi85Sg==
-  dependencies:
-    "@aws-crypto/ie11-detection" "^1.0.0"
-    "@aws-crypto/sha256-js" "^1.1.0"
-    "@aws-crypto/supports-web-crypto" "^1.0.0"
+    "@aws-crypto/ie11-detection" "^2.0.0"
+    "@aws-crypto/sha256-js" "^2.0.0"
+    "@aws-crypto/supports-web-crypto" "^2.0.0"
+    "@aws-crypto/util" "^2.0.0"
     "@aws-sdk/types" "^3.1.0"
     "@aws-sdk/util-locate-window" "^3.0.0"
     "@aws-sdk/util-utf8-browser" "^3.0.0"
     tslib "^1.11.1"
 
-"@aws-crypto/sha256-js@^1.0.0", "@aws-crypto/sha256-js@^1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@aws-crypto/sha256-js/-/sha256-js-1.1.0.tgz#a58386ad18186e392e0f1d98d18831261d27b071"
-  integrity sha512-VIhuqbPgXDVr8sZe2yhgQcDRRmzf4CI8fmC1A3bHiRfE6wlz1d8KpeemqbuoEHotz/Dch9yOxlshyQDNjNFeHA==
+"@aws-crypto/sha256-js@2.0.0", "@aws-crypto/sha256-js@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@aws-crypto/sha256-js/-/sha256-js-2.0.0.tgz#f1f936039bdebd0b9e2dd834d65afdc2aac4efcb"
+  integrity sha512-VZY+mCY4Nmrs5WGfitmNqXzaE873fcIZDu54cbaDaaamsaTOP1DBImV9F4pICc3EHjQXujyE8jig+PFCaew9ig==
+  dependencies:
+    "@aws-crypto/util" "^2.0.0"
+    "@aws-sdk/types" "^3.1.0"
+    tslib "^1.11.1"
+
+"@aws-crypto/supports-web-crypto@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@aws-crypto/supports-web-crypto/-/supports-web-crypto-2.0.0.tgz#fd6cde30b88f77d5a4f57b2c37c560d918014f9e"
+  integrity sha512-Ge7WQ3E0OC7FHYprsZV3h0QIcpdyJLvIeg+uTuHqRYm8D6qCFJoiC+edSzSyFiHtZf+NOQDJ1q46qxjtzIY2nA==
+  dependencies:
+    tslib "^1.11.1"
+
+"@aws-crypto/util@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@aws-crypto/util/-/util-2.0.0.tgz#17ba6f83c7e447b70fc24b84c5f6714d1e329f4a"
+  integrity sha512-YDooyH83m2P5A3h6lNH7hm6mIP93sU/dtzRmXIgtO4BCB7SvtX8ysVKQAE8tVky2DQ3HHxPCjNTuUe7YoAMrNQ==
   dependencies:
     "@aws-sdk/types" "^3.1.0"
     "@aws-sdk/util-utf8-browser" "^3.0.0"
-    tslib "^1.11.1"
-
-"@aws-crypto/supports-web-crypto@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@aws-crypto/supports-web-crypto/-/supports-web-crypto-1.0.0.tgz#c40901bc17ac1e875e248df16a2b47ad8bfd9a93"
-  integrity sha512-IHLfv+WmVH89EW4n6a5eE8/hUlz6qkWGMn/v4r5ZgzcXdTC5nolii2z3k46y01hWRiC2PPhOdeSLzMUCUMco7g==
-  dependencies:
     tslib "^1.11.1"
 
 "@babel/code-frame@7.12.11":


### PR DESCRIPTION
We pinned to 2.0.0 because crypto helpers 2.0.0+ is suppose to drop
support for Node.js 10. They may introduce warnings or breaking change
in any time. We should unpin the version after v3 drops the support
for Node.js 10 too.

### Issue
Resolves: https://github.com/aws/aws-sdk-js-v3/issues/2810

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
