### PR TITLE
fix(node-config-provider): allow undefined for booleanSelector obj keys

### DIFF
--- a/packages/node-config-provider/src/booleanSelector.ts
+++ b/packages/node-config-provider/src/booleanSelector.ts
@@ -11,7 +11,7 @@ export enum SelectorType {
  *
  * @internal
  */
-export const booleanSelector = (obj: { [key: string]: string }, key: string, type: SelectorType) => {
+export const booleanSelector = (obj: { [key: string]: string | undefined }, key: string, type: SelectorType) => {
   if (!(key in obj)) return undefined;
   if (obj[key] === "true") return true;
   if (obj[key] === "false") return false;


### PR DESCRIPTION
### Issue
Follow-up to the utility added in https://github.com/aws/aws-sdk-js-v3/pull/2941

### Description
Allows undefined values to be passed for booleanSelector obj keys.

This utility is going to be used in environmentVariableSelector and configFileSelector, both of which accept `string| undefined` as values:
* ProcessEnv: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/ddc4db52a9d14b0841b1f9e845790ad904d39b87/types/node/v12/globals.d.ts#L764-L766
* Profile: https://github.com/aws/aws-sdk-js-v3/blob/538d717f9fc77d63b86e7de026453e4eb274934d/packages/shared-ini-file-loader/src/index.ts#L24-L26

### Testing
CI

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
