### PR TITLE
chore(scripts): add generate:clients:generic script

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "copy-models": "node ./scripts/copy-models",
     "downlevel-dts": "node --es-module-specifier-resolution=node ./scripts/downlevel-dts",
     "generate-clients": "node ./scripts/generate-clients",
+    "generate:clients:generic": "node ./scripts/generate-clients/generic",
     "bootstrap": "yarn",
     "clean": "yarn clear-build-cache && yarn clear-build-info && lerna clean",
     "clear-build-cache": "rimraf ./packages/*/dist ./clients/*/dist ./lib/*/dist ./private/*/dist",

--- a/scripts/generate-clients/generic.js
+++ b/scripts/generate-clients/generic.js
@@ -1,0 +1,25 @@
+// @ts-check
+const path = require("path");
+const { emptyDirSync } = require("fs-extra");
+const { generateGenericClient } = require("./code-gen");
+const { copyToClients } = require("./copy-to-clients");
+const { CODE_GEN_GENERIC_CLIENT_OUTPUT_DIR } = require("./code-gen-dir");
+const { prettifyCode } = require("./code-prettify");
+const { eslintFixCode } = require("./code-eslint-fix");
+
+const PRIVATE_CLIENTS_DIR = path.normalize(path.join(__dirname, "..", "..", "private"));
+
+// TODO: remove this script when generate-clients code is refactored.
+(async () => {
+  try {
+    await generateGenericClient();
+
+    await eslintFixCode();
+    await prettifyCode(CODE_GEN_GENERIC_CLIENT_OUTPUT_DIR);
+    await copyToClients(CODE_GEN_GENERIC_CLIENT_OUTPUT_DIR, PRIVATE_CLIENTS_DIR);
+    emptyDirSync(CODE_GEN_GENERIC_CLIENT_OUTPUT_DIR);
+  } catch (e) {
+    console.log(e);
+    process.exit(1);
+  }
+})();


### PR DESCRIPTION
### Issue
Refs: https://github.com/aws/aws-sdk-js-v3/issues/2939

### Description
Adds generate:clients:generic script which will be called from `generic-client-tests` CI.

### Testing
Verified that generic client in `private/aws-echo-service` is updated when `generic-client-tests` CI is run.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
