### PR TITLE
[WIP] chore(clients): remove redundant endpoint configuration from PartitionHash

### DIFF
--- a/clients/client-account/src/endpoints.ts
+++ b/clients/client-account/src/endpoints.ts
@@ -39,12 +39,12 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    endpoint: "aws-global",
+    hostname: "account.{region}.amazonaws.com",
   },
   "aws-cn": {
     regions: ["aws-cn-global", "cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    endpoint: "aws-cn-global",
+    hostname: "account.{region}.amazonaws.com.cn",
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],

--- a/clients/client-account/src/endpoints.ts
+++ b/clients/client-account/src/endpoints.ts
@@ -1,16 +1,7 @@
 import { getRegionInfo, PartitionHash, RegionHash } from "@aws-sdk/config-resolver";
 import { RegionInfoProvider } from "@aws-sdk/types";
 
-const regionHash: RegionHash = {
-  "aws-cn-global": {
-    hostname: "account.cn-northwest-1.amazonaws.com.cn",
-    signingRegion: "cn-northwest-1",
-  },
-  "aws-global": {
-    hostname: "account.us-east-1.amazonaws.com",
-    signingRegion: "us-east-1",
-  },
-};
+const regionHash: RegionHash = {};
 
 const partitionHash: PartitionHash = {
   aws: {

--- a/clients/client-account/src/endpoints.ts
+++ b/clients/client-account/src/endpoints.ts
@@ -30,12 +30,12 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "account.{region}.amazonaws.com",
+    hostname: "account.us-east-1.amazonaws.com",
   },
   "aws-cn": {
     regions: ["aws-cn-global", "cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "account.{region}.amazonaws.com.cn",
+    hostname: "account.cn-northwest-1.amazonaws.com.cn",
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],

--- a/clients/client-budgets/src/endpoints.ts
+++ b/clients/client-budgets/src/endpoints.ts
@@ -39,12 +39,12 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    endpoint: "aws-global",
+    hostname: "budgets.{region}.amazonaws.com",
   },
   "aws-cn": {
     regions: ["aws-cn-global", "cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    endpoint: "aws-cn-global",
+    hostname: "budgets.{region}.amazonaws.com.cn",
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],

--- a/clients/client-budgets/src/endpoints.ts
+++ b/clients/client-budgets/src/endpoints.ts
@@ -30,12 +30,12 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "budgets.{region}.amazonaws.com",
+    hostname: "budgets.amazonaws.com",
   },
   "aws-cn": {
     regions: ["aws-cn-global", "cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "budgets.{region}.amazonaws.com.cn",
+    hostname: "budgets.amazonaws.com.cn",
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],

--- a/clients/client-budgets/src/endpoints.ts
+++ b/clients/client-budgets/src/endpoints.ts
@@ -1,16 +1,7 @@
 import { getRegionInfo, PartitionHash, RegionHash } from "@aws-sdk/config-resolver";
 import { RegionInfoProvider } from "@aws-sdk/types";
 
-const regionHash: RegionHash = {
-  "aws-cn-global": {
-    hostname: "budgets.amazonaws.com.cn",
-    signingRegion: "cn-northwest-1",
-  },
-  "aws-global": {
-    hostname: "budgets.amazonaws.com",
-    signingRegion: "us-east-1",
-  },
-};
+const regionHash: RegionHash = {};
 
 const partitionHash: PartitionHash = {
   aws: {

--- a/clients/client-chime/src/endpoints.ts
+++ b/clients/client-chime/src/endpoints.ts
@@ -1,12 +1,7 @@
 import { getRegionInfo, PartitionHash, RegionHash } from "@aws-sdk/config-resolver";
 import { RegionInfoProvider } from "@aws-sdk/types";
 
-const regionHash: RegionHash = {
-  "aws-global": {
-    hostname: "chime.us-east-1.amazonaws.com",
-    signingRegion: "us-east-1",
-  },
-};
+const regionHash: RegionHash = {};
 
 const partitionHash: PartitionHash = {
   aws: {

--- a/clients/client-chime/src/endpoints.ts
+++ b/clients/client-chime/src/endpoints.ts
@@ -30,7 +30,7 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "chime.{region}.amazonaws.com",
+    hostname: "chime.us-east-1.amazonaws.com",
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],

--- a/clients/client-chime/src/endpoints.ts
+++ b/clients/client-chime/src/endpoints.ts
@@ -35,7 +35,7 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    endpoint: "aws-global",
+    hostname: "chime.{region}.amazonaws.com",
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],

--- a/clients/client-cloudfront/src/endpoints.ts
+++ b/clients/client-cloudfront/src/endpoints.ts
@@ -30,12 +30,12 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "cloudfront.{region}.amazonaws.com",
+    hostname: "cloudfront.amazonaws.com",
   },
   "aws-cn": {
     regions: ["aws-cn-global", "cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "cloudfront.{region}.amazonaws.com.cn",
+    hostname: "cloudfront.cn-northwest-1.amazonaws.com.cn",
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],

--- a/clients/client-cloudfront/src/endpoints.ts
+++ b/clients/client-cloudfront/src/endpoints.ts
@@ -1,16 +1,7 @@
 import { getRegionInfo, PartitionHash, RegionHash } from "@aws-sdk/config-resolver";
 import { RegionInfoProvider } from "@aws-sdk/types";
 
-const regionHash: RegionHash = {
-  "aws-cn-global": {
-    hostname: "cloudfront.cn-northwest-1.amazonaws.com.cn",
-    signingRegion: "cn-northwest-1",
-  },
-  "aws-global": {
-    hostname: "cloudfront.amazonaws.com",
-    signingRegion: "us-east-1",
-  },
-};
+const regionHash: RegionHash = {};
 
 const partitionHash: PartitionHash = {
   aws: {

--- a/clients/client-cloudfront/src/endpoints.ts
+++ b/clients/client-cloudfront/src/endpoints.ts
@@ -39,12 +39,12 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    endpoint: "aws-global",
+    hostname: "cloudfront.{region}.amazonaws.com",
   },
   "aws-cn": {
     regions: ["aws-cn-global", "cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    endpoint: "aws-cn-global",
+    hostname: "cloudfront.{region}.amazonaws.com.cn",
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],

--- a/clients/client-cost-explorer/src/endpoints.ts
+++ b/clients/client-cost-explorer/src/endpoints.ts
@@ -30,12 +30,12 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "ce.{region}.amazonaws.com",
+    hostname: "ce.us-east-1.amazonaws.com",
   },
   "aws-cn": {
     regions: ["aws-cn-global", "cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "ce.{region}.amazonaws.com.cn",
+    hostname: "ce.cn-northwest-1.amazonaws.com.cn",
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],

--- a/clients/client-cost-explorer/src/endpoints.ts
+++ b/clients/client-cost-explorer/src/endpoints.ts
@@ -39,12 +39,12 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    endpoint: "aws-global",
+    hostname: "ce.{region}.amazonaws.com",
   },
   "aws-cn": {
     regions: ["aws-cn-global", "cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    endpoint: "aws-cn-global",
+    hostname: "ce.{region}.amazonaws.com.cn",
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],

--- a/clients/client-cost-explorer/src/endpoints.ts
+++ b/clients/client-cost-explorer/src/endpoints.ts
@@ -1,16 +1,7 @@
 import { getRegionInfo, PartitionHash, RegionHash } from "@aws-sdk/config-resolver";
 import { RegionInfoProvider } from "@aws-sdk/types";
 
-const regionHash: RegionHash = {
-  "aws-cn-global": {
-    hostname: "ce.cn-northwest-1.amazonaws.com.cn",
-    signingRegion: "cn-northwest-1",
-  },
-  "aws-global": {
-    hostname: "ce.us-east-1.amazonaws.com",
-    signingRegion: "us-east-1",
-  },
-};
+const regionHash: RegionHash = {};
 
 const partitionHash: PartitionHash = {
   aws: {

--- a/clients/client-iam/src/endpoints.ts
+++ b/clients/client-iam/src/endpoints.ts
@@ -60,27 +60,27 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    endpoint: "aws-global",
+    hostname: "iam.{region}.amazonaws.com",
   },
   "aws-cn": {
     regions: ["aws-cn-global", "cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    endpoint: "aws-cn-global",
+    hostname: "iam.{region}.amazonaws.com.cn",
   },
   "aws-iso": {
     regions: ["aws-iso-global", "us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    endpoint: "aws-iso-global",
+    hostname: "iam.{region}.c2s.ic.gov",
   },
   "aws-iso-b": {
     regions: ["aws-iso-b-global", "us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    endpoint: "aws-iso-b-global",
+    hostname: "iam.{region}.sc2s.sgov.gov",
   },
   "aws-us-gov": {
     regions: ["aws-us-gov-global", "iam-govcloud-fips", "us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    endpoint: "aws-us-gov-global",
+    hostname: "iam.{region}.amazonaws.com",
   },
 };
 

--- a/clients/client-iam/src/endpoints.ts
+++ b/clients/client-iam/src/endpoints.ts
@@ -31,27 +31,27 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "iam.{region}.amazonaws.com",
+    hostname: "iam.amazonaws.com",
   },
   "aws-cn": {
     regions: ["aws-cn-global", "cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "iam.{region}.amazonaws.com.cn",
+    hostname: "iam.cn-north-1.amazonaws.com.cn",
   },
   "aws-iso": {
     regions: ["aws-iso-global", "us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "iam.{region}.c2s.ic.gov",
+    hostname: "iam.us-iso-east-1.c2s.ic.gov",
   },
   "aws-iso-b": {
     regions: ["aws-iso-b-global", "us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "iam.{region}.sc2s.sgov.gov",
+    hostname: "iam.us-isob-east-1.sc2s.sgov.gov",
   },
   "aws-us-gov": {
     regions: ["aws-us-gov-global", "iam-govcloud-fips", "us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "iam.{region}.amazonaws.com",
+    hostname: "iam.us-gov.amazonaws.com",
   },
 };
 

--- a/clients/client-iam/src/endpoints.ts
+++ b/clients/client-iam/src/endpoints.ts
@@ -1,36 +1,7 @@
 import { getRegionInfo, PartitionHash, RegionHash } from "@aws-sdk/config-resolver";
 import { RegionInfoProvider } from "@aws-sdk/types";
 
-const regionHash: RegionHash = {
-  "aws-cn-global": {
-    hostname: "iam.cn-north-1.amazonaws.com.cn",
-    signingRegion: "cn-north-1",
-  },
-  "aws-global": {
-    hostname: "iam.amazonaws.com",
-    signingRegion: "us-east-1",
-  },
-  "aws-iso-b-global": {
-    hostname: "iam.us-isob-east-1.sc2s.sgov.gov",
-    signingRegion: "us-isob-east-1",
-  },
-  "aws-iso-global": {
-    hostname: "iam.us-iso-east-1.c2s.ic.gov",
-    signingRegion: "us-iso-east-1",
-  },
-  "aws-us-gov-global": {
-    hostname: "iam.us-gov.amazonaws.com",
-    signingRegion: "us-gov-west-1",
-  },
-  "iam-fips": {
-    hostname: "iam-fips.amazonaws.com",
-    signingRegion: "us-east-1",
-  },
-  "iam-govcloud-fips": {
-    hostname: "iam.us-gov.amazonaws.com",
-    signingRegion: "us-gov-west-1",
-  },
-};
+const regionHash: RegionHash = {};
 
 const partitionHash: PartitionHash = {
   aws: {

--- a/clients/client-organizations/src/endpoints.ts
+++ b/clients/client-organizations/src/endpoints.ts
@@ -31,12 +31,12 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "organizations.{region}.amazonaws.com",
+    hostname: "organizations.us-east-1.amazonaws.com",
   },
   "aws-cn": {
     regions: ["aws-cn-global", "cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "organizations.{region}.amazonaws.com.cn",
+    hostname: "organizations.cn-northwest-1.amazonaws.com.cn",
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
@@ -51,7 +51,7 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["aws-us-gov-global", "fips-aws-us-gov-global", "us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "organizations.{region}.amazonaws.com",
+    hostname: "organizations.us-gov-west-1.amazonaws.com",
   },
 };
 

--- a/clients/client-organizations/src/endpoints.ts
+++ b/clients/client-organizations/src/endpoints.ts
@@ -52,12 +52,12 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    endpoint: "aws-global",
+    hostname: "organizations.{region}.amazonaws.com",
   },
   "aws-cn": {
     regions: ["aws-cn-global", "cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    endpoint: "aws-cn-global",
+    hostname: "organizations.{region}.amazonaws.com.cn",
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
@@ -72,7 +72,7 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["aws-us-gov-global", "fips-aws-us-gov-global", "us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    endpoint: "aws-us-gov-global",
+    hostname: "organizations.{region}.amazonaws.com",
   },
 };
 

--- a/clients/client-organizations/src/endpoints.ts
+++ b/clients/client-organizations/src/endpoints.ts
@@ -1,28 +1,7 @@
 import { getRegionInfo, PartitionHash, RegionHash } from "@aws-sdk/config-resolver";
 import { RegionInfoProvider } from "@aws-sdk/types";
 
-const regionHash: RegionHash = {
-  "aws-cn-global": {
-    hostname: "organizations.cn-northwest-1.amazonaws.com.cn",
-    signingRegion: "cn-northwest-1",
-  },
-  "aws-global": {
-    hostname: "organizations.us-east-1.amazonaws.com",
-    signingRegion: "us-east-1",
-  },
-  "aws-us-gov-global": {
-    hostname: "organizations.us-gov-west-1.amazonaws.com",
-    signingRegion: "us-gov-west-1",
-  },
-  "fips-aws-global": {
-    hostname: "organizations-fips.us-east-1.amazonaws.com",
-    signingRegion: "us-east-1",
-  },
-  "fips-aws-us-gov-global": {
-    hostname: "organizations.us-gov-west-1.amazonaws.com",
-    signingRegion: "us-gov-west-1",
-  },
-};
+const regionHash: RegionHash = {};
 
 const partitionHash: PartitionHash = {
   aws: {

--- a/clients/client-route-53/src/endpoints.ts
+++ b/clients/client-route-53/src/endpoints.ts
@@ -1,36 +1,7 @@
 import { getRegionInfo, PartitionHash, RegionHash } from "@aws-sdk/config-resolver";
 import { RegionInfoProvider } from "@aws-sdk/types";
 
-const regionHash: RegionHash = {
-  "aws-cn-global": {
-    hostname: "route53.amazonaws.com.cn",
-    signingRegion: "cn-northwest-1",
-  },
-  "aws-global": {
-    hostname: "route53.amazonaws.com",
-    signingRegion: "us-east-1",
-  },
-  "aws-iso-b-global": {
-    hostname: "route53.sc2s.sgov.gov",
-    signingRegion: "us-isob-east-1",
-  },
-  "aws-iso-global": {
-    hostname: "route53.c2s.ic.gov",
-    signingRegion: "us-iso-east-1",
-  },
-  "aws-us-gov-global": {
-    hostname: "route53.us-gov.amazonaws.com",
-    signingRegion: "us-gov-west-1",
-  },
-  "fips-aws-global": {
-    hostname: "route53-fips.amazonaws.com",
-    signingRegion: "us-east-1",
-  },
-  "fips-aws-us-gov-global": {
-    hostname: "route53.us-gov.amazonaws.com",
-    signingRegion: "us-gov-west-1",
-  },
-};
+const regionHash: RegionHash = {};
 
 const partitionHash: PartitionHash = {
   aws: {

--- a/clients/client-route-53/src/endpoints.ts
+++ b/clients/client-route-53/src/endpoints.ts
@@ -60,27 +60,27 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    endpoint: "aws-global",
+    hostname: "route53.{region}.amazonaws.com",
   },
   "aws-cn": {
     regions: ["aws-cn-global", "cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    endpoint: "aws-cn-global",
+    hostname: "route53.{region}.amazonaws.com.cn",
   },
   "aws-iso": {
     regions: ["aws-iso-global", "us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    endpoint: "aws-iso-global",
+    hostname: "route53.{region}.c2s.ic.gov",
   },
   "aws-iso-b": {
     regions: ["aws-iso-b-global", "us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    endpoint: "aws-iso-b-global",
+    hostname: "route53.{region}.sc2s.sgov.gov",
   },
   "aws-us-gov": {
     regions: ["aws-us-gov-global", "fips-aws-us-gov-global", "us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    endpoint: "aws-us-gov-global",
+    hostname: "route53.{region}.amazonaws.com",
   },
 };
 

--- a/clients/client-route-53/src/endpoints.ts
+++ b/clients/client-route-53/src/endpoints.ts
@@ -31,27 +31,27 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "route53.{region}.amazonaws.com",
+    hostname: "route53.amazonaws.com",
   },
   "aws-cn": {
     regions: ["aws-cn-global", "cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "route53.{region}.amazonaws.com.cn",
+    hostname: "route53.amazonaws.com.cn",
   },
   "aws-iso": {
     regions: ["aws-iso-global", "us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "route53.{region}.c2s.ic.gov",
+    hostname: "route53.c2s.ic.gov",
   },
   "aws-iso-b": {
     regions: ["aws-iso-b-global", "us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "route53.{region}.sc2s.sgov.gov",
+    hostname: "route53.sc2s.sgov.gov",
   },
   "aws-us-gov": {
     regions: ["aws-us-gov-global", "fips-aws-us-gov-global", "us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "route53.{region}.amazonaws.com",
+    hostname: "route53.us-gov.amazonaws.com",
   },
 };
 

--- a/clients/client-savingsplans/src/endpoints.ts
+++ b/clients/client-savingsplans/src/endpoints.ts
@@ -1,12 +1,7 @@
 import { getRegionInfo, PartitionHash, RegionHash } from "@aws-sdk/config-resolver";
 import { RegionInfoProvider } from "@aws-sdk/types";
 
-const regionHash: RegionHash = {
-  "aws-global": {
-    hostname: "savingsplans.amazonaws.com",
-    signingRegion: "us-east-1",
-  },
-};
+const regionHash: RegionHash = {};
 
 const partitionHash: PartitionHash = {
   aws: {

--- a/clients/client-savingsplans/src/endpoints.ts
+++ b/clients/client-savingsplans/src/endpoints.ts
@@ -35,7 +35,7 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    endpoint: "aws-global",
+    hostname: "savingsplans.{region}.amazonaws.com",
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],

--- a/clients/client-savingsplans/src/endpoints.ts
+++ b/clients/client-savingsplans/src/endpoints.ts
@@ -30,7 +30,7 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "savingsplans.{region}.amazonaws.com",
+    hostname: "savingsplans.amazonaws.com",
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],

--- a/clients/client-shield/src/endpoints.ts
+++ b/clients/client-shield/src/endpoints.ts
@@ -1,16 +1,7 @@
 import { getRegionInfo, PartitionHash, RegionHash } from "@aws-sdk/config-resolver";
 import { RegionInfoProvider } from "@aws-sdk/types";
 
-const regionHash: RegionHash = {
-  "aws-global": {
-    hostname: "shield.us-east-1.amazonaws.com",
-    signingRegion: "us-east-1",
-  },
-  "fips-aws-global": {
-    hostname: "shield-fips.us-east-1.amazonaws.com",
-    signingRegion: "us-east-1",
-  },
-};
+const regionHash: RegionHash = {};
 
 const partitionHash: PartitionHash = {
   aws: {

--- a/clients/client-shield/src/endpoints.ts
+++ b/clients/client-shield/src/endpoints.ts
@@ -31,7 +31,7 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "shield.{region}.amazonaws.com",
+    hostname: "shield.us-east-1.amazonaws.com",
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],

--- a/clients/client-shield/src/endpoints.ts
+++ b/clients/client-shield/src/endpoints.ts
@@ -40,7 +40,7 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    endpoint: "aws-global",
+    hostname: "shield.{region}.amazonaws.com",
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],

--- a/clients/client-waf/src/endpoints.ts
+++ b/clients/client-waf/src/endpoints.ts
@@ -31,7 +31,7 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "waf.{region}.amazonaws.com",
+    hostname: "waf.amazonaws.com",
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],

--- a/clients/client-waf/src/endpoints.ts
+++ b/clients/client-waf/src/endpoints.ts
@@ -1,16 +1,7 @@
 import { getRegionInfo, PartitionHash, RegionHash } from "@aws-sdk/config-resolver";
 import { RegionInfoProvider } from "@aws-sdk/types";
 
-const regionHash: RegionHash = {
-  "aws-fips": {
-    hostname: "waf-fips.amazonaws.com",
-    signingRegion: "us-east-1",
-  },
-  "aws-global": {
-    hostname: "waf.amazonaws.com",
-    signingRegion: "us-east-1",
-  },
-};
+const regionHash: RegionHash = {};
 
 const partitionHash: PartitionHash = {
   aws: {

--- a/clients/client-waf/src/endpoints.ts
+++ b/clients/client-waf/src/endpoints.ts
@@ -40,7 +40,7 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    endpoint: "aws-global",
+    hostname: "waf.{region}.amazonaws.com",
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/EndpointGenerator.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/EndpointGenerator.java
@@ -131,9 +131,7 @@ final class EndpointGenerator implements Runnable {
                         }
                     });
                     writer.write("regionRegex: $S,", partition.regionRegex);
-                    OptionalUtils.ifPresentOrElse(partition.getPartitionEndpoint(),
-                        endpoint -> writer.write("endpoint: $S,", endpoint),
-                        () -> writer.write("hostname: $S,", partition.hostnameTemplate));
+                    writer.write("hostname: $S,", partition.hostnameTemplate);
                 });
             });
         });

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/EndpointGenerator.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/EndpointGenerator.java
@@ -88,16 +88,19 @@ final class EndpointGenerator implements Runnable {
             ObjectNode serviceData = partition.getService();
             ObjectNode endpointMap = serviceData.getObjectMember("endpoints").orElse(Node.objectNode());
 
-            for (Map.Entry<String, Node> entry : endpointMap.getStringMap().entrySet()) {
-                ObjectNode config = entry.getValue().expectObjectNode();
-                if (config.containsMember("hostname")) {
-                    // Resolve the hostname.
-                    String hostName = config.expectStringMember("hostname").getValue();
-                    hostName = hostName.replace("{dnsSuffix}", dnsSuffix);
-                    hostName = hostName.replace("{service}", endpointPrefix);
-                    hostName = hostName.replace("{region}", entry.getKey());
-                    config = config.withMember("hostname", hostName);
-                    endpoints.put(entry.getKey(), config);
+            // If partition endpoint is available, data will be populated in PartitionHash.
+            if (!partition.getPartitionEndpoint().isPresent()) {
+                for (Map.Entry<String, Node> entry : endpointMap.getStringMap().entrySet()) {
+                    ObjectNode config = entry.getValue().expectObjectNode();
+                    if (config.containsMember("hostname")) {
+                        // Resolve the hostname.
+                        String hostName = config.expectStringMember("hostname").getValue();
+                        hostName = hostName.replace("{dnsSuffix}", dnsSuffix);
+                        hostName = hostName.replace("{service}", endpointPrefix);
+                        hostName = hostName.replace("{region}", entry.getKey());
+                        config = config.withMember("hostname", hostName);
+                        endpoints.put(entry.getKey(), config);
+                    }
                 }
             }
         }

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/EndpointGenerator.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/EndpointGenerator.java
@@ -135,7 +135,16 @@ final class EndpointGenerator implements Runnable {
                         }
                     });
                     writer.write("regionRegex: $S,", partition.regionRegex);
-                    writer.write("hostname: $S,", partition.hostnameTemplate);
+                    String hostname = partition.hostnameTemplate;
+                    if (partition.getPartitionEndpoint().isPresent()) {
+                        String partitionEndpoint = partition.getPartitionEndpoint().get();
+                        Endpoint endpoint = endpoints.get(partitionEndpoint);
+                        ObjectNode config = endpoint.config;
+                        if (config.containsMember("hostname")) {
+                            hostname = config.expectStringMember("hostname").getValue();
+                        }
+                    }
+                    writer.write("hostname: $S,", hostname);
                 });
             });
         });

--- a/packages/config-resolver/src/regionInfo/PartitionHash.ts
+++ b/packages/config-resolver/src/regionInfo/PartitionHash.ts
@@ -4,5 +4,12 @@
  * and the hostname to be used for the partition.
  */
 export type PartitionHash = {
-  [key: string]: { regions: string[]; regionRegex: string; hostname?: string; endpoint?: string };
+  [key: string]: {
+    regions: string[];
+    regionRegex: string;
+    hostname?: string;
+    endpoint?: string;
+    signingRegion?: string;
+    signingService?: string;
+  };
 };


### PR DESCRIPTION
### Issue
Noticed while working on variants in https://github.com/aws/aws-sdk-js-v3/pull/2962

### Description
* Removes redundant endpoint configuration from PartitionHash.
* Populates signingRegion in PartitionHash instead.
* Removes redundant configuration from RegionHash.
* Updates getRegionInfo.

### Testing
Unit testing

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
