### PR TITLE
fix(config-resolver): resolve region first from regionHash

### DIFF
--- a/packages/config-resolver/src/regionInfo/getRegionInfo.spec.ts
+++ b/packages/config-resolver/src/regionInfo/getRegionInfo.spec.ts
@@ -52,7 +52,7 @@ describe(getRegionInfo.name, () => {
   });
 
   const getMockResolvedRegion = (regionCase: RegionCase): string =>
-    regionCase === RegionCase.REGION ? mockRegion : mockEndpointRegion;
+    regionCase !== RegionCase.ENDPOINT ? mockRegion : mockEndpointRegion;
 
   const getMockResolvedPartitionOptions = (partitionHash) => ({ partitionHash });
 

--- a/packages/config-resolver/src/regionInfo/getRegionInfo.ts
+++ b/packages/config-resolver/src/regionInfo/getRegionInfo.ts
@@ -17,7 +17,7 @@ export const getRegionInfo = (
   { signingService, regionHash, partitionHash }: GetRegionInfoOptions
 ): RegionInfo => {
   const partition = getResolvedPartition(region, { partitionHash });
-  const resolvedRegion = partitionHash[partition]?.endpoint ?? region;
+  const resolvedRegion = region in regionHash ? region : partitionHash[partition]?.endpoint ?? region;
 
   const hostname = getResolvedHostname(resolvedRegion, {
     signingService,

--- a/tests/functional/endpoints/fips/test_cases_supported.json
+++ b/tests/functional/endpoints/fips/test_cases_supported.json
@@ -1960,6 +1960,13 @@
     "hostname": "network-firewall-fips.us-west-2.amazonaws.com"
   },
   {
+    "endpointPrefix": "organizations",
+    "sdkId": "Organizations",
+    "region": "fips-aws-global",
+    "signingRegion": "us-east-1",
+    "hostname": "organizations-fips.us-east-1.amazonaws.com"
+  },
+  {
     "endpointPrefix": "outposts",
     "sdkId": "Outposts",
     "region": "fips-ca-central-1",
@@ -2154,6 +2161,13 @@
     "region": "fips-us-west-2",
     "signingRegion": "us-west-2",
     "hostname": "resource-groups-fips.us-west-2.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "route53",
+    "sdkId": "Route 53",
+    "region": "fips-aws-global",
+    "signingRegion": "us-east-1",
+    "hostname": "route53-fips.amazonaws.com"
   },
   {
     "endpointPrefix": "runtime.lex",
@@ -2371,6 +2385,13 @@
     "region": "fips-us-west-2",
     "signingRegion": "us-west-2",
     "hostname": "session.qldb-fips.us-west-2.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "shield",
+    "sdkId": "Shield",
+    "region": "fips-aws-global",
+    "signingRegion": "us-east-1",
+    "hostname": "shield-fips.us-east-1.amazonaws.com"
   },
   {
     "endpointPrefix": "sms",

--- a/tests/functional/endpoints/fips/test_cases_supported.json
+++ b/tests/functional/endpoints/fips/test_cases_supported.json
@@ -1554,6 +1554,13 @@
     "hostname": "health-fips.us-east-2.amazonaws.com"
   },
   {
+    "endpointPrefix": "iam",
+    "sdkId": "IAM",
+    "region": "iam-fips",
+    "signingRegion": "us-east-1",
+    "hostname": "iam-fips.amazonaws.com"
+  },
+  {
     "endpointPrefix": "identity-chime",
     "sdkId": "Chime SDK Identity",
     "region": "us-east-1-fips",
@@ -2863,6 +2870,13 @@
     "hostname": "translate-fips.us-west-2.amazonaws.com"
   },
   {
+    "endpointPrefix": "waf",
+    "sdkId": "WAF",
+    "region": "aws-fips",
+    "signingRegion": "us-east-1",
+    "hostname": "waf-fips.amazonaws.com"
+  },
+  {
     "endpointPrefix": "waf-regional",
     "sdkId": "WAF Regional",
     "region": "fips-af-south-1",
@@ -3750,6 +3764,13 @@
     "region": "fips-us-gov-west-1",
     "signingRegion": "us-gov-west-1",
     "hostname": "servicecatalog-appregistry.us-gov-west-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "servicediscovery",
+    "sdkId": "ServiceDiscovery",
+    "region": "servicediscovery-fips",
+    "signingRegion": "us-gov-west-1",
+    "hostname": "servicediscovery-fips.us-gov-west-1.amazonaws.com"
   },
   {
     "endpointPrefix": "servicequotas",

--- a/tests/functional/endpoints/fips/test_cases_unsupported.json
+++ b/tests/functional/endpoints/fips/test_cases_unsupported.json
@@ -42,27 +42,6 @@
     "hostname": "iam-fips.amazonaws.com"
   },
   {
-    "endpointPrefix": "organizations",
-    "sdkId": "Organizations",
-    "region": "fips-aws-global",
-    "signingRegion": "us-east-1",
-    "hostname": "organizations-fips.us-east-1.amazonaws.com"
-  },
-  {
-    "endpointPrefix": "route53",
-    "sdkId": "Route 53",
-    "region": "fips-aws-global",
-    "signingRegion": "us-east-1",
-    "hostname": "route53-fips.amazonaws.com"
-  },
-  {
-    "endpointPrefix": "shield",
-    "sdkId": "Shield",
-    "region": "fips-aws-global",
-    "signingRegion": "us-east-1",
-    "hostname": "shield-fips.us-east-1.amazonaws.com"
-  },
-  {
     "endpointPrefix": "servicediscovery",
     "sdkId": "ServiceDiscovery",
     "region": "servicediscovery-fips",

--- a/tests/functional/endpoints/fips/test_cases_unsupported.json
+++ b/tests/functional/endpoints/fips/test_cases_unsupported.json
@@ -28,27 +28,6 @@
     "hostname": "dms.us-isob-east-1.sc2s.sgov.gov"
   },
   {
-    "endpointPrefix": "waf",
-    "sdkId": "WAF",
-    "region": "aws-fips",
-    "signingRegion": "us-east-1",
-    "hostname": "waf-fips.amazonaws.com"
-  },
-  {
-    "endpointPrefix": "iam",
-    "sdkId": "IAM",
-    "region": "iam-fips",
-    "signingRegion": "us-east-1",
-    "hostname": "iam-fips.amazonaws.com"
-  },
-  {
-    "endpointPrefix": "servicediscovery",
-    "sdkId": "ServiceDiscovery",
-    "region": "servicediscovery-fips",
-    "signingRegion": "us-gov-west-1",
-    "hostname": "servicediscovery-fips.us-gov-west-1.amazonaws.com"
-  },
-  {
     "endpointPrefix": "servicediscovery",
     "sdkId": "ServiceDiscovery",
     "region": "servicediscovery-fips",


### PR DESCRIPTION
### Issue
Fixes: https://github.com/aws/aws-sdk-js-v3/issues/2966

### Description
Resolves region from regionHash first before checking for endpoint in partitionHash

### Testing
* Unit tests
* Functional tests

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
