### PR TITLE
feat(clients): populate variants in endpoints hashes

### DIFF
--- a/clients/client-accessanalyzer/src/endpoints.ts
+++ b/clients/client-accessanalyzer/src/endpoints.ts
@@ -2,33 +2,140 @@ import { getRegionInfo, PartitionHash, RegionHash } from "@aws-sdk/config-resolv
 import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
+  "ca-central-1": {
+    hostname: "access-analyzer.ca-central-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "access-analyzer.ca-central-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "access-analyzer-fips.ca-central-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
   "fips-ca-central-1": {
     hostname: "access-analyzer-fips.ca-central-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "access-analyzer-fips.ca-central-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "ca-central-1",
   },
   "fips-us-east-1": {
     hostname: "access-analyzer-fips.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "access-analyzer-fips.us-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-1",
   },
   "fips-us-east-2": {
     hostname: "access-analyzer-fips.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "access-analyzer-fips.us-east-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-2",
   },
   "fips-us-west-1": {
     hostname: "access-analyzer-fips.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "access-analyzer-fips.us-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-1",
   },
   "fips-us-west-2": {
     hostname: "access-analyzer-fips.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "access-analyzer-fips.us-west-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-2",
+  },
+  "us-east-1": {
+    hostname: "access-analyzer.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "access-analyzer.us-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "access-analyzer-fips.us-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-east-2": {
+    hostname: "access-analyzer.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "access-analyzer.us-east-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "access-analyzer-fips.us-east-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "us-gov-east-1": {
     hostname: "access-analyzer.us-gov-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "access-analyzer.us-gov-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-east-1",
   },
   "us-gov-west-1": {
     hostname: "access-analyzer.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "access-analyzer.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-west-1",
+  },
+  "us-west-1": {
+    hostname: "access-analyzer.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "access-analyzer.us-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "access-analyzer-fips.us-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-west-2": {
+    hostname: "access-analyzer.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "access-analyzer.us-west-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "access-analyzer-fips.us-west-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
 };
 
@@ -64,26 +171,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "access-analyzer.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "access-analyzer.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "access-analyzer-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "access-analyzer-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "access-analyzer.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "access-analyzer.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "access-analyzer.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "access-analyzer-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "access-analyzer-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "access-analyzer.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "access-analyzer.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "access-analyzer.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "access-analyzer.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "access-analyzer.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "access-analyzer.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "access-analyzer.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "access-analyzer-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "access-analyzer-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "access-analyzer.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-account/src/endpoints.ts
+++ b/clients/client-account/src/endpoints.ts
@@ -4,10 +4,22 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 const regionHash: RegionHash = {
   "aws-cn-global": {
     hostname: "account.cn-northwest-1.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "account.cn-northwest-1.amazonaws.com.cn",
+        tags: [],
+      },
+    ],
     signingRegion: "cn-northwest-1",
   },
   "aws-global": {
     hostname: "account.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "account.us-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-1",
   },
 };
@@ -39,27 +51,95 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
+    hostname: "account.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "account.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "account-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "account-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "account.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
     endpoint: "aws-global",
   },
   "aws-cn": {
     regions: ["aws-cn-global", "cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
+    hostname: "account.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "account.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "account-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "account-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "account.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
     endpoint: "aws-cn-global",
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "account.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "account.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "account.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "account.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "account.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "account.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "account-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "account-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "account.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-acm-pca/src/endpoints.ts
+++ b/clients/client-acm-pca/src/endpoints.ts
@@ -2,33 +2,166 @@ import { getRegionInfo, PartitionHash, RegionHash } from "@aws-sdk/config-resolv
 import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
+  "ca-central-1": {
+    hostname: "acm-pca.ca-central-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "acm-pca.ca-central-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "acm-pca-fips.ca-central-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
   "fips-ca-central-1": {
     hostname: "acm-pca-fips.ca-central-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "acm-pca-fips.ca-central-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "ca-central-1",
   },
   "fips-us-east-1": {
     hostname: "acm-pca-fips.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "acm-pca-fips.us-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-1",
   },
   "fips-us-east-2": {
     hostname: "acm-pca-fips.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "acm-pca-fips.us-east-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-2",
   },
   "fips-us-gov-east-1": {
     hostname: "acm-pca.us-gov-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "acm-pca.us-gov-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-east-1",
   },
   "fips-us-gov-west-1": {
     hostname: "acm-pca.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "acm-pca.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-west-1",
   },
   "fips-us-west-1": {
     hostname: "acm-pca-fips.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "acm-pca-fips.us-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-1",
   },
   "fips-us-west-2": {
     hostname: "acm-pca-fips.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "acm-pca-fips.us-west-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-2",
+  },
+  "us-east-1": {
+    hostname: "acm-pca.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "acm-pca.us-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "acm-pca-fips.us-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-east-2": {
+    hostname: "acm-pca.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "acm-pca.us-east-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "acm-pca-fips.us-east-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-gov-east-1": {
+    hostname: "acm-pca.us-gov-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "acm-pca.us-gov-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "acm-pca.us-gov-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-gov-west-1": {
+    hostname: "acm-pca.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "acm-pca.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "acm-pca.us-gov-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-west-1": {
+    hostname: "acm-pca.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "acm-pca.us-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "acm-pca-fips.us-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-west-2": {
+    hostname: "acm-pca.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "acm-pca.us-west-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "acm-pca-fips.us-west-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
 };
 
@@ -64,26 +197,84 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "acm-pca.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "acm-pca.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "acm-pca-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "acm-pca-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "acm-pca.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "acm-pca.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "acm-pca.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "acm-pca-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "acm-pca-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "acm-pca.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "acm-pca.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "acm-pca.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "acm-pca.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "acm-pca.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["fips-us-gov-east-1", "fips-us-gov-west-1", "us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "acm-pca.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "acm-pca.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "acm-pca.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
 };
 

--- a/clients/client-acm/src/endpoints.ts
+++ b/clients/client-acm/src/endpoints.ts
@@ -2,32 +2,139 @@ import { getRegionInfo, PartitionHash, RegionHash } from "@aws-sdk/config-resolv
 import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
+  "ca-central-1": {
+    hostname: "acm.ca-central-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "acm.ca-central-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "acm-fips.ca-central-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
   "ca-central-1-fips": {
     hostname: "acm-fips.ca-central-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "acm-fips.ca-central-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "ca-central-1",
+  },
+  "us-east-1": {
+    hostname: "acm.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "acm.us-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "acm-fips.us-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "us-east-1-fips": {
     hostname: "acm-fips.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "acm-fips.us-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-1",
+  },
+  "us-east-2": {
+    hostname: "acm.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "acm.us-east-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "acm-fips.us-east-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "us-east-2-fips": {
     hostname: "acm-fips.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "acm-fips.us-east-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-2",
   },
   "us-gov-east-1": {
     hostname: "acm.us-gov-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "acm.us-gov-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-east-1",
   },
   "us-gov-west-1": {
     hostname: "acm.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "acm.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-west-1",
+  },
+  "us-west-1": {
+    hostname: "acm.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "acm.us-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "acm-fips.us-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "us-west-1-fips": {
     hostname: "acm-fips.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "acm-fips.us-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-1",
+  },
+  "us-west-2": {
+    hostname: "acm.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "acm.us-west-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "acm-fips.us-west-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "us-west-2-fips": {
     hostname: "acm-fips.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "acm-fips.us-west-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-2",
   },
 };
@@ -64,26 +171,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "acm.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "acm.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "acm-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "acm-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "acm.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "acm.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "acm.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "acm-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "acm-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "acm.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "acm.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "acm.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "acm.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "acm.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "acm.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "acm.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "acm-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "acm-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "acm.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-alexa-for-business/src/endpoints.ts
+++ b/clients/client-alexa-for-business/src/endpoints.ts
@@ -30,26 +30,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "a4b.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "a4b.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "a4b-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "a4b-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "a4b.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "a4b.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "a4b.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "a4b-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "a4b-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "a4b.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "a4b.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "a4b.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "a4b.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "a4b.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "a4b.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "a4b.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "a4b-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "a4b-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "a4b.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-amp/src/endpoints.ts
+++ b/clients/client-amp/src/endpoints.ts
@@ -30,26 +30,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "aps.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "aps.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "aps-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "aps-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "aps.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "aps.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "aps.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "aps-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "aps-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "aps.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "aps.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "aps.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "aps.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "aps.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "aps.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "aps.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "aps-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "aps-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "aps.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-amplify/src/endpoints.ts
+++ b/clients/client-amplify/src/endpoints.ts
@@ -30,26 +30,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "amplify.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "amplify.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "amplify-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "amplify-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "amplify.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "amplify.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "amplify.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "amplify-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "amplify-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "amplify.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "amplify.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "amplify.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "amplify.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "amplify.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "amplify.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "amplify.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "amplify-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "amplify-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "amplify.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-amplifybackend/src/endpoints.ts
+++ b/clients/client-amplifybackend/src/endpoints.ts
@@ -30,26 +30,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "amplifybackend.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "amplifybackend.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "amplifybackend-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "amplifybackend-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "amplifybackend.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "amplifybackend.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "amplifybackend.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "amplifybackend-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "amplifybackend-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "amplifybackend.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "amplifybackend.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "amplifybackend.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "amplifybackend.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "amplifybackend.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "amplifybackend.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "amplifybackend.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "amplifybackend-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "amplifybackend-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "amplifybackend.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-api-gateway/src/endpoints.ts
+++ b/clients/client-api-gateway/src/endpoints.ts
@@ -30,26 +30,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "apigateway.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "apigateway.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "apigateway-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "apigateway-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "apigateway.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "apigateway.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "apigateway.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "apigateway-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "apigateway-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "apigateway.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "apigateway.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "apigateway.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "apigateway.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "apigateway.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "apigateway.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "apigateway.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "apigateway-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "apigateway-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "apigateway.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-apigatewaymanagementapi/src/endpoints.ts
+++ b/clients/client-apigatewaymanagementapi/src/endpoints.ts
@@ -30,26 +30,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "execute-api.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "execute-api.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "execute-api-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "execute-api-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "execute-api.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "execute-api.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "execute-api.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "execute-api-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "execute-api-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "execute-api.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "execute-api.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "execute-api.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "execute-api.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "execute-api.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "execute-api.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "execute-api.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "execute-api-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "execute-api-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "execute-api.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-apigatewayv2/src/endpoints.ts
+++ b/clients/client-apigatewayv2/src/endpoints.ts
@@ -30,26 +30,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "apigateway.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "apigateway.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "apigateway-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "apigateway-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "apigateway.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "apigateway.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "apigateway.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "apigateway-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "apigateway-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "apigateway.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "apigateway.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "apigateway.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "apigateway.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "apigateway.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "apigateway.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "apigateway.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "apigateway-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "apigateway-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "apigateway.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-app-mesh/src/endpoints.ts
+++ b/clients/client-app-mesh/src/endpoints.ts
@@ -30,26 +30,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "appmesh.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "appmesh.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "appmesh-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "appmesh-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "appmesh.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "appmesh.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "appmesh.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "appmesh-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "appmesh-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "appmesh.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "appmesh.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "appmesh.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "appmesh.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "appmesh.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "appmesh.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "appmesh.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "appmesh-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "appmesh-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "appmesh.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-appconfig/src/endpoints.ts
+++ b/clients/client-appconfig/src/endpoints.ts
@@ -30,26 +30,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "appconfig.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "appconfig.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "appconfig-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "appconfig-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "appconfig.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "appconfig.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "appconfig.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "appconfig-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "appconfig-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "appconfig.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "appconfig.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "appconfig.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "appconfig.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "appconfig.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "appconfig.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "appconfig.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "appconfig-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "appconfig-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "appconfig.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-appflow/src/endpoints.ts
+++ b/clients/client-appflow/src/endpoints.ts
@@ -30,26 +30,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "appflow.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "appflow.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "appflow-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "appflow-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "appflow.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "appflow.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "appflow.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "appflow-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "appflow-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "appflow.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "appflow.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "appflow.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "appflow.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "appflow.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "appflow.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "appflow.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "appflow-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "appflow-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "appflow.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-appintegrations/src/endpoints.ts
+++ b/clients/client-appintegrations/src/endpoints.ts
@@ -30,26 +30,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "app-integrations.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "app-integrations.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "app-integrations-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "app-integrations-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "app-integrations.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "app-integrations.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "app-integrations.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "app-integrations-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "app-integrations-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "app-integrations.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "app-integrations.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "app-integrations.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "app-integrations.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "app-integrations.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "app-integrations.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "app-integrations.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "app-integrations-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "app-integrations-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "app-integrations.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-application-auto-scaling/src/endpoints.ts
+++ b/clients/client-application-auto-scaling/src/endpoints.ts
@@ -30,26 +30,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "application-autoscaling.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "application-autoscaling.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "application-autoscaling-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "application-autoscaling-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "application-autoscaling.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "application-autoscaling.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "application-autoscaling.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "application-autoscaling-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "application-autoscaling-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "application-autoscaling.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "application-autoscaling.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "application-autoscaling.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "application-autoscaling.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "application-autoscaling.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "application-autoscaling.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "application-autoscaling.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "application-autoscaling-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "application-autoscaling-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "application-autoscaling.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-application-discovery-service/src/endpoints.ts
+++ b/clients/client-application-discovery-service/src/endpoints.ts
@@ -30,26 +30,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "discovery.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "discovery.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "discovery-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "discovery-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "discovery.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "discovery.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "discovery.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "discovery-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "discovery-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "discovery.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "discovery.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "discovery.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "discovery.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "discovery.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "discovery.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "discovery.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "discovery-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "discovery-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "discovery.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-application-insights/src/endpoints.ts
+++ b/clients/client-application-insights/src/endpoints.ts
@@ -4,10 +4,22 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 const regionHash: RegionHash = {
   "us-gov-east-1": {
     hostname: "applicationinsights.us-gov-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "applicationinsights.us-gov-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-east-1",
   },
   "us-gov-west-1": {
     hostname: "applicationinsights.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "applicationinsights.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-west-1",
   },
 };
@@ -39,26 +51,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "applicationinsights.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "applicationinsights.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "applicationinsights-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "applicationinsights-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "applicationinsights.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "applicationinsights.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "applicationinsights.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "applicationinsights-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "applicationinsights-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "applicationinsights.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "applicationinsights.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "applicationinsights.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "applicationinsights.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "applicationinsights.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "applicationinsights.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "applicationinsights.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "applicationinsights-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "applicationinsights-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "applicationinsights.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-applicationcostprofiler/src/endpoints.ts
+++ b/clients/client-applicationcostprofiler/src/endpoints.ts
@@ -30,26 +30,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "application-cost-profiler.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "application-cost-profiler.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "application-cost-profiler-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "application-cost-profiler-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "application-cost-profiler.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "application-cost-profiler.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "application-cost-profiler.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "application-cost-profiler-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "application-cost-profiler-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "application-cost-profiler.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "application-cost-profiler.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "application-cost-profiler.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "application-cost-profiler.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "application-cost-profiler.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "application-cost-profiler.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "application-cost-profiler.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "application-cost-profiler-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "application-cost-profiler-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "application-cost-profiler.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-apprunner/src/endpoints.ts
+++ b/clients/client-apprunner/src/endpoints.ts
@@ -30,26 +30,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "apprunner.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "apprunner.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "apprunner-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "apprunner-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "apprunner.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "apprunner.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "apprunner.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "apprunner-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "apprunner-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "apprunner.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "apprunner.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "apprunner.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "apprunner.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "apprunner.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "apprunner.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "apprunner.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "apprunner-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "apprunner-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "apprunner.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-appstream/src/endpoints.ts
+++ b/clients/client-appstream/src/endpoints.ts
@@ -4,18 +4,81 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 const regionHash: RegionHash = {
   fips: {
     hostname: "appstream2-fips.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "appstream2-fips.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-west-1",
+  },
+  "us-east-1": {
+    hostname: "appstream2.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "appstream2.us-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "appstream2-fips.us-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "us-east-1-fips": {
     hostname: "appstream2-fips.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "appstream2-fips.us-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-1",
+  },
+  "us-gov-west-1": {
+    hostname: "appstream2.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "appstream2.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "appstream2-fips.us-gov-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "us-gov-west-1-fips": {
     hostname: "appstream2-fips.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "appstream2-fips.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-west-1",
+  },
+  "us-west-2": {
+    hostname: "appstream2.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "appstream2.us-west-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "appstream2-fips.us-west-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "us-west-2-fips": {
     hostname: "appstream2-fips.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "appstream2-fips.us-west-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-2",
   },
 };
@@ -50,26 +113,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "appstream2.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "appstream2.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "appstream2-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "appstream2-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "appstream2.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "appstream2.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "appstream2.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "appstream2-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "appstream2-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "appstream2.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "appstream2.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "appstream2.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "appstream2.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "appstream2.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["fips", "us-gov-east-1", "us-gov-west-1", "us-gov-west-1-fips"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "appstream2.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "appstream2.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "appstream2-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "appstream2-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "appstream2.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-appsync/src/endpoints.ts
+++ b/clients/client-appsync/src/endpoints.ts
@@ -30,26 +30,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "appsync.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "appsync.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "appsync-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "appsync-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "appsync.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "appsync.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "appsync.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "appsync-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "appsync-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "appsync.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "appsync.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "appsync.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "appsync.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "appsync.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "appsync.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "appsync.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "appsync-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "appsync-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "appsync.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-athena/src/endpoints.ts
+++ b/clients/client-athena/src/endpoints.ts
@@ -4,27 +4,141 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 const regionHash: RegionHash = {
   "fips-us-east-1": {
     hostname: "athena-fips.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "athena-fips.us-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-1",
   },
   "fips-us-east-2": {
     hostname: "athena-fips.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "athena-fips.us-east-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-2",
   },
   "fips-us-gov-east-1": {
     hostname: "athena-fips.us-gov-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "athena-fips.us-gov-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-east-1",
   },
   "fips-us-gov-west-1": {
     hostname: "athena-fips.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "athena-fips.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-west-1",
   },
   "fips-us-west-1": {
     hostname: "athena-fips.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "athena-fips.us-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-1",
   },
   "fips-us-west-2": {
     hostname: "athena-fips.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "athena-fips.us-west-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-2",
+  },
+  "us-east-1": {
+    hostname: "athena.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "athena.us-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "athena-fips.us-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-east-2": {
+    hostname: "athena.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "athena.us-east-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "athena-fips.us-east-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-gov-east-1": {
+    hostname: "athena.us-gov-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "athena.us-gov-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "athena-fips.us-gov-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-gov-west-1": {
+    hostname: "athena.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "athena.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "athena-fips.us-gov-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-west-1": {
+    hostname: "athena.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "athena.us-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "athena-fips.us-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-west-2": {
+    hostname: "athena.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "athena.us-west-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "athena-fips.us-west-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
 };
 
@@ -59,26 +173,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "athena.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "athena.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "athena-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "athena-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "athena.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "athena.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "athena.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "athena-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "athena-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "athena.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "athena.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "athena.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "athena.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "athena.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["fips-us-gov-east-1", "fips-us-gov-west-1", "us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "athena.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "athena.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "athena-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "athena-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "athena.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-auditmanager/src/endpoints.ts
+++ b/clients/client-auditmanager/src/endpoints.ts
@@ -30,26 +30,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "auditmanager.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "auditmanager.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "auditmanager-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "auditmanager-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "auditmanager.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "auditmanager.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "auditmanager.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "auditmanager-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "auditmanager-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "auditmanager.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "auditmanager.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "auditmanager.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "auditmanager.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "auditmanager.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "auditmanager.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "auditmanager.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "auditmanager-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "auditmanager-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "auditmanager.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-auto-scaling-plans/src/endpoints.ts
+++ b/clients/client-auto-scaling-plans/src/endpoints.ts
@@ -30,26 +30,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "autoscaling-plans.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "autoscaling-plans.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "autoscaling-plans-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "autoscaling-plans-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "autoscaling-plans.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "autoscaling-plans.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "autoscaling-plans.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "autoscaling-plans-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "autoscaling-plans-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "autoscaling-plans.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "autoscaling-plans.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "autoscaling-plans.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "autoscaling-plans.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "autoscaling-plans.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "autoscaling-plans.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "autoscaling-plans.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "autoscaling-plans-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "autoscaling-plans-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "autoscaling-plans.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-auto-scaling/src/endpoints.ts
+++ b/clients/client-auto-scaling/src/endpoints.ts
@@ -30,26 +30,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "autoscaling.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "autoscaling.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "autoscaling-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "autoscaling-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "autoscaling.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "autoscaling.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "autoscaling.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "autoscaling-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "autoscaling-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "autoscaling.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "autoscaling.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "autoscaling.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "autoscaling.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "autoscaling.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "autoscaling.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "autoscaling.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "autoscaling-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "autoscaling-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "autoscaling.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-backup/src/endpoints.ts
+++ b/clients/client-backup/src/endpoints.ts
@@ -30,26 +30,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "backup.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "backup.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "backup-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "backup-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "backup.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "backup.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "backup.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "backup-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "backup-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "backup.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "backup.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "backup.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "backup.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "backup.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "backup.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "backup.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "backup-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "backup-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "backup.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-batch/src/endpoints.ts
+++ b/clients/client-batch/src/endpoints.ts
@@ -4,27 +4,141 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 const regionHash: RegionHash = {
   "fips-us-east-1": {
     hostname: "fips.batch.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "fips.batch.us-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-1",
   },
   "fips-us-east-2": {
     hostname: "fips.batch.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "fips.batch.us-east-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-2",
   },
   "fips-us-gov-east-1": {
     hostname: "batch.us-gov-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "batch.us-gov-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-east-1",
   },
   "fips-us-gov-west-1": {
     hostname: "batch.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "batch.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-west-1",
   },
   "fips-us-west-1": {
     hostname: "fips.batch.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "fips.batch.us-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-1",
   },
   "fips-us-west-2": {
     hostname: "fips.batch.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "fips.batch.us-west-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-2",
+  },
+  "us-east-1": {
+    hostname: "batch.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "batch.us-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "fips.batch.us-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-east-2": {
+    hostname: "batch.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "batch.us-east-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "fips.batch.us-east-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-gov-east-1": {
+    hostname: "batch.us-gov-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "batch.us-gov-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "batch.us-gov-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-gov-west-1": {
+    hostname: "batch.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "batch.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "batch.us-gov-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-west-1": {
+    hostname: "batch.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "batch.us-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "fips.batch.us-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-west-2": {
+    hostname: "batch.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "batch.us-west-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "fips.batch.us-west-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
 };
 
@@ -59,26 +173,76 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "batch.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "batch.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "fips.batch.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "batch.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "batch.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "batch-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "batch-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "batch.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "batch.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "batch.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "batch.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "batch.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["fips-us-gov-east-1", "fips-us-gov-west-1", "us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "batch.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "batch.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "batch.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
 };
 

--- a/clients/client-braket/src/endpoints.ts
+++ b/clients/client-braket/src/endpoints.ts
@@ -30,26 +30,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "braket.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "braket.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "braket-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "braket-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "braket.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "braket.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "braket.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "braket-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "braket-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "braket.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "braket.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "braket.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "braket.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "braket.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "braket.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "braket.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "braket-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "braket-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "braket.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-budgets/src/endpoints.ts
+++ b/clients/client-budgets/src/endpoints.ts
@@ -4,10 +4,22 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 const regionHash: RegionHash = {
   "aws-cn-global": {
     hostname: "budgets.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "budgets.amazonaws.com.cn",
+        tags: [],
+      },
+    ],
     signingRegion: "cn-northwest-1",
   },
   "aws-global": {
     hostname: "budgets.amazonaws.com",
+    variants: [
+      {
+        hostname: "budgets.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-1",
   },
 };
@@ -39,27 +51,95 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
+    hostname: "budgets.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "budgets.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "budgets-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "budgets-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "budgets.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
     endpoint: "aws-global",
   },
   "aws-cn": {
     regions: ["aws-cn-global", "cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
+    hostname: "budgets.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "budgets.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "budgets-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "budgets-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "budgets.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
     endpoint: "aws-cn-global",
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "budgets.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "budgets.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "budgets.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "budgets.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "budgets.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "budgets.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "budgets-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "budgets-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "budgets.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-chime-sdk-identity/src/endpoints.ts
+++ b/clients/client-chime-sdk-identity/src/endpoints.ts
@@ -2,8 +2,27 @@ import { getRegionInfo, PartitionHash, RegionHash } from "@aws-sdk/config-resolv
 import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
+  "us-east-1": {
+    hostname: "identity-chime.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "identity-chime.us-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "identity-chime-fips.us-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
   "us-east-1-fips": {
     hostname: "identity-chime-fips.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "identity-chime-fips.us-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-1",
   },
 };
@@ -36,26 +55,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "identity-chime.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "identity-chime.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "identity-chime-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "identity-chime-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "identity-chime.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "identity-chime.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "identity-chime.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "identity-chime-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "identity-chime-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "identity-chime.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "identity-chime.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "identity-chime.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "identity-chime.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "identity-chime.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "identity-chime.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "identity-chime.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "identity-chime-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "identity-chime-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "identity-chime.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-chime-sdk-messaging/src/endpoints.ts
+++ b/clients/client-chime-sdk-messaging/src/endpoints.ts
@@ -2,8 +2,27 @@ import { getRegionInfo, PartitionHash, RegionHash } from "@aws-sdk/config-resolv
 import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
+  "us-east-1": {
+    hostname: "messaging-chime.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "messaging-chime.us-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "messaging-chime-fips.us-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
   "us-east-1-fips": {
     hostname: "messaging-chime-fips.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "messaging-chime-fips.us-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-1",
   },
 };
@@ -36,26 +55,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "messaging-chime.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "messaging-chime.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "messaging-chime-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "messaging-chime-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "messaging-chime.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "messaging-chime.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "messaging-chime.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "messaging-chime-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "messaging-chime-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "messaging-chime.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "messaging-chime.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "messaging-chime.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "messaging-chime.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "messaging-chime.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "messaging-chime.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "messaging-chime.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "messaging-chime-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "messaging-chime-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "messaging-chime.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-chime/src/endpoints.ts
+++ b/clients/client-chime/src/endpoints.ts
@@ -4,6 +4,12 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 const regionHash: RegionHash = {
   "aws-global": {
     hostname: "chime.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "chime.us-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-1",
   },
 };
@@ -35,27 +41,94 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
+    hostname: "chime.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "chime.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "chime-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "chime-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "chime.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
     endpoint: "aws-global",
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "chime.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "chime.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "chime-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "chime-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "chime.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "chime.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "chime.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "chime.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "chime.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "chime.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "chime.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "chime-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "chime-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "chime.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-cloud9/src/endpoints.ts
+++ b/clients/client-cloud9/src/endpoints.ts
@@ -30,26 +30,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "cloud9.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "cloud9.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "cloud9-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "cloud9-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "cloud9.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "cloud9.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "cloud9.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "cloud9-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "cloud9-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "cloud9.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "cloud9.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "cloud9.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "cloud9.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "cloud9.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "cloud9.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "cloud9.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "cloud9-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "cloud9-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "cloud9.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-cloudcontrol/src/endpoints.ts
+++ b/clients/client-cloudcontrol/src/endpoints.ts
@@ -2,33 +2,166 @@ import { getRegionInfo, PartitionHash, RegionHash } from "@aws-sdk/config-resolv
 import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
+  "ca-central-1": {
+    hostname: "cloudcontrolapi.ca-central-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "cloudcontrolapi.ca-central-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "cloudcontrolapi-fips.ca-central-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
   "fips-ca-central-1": {
     hostname: "cloudcontrolapi-fips.ca-central-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "cloudcontrolapi-fips.ca-central-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "ca-central-1",
   },
   "fips-us-east-1": {
     hostname: "cloudcontrolapi-fips.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "cloudcontrolapi-fips.us-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-1",
   },
   "fips-us-east-2": {
     hostname: "cloudcontrolapi-fips.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "cloudcontrolapi-fips.us-east-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-2",
   },
   "fips-us-gov-east-1": {
     hostname: "cloudcontrolapi-fips.us-gov-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "cloudcontrolapi-fips.us-gov-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-east-1",
   },
   "fips-us-gov-west-1": {
     hostname: "cloudcontrolapi-fips.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "cloudcontrolapi-fips.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-west-1",
   },
   "fips-us-west-1": {
     hostname: "cloudcontrolapi-fips.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "cloudcontrolapi-fips.us-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-1",
   },
   "fips-us-west-2": {
     hostname: "cloudcontrolapi-fips.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "cloudcontrolapi-fips.us-west-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-2",
+  },
+  "us-east-1": {
+    hostname: "cloudcontrolapi.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "cloudcontrolapi.us-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "cloudcontrolapi-fips.us-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-east-2": {
+    hostname: "cloudcontrolapi.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "cloudcontrolapi.us-east-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "cloudcontrolapi-fips.us-east-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-gov-east-1": {
+    hostname: "cloudcontrolapi.us-gov-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "cloudcontrolapi.us-gov-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "cloudcontrolapi-fips.us-gov-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-gov-west-1": {
+    hostname: "cloudcontrolapi.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "cloudcontrolapi.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "cloudcontrolapi-fips.us-gov-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-west-1": {
+    hostname: "cloudcontrolapi.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "cloudcontrolapi.us-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "cloudcontrolapi-fips.us-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-west-2": {
+    hostname: "cloudcontrolapi.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "cloudcontrolapi.us-west-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "cloudcontrolapi-fips.us-west-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
 };
 
@@ -64,26 +197,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "cloudcontrolapi.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "cloudcontrolapi.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "cloudcontrolapi-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "cloudcontrolapi-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "cloudcontrolapi.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "cloudcontrolapi.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "cloudcontrolapi.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "cloudcontrolapi-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "cloudcontrolapi-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "cloudcontrolapi.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "cloudcontrolapi.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "cloudcontrolapi.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "cloudcontrolapi.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "cloudcontrolapi.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["fips-us-gov-east-1", "fips-us-gov-west-1", "us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "cloudcontrolapi.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "cloudcontrolapi.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "cloudcontrolapi-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "cloudcontrolapi-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "cloudcontrolapi.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-clouddirectory/src/endpoints.ts
+++ b/clients/client-clouddirectory/src/endpoints.ts
@@ -30,26 +30,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "clouddirectory.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "clouddirectory.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "clouddirectory-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "clouddirectory-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "clouddirectory.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "clouddirectory.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "clouddirectory.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "clouddirectory-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "clouddirectory-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "clouddirectory.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "clouddirectory.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "clouddirectory.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "clouddirectory.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "clouddirectory.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "clouddirectory.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "clouddirectory.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "clouddirectory-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "clouddirectory-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "clouddirectory.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-cloudformation/src/endpoints.ts
+++ b/clients/client-cloudformation/src/endpoints.ts
@@ -2,28 +2,116 @@ import { getRegionInfo, PartitionHash, RegionHash } from "@aws-sdk/config-resolv
 import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
+  "us-east-1": {
+    hostname: "cloudformation.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "cloudformation.us-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "cloudformation-fips.us-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
   "us-east-1-fips": {
     hostname: "cloudformation-fips.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "cloudformation-fips.us-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-1",
+  },
+  "us-east-2": {
+    hostname: "cloudformation.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "cloudformation.us-east-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "cloudformation-fips.us-east-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "us-east-2-fips": {
     hostname: "cloudformation-fips.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "cloudformation-fips.us-east-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-2",
   },
   "us-gov-east-1": {
     hostname: "cloudformation.us-gov-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "cloudformation.us-gov-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-east-1",
   },
   "us-gov-west-1": {
     hostname: "cloudformation.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "cloudformation.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-west-1",
+  },
+  "us-west-1": {
+    hostname: "cloudformation.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "cloudformation.us-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "cloudformation-fips.us-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "us-west-1-fips": {
     hostname: "cloudformation-fips.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "cloudformation-fips.us-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-1",
+  },
+  "us-west-2": {
+    hostname: "cloudformation.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "cloudformation.us-west-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "cloudformation-fips.us-west-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "us-west-2-fips": {
     hostname: "cloudformation-fips.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "cloudformation-fips.us-west-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-2",
   },
 };
@@ -59,26 +147,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "cloudformation.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "cloudformation.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "cloudformation-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "cloudformation-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "cloudformation.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "cloudformation.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "cloudformation.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "cloudformation-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "cloudformation-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "cloudformation.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "cloudformation.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "cloudformation.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "cloudformation.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "cloudformation.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "cloudformation.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "cloudformation.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "cloudformation-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "cloudformation-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "cloudformation.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-cloudfront/src/endpoints.ts
+++ b/clients/client-cloudfront/src/endpoints.ts
@@ -4,10 +4,22 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 const regionHash: RegionHash = {
   "aws-cn-global": {
     hostname: "cloudfront.cn-northwest-1.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "cloudfront.cn-northwest-1.amazonaws.com.cn",
+        tags: [],
+      },
+    ],
     signingRegion: "cn-northwest-1",
   },
   "aws-global": {
     hostname: "cloudfront.amazonaws.com",
+    variants: [
+      {
+        hostname: "cloudfront.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-1",
   },
 };
@@ -39,27 +51,95 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
+    hostname: "cloudfront.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "cloudfront.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "cloudfront-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "cloudfront-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "cloudfront.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
     endpoint: "aws-global",
   },
   "aws-cn": {
     regions: ["aws-cn-global", "cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
+    hostname: "cloudfront.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "cloudfront.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "cloudfront-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "cloudfront-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "cloudfront.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
     endpoint: "aws-cn-global",
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "cloudfront.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "cloudfront.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "cloudfront.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "cloudfront.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "cloudfront.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "cloudfront.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "cloudfront-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "cloudfront-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "cloudfront.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-cloudhsm-v2/src/endpoints.ts
+++ b/clients/client-cloudhsm-v2/src/endpoints.ts
@@ -30,26 +30,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "cloudhsmv2.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "cloudhsmv2.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "cloudhsmv2-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "cloudhsmv2-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "cloudhsmv2.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "cloudhsmv2.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "cloudhsmv2.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "cloudhsmv2-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "cloudhsmv2-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "cloudhsmv2.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "cloudhsmv2.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "cloudhsmv2.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "cloudhsmv2.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "cloudhsmv2.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "cloudhsmv2.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "cloudhsmv2.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "cloudhsmv2-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "cloudhsmv2-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "cloudhsmv2.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-cloudhsm/src/endpoints.ts
+++ b/clients/client-cloudhsm/src/endpoints.ts
@@ -30,26 +30,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "cloudhsm.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "cloudhsm.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "cloudhsm-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "cloudhsm-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "cloudhsm.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "cloudhsm.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "cloudhsm.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "cloudhsm-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "cloudhsm-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "cloudhsm.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "cloudhsm.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "cloudhsm.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "cloudhsm.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "cloudhsm.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "cloudhsm.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "cloudhsm.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "cloudhsm-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "cloudhsm-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "cloudhsm.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-cloudsearch-domain/src/endpoints.ts
+++ b/clients/client-cloudsearch-domain/src/endpoints.ts
@@ -30,26 +30,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "cloudsearchdomain.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "cloudsearchdomain.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "cloudsearchdomain-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "cloudsearchdomain-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "cloudsearchdomain.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "cloudsearchdomain.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "cloudsearchdomain.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "cloudsearchdomain-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "cloudsearchdomain-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "cloudsearchdomain.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "cloudsearchdomain.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "cloudsearchdomain.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "cloudsearchdomain.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "cloudsearchdomain.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "cloudsearchdomain.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "cloudsearchdomain.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "cloudsearchdomain-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "cloudsearchdomain-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "cloudsearchdomain.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-cloudsearch/src/endpoints.ts
+++ b/clients/client-cloudsearch/src/endpoints.ts
@@ -30,26 +30,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "cloudsearch.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "cloudsearch.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "cloudsearch-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "cloudsearch-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "cloudsearch.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "cloudsearch.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "cloudsearch.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "cloudsearch-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "cloudsearch-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "cloudsearch.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "cloudsearch.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "cloudsearch.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "cloudsearch.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "cloudsearch.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "cloudsearch.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "cloudsearch.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "cloudsearch-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "cloudsearch-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "cloudsearch.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-cloudtrail/src/endpoints.ts
+++ b/clients/client-cloudtrail/src/endpoints.ts
@@ -4,27 +4,115 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 const regionHash: RegionHash = {
   "fips-us-east-1": {
     hostname: "cloudtrail-fips.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "cloudtrail-fips.us-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-1",
   },
   "fips-us-east-2": {
     hostname: "cloudtrail-fips.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "cloudtrail-fips.us-east-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-2",
   },
   "fips-us-west-1": {
     hostname: "cloudtrail-fips.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "cloudtrail-fips.us-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-1",
   },
   "fips-us-west-2": {
     hostname: "cloudtrail-fips.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "cloudtrail-fips.us-west-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-2",
+  },
+  "us-east-1": {
+    hostname: "cloudtrail.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "cloudtrail.us-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "cloudtrail-fips.us-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-east-2": {
+    hostname: "cloudtrail.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "cloudtrail.us-east-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "cloudtrail-fips.us-east-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "us-gov-east-1": {
     hostname: "cloudtrail.us-gov-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "cloudtrail.us-gov-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-east-1",
   },
   "us-gov-west-1": {
     hostname: "cloudtrail.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "cloudtrail.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-west-1",
+  },
+  "us-west-1": {
+    hostname: "cloudtrail.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "cloudtrail.us-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "cloudtrail-fips.us-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-west-2": {
+    hostname: "cloudtrail.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "cloudtrail.us-west-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "cloudtrail-fips.us-west-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
 };
 
@@ -59,26 +147,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "cloudtrail.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "cloudtrail.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "cloudtrail-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "cloudtrail-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "cloudtrail.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "cloudtrail.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "cloudtrail.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "cloudtrail-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "cloudtrail-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "cloudtrail.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "cloudtrail.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "cloudtrail.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "cloudtrail.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "cloudtrail.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "cloudtrail.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "cloudtrail.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "cloudtrail-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "cloudtrail-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "cloudtrail.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-cloudwatch-events/src/endpoints.ts
+++ b/clients/client-cloudwatch-events/src/endpoints.ts
@@ -4,27 +4,115 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 const regionHash: RegionHash = {
   "fips-us-east-1": {
     hostname: "events-fips.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "events-fips.us-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-1",
   },
   "fips-us-east-2": {
     hostname: "events-fips.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "events-fips.us-east-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-2",
   },
   "fips-us-west-1": {
     hostname: "events-fips.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "events-fips.us-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-1",
   },
   "fips-us-west-2": {
     hostname: "events-fips.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "events-fips.us-west-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-2",
+  },
+  "us-east-1": {
+    hostname: "events.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "events.us-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "events-fips.us-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-east-2": {
+    hostname: "events.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "events.us-east-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "events-fips.us-east-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "us-gov-east-1": {
     hostname: "events.us-gov-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "events.us-gov-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-east-1",
   },
   "us-gov-west-1": {
     hostname: "events.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "events.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-west-1",
+  },
+  "us-west-1": {
+    hostname: "events.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "events.us-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "events-fips.us-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-west-2": {
+    hostname: "events.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "events.us-west-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "events-fips.us-west-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
 };
 
@@ -59,26 +147,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "events.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "events.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "events-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "events-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "events.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "events.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "events.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "events-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "events-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "events.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "events.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "events.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "events.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "events.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "events.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "events.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "events-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "events-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "events.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-cloudwatch-logs/src/endpoints.ts
+++ b/clients/client-cloudwatch-logs/src/endpoints.ts
@@ -4,27 +4,115 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 const regionHash: RegionHash = {
   "fips-us-east-1": {
     hostname: "logs-fips.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "logs-fips.us-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-1",
   },
   "fips-us-east-2": {
     hostname: "logs-fips.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "logs-fips.us-east-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-2",
   },
   "fips-us-west-1": {
     hostname: "logs-fips.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "logs-fips.us-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-1",
   },
   "fips-us-west-2": {
     hostname: "logs-fips.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "logs-fips.us-west-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-2",
+  },
+  "us-east-1": {
+    hostname: "logs.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "logs.us-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "logs-fips.us-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-east-2": {
+    hostname: "logs.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "logs.us-east-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "logs-fips.us-east-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "us-gov-east-1": {
     hostname: "logs.us-gov-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "logs.us-gov-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-east-1",
   },
   "us-gov-west-1": {
     hostname: "logs.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "logs.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-west-1",
+  },
+  "us-west-1": {
+    hostname: "logs.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "logs.us-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "logs-fips.us-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-west-2": {
+    hostname: "logs.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "logs.us-west-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "logs-fips.us-west-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
 };
 
@@ -59,26 +147,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "logs.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "logs.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "logs-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "logs-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "logs.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "logs.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "logs.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "logs-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "logs-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "logs.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "logs.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "logs.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "logs.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "logs.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "logs.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "logs.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "logs-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "logs-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "logs.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-cloudwatch/src/endpoints.ts
+++ b/clients/client-cloudwatch/src/endpoints.ts
@@ -4,27 +4,141 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 const regionHash: RegionHash = {
   "fips-us-east-1": {
     hostname: "monitoring-fips.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "monitoring-fips.us-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-1",
   },
   "fips-us-east-2": {
     hostname: "monitoring-fips.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "monitoring-fips.us-east-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-2",
   },
   "fips-us-gov-east-1": {
     hostname: "monitoring.us-gov-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "monitoring.us-gov-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-east-1",
   },
   "fips-us-gov-west-1": {
     hostname: "monitoring.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "monitoring.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-west-1",
   },
   "fips-us-west-1": {
     hostname: "monitoring-fips.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "monitoring-fips.us-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-1",
   },
   "fips-us-west-2": {
     hostname: "monitoring-fips.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "monitoring-fips.us-west-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-2",
+  },
+  "us-east-1": {
+    hostname: "monitoring.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "monitoring.us-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "monitoring-fips.us-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-east-2": {
+    hostname: "monitoring.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "monitoring.us-east-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "monitoring-fips.us-east-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-gov-east-1": {
+    hostname: "monitoring.us-gov-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "monitoring.us-gov-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "monitoring.us-gov-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-gov-west-1": {
+    hostname: "monitoring.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "monitoring.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "monitoring.us-gov-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-west-1": {
+    hostname: "monitoring.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "monitoring.us-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "monitoring-fips.us-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-west-2": {
+    hostname: "monitoring.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "monitoring.us-west-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "monitoring-fips.us-west-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
 };
 
@@ -59,26 +173,84 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "monitoring.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "monitoring.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "monitoring-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "monitoring-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "monitoring.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "monitoring.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "monitoring.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "monitoring-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "monitoring-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "monitoring.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "monitoring.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "monitoring.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "monitoring.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "monitoring.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["fips-us-gov-east-1", "fips-us-gov-west-1", "us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "monitoring.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "monitoring.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "monitoring.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
 };
 

--- a/clients/client-codeartifact/src/endpoints.ts
+++ b/clients/client-codeartifact/src/endpoints.ts
@@ -30,26 +30,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "codeartifact.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "codeartifact.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "codeartifact-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "codeartifact-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "codeartifact.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "codeartifact.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "codeartifact.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "codeartifact-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "codeartifact-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "codeartifact.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "codeartifact.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "codeartifact.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "codeartifact.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "codeartifact.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "codeartifact.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "codeartifact.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "codeartifact-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "codeartifact-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "codeartifact.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-codebuild/src/endpoints.ts
+++ b/clients/client-codebuild/src/endpoints.ts
@@ -2,28 +2,142 @@ import { getRegionInfo, PartitionHash, RegionHash } from "@aws-sdk/config-resolv
 import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
+  "us-east-1": {
+    hostname: "codebuild.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "codebuild.us-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "codebuild-fips.us-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
   "us-east-1-fips": {
     hostname: "codebuild-fips.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "codebuild-fips.us-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-1",
+  },
+  "us-east-2": {
+    hostname: "codebuild.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "codebuild.us-east-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "codebuild-fips.us-east-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "us-east-2-fips": {
     hostname: "codebuild-fips.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "codebuild-fips.us-east-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-2",
+  },
+  "us-gov-east-1": {
+    hostname: "codebuild.us-gov-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "codebuild.us-gov-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "codebuild-fips.us-gov-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "us-gov-east-1-fips": {
     hostname: "codebuild-fips.us-gov-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "codebuild-fips.us-gov-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-east-1",
+  },
+  "us-gov-west-1": {
+    hostname: "codebuild.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "codebuild.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "codebuild-fips.us-gov-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "us-gov-west-1-fips": {
     hostname: "codebuild-fips.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "codebuild-fips.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-west-1",
+  },
+  "us-west-1": {
+    hostname: "codebuild.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "codebuild.us-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "codebuild-fips.us-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "us-west-1-fips": {
     hostname: "codebuild-fips.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "codebuild-fips.us-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-1",
+  },
+  "us-west-2": {
+    hostname: "codebuild.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "codebuild.us-west-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "codebuild-fips.us-west-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "us-west-2-fips": {
     hostname: "codebuild-fips.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "codebuild-fips.us-west-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-2",
   },
 };
@@ -59,26 +173,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "codebuild.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "codebuild.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "codebuild-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "codebuild-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "codebuild.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "codebuild.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "codebuild.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "codebuild-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "codebuild-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "codebuild.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "codebuild.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "codebuild.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "codebuild.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "codebuild.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-east-1-fips", "us-gov-west-1", "us-gov-west-1-fips"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "codebuild.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "codebuild.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "codebuild-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "codebuild-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "codebuild.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-codecommit/src/endpoints.ts
+++ b/clients/client-codecommit/src/endpoints.ts
@@ -2,36 +2,175 @@ import { getRegionInfo, PartitionHash, RegionHash } from "@aws-sdk/config-resolv
 import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
+  "ca-central-1": {
+    hostname: "codecommit.ca-central-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "codecommit.ca-central-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "codecommit-fips.ca-central-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
   "ca-central-1-fips": {
     hostname: "codecommit-fips.ca-central-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "codecommit-fips.ca-central-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "ca-central-1",
   },
   fips: {
     hostname: "codecommit-fips.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "codecommit-fips.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-west-1",
+  },
+  "us-east-1": {
+    hostname: "codecommit.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "codecommit.us-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "codecommit-fips.us-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "us-east-1-fips": {
     hostname: "codecommit-fips.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "codecommit-fips.us-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-1",
+  },
+  "us-east-2": {
+    hostname: "codecommit.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "codecommit.us-east-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "codecommit-fips.us-east-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "us-east-2-fips": {
     hostname: "codecommit-fips.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "codecommit-fips.us-east-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-2",
+  },
+  "us-gov-east-1": {
+    hostname: "codecommit.us-gov-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "codecommit.us-gov-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "codecommit-fips.us-gov-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "us-gov-east-1-fips": {
     hostname: "codecommit-fips.us-gov-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "codecommit-fips.us-gov-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-east-1",
+  },
+  "us-gov-west-1": {
+    hostname: "codecommit.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "codecommit.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "codecommit-fips.us-gov-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "us-gov-west-1-fips": {
     hostname: "codecommit-fips.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "codecommit-fips.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-west-1",
+  },
+  "us-west-1": {
+    hostname: "codecommit.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "codecommit.us-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "codecommit-fips.us-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "us-west-1-fips": {
     hostname: "codecommit-fips.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "codecommit-fips.us-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-1",
+  },
+  "us-west-2": {
+    hostname: "codecommit.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "codecommit.us-west-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "codecommit-fips.us-west-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "us-west-2-fips": {
     hostname: "codecommit-fips.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "codecommit-fips.us-west-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-2",
   },
 };
@@ -69,26 +208,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "codecommit.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "codecommit.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "codecommit-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "codecommit-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "codecommit.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "codecommit.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "codecommit.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "codecommit-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "codecommit-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "codecommit.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "codecommit.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "codecommit.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "codecommit.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "codecommit.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["fips", "us-gov-east-1", "us-gov-east-1-fips", "us-gov-west-1", "us-gov-west-1-fips"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "codecommit.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "codecommit.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "codecommit-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "codecommit-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "codecommit.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-codedeploy/src/endpoints.ts
+++ b/clients/client-codedeploy/src/endpoints.ts
@@ -2,28 +2,142 @@ import { getRegionInfo, PartitionHash, RegionHash } from "@aws-sdk/config-resolv
 import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
+  "us-east-1": {
+    hostname: "codedeploy.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "codedeploy.us-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "codedeploy-fips.us-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
   "us-east-1-fips": {
     hostname: "codedeploy-fips.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "codedeploy-fips.us-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-1",
+  },
+  "us-east-2": {
+    hostname: "codedeploy.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "codedeploy.us-east-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "codedeploy-fips.us-east-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "us-east-2-fips": {
     hostname: "codedeploy-fips.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "codedeploy-fips.us-east-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-2",
+  },
+  "us-gov-east-1": {
+    hostname: "codedeploy.us-gov-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "codedeploy.us-gov-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "codedeploy-fips.us-gov-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "us-gov-east-1-fips": {
     hostname: "codedeploy-fips.us-gov-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "codedeploy-fips.us-gov-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-east-1",
+  },
+  "us-gov-west-1": {
+    hostname: "codedeploy.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "codedeploy.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "codedeploy-fips.us-gov-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "us-gov-west-1-fips": {
     hostname: "codedeploy-fips.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "codedeploy-fips.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-west-1",
+  },
+  "us-west-1": {
+    hostname: "codedeploy.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "codedeploy.us-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "codedeploy-fips.us-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "us-west-1-fips": {
     hostname: "codedeploy-fips.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "codedeploy-fips.us-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-1",
+  },
+  "us-west-2": {
+    hostname: "codedeploy.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "codedeploy.us-west-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "codedeploy-fips.us-west-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "us-west-2-fips": {
     hostname: "codedeploy-fips.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "codedeploy-fips.us-west-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-2",
   },
 };
@@ -59,26 +173,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "codedeploy.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "codedeploy.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "codedeploy-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "codedeploy-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "codedeploy.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "codedeploy.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "codedeploy.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "codedeploy-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "codedeploy-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "codedeploy.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "codedeploy.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "codedeploy.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "codedeploy.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "codedeploy.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-east-1-fips", "us-gov-west-1", "us-gov-west-1-fips"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "codedeploy.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "codedeploy.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "codedeploy-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "codedeploy-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "codedeploy.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-codeguru-reviewer/src/endpoints.ts
+++ b/clients/client-codeguru-reviewer/src/endpoints.ts
@@ -30,26 +30,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "codeguru-reviewer.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "codeguru-reviewer.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "codeguru-reviewer-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "codeguru-reviewer-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "codeguru-reviewer.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "codeguru-reviewer.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "codeguru-reviewer.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "codeguru-reviewer-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "codeguru-reviewer-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "codeguru-reviewer.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "codeguru-reviewer.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "codeguru-reviewer.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "codeguru-reviewer.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "codeguru-reviewer.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "codeguru-reviewer.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "codeguru-reviewer.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "codeguru-reviewer-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "codeguru-reviewer-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "codeguru-reviewer.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-codeguruprofiler/src/endpoints.ts
+++ b/clients/client-codeguruprofiler/src/endpoints.ts
@@ -30,26 +30,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "codeguru-profiler.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "codeguru-profiler.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "codeguru-profiler-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "codeguru-profiler-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "codeguru-profiler.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "codeguru-profiler.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "codeguru-profiler.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "codeguru-profiler-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "codeguru-profiler-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "codeguru-profiler.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "codeguru-profiler.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "codeguru-profiler.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "codeguru-profiler.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "codeguru-profiler.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "codeguru-profiler.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "codeguru-profiler.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "codeguru-profiler-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "codeguru-profiler-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "codeguru-profiler.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-codepipeline/src/endpoints.ts
+++ b/clients/client-codepipeline/src/endpoints.ts
@@ -2,29 +2,143 @@ import { getRegionInfo, PartitionHash, RegionHash } from "@aws-sdk/config-resolv
 import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
+  "ca-central-1": {
+    hostname: "codepipeline.ca-central-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "codepipeline.ca-central-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "codepipeline-fips.ca-central-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
   "fips-ca-central-1": {
     hostname: "codepipeline-fips.ca-central-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "codepipeline-fips.ca-central-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "ca-central-1",
   },
   "fips-us-east-1": {
     hostname: "codepipeline-fips.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "codepipeline-fips.us-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-1",
   },
   "fips-us-east-2": {
     hostname: "codepipeline-fips.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "codepipeline-fips.us-east-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-2",
   },
   "fips-us-gov-west-1": {
     hostname: "codepipeline-fips.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "codepipeline-fips.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-west-1",
   },
   "fips-us-west-1": {
     hostname: "codepipeline-fips.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "codepipeline-fips.us-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-1",
   },
   "fips-us-west-2": {
     hostname: "codepipeline-fips.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "codepipeline-fips.us-west-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-2",
+  },
+  "us-east-1": {
+    hostname: "codepipeline.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "codepipeline.us-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "codepipeline-fips.us-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-east-2": {
+    hostname: "codepipeline.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "codepipeline.us-east-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "codepipeline-fips.us-east-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-gov-west-1": {
+    hostname: "codepipeline.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "codepipeline.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "codepipeline-fips.us-gov-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-west-1": {
+    hostname: "codepipeline.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "codepipeline.us-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "codepipeline-fips.us-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-west-2": {
+    hostname: "codepipeline.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "codepipeline.us-west-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "codepipeline-fips.us-west-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
 };
 
@@ -60,26 +174,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "codepipeline.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "codepipeline.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "codepipeline-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "codepipeline-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "codepipeline.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "codepipeline.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "codepipeline.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "codepipeline-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "codepipeline-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "codepipeline.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "codepipeline.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "codepipeline.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "codepipeline.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "codepipeline.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["fips-us-gov-west-1", "us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "codepipeline.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "codepipeline.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "codepipeline-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "codepipeline-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "codepipeline.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-codestar-connections/src/endpoints.ts
+++ b/clients/client-codestar-connections/src/endpoints.ts
@@ -30,26 +30,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "codestar-connections.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "codestar-connections.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "codestar-connections-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "codestar-connections-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "codestar-connections.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "codestar-connections.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "codestar-connections.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "codestar-connections-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "codestar-connections-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "codestar-connections.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "codestar-connections.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "codestar-connections.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "codestar-connections.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "codestar-connections.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "codestar-connections.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "codestar-connections.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "codestar-connections-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "codestar-connections-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "codestar-connections.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-codestar-notifications/src/endpoints.ts
+++ b/clients/client-codestar-notifications/src/endpoints.ts
@@ -30,26 +30,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "codestar-notifications.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "codestar-notifications.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "codestar-notifications-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "codestar-notifications-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "codestar-notifications.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "codestar-notifications.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "codestar-notifications.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "codestar-notifications-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "codestar-notifications-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "codestar-notifications.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "codestar-notifications.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "codestar-notifications.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "codestar-notifications.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "codestar-notifications.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "codestar-notifications.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "codestar-notifications.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "codestar-notifications-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "codestar-notifications-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "codestar-notifications.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-codestar/src/endpoints.ts
+++ b/clients/client-codestar/src/endpoints.ts
@@ -30,26 +30,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "codestar.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "codestar.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "codestar-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "codestar-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "codestar.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "codestar.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "codestar.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "codestar-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "codestar-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "codestar.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "codestar.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "codestar.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "codestar.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "codestar.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "codestar.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "codestar.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "codestar-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "codestar-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "codestar.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-cognito-identity-provider/src/endpoints.ts
+++ b/clients/client-cognito-identity-provider/src/endpoints.ts
@@ -4,23 +4,118 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 const regionHash: RegionHash = {
   "fips-us-east-1": {
     hostname: "cognito-idp-fips.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "cognito-idp-fips.us-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-1",
   },
   "fips-us-east-2": {
     hostname: "cognito-idp-fips.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "cognito-idp-fips.us-east-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-2",
   },
   "fips-us-gov-west-1": {
     hostname: "cognito-idp-fips.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "cognito-idp-fips.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-west-1",
   },
   "fips-us-west-1": {
     hostname: "cognito-idp-fips.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "cognito-idp-fips.us-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-1",
   },
   "fips-us-west-2": {
     hostname: "cognito-idp-fips.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "cognito-idp-fips.us-west-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-2",
+  },
+  "us-east-1": {
+    hostname: "cognito-idp.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "cognito-idp.us-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "cognito-idp-fips.us-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-east-2": {
+    hostname: "cognito-idp.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "cognito-idp.us-east-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "cognito-idp-fips.us-east-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-gov-west-1": {
+    hostname: "cognito-idp.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "cognito-idp.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "cognito-idp-fips.us-gov-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-west-1": {
+    hostname: "cognito-idp.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "cognito-idp.us-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "cognito-idp-fips.us-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-west-2": {
+    hostname: "cognito-idp.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "cognito-idp.us-west-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "cognito-idp-fips.us-west-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
 };
 
@@ -55,26 +150,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "cognito-idp.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "cognito-idp.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "cognito-idp-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "cognito-idp-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "cognito-idp.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "cognito-idp.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "cognito-idp.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "cognito-idp-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "cognito-idp-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "cognito-idp.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "cognito-idp.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "cognito-idp.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "cognito-idp.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "cognito-idp.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["fips-us-gov-west-1", "us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "cognito-idp.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "cognito-idp.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "cognito-idp-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "cognito-idp-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "cognito-idp.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-cognito-identity/src/endpoints.ts
+++ b/clients/client-cognito-identity/src/endpoints.ts
@@ -4,19 +4,95 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 const regionHash: RegionHash = {
   "fips-us-east-1": {
     hostname: "cognito-identity-fips.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "cognito-identity-fips.us-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-1",
   },
   "fips-us-east-2": {
     hostname: "cognito-identity-fips.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "cognito-identity-fips.us-east-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-2",
   },
   "fips-us-gov-west-1": {
     hostname: "cognito-identity-fips.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "cognito-identity-fips.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-west-1",
   },
   "fips-us-west-2": {
     hostname: "cognito-identity-fips.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "cognito-identity-fips.us-west-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-2",
+  },
+  "us-east-1": {
+    hostname: "cognito-identity.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "cognito-identity.us-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "cognito-identity-fips.us-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-east-2": {
+    hostname: "cognito-identity.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "cognito-identity.us-east-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "cognito-identity-fips.us-east-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-gov-west-1": {
+    hostname: "cognito-identity.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "cognito-identity.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "cognito-identity-fips.us-gov-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-west-2": {
+    hostname: "cognito-identity.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "cognito-identity.us-west-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "cognito-identity-fips.us-west-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
 };
 
@@ -50,26 +126,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "cognito-identity.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "cognito-identity.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "cognito-identity-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "cognito-identity-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "cognito-identity.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "cognito-identity.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "cognito-identity.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "cognito-identity-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "cognito-identity-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "cognito-identity.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "cognito-identity.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "cognito-identity.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "cognito-identity.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "cognito-identity.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["fips-us-gov-west-1", "us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "cognito-identity.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "cognito-identity.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "cognito-identity-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "cognito-identity-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "cognito-identity.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-cognito-sync/src/endpoints.ts
+++ b/clients/client-cognito-sync/src/endpoints.ts
@@ -30,26 +30,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "cognito-sync.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "cognito-sync.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "cognito-sync-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "cognito-sync-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "cognito-sync.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "cognito-sync.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "cognito-sync.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "cognito-sync-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "cognito-sync-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "cognito-sync.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "cognito-sync.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "cognito-sync.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "cognito-sync.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "cognito-sync.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "cognito-sync.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "cognito-sync.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "cognito-sync-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "cognito-sync-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "cognito-sync.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-comprehend/src/endpoints.ts
+++ b/clients/client-comprehend/src/endpoints.ts
@@ -4,19 +4,95 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 const regionHash: RegionHash = {
   "fips-us-east-1": {
     hostname: "comprehend-fips.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "comprehend-fips.us-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-1",
   },
   "fips-us-east-2": {
     hostname: "comprehend-fips.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "comprehend-fips.us-east-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-2",
   },
   "fips-us-gov-west-1": {
     hostname: "comprehend-fips.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "comprehend-fips.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-west-1",
   },
   "fips-us-west-2": {
     hostname: "comprehend-fips.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "comprehend-fips.us-west-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-2",
+  },
+  "us-east-1": {
+    hostname: "comprehend.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "comprehend.us-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "comprehend-fips.us-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-east-2": {
+    hostname: "comprehend.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "comprehend.us-east-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "comprehend-fips.us-east-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-gov-west-1": {
+    hostname: "comprehend.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "comprehend.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "comprehend-fips.us-gov-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-west-2": {
+    hostname: "comprehend.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "comprehend.us-west-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "comprehend-fips.us-west-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
 };
 
@@ -50,26 +126,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "comprehend.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "comprehend.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "comprehend-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "comprehend-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "comprehend.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "comprehend.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "comprehend.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "comprehend-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "comprehend-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "comprehend.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "comprehend.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "comprehend.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "comprehend.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "comprehend.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["fips-us-gov-west-1", "us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "comprehend.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "comprehend.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "comprehend-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "comprehend-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "comprehend.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-comprehendmedical/src/endpoints.ts
+++ b/clients/client-comprehendmedical/src/endpoints.ts
@@ -4,19 +4,95 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 const regionHash: RegionHash = {
   "fips-us-east-1": {
     hostname: "comprehendmedical-fips.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "comprehendmedical-fips.us-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-1",
   },
   "fips-us-east-2": {
     hostname: "comprehendmedical-fips.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "comprehendmedical-fips.us-east-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-2",
   },
   "fips-us-gov-west-1": {
     hostname: "comprehendmedical-fips.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "comprehendmedical-fips.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-west-1",
   },
   "fips-us-west-2": {
     hostname: "comprehendmedical-fips.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "comprehendmedical-fips.us-west-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-2",
+  },
+  "us-east-1": {
+    hostname: "comprehendmedical.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "comprehendmedical.us-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "comprehendmedical-fips.us-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-east-2": {
+    hostname: "comprehendmedical.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "comprehendmedical.us-east-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "comprehendmedical-fips.us-east-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-gov-west-1": {
+    hostname: "comprehendmedical.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "comprehendmedical.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "comprehendmedical-fips.us-gov-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-west-2": {
+    hostname: "comprehendmedical.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "comprehendmedical.us-west-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "comprehendmedical-fips.us-west-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
 };
 
@@ -50,26 +126,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "comprehendmedical.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "comprehendmedical.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "comprehendmedical-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "comprehendmedical-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "comprehendmedical.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "comprehendmedical.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "comprehendmedical.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "comprehendmedical-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "comprehendmedical-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "comprehendmedical.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "comprehendmedical.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "comprehendmedical.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "comprehendmedical.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "comprehendmedical.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["fips-us-gov-west-1", "us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "comprehendmedical.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "comprehendmedical.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "comprehendmedical-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "comprehendmedical-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "comprehendmedical.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-compute-optimizer/src/endpoints.ts
+++ b/clients/client-compute-optimizer/src/endpoints.ts
@@ -30,26 +30,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "compute-optimizer.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "compute-optimizer.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "compute-optimizer-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "compute-optimizer-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "compute-optimizer.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "compute-optimizer.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "compute-optimizer.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "compute-optimizer-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "compute-optimizer-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "compute-optimizer.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "compute-optimizer.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "compute-optimizer.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "compute-optimizer.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "compute-optimizer.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "compute-optimizer.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "compute-optimizer.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "compute-optimizer-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "compute-optimizer-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "compute-optimizer.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-config-service/src/endpoints.ts
+++ b/clients/client-config-service/src/endpoints.ts
@@ -4,27 +4,141 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 const regionHash: RegionHash = {
   "fips-us-east-1": {
     hostname: "config-fips.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "config-fips.us-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-1",
   },
   "fips-us-east-2": {
     hostname: "config-fips.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "config-fips.us-east-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-2",
   },
   "fips-us-gov-east-1": {
     hostname: "config.us-gov-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "config.us-gov-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-east-1",
   },
   "fips-us-gov-west-1": {
     hostname: "config.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "config.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-west-1",
   },
   "fips-us-west-1": {
     hostname: "config-fips.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "config-fips.us-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-1",
   },
   "fips-us-west-2": {
     hostname: "config-fips.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "config-fips.us-west-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-2",
+  },
+  "us-east-1": {
+    hostname: "config.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "config.us-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "config-fips.us-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-east-2": {
+    hostname: "config.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "config.us-east-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "config-fips.us-east-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-gov-east-1": {
+    hostname: "config.us-gov-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "config.us-gov-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "config.us-gov-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-gov-west-1": {
+    hostname: "config.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "config.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "config.us-gov-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-west-1": {
+    hostname: "config.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "config.us-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "config-fips.us-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-west-2": {
+    hostname: "config.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "config.us-west-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "config-fips.us-west-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
 };
 
@@ -59,26 +173,84 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "config.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "config.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "config-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "config-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "config.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "config.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "config.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "config-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "config-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "config.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "config.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "config.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "config.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "config.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["fips-us-gov-east-1", "fips-us-gov-west-1", "us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "config.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "config.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "config.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
 };
 

--- a/clients/client-connect-contact-lens/src/endpoints.ts
+++ b/clients/client-connect-contact-lens/src/endpoints.ts
@@ -30,26 +30,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "contact-lens.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "contact-lens.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "contact-lens-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "contact-lens-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "contact-lens.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "contact-lens.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "contact-lens.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "contact-lens-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "contact-lens-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "contact-lens.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "contact-lens.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "contact-lens.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "contact-lens.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "contact-lens.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "contact-lens.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "contact-lens.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "contact-lens-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "contact-lens-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "contact-lens.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-connect/src/endpoints.ts
+++ b/clients/client-connect/src/endpoints.ts
@@ -30,26 +30,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "connect.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "connect.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "connect-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "connect-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "connect.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "connect.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "connect.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "connect-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "connect-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "connect.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "connect.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "connect.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "connect.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "connect.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "connect.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "connect.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "connect-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "connect-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "connect.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-connectparticipant/src/endpoints.ts
+++ b/clients/client-connectparticipant/src/endpoints.ts
@@ -30,26 +30,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "participant.connect.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "participant.connect.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "participant.connect-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "participant.connect-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "participant.connect.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "participant.connect.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "participant.connect.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "participant.connect-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "participant.connect-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "participant.connect.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "participant.connect.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "participant.connect.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "participant.connect.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "participant.connect.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "participant.connect.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "participant.connect.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "participant.connect-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "participant.connect-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "participant.connect.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-cost-and-usage-report-service/src/endpoints.ts
+++ b/clients/client-cost-and-usage-report-service/src/endpoints.ts
@@ -30,26 +30,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "cur.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "cur.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "cur-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "cur-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "cur.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "cur.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "cur.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "cur-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "cur-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "cur.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "cur.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "cur.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "cur.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "cur.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "cur.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "cur.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "cur-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "cur-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "cur.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-cost-explorer/src/endpoints.ts
+++ b/clients/client-cost-explorer/src/endpoints.ts
@@ -4,10 +4,22 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 const regionHash: RegionHash = {
   "aws-cn-global": {
     hostname: "ce.cn-northwest-1.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "ce.cn-northwest-1.amazonaws.com.cn",
+        tags: [],
+      },
+    ],
     signingRegion: "cn-northwest-1",
   },
   "aws-global": {
     hostname: "ce.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "ce.us-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-1",
   },
 };
@@ -39,27 +51,95 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
+    hostname: "ce.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "ce.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "ce-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "ce-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "ce.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
     endpoint: "aws-global",
   },
   "aws-cn": {
     regions: ["aws-cn-global", "cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
+    hostname: "ce.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "ce.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "ce-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "ce-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "ce.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
     endpoint: "aws-cn-global",
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "ce.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "ce.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "ce.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "ce.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "ce.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "ce.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "ce-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "ce-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "ce.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-customer-profiles/src/endpoints.ts
+++ b/clients/client-customer-profiles/src/endpoints.ts
@@ -30,26 +30,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "profile.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "profile.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "profile-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "profile-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "profile.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "profile.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "profile.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "profile-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "profile-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "profile.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "profile.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "profile.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "profile.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "profile.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "profile.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "profile.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "profile-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "profile-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "profile.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-data-pipeline/src/endpoints.ts
+++ b/clients/client-data-pipeline/src/endpoints.ts
@@ -30,26 +30,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "datapipeline.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "datapipeline.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "datapipeline-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "datapipeline-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "datapipeline.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "datapipeline.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "datapipeline.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "datapipeline-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "datapipeline-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "datapipeline.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "datapipeline.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "datapipeline.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "datapipeline.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "datapipeline.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "datapipeline.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "datapipeline.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "datapipeline-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "datapipeline-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "datapipeline.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-database-migration-service/src/endpoints.ts
+++ b/clients/client-database-migration-service/src/endpoints.ts
@@ -2,40 +2,212 @@ import { getRegionInfo, PartitionHash, RegionHash } from "@aws-sdk/config-resolv
 import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
+  dms: {
+    hostname: "dms.dms.amazonaws.com",
+    variants: [
+      {
+        hostname: "dms.dms.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "dms.us-gov-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+    signingRegion: "us-gov-west-1",
+  },
   "dms-fips": {
     hostname: "dms.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "dms.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-west-1",
+  },
+  "us-east-1": {
+    hostname: "dms.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "dms.us-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "dms-fips.us-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "us-east-1-fips": {
     hostname: "dms-fips.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "dms-fips.us-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-1",
+  },
+  "us-east-2": {
+    hostname: "dms.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "dms.us-east-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "dms-fips.us-east-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "us-east-2-fips": {
     hostname: "dms-fips.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "dms-fips.us-east-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-2",
+  },
+  "us-gov-east-1": {
+    hostname: "dms.us-gov-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "dms.us-gov-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "dms.us-gov-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "us-gov-east-1-fips": {
     hostname: "dms.us-gov-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "dms.us-gov-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-east-1",
+  },
+  "us-gov-west-1": {
+    hostname: "dms.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "dms.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "dms.us-gov-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "us-gov-west-1-fips": {
     hostname: "dms.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "dms.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-west-1",
+  },
+  "us-iso-east-1": {
+    hostname: "dms.us-iso-east-1.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "dms.us-iso-east-1.c2s.ic.gov",
+        tags: [],
+      },
+      {
+        hostname: "dms.us-iso-east-1.c2s.ic.gov",
+        tags: ["fips"],
+      },
+    ],
   },
   "us-iso-east-1-fips": {
     hostname: "dms.us-iso-east-1.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "dms.us-iso-east-1.c2s.ic.gov",
+        tags: [],
+      },
+    ],
     signingRegion: "us-iso-east-1",
+  },
+  "us-isob-east-1": {
+    hostname: "dms.us-isob-east-1.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "dms.us-isob-east-1.sc2s.sgov.gov",
+        tags: [],
+      },
+      {
+        hostname: "dms.us-isob-east-1.sc2s.sgov.gov",
+        tags: ["fips"],
+      },
+    ],
   },
   "us-isob-east-1-fips": {
     hostname: "dms.us-isob-east-1.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "dms.us-isob-east-1.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
     signingRegion: "us-isob-east-1",
+  },
+  "us-west-1": {
+    hostname: "dms.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "dms.us-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "dms-fips.us-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "us-west-1-fips": {
     hostname: "dms-fips.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "dms-fips.us-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-1",
+  },
+  "us-west-2": {
+    hostname: "dms.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "dms.us-west-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "dms-fips.us-west-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "us-west-2-fips": {
     hostname: "dms-fips.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "dms-fips.us-west-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-2",
   },
 };
@@ -73,26 +245,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "dms.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "dms.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "dms-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "dms-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "dms.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "dms.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "dms.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "dms-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "dms-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "dms.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["dms", "dms-fips", "us-iso-east-1", "us-iso-east-1-fips", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "dms.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "dms.{region}.c2s.ic.gov",
+        tags: [],
+      },
+      {
+        hostname: "dms.{region}.c2s.ic.gov",
+        tags: ["fips"],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["dms", "dms-fips", "us-isob-east-1", "us-isob-east-1-fips"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "dms.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "dms.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+      {
+        hostname: "dms.{region}.sc2s.sgov.gov",
+        tags: ["fips"],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["dms", "dms-fips", "us-gov-east-1", "us-gov-east-1-fips", "us-gov-west-1", "us-gov-west-1-fips"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "dms.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "dms.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "dms.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
 };
 

--- a/clients/client-databrew/src/endpoints.ts
+++ b/clients/client-databrew/src/endpoints.ts
@@ -30,26 +30,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "databrew.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "databrew.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "databrew-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "databrew-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "databrew.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "databrew.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "databrew.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "databrew-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "databrew-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "databrew.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "databrew.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "databrew.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "databrew.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "databrew.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "databrew.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "databrew.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "databrew-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "databrew-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "databrew.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-dataexchange/src/endpoints.ts
+++ b/clients/client-dataexchange/src/endpoints.ts
@@ -30,26 +30,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "dataexchange.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "dataexchange.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "dataexchange-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "dataexchange-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "dataexchange.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "dataexchange.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "dataexchange.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "dataexchange-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "dataexchange-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "dataexchange.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "dataexchange.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "dataexchange.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "dataexchange.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "dataexchange.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "dataexchange.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "dataexchange.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "dataexchange-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "dataexchange-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "dataexchange.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-datasync/src/endpoints.ts
+++ b/clients/client-datasync/src/endpoints.ts
@@ -2,33 +2,166 @@ import { getRegionInfo, PartitionHash, RegionHash } from "@aws-sdk/config-resolv
 import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
+  "ca-central-1": {
+    hostname: "datasync.ca-central-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "datasync.ca-central-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "datasync-fips.ca-central-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
   "fips-ca-central-1": {
     hostname: "datasync-fips.ca-central-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "datasync-fips.ca-central-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "ca-central-1",
   },
   "fips-us-east-1": {
     hostname: "datasync-fips.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "datasync-fips.us-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-1",
   },
   "fips-us-east-2": {
     hostname: "datasync-fips.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "datasync-fips.us-east-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-2",
   },
   "fips-us-gov-east-1": {
     hostname: "datasync-fips.us-gov-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "datasync-fips.us-gov-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-east-1",
   },
   "fips-us-gov-west-1": {
     hostname: "datasync-fips.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "datasync-fips.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-west-1",
   },
   "fips-us-west-1": {
     hostname: "datasync-fips.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "datasync-fips.us-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-1",
   },
   "fips-us-west-2": {
     hostname: "datasync-fips.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "datasync-fips.us-west-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-2",
+  },
+  "us-east-1": {
+    hostname: "datasync.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "datasync.us-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "datasync-fips.us-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-east-2": {
+    hostname: "datasync.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "datasync.us-east-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "datasync-fips.us-east-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-gov-east-1": {
+    hostname: "datasync.us-gov-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "datasync.us-gov-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "datasync-fips.us-gov-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-gov-west-1": {
+    hostname: "datasync.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "datasync.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "datasync-fips.us-gov-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-west-1": {
+    hostname: "datasync.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "datasync.us-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "datasync-fips.us-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-west-2": {
+    hostname: "datasync.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "datasync.us-west-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "datasync-fips.us-west-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
 };
 
@@ -64,26 +197,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "datasync.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "datasync.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "datasync-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "datasync-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "datasync.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "datasync.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "datasync.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "datasync-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "datasync-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "datasync.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "datasync.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "datasync.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "datasync.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "datasync.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["fips-us-gov-east-1", "fips-us-gov-west-1", "us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "datasync.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "datasync.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "datasync-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "datasync-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "datasync.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-dax/src/endpoints.ts
+++ b/clients/client-dax/src/endpoints.ts
@@ -30,26 +30,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "dax.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "dax.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "dax-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "dax-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "dax.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "dax.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "dax.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "dax-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "dax-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "dax.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "dax.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "dax.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "dax.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "dax.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "dax.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "dax.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "dax-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "dax-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "dax.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-detective/src/endpoints.ts
+++ b/clients/client-detective/src/endpoints.ts
@@ -2,28 +2,142 @@ import { getRegionInfo, PartitionHash, RegionHash } from "@aws-sdk/config-resolv
 import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
+  "us-east-1": {
+    hostname: "api.detective.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "api.detective.us-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "api.detective-fips.us-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
   "us-east-1-fips": {
     hostname: "api.detective-fips.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "api.detective-fips.us-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-1",
+  },
+  "us-east-2": {
+    hostname: "api.detective.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "api.detective.us-east-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "api.detective-fips.us-east-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "us-east-2-fips": {
     hostname: "api.detective-fips.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "api.detective-fips.us-east-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-2",
+  },
+  "us-gov-east-1": {
+    hostname: "api.detective.us-gov-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "api.detective.us-gov-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "api.detective-fips.us-gov-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "us-gov-east-1-fips": {
     hostname: "api.detective-fips.us-gov-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "api.detective-fips.us-gov-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-east-1",
+  },
+  "us-gov-west-1": {
+    hostname: "api.detective.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "api.detective.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "api.detective-fips.us-gov-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "us-gov-west-1-fips": {
     hostname: "api.detective-fips.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "api.detective-fips.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-west-1",
+  },
+  "us-west-1": {
+    hostname: "api.detective.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "api.detective.us-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "api.detective-fips.us-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "us-west-1-fips": {
     hostname: "api.detective-fips.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "api.detective-fips.us-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-1",
+  },
+  "us-west-2": {
+    hostname: "api.detective.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "api.detective.us-west-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "api.detective-fips.us-west-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "us-west-2-fips": {
     hostname: "api.detective-fips.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "api.detective-fips.us-west-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-2",
   },
 };
@@ -59,26 +173,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "api.detective.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "api.detective.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "api.detective-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "api.detective-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "api.detective.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "api.detective.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "api.detective.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "api.detective-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "api.detective-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "api.detective.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "api.detective.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "api.detective.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "api.detective.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "api.detective.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-east-1-fips", "us-gov-west-1", "us-gov-west-1-fips"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "api.detective.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "api.detective.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "api.detective-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "api.detective-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "api.detective.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-device-farm/src/endpoints.ts
+++ b/clients/client-device-farm/src/endpoints.ts
@@ -30,26 +30,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "devicefarm.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "devicefarm.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "devicefarm-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "devicefarm-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "devicefarm.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "devicefarm.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "devicefarm.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "devicefarm-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "devicefarm-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "devicefarm.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "devicefarm.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "devicefarm.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "devicefarm.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "devicefarm.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "devicefarm.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "devicefarm.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "devicefarm-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "devicefarm-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "devicefarm.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-devops-guru/src/endpoints.ts
+++ b/clients/client-devops-guru/src/endpoints.ts
@@ -30,26 +30,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "devops-guru.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "devops-guru.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "devops-guru-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "devops-guru-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "devops-guru.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "devops-guru.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "devops-guru.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "devops-guru-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "devops-guru-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "devops-guru.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "devops-guru.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "devops-guru.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "devops-guru.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "devops-guru.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "devops-guru.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "devops-guru.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "devops-guru-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "devops-guru-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "devops-guru.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-direct-connect/src/endpoints.ts
+++ b/clients/client-direct-connect/src/endpoints.ts
@@ -4,27 +4,115 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 const regionHash: RegionHash = {
   "fips-us-east-1": {
     hostname: "directconnect-fips.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "directconnect-fips.us-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-1",
   },
   "fips-us-east-2": {
     hostname: "directconnect-fips.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "directconnect-fips.us-east-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-2",
   },
   "fips-us-west-1": {
     hostname: "directconnect-fips.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "directconnect-fips.us-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-1",
   },
   "fips-us-west-2": {
     hostname: "directconnect-fips.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "directconnect-fips.us-west-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-2",
+  },
+  "us-east-1": {
+    hostname: "directconnect.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "directconnect.us-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "directconnect-fips.us-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-east-2": {
+    hostname: "directconnect.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "directconnect.us-east-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "directconnect-fips.us-east-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "us-gov-east-1": {
     hostname: "directconnect.us-gov-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "directconnect.us-gov-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-east-1",
   },
   "us-gov-west-1": {
     hostname: "directconnect.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "directconnect.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-west-1",
+  },
+  "us-west-1": {
+    hostname: "directconnect.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "directconnect.us-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "directconnect-fips.us-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-west-2": {
+    hostname: "directconnect.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "directconnect.us-west-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "directconnect-fips.us-west-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
 };
 
@@ -59,26 +147,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "directconnect.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "directconnect.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "directconnect-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "directconnect-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "directconnect.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "directconnect.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "directconnect.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "directconnect-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "directconnect-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "directconnect.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "directconnect.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "directconnect.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "directconnect.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "directconnect.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "directconnect.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "directconnect.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "directconnect-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "directconnect-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "directconnect.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-directory-service/src/endpoints.ts
+++ b/clients/client-directory-service/src/endpoints.ts
@@ -2,33 +2,166 @@ import { getRegionInfo, PartitionHash, RegionHash } from "@aws-sdk/config-resolv
 import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
+  "ca-central-1": {
+    hostname: "ds.ca-central-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "ds.ca-central-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "ds-fips.ca-central-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
   "fips-ca-central-1": {
     hostname: "ds-fips.ca-central-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "ds-fips.ca-central-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "ca-central-1",
   },
   "fips-us-east-1": {
     hostname: "ds-fips.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "ds-fips.us-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-1",
   },
   "fips-us-east-2": {
     hostname: "ds-fips.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "ds-fips.us-east-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-2",
   },
   "fips-us-gov-east-1": {
     hostname: "ds-fips.us-gov-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "ds-fips.us-gov-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-east-1",
   },
   "fips-us-gov-west-1": {
     hostname: "ds-fips.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "ds-fips.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-west-1",
   },
   "fips-us-west-1": {
     hostname: "ds-fips.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "ds-fips.us-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-1",
   },
   "fips-us-west-2": {
     hostname: "ds-fips.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "ds-fips.us-west-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-2",
+  },
+  "us-east-1": {
+    hostname: "ds.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "ds.us-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "ds-fips.us-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-east-2": {
+    hostname: "ds.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "ds.us-east-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "ds-fips.us-east-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-gov-east-1": {
+    hostname: "ds.us-gov-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "ds.us-gov-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "ds-fips.us-gov-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-gov-west-1": {
+    hostname: "ds.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "ds.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "ds-fips.us-gov-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-west-1": {
+    hostname: "ds.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "ds.us-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "ds-fips.us-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-west-2": {
+    hostname: "ds.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "ds.us-west-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "ds-fips.us-west-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
 };
 
@@ -64,26 +197,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "ds.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "ds.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "ds-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "ds-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "ds.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "ds.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "ds.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "ds-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "ds-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "ds.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "ds.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "ds.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "ds.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "ds.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["fips-us-gov-east-1", "fips-us-gov-west-1", "us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "ds.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "ds.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "ds-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "ds-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "ds.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-dlm/src/endpoints.ts
+++ b/clients/client-dlm/src/endpoints.ts
@@ -30,26 +30,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "dlm.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "dlm.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "dlm-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "dlm-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "dlm.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "dlm.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "dlm.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "dlm-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "dlm-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "dlm.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "dlm.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "dlm.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "dlm.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "dlm.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "dlm.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "dlm.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "dlm-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "dlm-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "dlm.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-docdb/src/endpoints.ts
+++ b/clients/client-docdb/src/endpoints.ts
@@ -2,60 +2,305 @@ import { getRegionInfo, PartitionHash, RegionHash } from "@aws-sdk/config-resolv
 import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
+  "ca-central-1": {
+    hostname: "rds.ca-central-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "rds.ca-central-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "rds-fips.ca-central-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
   "ca-central-1-fips": {
     hostname: "rds-fips.ca-central-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "rds-fips.ca-central-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "ca-central-1",
   },
   "rds-fips.ca-central-1": {
     hostname: "rds-fips.ca-central-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "rds-fips.ca-central-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "ca-central-1",
   },
   "rds-fips.us-east-1": {
     hostname: "rds-fips.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "rds-fips.us-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-1",
   },
   "rds-fips.us-east-2": {
     hostname: "rds-fips.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "rds-fips.us-east-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-2",
   },
   "rds-fips.us-west-1": {
     hostname: "rds-fips.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "rds-fips.us-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-1",
   },
   "rds-fips.us-west-2": {
     hostname: "rds-fips.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "rds-fips.us-west-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-2",
+  },
+  "rds.ca-central-1": {
+    hostname: "rds.rds.ca-central-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "rds.rds.ca-central-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "rds-fips.ca-central-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+    signingRegion: "ca-central-1",
+  },
+  "rds.us-east-1": {
+    hostname: "rds.rds.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "rds.rds.us-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "rds-fips.us-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+    signingRegion: "us-east-1",
+  },
+  "rds.us-east-2": {
+    hostname: "rds.rds.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "rds.rds.us-east-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "rds-fips.us-east-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+    signingRegion: "us-east-2",
   },
   "rds.us-gov-east-1": {
     hostname: "rds.us-gov-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "rds.us-gov-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-east-1",
   },
   "rds.us-gov-west-1": {
     hostname: "rds.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "rds.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-west-1",
+  },
+  "rds.us-west-1": {
+    hostname: "rds.rds.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "rds.rds.us-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "rds-fips.us-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+    signingRegion: "us-west-1",
+  },
+  "rds.us-west-2": {
+    hostname: "rds.rds.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "rds.rds.us-west-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "rds-fips.us-west-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+    signingRegion: "us-west-2",
+  },
+  "us-east-1": {
+    hostname: "rds.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "rds.us-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "rds-fips.us-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "us-east-1-fips": {
     hostname: "rds-fips.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "rds-fips.us-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-1",
+  },
+  "us-east-2": {
+    hostname: "rds.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "rds.us-east-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "rds-fips.us-east-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "us-east-2-fips": {
     hostname: "rds-fips.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "rds-fips.us-east-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-2",
+  },
+  "us-gov-east-1": {
+    hostname: "rds.us-gov-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "rds.us-gov-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "rds.us-gov-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "us-gov-east-1-fips": {
     hostname: "rds.us-gov-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "rds.us-gov-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-east-1",
+  },
+  "us-gov-west-1": {
+    hostname: "rds.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "rds.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "rds.us-gov-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "us-gov-west-1-fips": {
     hostname: "rds.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "rds.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-west-1",
+  },
+  "us-west-1": {
+    hostname: "rds.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "rds.us-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "rds-fips.us-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "us-west-1-fips": {
     hostname: "rds-fips.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "rds-fips.us-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-1",
+  },
+  "us-west-2": {
+    hostname: "rds.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "rds.us-west-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "rds-fips.us-west-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "us-west-2-fips": {
     hostname: "rds-fips.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "rds-fips.us-west-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-2",
   },
 };
@@ -102,21 +347,69 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "rds.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "rds.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "rds-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "rds-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "rds.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "rds.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "rds.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "rds-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "rds-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "rds.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "rds.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "rds.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "rds.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "rds.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: [
@@ -129,6 +422,24 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "rds.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "rds.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "rds-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "rds-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "rds.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-dynamodb-streams/src/endpoints.ts
+++ b/clients/client-dynamodb-streams/src/endpoints.ts
@@ -4,34 +4,82 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 const regionHash: RegionHash = {
   "ca-central-1-fips": {
     hostname: "dynamodb-fips.ca-central-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "dynamodb-fips.ca-central-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "ca-central-1",
   },
   local: {
     hostname: "localhost:8000",
+    variants: [
+      {
+        hostname: "localhost:8000",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-1",
   },
   "us-east-1-fips": {
     hostname: "dynamodb-fips.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "dynamodb-fips.us-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-1",
   },
   "us-east-2-fips": {
     hostname: "dynamodb-fips.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "dynamodb-fips.us-east-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-2",
   },
   "us-gov-east-1-fips": {
     hostname: "dynamodb.us-gov-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "dynamodb.us-gov-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-east-1",
   },
   "us-gov-west-1-fips": {
     hostname: "dynamodb.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "dynamodb.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-west-1",
   },
   "us-west-1-fips": {
     hostname: "dynamodb-fips.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "dynamodb-fips.us-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-1",
   },
   "us-west-2-fips": {
     hostname: "dynamodb-fips.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "dynamodb-fips.us-west-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-2",
   },
 };
@@ -69,26 +117,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "streams.dynamodb.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "streams.dynamodb.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "streams.dynamodb-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "streams.dynamodb-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "streams.dynamodb.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "streams.dynamodb.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "streams.dynamodb.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "streams.dynamodb-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "streams.dynamodb-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "streams.dynamodb.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "streams.dynamodb.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "streams.dynamodb.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "streams.dynamodb.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "streams.dynamodb.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-east-1-fips", "us-gov-west-1", "us-gov-west-1-fips"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "streams.dynamodb.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "streams.dynamodb.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "streams.dynamodb-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "streams.dynamodb-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "streams.dynamodb.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-dynamodb/src/endpoints.ts
+++ b/clients/client-dynamodb/src/endpoints.ts
@@ -2,36 +2,175 @@ import { getRegionInfo, PartitionHash, RegionHash } from "@aws-sdk/config-resolv
 import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
+  "ca-central-1": {
+    hostname: "dynamodb.ca-central-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "dynamodb.ca-central-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "dynamodb-fips.ca-central-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
   "ca-central-1-fips": {
     hostname: "dynamodb-fips.ca-central-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "dynamodb-fips.ca-central-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "ca-central-1",
   },
   local: {
     hostname: "localhost:8000",
+    variants: [
+      {
+        hostname: "localhost:8000",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-1",
+  },
+  "us-east-1": {
+    hostname: "dynamodb.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "dynamodb.us-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "dynamodb-fips.us-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "us-east-1-fips": {
     hostname: "dynamodb-fips.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "dynamodb-fips.us-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-1",
+  },
+  "us-east-2": {
+    hostname: "dynamodb.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "dynamodb.us-east-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "dynamodb-fips.us-east-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "us-east-2-fips": {
     hostname: "dynamodb-fips.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "dynamodb-fips.us-east-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-2",
+  },
+  "us-gov-east-1": {
+    hostname: "dynamodb.us-gov-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "dynamodb.us-gov-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "dynamodb.us-gov-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "us-gov-east-1-fips": {
     hostname: "dynamodb.us-gov-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "dynamodb.us-gov-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-east-1",
+  },
+  "us-gov-west-1": {
+    hostname: "dynamodb.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "dynamodb.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "dynamodb.us-gov-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "us-gov-west-1-fips": {
     hostname: "dynamodb.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "dynamodb.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-west-1",
+  },
+  "us-west-1": {
+    hostname: "dynamodb.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "dynamodb.us-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "dynamodb-fips.us-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "us-west-1-fips": {
     hostname: "dynamodb-fips.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "dynamodb-fips.us-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-1",
+  },
+  "us-west-2": {
+    hostname: "dynamodb.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "dynamodb.us-west-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "dynamodb-fips.us-west-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "us-west-2-fips": {
     hostname: "dynamodb-fips.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "dynamodb-fips.us-west-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-2",
   },
 };
@@ -69,26 +208,84 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "dynamodb.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "dynamodb.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "dynamodb-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "dynamodb-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "dynamodb.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "dynamodb.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "dynamodb.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "dynamodb-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "dynamodb-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "dynamodb.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "dynamodb.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "dynamodb.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "dynamodb.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "dynamodb.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-east-1-fips", "us-gov-west-1", "us-gov-west-1-fips"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "dynamodb.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "dynamodb.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "dynamodb.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
 };
 

--- a/clients/client-ebs/src/endpoints.ts
+++ b/clients/client-ebs/src/endpoints.ts
@@ -2,25 +2,120 @@ import { getRegionInfo, PartitionHash, RegionHash } from "@aws-sdk/config-resolv
 import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
+  "ca-central-1": {
+    hostname: "ebs.ca-central-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "ebs.ca-central-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "ebs-fips.ca-central-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
   "fips-ca-central-1": {
     hostname: "ebs-fips.ca-central-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "ebs-fips.ca-central-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "ca-central-1",
   },
   "fips-us-east-1": {
     hostname: "ebs-fips.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "ebs-fips.us-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-1",
   },
   "fips-us-east-2": {
     hostname: "ebs-fips.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "ebs-fips.us-east-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-2",
   },
   "fips-us-west-1": {
     hostname: "ebs-fips.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "ebs-fips.us-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-1",
   },
   "fips-us-west-2": {
     hostname: "ebs-fips.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "ebs-fips.us-west-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-2",
+  },
+  "us-east-1": {
+    hostname: "ebs.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "ebs.us-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "ebs-fips.us-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-east-2": {
+    hostname: "ebs.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "ebs.us-east-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "ebs-fips.us-east-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-west-1": {
+    hostname: "ebs.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "ebs.us-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "ebs-fips.us-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-west-2": {
+    hostname: "ebs.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "ebs.us-west-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "ebs-fips.us-west-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
 };
 
@@ -56,26 +151,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "ebs.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "ebs.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "ebs-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "ebs-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "ebs.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "ebs.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "ebs.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "ebs-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "ebs-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "ebs.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "ebs.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "ebs.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "ebs.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "ebs.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "ebs.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "ebs.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "ebs-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "ebs-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "ebs.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-ec2-instance-connect/src/endpoints.ts
+++ b/clients/client-ec2-instance-connect/src/endpoints.ts
@@ -30,26 +30,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "ec2-instance-connect.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "ec2-instance-connect.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "ec2-instance-connect-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "ec2-instance-connect-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "ec2-instance-connect.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "ec2-instance-connect.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "ec2-instance-connect.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "ec2-instance-connect-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "ec2-instance-connect-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "ec2-instance-connect.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "ec2-instance-connect.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "ec2-instance-connect.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "ec2-instance-connect.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "ec2-instance-connect.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "ec2-instance-connect.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "ec2-instance-connect.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "ec2-instance-connect-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "ec2-instance-connect-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "ec2-instance-connect.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-ec2/src/endpoints.ts
+++ b/clients/client-ec2/src/endpoints.ts
@@ -2,33 +2,191 @@ import { getRegionInfo, PartitionHash, RegionHash } from "@aws-sdk/config-resolv
 import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
+  "ap-south-1": {
+    hostname: "ec2.ap-south-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "ec2.ap-south-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "api.ec2.ap-south-1.aws",
+        tags: ["dualstack"],
+      },
+    ],
+  },
+  "ca-central-1": {
+    hostname: "ec2.ca-central-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "ec2.ca-central-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "ec2-fips.ca-central-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "eu-west-1": {
+    hostname: "ec2.eu-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "ec2.eu-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "api.ec2.eu-west-1.aws",
+        tags: ["dualstack"],
+      },
+    ],
+  },
   "fips-ca-central-1": {
     hostname: "ec2-fips.ca-central-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "ec2-fips.ca-central-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "ca-central-1",
   },
   "fips-us-east-1": {
     hostname: "ec2-fips.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "ec2-fips.us-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-1",
   },
   "fips-us-east-2": {
     hostname: "ec2-fips.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "ec2-fips.us-east-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-2",
   },
   "fips-us-west-1": {
     hostname: "ec2-fips.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "ec2-fips.us-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-1",
   },
   "fips-us-west-2": {
     hostname: "ec2-fips.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "ec2-fips.us-west-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-2",
+  },
+  "sa-east-1": {
+    hostname: "ec2.sa-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "ec2.sa-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "api.ec2.sa-east-1.aws",
+        tags: ["dualstack"],
+      },
+    ],
+  },
+  "us-east-1": {
+    hostname: "ec2.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "ec2.us-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "api.ec2.us-east-1.aws",
+        tags: ["dualstack"],
+      },
+      {
+        hostname: "ec2-fips.us-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-east-2": {
+    hostname: "ec2.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "ec2.us-east-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "api.ec2.us-east-2.aws",
+        tags: ["dualstack"],
+      },
+      {
+        hostname: "ec2-fips.us-east-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "us-gov-east-1": {
     hostname: "ec2.us-gov-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "ec2.us-gov-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-east-1",
   },
   "us-gov-west-1": {
     hostname: "ec2.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "ec2.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-west-1",
+  },
+  "us-west-1": {
+    hostname: "ec2.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "ec2.us-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "ec2-fips.us-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-west-2": {
+    hostname: "ec2.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "ec2.us-west-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "api.ec2.us-west-2.aws",
+        tags: ["dualstack"],
+      },
+      {
+        hostname: "ec2-fips.us-west-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
 };
 
@@ -64,26 +222,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "ec2.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "ec2.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "ec2-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "ec2-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "ec2.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "ec2.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "ec2.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "ec2-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "ec2-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "ec2.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "ec2.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "ec2.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "ec2.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "ec2.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "ec2.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "ec2.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "ec2-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "ec2-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "ec2.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-ecr-public/src/endpoints.ts
+++ b/clients/client-ecr-public/src/endpoints.ts
@@ -30,26 +30,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "api.ecr-public.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "api.ecr-public.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "api.ecr-public-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "api.ecr-public-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "api.ecr-public.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "api.ecr-public.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "api.ecr-public.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "api.ecr-public-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "api.ecr-public-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "api.ecr-public.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "api.ecr-public.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "api.ecr-public.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "api.ecr-public.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "api.ecr-public.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "api.ecr-public.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "api.ecr-public.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "api.ecr-public-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "api.ecr-public-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "api.ecr-public.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-ecr/src/endpoints.ts
+++ b/clients/client-ecr/src/endpoints.ts
@@ -4,162 +4,510 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 const regionHash: RegionHash = {
   "af-south-1": {
     hostname: "api.ecr.af-south-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "api.ecr.af-south-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "af-south-1",
   },
   "ap-east-1": {
     hostname: "api.ecr.ap-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "api.ecr.ap-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "ap-east-1",
   },
   "ap-northeast-1": {
     hostname: "api.ecr.ap-northeast-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "api.ecr.ap-northeast-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "ap-northeast-1",
   },
   "ap-northeast-2": {
     hostname: "api.ecr.ap-northeast-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "api.ecr.ap-northeast-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "ap-northeast-2",
   },
   "ap-northeast-3": {
     hostname: "api.ecr.ap-northeast-3.amazonaws.com",
+    variants: [
+      {
+        hostname: "api.ecr.ap-northeast-3.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "ap-northeast-3",
   },
   "ap-south-1": {
     hostname: "api.ecr.ap-south-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "api.ecr.ap-south-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "ap-south-1",
   },
   "ap-southeast-1": {
     hostname: "api.ecr.ap-southeast-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "api.ecr.ap-southeast-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "ap-southeast-1",
   },
   "ap-southeast-2": {
     hostname: "api.ecr.ap-southeast-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "api.ecr.ap-southeast-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "ap-southeast-2",
   },
   "ca-central-1": {
     hostname: "api.ecr.ca-central-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "api.ecr.ca-central-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "ca-central-1",
   },
   "cn-north-1": {
     hostname: "api.ecr.cn-north-1.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "api.ecr.cn-north-1.amazonaws.com.cn",
+        tags: [],
+      },
+    ],
     signingRegion: "cn-north-1",
   },
   "cn-northwest-1": {
     hostname: "api.ecr.cn-northwest-1.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "api.ecr.cn-northwest-1.amazonaws.com.cn",
+        tags: [],
+      },
+    ],
     signingRegion: "cn-northwest-1",
+  },
+  "dkr-us-east-1": {
+    hostname: "api.ecr.dkr-us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "api.ecr.dkr-us-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "ecr-fips.us-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+    signingRegion: "us-east-1",
+  },
+  "dkr-us-east-2": {
+    hostname: "api.ecr.dkr-us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "api.ecr.dkr-us-east-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "ecr-fips.us-east-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+    signingRegion: "us-east-2",
+  },
+  "dkr-us-gov-east-1": {
+    hostname: "api.ecr.dkr-us-gov-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "api.ecr.dkr-us-gov-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "ecr-fips.us-gov-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+    signingRegion: "us-gov-east-1",
+  },
+  "dkr-us-gov-west-1": {
+    hostname: "api.ecr.dkr-us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "api.ecr.dkr-us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "ecr-fips.us-gov-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+    signingRegion: "us-gov-west-1",
+  },
+  "dkr-us-west-1": {
+    hostname: "api.ecr.dkr-us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "api.ecr.dkr-us-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "ecr-fips.us-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+    signingRegion: "us-west-1",
+  },
+  "dkr-us-west-2": {
+    hostname: "api.ecr.dkr-us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "api.ecr.dkr-us-west-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "ecr-fips.us-west-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+    signingRegion: "us-west-2",
   },
   "eu-central-1": {
     hostname: "api.ecr.eu-central-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "api.ecr.eu-central-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "eu-central-1",
   },
   "eu-north-1": {
     hostname: "api.ecr.eu-north-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "api.ecr.eu-north-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "eu-north-1",
   },
   "eu-south-1": {
     hostname: "api.ecr.eu-south-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "api.ecr.eu-south-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "eu-south-1",
   },
   "eu-west-1": {
     hostname: "api.ecr.eu-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "api.ecr.eu-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "eu-west-1",
   },
   "eu-west-2": {
     hostname: "api.ecr.eu-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "api.ecr.eu-west-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "eu-west-2",
   },
   "eu-west-3": {
     hostname: "api.ecr.eu-west-3.amazonaws.com",
+    variants: [
+      {
+        hostname: "api.ecr.eu-west-3.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "eu-west-3",
   },
   "fips-dkr-us-east-1": {
     hostname: "ecr-fips.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "ecr-fips.us-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-1",
   },
   "fips-dkr-us-east-2": {
     hostname: "ecr-fips.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "ecr-fips.us-east-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-2",
   },
   "fips-dkr-us-gov-east-1": {
     hostname: "ecr-fips.us-gov-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "ecr-fips.us-gov-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-east-1",
   },
   "fips-dkr-us-gov-west-1": {
     hostname: "ecr-fips.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "ecr-fips.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-west-1",
   },
   "fips-dkr-us-west-1": {
     hostname: "ecr-fips.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "ecr-fips.us-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-1",
   },
   "fips-dkr-us-west-2": {
     hostname: "ecr-fips.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "ecr-fips.us-west-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-2",
   },
   "fips-us-east-1": {
     hostname: "ecr-fips.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "ecr-fips.us-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-1",
   },
   "fips-us-east-2": {
     hostname: "ecr-fips.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "ecr-fips.us-east-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-2",
   },
   "fips-us-gov-east-1": {
     hostname: "ecr-fips.us-gov-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "ecr-fips.us-gov-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-east-1",
   },
   "fips-us-gov-west-1": {
     hostname: "ecr-fips.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "ecr-fips.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-west-1",
   },
   "fips-us-west-1": {
     hostname: "ecr-fips.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "ecr-fips.us-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-1",
   },
   "fips-us-west-2": {
     hostname: "ecr-fips.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "ecr-fips.us-west-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-2",
   },
   "me-south-1": {
     hostname: "api.ecr.me-south-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "api.ecr.me-south-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "me-south-1",
   },
   "sa-east-1": {
     hostname: "api.ecr.sa-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "api.ecr.sa-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "sa-east-1",
   },
   "us-east-1": {
     hostname: "api.ecr.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "api.ecr.us-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "ecr-fips.us-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
     signingRegion: "us-east-1",
   },
   "us-east-2": {
     hostname: "api.ecr.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "api.ecr.us-east-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "ecr-fips.us-east-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
     signingRegion: "us-east-2",
   },
   "us-gov-east-1": {
     hostname: "api.ecr.us-gov-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "api.ecr.us-gov-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "ecr-fips.us-gov-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
     signingRegion: "us-gov-east-1",
   },
   "us-gov-west-1": {
     hostname: "api.ecr.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "api.ecr.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "ecr-fips.us-gov-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
     signingRegion: "us-gov-west-1",
   },
   "us-iso-east-1": {
     hostname: "api.ecr.us-iso-east-1.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "api.ecr.us-iso-east-1.c2s.ic.gov",
+        tags: [],
+      },
+    ],
     signingRegion: "us-iso-east-1",
   },
   "us-iso-west-1": {
     hostname: "api.ecr.us-iso-west-1.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "api.ecr.us-iso-west-1.c2s.ic.gov",
+        tags: [],
+      },
+    ],
     signingRegion: "us-iso-west-1",
   },
   "us-isob-east-1": {
     hostname: "api.ecr.us-isob-east-1.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "api.ecr.us-isob-east-1.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
     signingRegion: "us-isob-east-1",
   },
   "us-west-1": {
     hostname: "api.ecr.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "api.ecr.us-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "ecr-fips.us-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
     signingRegion: "us-west-1",
   },
   "us-west-2": {
     hostname: "api.ecr.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "api.ecr.us-west-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "ecr-fips.us-west-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
     signingRegion: "us-west-2",
   },
 };
@@ -203,21 +551,61 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "api.ecr.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "api.ecr.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "ecr-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "api.ecr.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "api.ecr.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "api.ecr-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "api.ecr-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "api.ecr.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "api.ecr.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "api.ecr.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "api.ecr.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "api.ecr.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: [
@@ -232,6 +620,16 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "api.ecr.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "api.ecr.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "ecr-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
 };
 

--- a/clients/client-ecs/src/endpoints.ts
+++ b/clients/client-ecs/src/endpoints.ts
@@ -4,27 +4,141 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 const regionHash: RegionHash = {
   "fips-us-east-1": {
     hostname: "ecs-fips.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "ecs-fips.us-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-1",
   },
   "fips-us-east-2": {
     hostname: "ecs-fips.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "ecs-fips.us-east-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-2",
   },
   "fips-us-gov-east-1": {
     hostname: "ecs-fips.us-gov-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "ecs-fips.us-gov-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-east-1",
   },
   "fips-us-gov-west-1": {
     hostname: "ecs-fips.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "ecs-fips.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-west-1",
   },
   "fips-us-west-1": {
     hostname: "ecs-fips.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "ecs-fips.us-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-1",
   },
   "fips-us-west-2": {
     hostname: "ecs-fips.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "ecs-fips.us-west-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-2",
+  },
+  "us-east-1": {
+    hostname: "ecs.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "ecs.us-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "ecs-fips.us-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-east-2": {
+    hostname: "ecs.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "ecs.us-east-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "ecs-fips.us-east-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-gov-east-1": {
+    hostname: "ecs.us-gov-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "ecs.us-gov-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "ecs-fips.us-gov-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-gov-west-1": {
+    hostname: "ecs.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "ecs.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "ecs-fips.us-gov-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-west-1": {
+    hostname: "ecs.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "ecs.us-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "ecs-fips.us-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-west-2": {
+    hostname: "ecs.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "ecs.us-west-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "ecs-fips.us-west-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
 };
 
@@ -59,26 +173,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "ecs.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "ecs.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "ecs-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "ecs-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "ecs.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "ecs.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "ecs.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "ecs-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "ecs-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "ecs.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "ecs.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "ecs.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "ecs.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "ecs.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["fips-us-gov-east-1", "fips-us-gov-west-1", "us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "ecs.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "ecs.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "ecs-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "ecs-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "ecs.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-efs/src/endpoints.ts
+++ b/clients/client-efs/src/endpoints.ts
@@ -2,109 +2,603 @@ import { getRegionInfo, PartitionHash, RegionHash } from "@aws-sdk/config-resolv
 import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
+  "af-south-1": {
+    hostname: "elasticfilesystem.af-south-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "elasticfilesystem.af-south-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "elasticfilesystem-fips.af-south-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "ap-east-1": {
+    hostname: "elasticfilesystem.ap-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "elasticfilesystem.ap-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "elasticfilesystem-fips.ap-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "ap-northeast-1": {
+    hostname: "elasticfilesystem.ap-northeast-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "elasticfilesystem.ap-northeast-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "elasticfilesystem-fips.ap-northeast-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "ap-northeast-2": {
+    hostname: "elasticfilesystem.ap-northeast-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "elasticfilesystem.ap-northeast-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "elasticfilesystem-fips.ap-northeast-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "ap-northeast-3": {
+    hostname: "elasticfilesystem.ap-northeast-3.amazonaws.com",
+    variants: [
+      {
+        hostname: "elasticfilesystem.ap-northeast-3.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "elasticfilesystem-fips.ap-northeast-3.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "ap-south-1": {
+    hostname: "elasticfilesystem.ap-south-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "elasticfilesystem.ap-south-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "elasticfilesystem-fips.ap-south-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "ap-southeast-1": {
+    hostname: "elasticfilesystem.ap-southeast-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "elasticfilesystem.ap-southeast-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "elasticfilesystem-fips.ap-southeast-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "ap-southeast-2": {
+    hostname: "elasticfilesystem.ap-southeast-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "elasticfilesystem.ap-southeast-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "elasticfilesystem-fips.ap-southeast-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "ca-central-1": {
+    hostname: "elasticfilesystem.ca-central-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "elasticfilesystem.ca-central-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "elasticfilesystem-fips.ca-central-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "cn-north-1": {
+    hostname: "elasticfilesystem.cn-north-1.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "elasticfilesystem.cn-north-1.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "elasticfilesystem-fips.cn-north-1.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "cn-northwest-1": {
+    hostname: "elasticfilesystem.cn-northwest-1.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "elasticfilesystem.cn-northwest-1.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "elasticfilesystem-fips.cn-northwest-1.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "eu-central-1": {
+    hostname: "elasticfilesystem.eu-central-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "elasticfilesystem.eu-central-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "elasticfilesystem-fips.eu-central-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "eu-north-1": {
+    hostname: "elasticfilesystem.eu-north-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "elasticfilesystem.eu-north-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "elasticfilesystem-fips.eu-north-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "eu-south-1": {
+    hostname: "elasticfilesystem.eu-south-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "elasticfilesystem.eu-south-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "elasticfilesystem-fips.eu-south-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "eu-west-1": {
+    hostname: "elasticfilesystem.eu-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "elasticfilesystem.eu-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "elasticfilesystem-fips.eu-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "eu-west-2": {
+    hostname: "elasticfilesystem.eu-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "elasticfilesystem.eu-west-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "elasticfilesystem-fips.eu-west-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "eu-west-3": {
+    hostname: "elasticfilesystem.eu-west-3.amazonaws.com",
+    variants: [
+      {
+        hostname: "elasticfilesystem.eu-west-3.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "elasticfilesystem-fips.eu-west-3.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
   "fips-af-south-1": {
     hostname: "elasticfilesystem-fips.af-south-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "elasticfilesystem-fips.af-south-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "af-south-1",
   },
   "fips-ap-east-1": {
     hostname: "elasticfilesystem-fips.ap-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "elasticfilesystem-fips.ap-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "ap-east-1",
   },
   "fips-ap-northeast-1": {
     hostname: "elasticfilesystem-fips.ap-northeast-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "elasticfilesystem-fips.ap-northeast-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "ap-northeast-1",
   },
   "fips-ap-northeast-2": {
     hostname: "elasticfilesystem-fips.ap-northeast-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "elasticfilesystem-fips.ap-northeast-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "ap-northeast-2",
   },
   "fips-ap-northeast-3": {
     hostname: "elasticfilesystem-fips.ap-northeast-3.amazonaws.com",
+    variants: [
+      {
+        hostname: "elasticfilesystem-fips.ap-northeast-3.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "ap-northeast-3",
   },
   "fips-ap-south-1": {
     hostname: "elasticfilesystem-fips.ap-south-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "elasticfilesystem-fips.ap-south-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "ap-south-1",
   },
   "fips-ap-southeast-1": {
     hostname: "elasticfilesystem-fips.ap-southeast-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "elasticfilesystem-fips.ap-southeast-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "ap-southeast-1",
   },
   "fips-ap-southeast-2": {
     hostname: "elasticfilesystem-fips.ap-southeast-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "elasticfilesystem-fips.ap-southeast-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "ap-southeast-2",
   },
   "fips-ca-central-1": {
     hostname: "elasticfilesystem-fips.ca-central-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "elasticfilesystem-fips.ca-central-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "ca-central-1",
   },
   "fips-cn-north-1": {
     hostname: "elasticfilesystem-fips.cn-north-1.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "elasticfilesystem-fips.cn-north-1.amazonaws.com.cn",
+        tags: [],
+      },
+    ],
     signingRegion: "cn-north-1",
   },
   "fips-cn-northwest-1": {
     hostname: "elasticfilesystem-fips.cn-northwest-1.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "elasticfilesystem-fips.cn-northwest-1.amazonaws.com.cn",
+        tags: [],
+      },
+    ],
     signingRegion: "cn-northwest-1",
   },
   "fips-eu-central-1": {
     hostname: "elasticfilesystem-fips.eu-central-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "elasticfilesystem-fips.eu-central-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "eu-central-1",
   },
   "fips-eu-north-1": {
     hostname: "elasticfilesystem-fips.eu-north-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "elasticfilesystem-fips.eu-north-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "eu-north-1",
   },
   "fips-eu-south-1": {
     hostname: "elasticfilesystem-fips.eu-south-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "elasticfilesystem-fips.eu-south-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "eu-south-1",
   },
   "fips-eu-west-1": {
     hostname: "elasticfilesystem-fips.eu-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "elasticfilesystem-fips.eu-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "eu-west-1",
   },
   "fips-eu-west-2": {
     hostname: "elasticfilesystem-fips.eu-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "elasticfilesystem-fips.eu-west-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "eu-west-2",
   },
   "fips-eu-west-3": {
     hostname: "elasticfilesystem-fips.eu-west-3.amazonaws.com",
+    variants: [
+      {
+        hostname: "elasticfilesystem-fips.eu-west-3.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "eu-west-3",
   },
   "fips-me-south-1": {
     hostname: "elasticfilesystem-fips.me-south-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "elasticfilesystem-fips.me-south-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "me-south-1",
   },
   "fips-sa-east-1": {
     hostname: "elasticfilesystem-fips.sa-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "elasticfilesystem-fips.sa-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "sa-east-1",
   },
   "fips-us-east-1": {
     hostname: "elasticfilesystem-fips.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "elasticfilesystem-fips.us-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-1",
   },
   "fips-us-east-2": {
     hostname: "elasticfilesystem-fips.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "elasticfilesystem-fips.us-east-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-2",
   },
   "fips-us-gov-east-1": {
     hostname: "elasticfilesystem-fips.us-gov-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "elasticfilesystem-fips.us-gov-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-east-1",
   },
   "fips-us-gov-west-1": {
     hostname: "elasticfilesystem-fips.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "elasticfilesystem-fips.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-west-1",
   },
   "fips-us-iso-east-1": {
     hostname: "elasticfilesystem-fips.us-iso-east-1.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "elasticfilesystem-fips.us-iso-east-1.c2s.ic.gov",
+        tags: [],
+      },
+    ],
     signingRegion: "us-iso-east-1",
   },
   "fips-us-west-1": {
     hostname: "elasticfilesystem-fips.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "elasticfilesystem-fips.us-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-1",
   },
   "fips-us-west-2": {
     hostname: "elasticfilesystem-fips.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "elasticfilesystem-fips.us-west-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-2",
+  },
+  "me-south-1": {
+    hostname: "elasticfilesystem.me-south-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "elasticfilesystem.me-south-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "elasticfilesystem-fips.me-south-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "sa-east-1": {
+    hostname: "elasticfilesystem.sa-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "elasticfilesystem.sa-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "elasticfilesystem-fips.sa-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-east-1": {
+    hostname: "elasticfilesystem.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "elasticfilesystem.us-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "elasticfilesystem-fips.us-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-east-2": {
+    hostname: "elasticfilesystem.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "elasticfilesystem.us-east-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "elasticfilesystem-fips.us-east-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-gov-east-1": {
+    hostname: "elasticfilesystem.us-gov-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "elasticfilesystem.us-gov-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "elasticfilesystem-fips.us-gov-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-gov-west-1": {
+    hostname: "elasticfilesystem.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "elasticfilesystem.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "elasticfilesystem-fips.us-gov-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-iso-east-1": {
+    hostname: "elasticfilesystem.us-iso-east-1.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "elasticfilesystem.us-iso-east-1.c2s.ic.gov",
+        tags: [],
+      },
+      {
+        hostname: "elasticfilesystem-fips.us-iso-east-1.c2s.ic.gov",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-west-1": {
+    hostname: "elasticfilesystem.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "elasticfilesystem.us-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "elasticfilesystem-fips.us-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-west-2": {
+    hostname: "elasticfilesystem.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "elasticfilesystem.us-west-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "elasticfilesystem-fips.us-west-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
 };
 
@@ -156,26 +650,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "elasticfilesystem.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "elasticfilesystem.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "elasticfilesystem-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "elasticfilesystem-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "elasticfilesystem.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1", "fips-cn-north-1", "fips-cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "elasticfilesystem.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "elasticfilesystem.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "elasticfilesystem-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "elasticfilesystem-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "elasticfilesystem.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["fips-us-iso-east-1", "us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "elasticfilesystem.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "elasticfilesystem.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "elasticfilesystem.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "elasticfilesystem.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["fips-us-gov-east-1", "fips-us-gov-west-1", "us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "elasticfilesystem.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "elasticfilesystem.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "elasticfilesystem-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "elasticfilesystem-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "elasticfilesystem.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-eks/src/endpoints.ts
+++ b/clients/client-eks/src/endpoints.ts
@@ -4,27 +4,141 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 const regionHash: RegionHash = {
   "fips-us-east-1": {
     hostname: "fips.eks.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "fips.eks.us-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-1",
   },
   "fips-us-east-2": {
     hostname: "fips.eks.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "fips.eks.us-east-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-2",
   },
   "fips-us-gov-east-1": {
     hostname: "eks.us-gov-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "eks.us-gov-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-east-1",
   },
   "fips-us-gov-west-1": {
     hostname: "eks.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "eks.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-west-1",
   },
   "fips-us-west-1": {
     hostname: "fips.eks.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "fips.eks.us-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-1",
   },
   "fips-us-west-2": {
     hostname: "fips.eks.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "fips.eks.us-west-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-2",
+  },
+  "us-east-1": {
+    hostname: "eks.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "eks.us-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "fips.eks.us-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-east-2": {
+    hostname: "eks.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "eks.us-east-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "fips.eks.us-east-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-gov-east-1": {
+    hostname: "eks.us-gov-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "eks.us-gov-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "eks.us-gov-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-gov-west-1": {
+    hostname: "eks.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "eks.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "eks.us-gov-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-west-1": {
+    hostname: "eks.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "eks.us-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "fips.eks.us-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-west-2": {
+    hostname: "eks.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "eks.us-west-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "fips.eks.us-west-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
 };
 
@@ -59,26 +173,76 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "eks.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "eks.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "fips.eks.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "eks.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "eks.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "eks-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "eks-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "eks.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "eks.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "eks.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "eks.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "eks.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["fips-us-gov-east-1", "fips-us-gov-west-1", "us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "eks.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "eks.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "eks.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
 };
 

--- a/clients/client-elastic-beanstalk/src/endpoints.ts
+++ b/clients/client-elastic-beanstalk/src/endpoints.ts
@@ -4,27 +4,115 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 const regionHash: RegionHash = {
   "fips-us-east-1": {
     hostname: "elasticbeanstalk-fips.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "elasticbeanstalk-fips.us-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-1",
   },
   "fips-us-east-2": {
     hostname: "elasticbeanstalk-fips.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "elasticbeanstalk-fips.us-east-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-2",
   },
   "fips-us-west-1": {
     hostname: "elasticbeanstalk-fips.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "elasticbeanstalk-fips.us-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-1",
   },
   "fips-us-west-2": {
     hostname: "elasticbeanstalk-fips.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "elasticbeanstalk-fips.us-west-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-2",
+  },
+  "us-east-1": {
+    hostname: "elasticbeanstalk.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "elasticbeanstalk.us-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "elasticbeanstalk-fips.us-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-east-2": {
+    hostname: "elasticbeanstalk.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "elasticbeanstalk.us-east-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "elasticbeanstalk-fips.us-east-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "us-gov-east-1": {
     hostname: "elasticbeanstalk.us-gov-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "elasticbeanstalk.us-gov-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-east-1",
   },
   "us-gov-west-1": {
     hostname: "elasticbeanstalk.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "elasticbeanstalk.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-west-1",
+  },
+  "us-west-1": {
+    hostname: "elasticbeanstalk.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "elasticbeanstalk.us-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "elasticbeanstalk-fips.us-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-west-2": {
+    hostname: "elasticbeanstalk.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "elasticbeanstalk.us-west-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "elasticbeanstalk-fips.us-west-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
 };
 
@@ -59,26 +147,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "elasticbeanstalk.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "elasticbeanstalk.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "elasticbeanstalk-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "elasticbeanstalk-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "elasticbeanstalk.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "elasticbeanstalk.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "elasticbeanstalk.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "elasticbeanstalk-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "elasticbeanstalk-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "elasticbeanstalk.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "elasticbeanstalk.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "elasticbeanstalk.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "elasticbeanstalk.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "elasticbeanstalk.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "elasticbeanstalk.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "elasticbeanstalk.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "elasticbeanstalk-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "elasticbeanstalk-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "elasticbeanstalk.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-elastic-inference/src/endpoints.ts
+++ b/clients/client-elastic-inference/src/endpoints.ts
@@ -4,21 +4,57 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 const regionHash: RegionHash = {
   "ap-northeast-1": {
     hostname: "api.elastic-inference.ap-northeast-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "api.elastic-inference.ap-northeast-1.amazonaws.com",
+        tags: [],
+      },
+    ],
   },
   "ap-northeast-2": {
     hostname: "api.elastic-inference.ap-northeast-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "api.elastic-inference.ap-northeast-2.amazonaws.com",
+        tags: [],
+      },
+    ],
   },
   "eu-west-1": {
     hostname: "api.elastic-inference.eu-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "api.elastic-inference.eu-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
   },
   "us-east-1": {
     hostname: "api.elastic-inference.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "api.elastic-inference.us-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
   },
   "us-east-2": {
     hostname: "api.elastic-inference.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "api.elastic-inference.us-east-2.amazonaws.com",
+        tags: [],
+      },
+    ],
   },
   "us-west-2": {
     hostname: "api.elastic-inference.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "api.elastic-inference.us-west-2.amazonaws.com",
+        tags: [],
+      },
+    ],
   },
 };
 
@@ -49,26 +85,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "api.elastic-inference.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "api.elastic-inference.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "api.elastic-inference-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "api.elastic-inference-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "api.elastic-inference.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "api.elastic-inference.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "api.elastic-inference.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "api.elastic-inference-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "api.elastic-inference-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "api.elastic-inference.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "api.elastic-inference.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "api.elastic-inference.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "api.elastic-inference.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "api.elastic-inference.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "api.elastic-inference.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "api.elastic-inference.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "api.elastic-inference-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "api.elastic-inference-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "api.elastic-inference.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-elastic-load-balancing-v2/src/endpoints.ts
+++ b/clients/client-elastic-load-balancing-v2/src/endpoints.ts
@@ -4,27 +4,141 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 const regionHash: RegionHash = {
   "fips-us-east-1": {
     hostname: "elasticloadbalancing-fips.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "elasticloadbalancing-fips.us-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-1",
   },
   "fips-us-east-2": {
     hostname: "elasticloadbalancing-fips.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "elasticloadbalancing-fips.us-east-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-2",
   },
   "fips-us-gov-east-1": {
     hostname: "elasticloadbalancing.us-gov-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "elasticloadbalancing.us-gov-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-east-1",
   },
   "fips-us-gov-west-1": {
     hostname: "elasticloadbalancing.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "elasticloadbalancing.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-west-1",
   },
   "fips-us-west-1": {
     hostname: "elasticloadbalancing-fips.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "elasticloadbalancing-fips.us-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-1",
   },
   "fips-us-west-2": {
     hostname: "elasticloadbalancing-fips.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "elasticloadbalancing-fips.us-west-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-2",
+  },
+  "us-east-1": {
+    hostname: "elasticloadbalancing.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "elasticloadbalancing.us-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "elasticloadbalancing-fips.us-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-east-2": {
+    hostname: "elasticloadbalancing.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "elasticloadbalancing.us-east-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "elasticloadbalancing-fips.us-east-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-gov-east-1": {
+    hostname: "elasticloadbalancing.us-gov-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "elasticloadbalancing.us-gov-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "elasticloadbalancing.us-gov-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-gov-west-1": {
+    hostname: "elasticloadbalancing.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "elasticloadbalancing.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "elasticloadbalancing.us-gov-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-west-1": {
+    hostname: "elasticloadbalancing.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "elasticloadbalancing.us-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "elasticloadbalancing-fips.us-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-west-2": {
+    hostname: "elasticloadbalancing.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "elasticloadbalancing.us-west-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "elasticloadbalancing-fips.us-west-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
 };
 
@@ -59,26 +173,84 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "elasticloadbalancing.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "elasticloadbalancing.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "elasticloadbalancing-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "elasticloadbalancing-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "elasticloadbalancing.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "elasticloadbalancing.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "elasticloadbalancing.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "elasticloadbalancing-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "elasticloadbalancing-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "elasticloadbalancing.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "elasticloadbalancing.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "elasticloadbalancing.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "elasticloadbalancing.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "elasticloadbalancing.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["fips-us-gov-east-1", "fips-us-gov-west-1", "us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "elasticloadbalancing.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "elasticloadbalancing.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "elasticloadbalancing.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
 };
 

--- a/clients/client-elastic-load-balancing/src/endpoints.ts
+++ b/clients/client-elastic-load-balancing/src/endpoints.ts
@@ -4,27 +4,141 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 const regionHash: RegionHash = {
   "fips-us-east-1": {
     hostname: "elasticloadbalancing-fips.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "elasticloadbalancing-fips.us-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-1",
   },
   "fips-us-east-2": {
     hostname: "elasticloadbalancing-fips.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "elasticloadbalancing-fips.us-east-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-2",
   },
   "fips-us-gov-east-1": {
     hostname: "elasticloadbalancing.us-gov-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "elasticloadbalancing.us-gov-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-east-1",
   },
   "fips-us-gov-west-1": {
     hostname: "elasticloadbalancing.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "elasticloadbalancing.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-west-1",
   },
   "fips-us-west-1": {
     hostname: "elasticloadbalancing-fips.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "elasticloadbalancing-fips.us-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-1",
   },
   "fips-us-west-2": {
     hostname: "elasticloadbalancing-fips.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "elasticloadbalancing-fips.us-west-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-2",
+  },
+  "us-east-1": {
+    hostname: "elasticloadbalancing.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "elasticloadbalancing.us-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "elasticloadbalancing-fips.us-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-east-2": {
+    hostname: "elasticloadbalancing.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "elasticloadbalancing.us-east-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "elasticloadbalancing-fips.us-east-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-gov-east-1": {
+    hostname: "elasticloadbalancing.us-gov-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "elasticloadbalancing.us-gov-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "elasticloadbalancing.us-gov-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-gov-west-1": {
+    hostname: "elasticloadbalancing.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "elasticloadbalancing.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "elasticloadbalancing.us-gov-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-west-1": {
+    hostname: "elasticloadbalancing.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "elasticloadbalancing.us-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "elasticloadbalancing-fips.us-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-west-2": {
+    hostname: "elasticloadbalancing.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "elasticloadbalancing.us-west-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "elasticloadbalancing-fips.us-west-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
 };
 
@@ -59,26 +173,84 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "elasticloadbalancing.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "elasticloadbalancing.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "elasticloadbalancing-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "elasticloadbalancing-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "elasticloadbalancing.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "elasticloadbalancing.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "elasticloadbalancing.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "elasticloadbalancing-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "elasticloadbalancing-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "elasticloadbalancing.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "elasticloadbalancing.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "elasticloadbalancing.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "elasticloadbalancing.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "elasticloadbalancing.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["fips-us-gov-east-1", "fips-us-gov-west-1", "us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "elasticloadbalancing.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "elasticloadbalancing.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "elasticloadbalancing.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
 };
 

--- a/clients/client-elastic-transcoder/src/endpoints.ts
+++ b/clients/client-elastic-transcoder/src/endpoints.ts
@@ -30,26 +30,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "elastictranscoder.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "elastictranscoder.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "elastictranscoder-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "elastictranscoder-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "elastictranscoder.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "elastictranscoder.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "elastictranscoder.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "elastictranscoder-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "elastictranscoder-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "elastictranscoder.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "elastictranscoder.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "elastictranscoder.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "elastictranscoder.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "elastictranscoder.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "elastictranscoder.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "elastictranscoder.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "elastictranscoder-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "elastictranscoder-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "elastictranscoder.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-elasticache/src/endpoints.ts
+++ b/clients/client-elasticache/src/endpoints.ts
@@ -4,26 +4,127 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 const regionHash: RegionHash = {
   fips: {
     hostname: "elasticache.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "elasticache.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-west-1",
+  },
+  "us-east-1": {
+    hostname: "elasticache.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "elasticache.us-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "elasticache-fips.us-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "us-east-1-fips": {
     hostname: "elasticache-fips.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "elasticache-fips.us-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-1",
+  },
+  "us-east-2": {
+    hostname: "elasticache.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "elasticache.us-east-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "elasticache-fips.us-east-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "us-east-2-fips": {
     hostname: "elasticache-fips.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "elasticache-fips.us-east-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-2",
+  },
+  "us-gov-west-1": {
+    hostname: "elasticache.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "elasticache.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "elasticache.us-gov-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "us-gov-west-1-fips": {
     hostname: "elasticache.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "elasticache.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-west-1",
+  },
+  "us-west-1": {
+    hostname: "elasticache.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "elasticache.us-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "elasticache-fips.us-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "us-west-1-fips": {
     hostname: "elasticache-fips.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "elasticache-fips.us-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-1",
+  },
+  "us-west-2": {
+    hostname: "elasticache.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "elasticache.us-west-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "elasticache-fips.us-west-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "us-west-2-fips": {
     hostname: "elasticache-fips.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "elasticache-fips.us-west-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-2",
   },
 };
@@ -60,26 +161,84 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "elasticache.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "elasticache.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "elasticache-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "elasticache-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "elasticache.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "elasticache.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "elasticache.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "elasticache-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "elasticache-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "elasticache.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "elasticache.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "elasticache.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "elasticache.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "elasticache.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["fips", "us-gov-east-1", "us-gov-west-1", "us-gov-west-1-fips"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "elasticache.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "elasticache.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "elasticache.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
 };
 

--- a/clients/client-elasticsearch-service/src/endpoints.ts
+++ b/clients/client-elasticsearch-service/src/endpoints.ts
@@ -4,30 +4,150 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 const regionHash: RegionHash = {
   fips: {
     hostname: "es-fips.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "es-fips.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-west-1",
+  },
+  "us-east-1": {
+    hostname: "es.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "es.us-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "es-fips.us-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "us-east-1-fips": {
     hostname: "es-fips.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "es-fips.us-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-1",
+  },
+  "us-east-2": {
+    hostname: "es.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "es.us-east-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "es-fips.us-east-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "us-east-2-fips": {
     hostname: "es-fips.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "es-fips.us-east-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-2",
+  },
+  "us-gov-east-1": {
+    hostname: "es.us-gov-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "es.us-gov-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "es-fips.us-gov-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "us-gov-east-1-fips": {
     hostname: "es-fips.us-gov-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "es-fips.us-gov-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-east-1",
+  },
+  "us-gov-west-1": {
+    hostname: "es.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "es.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "es-fips.us-gov-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "us-gov-west-1-fips": {
     hostname: "es-fips.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "es-fips.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-west-1",
+  },
+  "us-west-1": {
+    hostname: "es.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "es.us-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "es-fips.us-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "us-west-1-fips": {
     hostname: "es-fips.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "es-fips.us-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-1",
+  },
+  "us-west-2": {
+    hostname: "es.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "es.us-west-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "es-fips.us-west-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "us-west-2-fips": {
     hostname: "es-fips.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "es-fips.us-west-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-2",
   },
 };
@@ -64,26 +184,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "es.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "es.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "es-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "es-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "es.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "es.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "es.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "es-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "es-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "es.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "es.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "es.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "es.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "es.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["fips", "us-gov-east-1", "us-gov-east-1-fips", "us-gov-west-1", "us-gov-west-1-fips"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "es.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "es.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "es-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "es-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "es.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-emr-containers/src/endpoints.ts
+++ b/clients/client-emr-containers/src/endpoints.ts
@@ -2,25 +2,120 @@ import { getRegionInfo, PartitionHash, RegionHash } from "@aws-sdk/config-resolv
 import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
+  "ca-central-1": {
+    hostname: "emr-containers.ca-central-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "emr-containers.ca-central-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "emr-containers-fips.ca-central-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
   "fips-ca-central-1": {
     hostname: "emr-containers-fips.ca-central-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "emr-containers-fips.ca-central-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "ca-central-1",
   },
   "fips-us-east-1": {
     hostname: "emr-containers-fips.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "emr-containers-fips.us-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-1",
   },
   "fips-us-east-2": {
     hostname: "emr-containers-fips.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "emr-containers-fips.us-east-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-2",
   },
   "fips-us-west-1": {
     hostname: "emr-containers-fips.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "emr-containers-fips.us-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-1",
   },
   "fips-us-west-2": {
     hostname: "emr-containers-fips.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "emr-containers-fips.us-west-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-2",
+  },
+  "us-east-1": {
+    hostname: "emr-containers.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "emr-containers.us-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "emr-containers-fips.us-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-east-2": {
+    hostname: "emr-containers.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "emr-containers.us-east-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "emr-containers-fips.us-east-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-west-1": {
+    hostname: "emr-containers.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "emr-containers.us-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "emr-containers-fips.us-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-west-2": {
+    hostname: "emr-containers.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "emr-containers.us-west-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "emr-containers-fips.us-west-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
 };
 
@@ -56,26 +151,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "emr-containers.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "emr-containers.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "emr-containers-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "emr-containers-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "emr-containers.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "emr-containers.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "emr-containers.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "emr-containers-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "emr-containers-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "emr-containers.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "emr-containers.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "emr-containers.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "emr-containers.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "emr-containers.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "emr-containers.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "emr-containers.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "emr-containers-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "emr-containers-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "emr-containers.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-emr/src/endpoints.ts
+++ b/clients/client-emr/src/endpoints.ts
@@ -2,33 +2,166 @@ import { getRegionInfo, PartitionHash, RegionHash } from "@aws-sdk/config-resolv
 import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
+  "ca-central-1": {
+    hostname: "elasticmapreduce.ca-central-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "elasticmapreduce.ca-central-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "elasticmapreduce-fips.ca-central-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
   "fips-ca-central-1": {
     hostname: "elasticmapreduce-fips.ca-central-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "elasticmapreduce-fips.ca-central-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "ca-central-1",
   },
   "fips-us-east-1": {
     hostname: "elasticmapreduce-fips.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "elasticmapreduce-fips.us-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-1",
   },
   "fips-us-east-2": {
     hostname: "elasticmapreduce-fips.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "elasticmapreduce-fips.us-east-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-2",
   },
   "fips-us-gov-east-1": {
     hostname: "elasticmapreduce.us-gov-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "elasticmapreduce.us-gov-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-east-1",
   },
   "fips-us-gov-west-1": {
     hostname: "elasticmapreduce.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "elasticmapreduce.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-west-1",
   },
   "fips-us-west-1": {
     hostname: "elasticmapreduce-fips.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "elasticmapreduce-fips.us-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-1",
   },
   "fips-us-west-2": {
     hostname: "elasticmapreduce-fips.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "elasticmapreduce-fips.us-west-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-2",
+  },
+  "us-east-1": {
+    hostname: "elasticmapreduce.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "elasticmapreduce.us-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "elasticmapreduce-fips.us-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-east-2": {
+    hostname: "elasticmapreduce.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "elasticmapreduce.us-east-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "elasticmapreduce-fips.us-east-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-gov-east-1": {
+    hostname: "elasticmapreduce.us-gov-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "elasticmapreduce.us-gov-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "elasticmapreduce.us-gov-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-gov-west-1": {
+    hostname: "elasticmapreduce.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "elasticmapreduce.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "elasticmapreduce.us-gov-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-west-1": {
+    hostname: "elasticmapreduce.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "elasticmapreduce.us-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "elasticmapreduce-fips.us-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-west-2": {
+    hostname: "elasticmapreduce.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "elasticmapreduce.us-west-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "elasticmapreduce-fips.us-west-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
 };
 
@@ -64,26 +197,84 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "elasticmapreduce.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "elasticmapreduce.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "elasticmapreduce-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "elasticmapreduce-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "elasticmapreduce.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "elasticmapreduce.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "elasticmapreduce.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "elasticmapreduce-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "elasticmapreduce-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "elasticmapreduce.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "elasticmapreduce.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "elasticmapreduce.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "elasticmapreduce.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "elasticmapreduce.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["fips-us-gov-east-1", "fips-us-gov-west-1", "us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "elasticmapreduce.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "elasticmapreduce.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "elasticmapreduce.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
 };
 

--- a/clients/client-eventbridge/src/endpoints.ts
+++ b/clients/client-eventbridge/src/endpoints.ts
@@ -4,27 +4,115 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 const regionHash: RegionHash = {
   "fips-us-east-1": {
     hostname: "events-fips.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "events-fips.us-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-1",
   },
   "fips-us-east-2": {
     hostname: "events-fips.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "events-fips.us-east-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-2",
   },
   "fips-us-west-1": {
     hostname: "events-fips.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "events-fips.us-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-1",
   },
   "fips-us-west-2": {
     hostname: "events-fips.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "events-fips.us-west-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-2",
+  },
+  "us-east-1": {
+    hostname: "events.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "events.us-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "events-fips.us-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-east-2": {
+    hostname: "events.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "events.us-east-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "events-fips.us-east-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "us-gov-east-1": {
     hostname: "events.us-gov-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "events.us-gov-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-east-1",
   },
   "us-gov-west-1": {
     hostname: "events.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "events.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-west-1",
+  },
+  "us-west-1": {
+    hostname: "events.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "events.us-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "events-fips.us-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-west-2": {
+    hostname: "events.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "events.us-west-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "events-fips.us-west-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
 };
 
@@ -59,26 +147,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "events.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "events.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "events-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "events-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "events.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "events.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "events.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "events-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "events-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "events.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "events.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "events.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "events.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "events.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "events.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "events.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "events-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "events-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "events.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-finspace-data/src/endpoints.ts
+++ b/clients/client-finspace-data/src/endpoints.ts
@@ -30,26 +30,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "finspace-api.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "finspace-api.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "finspace-api-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "finspace-api-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "finspace-api.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "finspace-api.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "finspace-api.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "finspace-api-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "finspace-api-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "finspace-api.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "finspace-api.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "finspace-api.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "finspace-api.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "finspace-api.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "finspace-api.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "finspace-api.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "finspace-api-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "finspace-api-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "finspace-api.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-finspace/src/endpoints.ts
+++ b/clients/client-finspace/src/endpoints.ts
@@ -30,26 +30,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "finspace.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "finspace.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "finspace-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "finspace-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "finspace.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "finspace.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "finspace.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "finspace-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "finspace-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "finspace.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "finspace.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "finspace.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "finspace.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "finspace.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "finspace.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "finspace.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "finspace-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "finspace-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "finspace.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-firehose/src/endpoints.ts
+++ b/clients/client-firehose/src/endpoints.ts
@@ -4,27 +4,141 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 const regionHash: RegionHash = {
   "fips-us-east-1": {
     hostname: "firehose-fips.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "firehose-fips.us-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-1",
   },
   "fips-us-east-2": {
     hostname: "firehose-fips.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "firehose-fips.us-east-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-2",
   },
   "fips-us-gov-east-1": {
     hostname: "firehose-fips.us-gov-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "firehose-fips.us-gov-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-east-1",
   },
   "fips-us-gov-west-1": {
     hostname: "firehose-fips.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "firehose-fips.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-west-1",
   },
   "fips-us-west-1": {
     hostname: "firehose-fips.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "firehose-fips.us-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-1",
   },
   "fips-us-west-2": {
     hostname: "firehose-fips.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "firehose-fips.us-west-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-2",
+  },
+  "us-east-1": {
+    hostname: "firehose.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "firehose.us-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "firehose-fips.us-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-east-2": {
+    hostname: "firehose.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "firehose.us-east-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "firehose-fips.us-east-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-gov-east-1": {
+    hostname: "firehose.us-gov-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "firehose.us-gov-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "firehose-fips.us-gov-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-gov-west-1": {
+    hostname: "firehose.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "firehose.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "firehose-fips.us-gov-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-west-1": {
+    hostname: "firehose.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "firehose.us-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "firehose-fips.us-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-west-2": {
+    hostname: "firehose.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "firehose.us-west-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "firehose-fips.us-west-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
 };
 
@@ -59,26 +173,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "firehose.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "firehose.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "firehose-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "firehose-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "firehose.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "firehose.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "firehose.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "firehose-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "firehose-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "firehose.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "firehose.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "firehose.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "firehose.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "firehose.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["fips-us-gov-east-1", "fips-us-gov-west-1", "us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "firehose.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "firehose.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "firehose-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "firehose-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "firehose.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-fis/src/endpoints.ts
+++ b/clients/client-fis/src/endpoints.ts
@@ -30,26 +30,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "fis.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "fis.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "fis-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "fis-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "fis.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "fis.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "fis.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "fis-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "fis-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "fis.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "fis.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "fis.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "fis.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "fis.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "fis.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "fis.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "fis-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "fis-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "fis.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-fms/src/endpoints.ts
+++ b/clients/client-fms/src/endpoints.ts
@@ -2,89 +2,488 @@ import { getRegionInfo, PartitionHash, RegionHash } from "@aws-sdk/config-resolv
 import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
+  "af-south-1": {
+    hostname: "fms.af-south-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "fms.af-south-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "fms-fips.af-south-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "ap-east-1": {
+    hostname: "fms.ap-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "fms.ap-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "fms-fips.ap-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "ap-northeast-1": {
+    hostname: "fms.ap-northeast-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "fms.ap-northeast-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "fms-fips.ap-northeast-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "ap-northeast-2": {
+    hostname: "fms.ap-northeast-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "fms.ap-northeast-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "fms-fips.ap-northeast-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "ap-south-1": {
+    hostname: "fms.ap-south-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "fms.ap-south-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "fms-fips.ap-south-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "ap-southeast-1": {
+    hostname: "fms.ap-southeast-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "fms.ap-southeast-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "fms-fips.ap-southeast-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "ap-southeast-2": {
+    hostname: "fms.ap-southeast-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "fms.ap-southeast-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "fms-fips.ap-southeast-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "ca-central-1": {
+    hostname: "fms.ca-central-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "fms.ca-central-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "fms-fips.ca-central-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "eu-central-1": {
+    hostname: "fms.eu-central-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "fms.eu-central-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "fms-fips.eu-central-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "eu-south-1": {
+    hostname: "fms.eu-south-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "fms.eu-south-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "fms-fips.eu-south-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "eu-west-1": {
+    hostname: "fms.eu-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "fms.eu-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "fms-fips.eu-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "eu-west-2": {
+    hostname: "fms.eu-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "fms.eu-west-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "fms-fips.eu-west-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "eu-west-3": {
+    hostname: "fms.eu-west-3.amazonaws.com",
+    variants: [
+      {
+        hostname: "fms.eu-west-3.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "fms-fips.eu-west-3.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
   "fips-af-south-1": {
     hostname: "fms-fips.af-south-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "fms-fips.af-south-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "af-south-1",
   },
   "fips-ap-east-1": {
     hostname: "fms-fips.ap-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "fms-fips.ap-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "ap-east-1",
   },
   "fips-ap-northeast-1": {
     hostname: "fms-fips.ap-northeast-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "fms-fips.ap-northeast-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "ap-northeast-1",
   },
   "fips-ap-northeast-2": {
     hostname: "fms-fips.ap-northeast-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "fms-fips.ap-northeast-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "ap-northeast-2",
   },
   "fips-ap-south-1": {
     hostname: "fms-fips.ap-south-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "fms-fips.ap-south-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "ap-south-1",
   },
   "fips-ap-southeast-1": {
     hostname: "fms-fips.ap-southeast-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "fms-fips.ap-southeast-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "ap-southeast-1",
   },
   "fips-ap-southeast-2": {
     hostname: "fms-fips.ap-southeast-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "fms-fips.ap-southeast-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "ap-southeast-2",
   },
   "fips-ca-central-1": {
     hostname: "fms-fips.ca-central-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "fms-fips.ca-central-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "ca-central-1",
   },
   "fips-eu-central-1": {
     hostname: "fms-fips.eu-central-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "fms-fips.eu-central-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "eu-central-1",
   },
   "fips-eu-south-1": {
     hostname: "fms-fips.eu-south-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "fms-fips.eu-south-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "eu-south-1",
   },
   "fips-eu-west-1": {
     hostname: "fms-fips.eu-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "fms-fips.eu-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "eu-west-1",
   },
   "fips-eu-west-2": {
     hostname: "fms-fips.eu-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "fms-fips.eu-west-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "eu-west-2",
   },
   "fips-eu-west-3": {
     hostname: "fms-fips.eu-west-3.amazonaws.com",
+    variants: [
+      {
+        hostname: "fms-fips.eu-west-3.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "eu-west-3",
   },
   "fips-me-south-1": {
     hostname: "fms-fips.me-south-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "fms-fips.me-south-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "me-south-1",
   },
   "fips-sa-east-1": {
     hostname: "fms-fips.sa-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "fms-fips.sa-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "sa-east-1",
   },
   "fips-us-east-1": {
     hostname: "fms-fips.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "fms-fips.us-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-1",
   },
   "fips-us-east-2": {
     hostname: "fms-fips.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "fms-fips.us-east-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-2",
   },
   "fips-us-gov-east-1": {
     hostname: "fms-fips.us-gov-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "fms-fips.us-gov-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-east-1",
   },
   "fips-us-gov-west-1": {
     hostname: "fms-fips.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "fms-fips.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-west-1",
   },
   "fips-us-west-1": {
     hostname: "fms-fips.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "fms-fips.us-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-1",
   },
   "fips-us-west-2": {
     hostname: "fms-fips.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "fms-fips.us-west-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-2",
+  },
+  "me-south-1": {
+    hostname: "fms.me-south-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "fms.me-south-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "fms-fips.me-south-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "sa-east-1": {
+    hostname: "fms.sa-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "fms.sa-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "fms-fips.sa-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-east-1": {
+    hostname: "fms.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "fms.us-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "fms-fips.us-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-east-2": {
+    hostname: "fms.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "fms.us-east-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "fms-fips.us-east-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-gov-east-1": {
+    hostname: "fms.us-gov-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "fms.us-gov-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "fms-fips.us-gov-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-gov-west-1": {
+    hostname: "fms.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "fms.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "fms-fips.us-gov-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-west-1": {
+    hostname: "fms.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "fms.us-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "fms-fips.us-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-west-2": {
+    hostname: "fms.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "fms.us-west-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "fms-fips.us-west-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
 };
 
@@ -134,26 +533,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "fms.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "fms.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "fms-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "fms-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "fms.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "fms.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "fms.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "fms-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "fms-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "fms.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "fms.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "fms.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "fms.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "fms.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["fips-us-gov-east-1", "fips-us-gov-west-1", "us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "fms.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "fms.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "fms-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "fms-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "fms.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-forecast/src/endpoints.ts
+++ b/clients/client-forecast/src/endpoints.ts
@@ -4,15 +4,72 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 const regionHash: RegionHash = {
   "fips-us-east-1": {
     hostname: "forecast-fips.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "forecast-fips.us-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-1",
   },
   "fips-us-east-2": {
     hostname: "forecast-fips.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "forecast-fips.us-east-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-2",
   },
   "fips-us-west-2": {
     hostname: "forecast-fips.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "forecast-fips.us-west-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-2",
+  },
+  "us-east-1": {
+    hostname: "forecast.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "forecast.us-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "forecast-fips.us-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-east-2": {
+    hostname: "forecast.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "forecast.us-east-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "forecast-fips.us-east-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-west-2": {
+    hostname: "forecast.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "forecast.us-west-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "forecast-fips.us-west-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
 };
 
@@ -46,26 +103,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "forecast.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "forecast.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "forecast-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "forecast-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "forecast.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "forecast.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "forecast.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "forecast-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "forecast-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "forecast.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "forecast.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "forecast.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "forecast.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "forecast.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "forecast.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "forecast.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "forecast-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "forecast-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "forecast.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-forecastquery/src/endpoints.ts
+++ b/clients/client-forecastquery/src/endpoints.ts
@@ -4,15 +4,72 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 const regionHash: RegionHash = {
   "fips-us-east-1": {
     hostname: "forecastquery-fips.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "forecastquery-fips.us-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-1",
   },
   "fips-us-east-2": {
     hostname: "forecastquery-fips.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "forecastquery-fips.us-east-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-2",
   },
   "fips-us-west-2": {
     hostname: "forecastquery-fips.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "forecastquery-fips.us-west-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-2",
+  },
+  "us-east-1": {
+    hostname: "forecastquery.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "forecastquery.us-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "forecastquery-fips.us-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-east-2": {
+    hostname: "forecastquery.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "forecastquery.us-east-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "forecastquery-fips.us-east-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-west-2": {
+    hostname: "forecastquery.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "forecastquery.us-west-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "forecastquery-fips.us-west-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
 };
 
@@ -46,26 +103,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "forecastquery.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "forecastquery.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "forecastquery-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "forecastquery-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "forecastquery.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "forecastquery.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "forecastquery.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "forecastquery-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "forecastquery-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "forecastquery.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "forecastquery.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "forecastquery.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "forecastquery.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "forecastquery.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "forecastquery.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "forecastquery.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "forecastquery-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "forecastquery-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "forecastquery.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-frauddetector/src/endpoints.ts
+++ b/clients/client-frauddetector/src/endpoints.ts
@@ -30,26 +30,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "frauddetector.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "frauddetector.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "frauddetector-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "frauddetector-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "frauddetector.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "frauddetector.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "frauddetector.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "frauddetector-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "frauddetector-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "frauddetector.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "frauddetector.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "frauddetector.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "frauddetector.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "frauddetector.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "frauddetector.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "frauddetector.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "frauddetector-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "frauddetector-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "frauddetector.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-fsx/src/endpoints.ts
+++ b/clients/client-fsx/src/endpoints.ts
@@ -2,61 +2,334 @@ import { getRegionInfo, PartitionHash, RegionHash } from "@aws-sdk/config-resolv
 import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
+  "ca-central-1": {
+    hostname: "fsx.ca-central-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "fsx.ca-central-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "fsx-fips.ca-central-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
   "fips-ca-central-1": {
     hostname: "fsx-fips.ca-central-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "fsx-fips.ca-central-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "ca-central-1",
   },
   "fips-prod-ca-central-1": {
     hostname: "fsx-fips.ca-central-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "fsx-fips.ca-central-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "ca-central-1",
   },
   "fips-prod-us-east-1": {
     hostname: "fsx-fips.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "fsx-fips.us-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-1",
   },
   "fips-prod-us-east-2": {
     hostname: "fsx-fips.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "fsx-fips.us-east-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-2",
   },
   "fips-prod-us-gov-east-1": {
     hostname: "fsx-fips.us-gov-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "fsx-fips.us-gov-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-east-1",
   },
   "fips-prod-us-gov-west-1": {
     hostname: "fsx-fips.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "fsx-fips.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-west-1",
   },
   "fips-prod-us-west-1": {
     hostname: "fsx-fips.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "fsx-fips.us-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-1",
   },
   "fips-prod-us-west-2": {
     hostname: "fsx-fips.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "fsx-fips.us-west-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-2",
   },
   "fips-us-east-1": {
     hostname: "fsx-fips.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "fsx-fips.us-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-1",
   },
   "fips-us-east-2": {
     hostname: "fsx-fips.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "fsx-fips.us-east-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-2",
   },
   "fips-us-gov-east-1": {
     hostname: "fsx-fips.us-gov-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "fsx-fips.us-gov-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-east-1",
   },
   "fips-us-gov-west-1": {
     hostname: "fsx-fips.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "fsx-fips.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-west-1",
   },
   "fips-us-west-1": {
     hostname: "fsx-fips.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "fsx-fips.us-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-1",
   },
   "fips-us-west-2": {
     hostname: "fsx-fips.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "fsx-fips.us-west-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-2",
+  },
+  "prod-ca-central-1": {
+    hostname: "fsx.prod-ca-central-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "fsx.prod-ca-central-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "fsx-fips.ca-central-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+    signingRegion: "ca-central-1",
+  },
+  "prod-us-east-1": {
+    hostname: "fsx.prod-us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "fsx.prod-us-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "fsx-fips.us-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+    signingRegion: "us-east-1",
+  },
+  "prod-us-east-2": {
+    hostname: "fsx.prod-us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "fsx.prod-us-east-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "fsx-fips.us-east-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+    signingRegion: "us-east-2",
+  },
+  "prod-us-gov-east-1": {
+    hostname: "fsx.prod-us-gov-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "fsx.prod-us-gov-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "fsx-fips.us-gov-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+    signingRegion: "us-gov-east-1",
+  },
+  "prod-us-gov-west-1": {
+    hostname: "fsx.prod-us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "fsx.prod-us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "fsx-fips.us-gov-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+    signingRegion: "us-gov-west-1",
+  },
+  "prod-us-west-1": {
+    hostname: "fsx.prod-us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "fsx.prod-us-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "fsx-fips.us-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+    signingRegion: "us-west-1",
+  },
+  "prod-us-west-2": {
+    hostname: "fsx.prod-us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "fsx.prod-us-west-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "fsx-fips.us-west-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+    signingRegion: "us-west-2",
+  },
+  "us-east-1": {
+    hostname: "fsx.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "fsx.us-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "fsx-fips.us-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-east-2": {
+    hostname: "fsx.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "fsx.us-east-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "fsx-fips.us-east-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-gov-east-1": {
+    hostname: "fsx.us-gov-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "fsx.us-gov-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "fsx-fips.us-gov-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-gov-west-1": {
+    hostname: "fsx.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "fsx.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "fsx-fips.us-gov-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-west-1": {
+    hostname: "fsx.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "fsx.us-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "fsx-fips.us-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-west-2": {
+    hostname: "fsx.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "fsx.us-west-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "fsx-fips.us-west-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
 };
 
@@ -102,21 +375,69 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "fsx.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "fsx.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "fsx-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "fsx-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "fsx.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "fsx.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "fsx.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "fsx-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "fsx-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "fsx.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "fsx.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "fsx.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "fsx.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "fsx.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: [
@@ -131,6 +452,24 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "fsx.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "fsx.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "fsx-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "fsx-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "fsx.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-gamelift/src/endpoints.ts
+++ b/clients/client-gamelift/src/endpoints.ts
@@ -30,26 +30,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "gamelift.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "gamelift.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "gamelift-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "gamelift-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "gamelift.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "gamelift.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "gamelift.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "gamelift-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "gamelift-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "gamelift.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "gamelift.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "gamelift.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "gamelift.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "gamelift.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "gamelift.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "gamelift.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "gamelift-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "gamelift-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "gamelift.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-glacier/src/endpoints.ts
+++ b/clients/client-glacier/src/endpoints.ts
@@ -2,33 +2,140 @@ import { getRegionInfo, PartitionHash, RegionHash } from "@aws-sdk/config-resolv
 import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
+  "ca-central-1": {
+    hostname: "glacier.ca-central-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "glacier.ca-central-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "glacier-fips.ca-central-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
   "fips-ca-central-1": {
     hostname: "glacier-fips.ca-central-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "glacier-fips.ca-central-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "ca-central-1",
   },
   "fips-us-east-1": {
     hostname: "glacier-fips.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "glacier-fips.us-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-1",
   },
   "fips-us-east-2": {
     hostname: "glacier-fips.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "glacier-fips.us-east-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-2",
   },
   "fips-us-west-1": {
     hostname: "glacier-fips.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "glacier-fips.us-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-1",
   },
   "fips-us-west-2": {
     hostname: "glacier-fips.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "glacier-fips.us-west-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-2",
+  },
+  "us-east-1": {
+    hostname: "glacier.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "glacier.us-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "glacier-fips.us-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-east-2": {
+    hostname: "glacier.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "glacier.us-east-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "glacier-fips.us-east-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "us-gov-east-1": {
     hostname: "glacier.us-gov-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "glacier.us-gov-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-east-1",
   },
   "us-gov-west-1": {
     hostname: "glacier.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "glacier.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-west-1",
+  },
+  "us-west-1": {
+    hostname: "glacier.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "glacier.us-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "glacier-fips.us-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-west-2": {
+    hostname: "glacier.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "glacier.us-west-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "glacier-fips.us-west-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
 };
 
@@ -64,26 +171,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "glacier.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "glacier.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "glacier-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "glacier-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "glacier.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "glacier.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "glacier.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "glacier-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "glacier-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "glacier.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "glacier.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "glacier.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "glacier.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "glacier.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "glacier.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "glacier.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "glacier-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "glacier-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "glacier.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-global-accelerator/src/endpoints.ts
+++ b/clients/client-global-accelerator/src/endpoints.ts
@@ -30,26 +30,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "globalaccelerator.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "globalaccelerator.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "globalaccelerator-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "globalaccelerator-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "globalaccelerator.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "globalaccelerator.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "globalaccelerator.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "globalaccelerator-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "globalaccelerator-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "globalaccelerator.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "globalaccelerator.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "globalaccelerator.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "globalaccelerator.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "globalaccelerator.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "globalaccelerator.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "globalaccelerator.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "globalaccelerator-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "globalaccelerator-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "globalaccelerator.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-glue/src/endpoints.ts
+++ b/clients/client-glue/src/endpoints.ts
@@ -4,27 +4,141 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 const regionHash: RegionHash = {
   "fips-us-east-1": {
     hostname: "glue-fips.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "glue-fips.us-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-1",
   },
   "fips-us-east-2": {
     hostname: "glue-fips.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "glue-fips.us-east-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-2",
   },
   "fips-us-gov-east-1": {
     hostname: "glue-fips.us-gov-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "glue-fips.us-gov-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-east-1",
   },
   "fips-us-gov-west-1": {
     hostname: "glue-fips.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "glue-fips.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-west-1",
   },
   "fips-us-west-1": {
     hostname: "glue-fips.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "glue-fips.us-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-1",
   },
   "fips-us-west-2": {
     hostname: "glue-fips.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "glue-fips.us-west-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-2",
+  },
+  "us-east-1": {
+    hostname: "glue.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "glue.us-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "glue-fips.us-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-east-2": {
+    hostname: "glue.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "glue.us-east-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "glue-fips.us-east-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-gov-east-1": {
+    hostname: "glue.us-gov-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "glue.us-gov-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "glue-fips.us-gov-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-gov-west-1": {
+    hostname: "glue.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "glue.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "glue-fips.us-gov-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-west-1": {
+    hostname: "glue.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "glue.us-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "glue-fips.us-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-west-2": {
+    hostname: "glue.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "glue.us-west-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "glue-fips.us-west-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
 };
 
@@ -59,26 +173,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "glue.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "glue.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "glue-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "glue-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "glue.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "glue.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "glue.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "glue-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "glue-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "glue.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "glue.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "glue.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "glue.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "glue.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["fips-us-gov-east-1", "fips-us-gov-west-1", "us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "glue.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "glue.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "glue-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "glue-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "glue.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-grafana/src/endpoints.ts
+++ b/clients/client-grafana/src/endpoints.ts
@@ -4,42 +4,102 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 const regionHash: RegionHash = {
   "ap-northeast-1": {
     hostname: "grafana.ap-northeast-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "grafana.ap-northeast-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "ap-northeast-1",
   },
   "ap-northeast-2": {
     hostname: "grafana.ap-northeast-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "grafana.ap-northeast-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "ap-northeast-2",
   },
   "ap-southeast-1": {
     hostname: "grafana.ap-southeast-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "grafana.ap-southeast-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "ap-southeast-1",
   },
   "ap-southeast-2": {
     hostname: "grafana.ap-southeast-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "grafana.ap-southeast-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "ap-southeast-2",
   },
   "eu-central-1": {
     hostname: "grafana.eu-central-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "grafana.eu-central-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "eu-central-1",
   },
   "eu-west-1": {
     hostname: "grafana.eu-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "grafana.eu-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "eu-west-1",
   },
   "eu-west-2": {
     hostname: "grafana.eu-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "grafana.eu-west-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "eu-west-2",
   },
   "us-east-1": {
     hostname: "grafana.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "grafana.us-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-1",
   },
   "us-east-2": {
     hostname: "grafana.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "grafana.us-east-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-2",
   },
   "us-west-2": {
     hostname: "grafana.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "grafana.us-west-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-2",
   },
 };
@@ -71,26 +131,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "grafana.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "grafana.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "grafana-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "grafana-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "grafana.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "grafana.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "grafana.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "grafana-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "grafana-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "grafana.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "grafana.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "grafana.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "grafana.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "grafana.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "grafana.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "grafana.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "grafana-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "grafana-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "grafana.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-greengrass/src/endpoints.ts
+++ b/clients/client-greengrass/src/endpoints.ts
@@ -4,22 +4,56 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 const regionHash: RegionHash = {
   "dataplane-us-gov-east-1": {
     hostname: "greengrass-ats.iot.us-gov-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "greengrass-ats.iot.us-gov-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-east-1",
   },
   "dataplane-us-gov-west-1": {
     hostname: "greengrass-ats.iot.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "greengrass-ats.iot.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-west-1",
   },
   "fips-us-gov-east-1": {
     hostname: "greengrass-fips.us-gov-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "greengrass-fips.us-gov-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-east-1",
   },
   "us-gov-east-1": {
     hostname: "greengrass.us-gov-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "greengrass.us-gov-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "greengrass-fips.us-gov-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
     signingRegion: "us-gov-east-1",
   },
   "us-gov-west-1": {
     hostname: "greengrass.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "greengrass.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-west-1",
   },
 };
@@ -51,21 +85,69 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "greengrass.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "greengrass.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "greengrass-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "greengrass-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "greengrass.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "greengrass.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "greengrass.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "greengrass-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "greengrass-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "greengrass.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "greengrass.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "greengrass.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "greengrass.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "greengrass.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: [
@@ -77,6 +159,24 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "greengrass.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "greengrass.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "greengrass-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "greengrass-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "greengrass.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-greengrassv2/src/endpoints.ts
+++ b/clients/client-greengrassv2/src/endpoints.ts
@@ -4,22 +4,56 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 const regionHash: RegionHash = {
   "dataplane-us-gov-east-1": {
     hostname: "greengrass-ats.iot.us-gov-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "greengrass-ats.iot.us-gov-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-east-1",
   },
   "dataplane-us-gov-west-1": {
     hostname: "greengrass-ats.iot.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "greengrass-ats.iot.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-west-1",
   },
   "fips-us-gov-east-1": {
     hostname: "greengrass-fips.us-gov-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "greengrass-fips.us-gov-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-east-1",
   },
   "us-gov-east-1": {
     hostname: "greengrass.us-gov-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "greengrass.us-gov-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "greengrass-fips.us-gov-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
     signingRegion: "us-gov-east-1",
   },
   "us-gov-west-1": {
     hostname: "greengrass.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "greengrass.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-west-1",
   },
 };
@@ -51,21 +85,69 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "greengrass.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "greengrass.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "greengrass-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "greengrass-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "greengrass.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "greengrass.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "greengrass.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "greengrass-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "greengrass-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "greengrass.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "greengrass.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "greengrass.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "greengrass.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "greengrass.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: [
@@ -77,6 +159,24 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "greengrass.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "greengrass.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "greengrass-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "greengrass-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "greengrass.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-groundstation/src/endpoints.ts
+++ b/clients/client-groundstation/src/endpoints.ts
@@ -4,15 +4,72 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 const regionHash: RegionHash = {
   "fips-us-east-1": {
     hostname: "groundstation-fips.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "groundstation-fips.us-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-1",
   },
   "fips-us-east-2": {
     hostname: "groundstation-fips.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "groundstation-fips.us-east-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-2",
   },
   "fips-us-west-2": {
     hostname: "groundstation-fips.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "groundstation-fips.us-west-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-2",
+  },
+  "us-east-1": {
+    hostname: "groundstation.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "groundstation.us-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "groundstation-fips.us-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-east-2": {
+    hostname: "groundstation.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "groundstation.us-east-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "groundstation-fips.us-east-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-west-2": {
+    hostname: "groundstation.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "groundstation.us-west-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "groundstation-fips.us-west-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
 };
 
@@ -46,26 +103,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "groundstation.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "groundstation.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "groundstation-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "groundstation-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "groundstation.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "groundstation.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "groundstation.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "groundstation-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "groundstation-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "groundstation.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "groundstation.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "groundstation.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "groundstation.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "groundstation.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "groundstation.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "groundstation.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "groundstation-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "groundstation-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "groundstation.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-guardduty/src/endpoints.ts
+++ b/clients/client-guardduty/src/endpoints.ts
@@ -2,28 +2,142 @@ import { getRegionInfo, PartitionHash, RegionHash } from "@aws-sdk/config-resolv
 import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
+  "us-east-1": {
+    hostname: "guardduty.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "guardduty.us-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "guardduty-fips.us-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
   "us-east-1-fips": {
     hostname: "guardduty-fips.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "guardduty-fips.us-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-1",
+  },
+  "us-east-2": {
+    hostname: "guardduty.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "guardduty.us-east-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "guardduty-fips.us-east-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "us-east-2-fips": {
     hostname: "guardduty-fips.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "guardduty-fips.us-east-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-2",
+  },
+  "us-gov-east-1": {
+    hostname: "guardduty.us-gov-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "guardduty.us-gov-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "guardduty.us-gov-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "us-gov-east-1-fips": {
     hostname: "guardduty.us-gov-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "guardduty.us-gov-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-east-1",
+  },
+  "us-gov-west-1": {
+    hostname: "guardduty.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "guardduty.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "guardduty.us-gov-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "us-gov-west-1-fips": {
     hostname: "guardduty.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "guardduty.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-west-1",
+  },
+  "us-west-1": {
+    hostname: "guardduty.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "guardduty.us-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "guardduty-fips.us-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "us-west-1-fips": {
     hostname: "guardduty-fips.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "guardduty-fips.us-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-1",
+  },
+  "us-west-2": {
+    hostname: "guardduty.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "guardduty.us-west-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "guardduty-fips.us-west-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "us-west-2-fips": {
     hostname: "guardduty-fips.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "guardduty-fips.us-west-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-2",
   },
 };
@@ -59,26 +173,84 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "guardduty.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "guardduty.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "guardduty-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "guardduty-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "guardduty.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "guardduty.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "guardduty.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "guardduty-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "guardduty-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "guardduty.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "guardduty.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "guardduty.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "guardduty.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "guardduty.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-east-1-fips", "us-gov-west-1", "us-gov-west-1-fips"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "guardduty.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "guardduty.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "guardduty.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
 };
 

--- a/clients/client-health/src/endpoints.ts
+++ b/clients/client-health/src/endpoints.ts
@@ -4,10 +4,50 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 const regionHash: RegionHash = {
   "fips-us-east-2": {
     hostname: "health-fips.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "health-fips.us-east-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-2",
   },
   "fips-us-gov-west-1": {
     hostname: "health-fips.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "health-fips.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
+    signingRegion: "us-gov-west-1",
+  },
+  "us-east-2": {
+    hostname: "health.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "health.us-east-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "health-fips.us-east-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+    signingRegion: "us-east-2",
+  },
+  "us-gov-west-1": {
+    hostname: "health.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "health.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "health-fips.us-gov-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
     signingRegion: "us-gov-west-1",
   },
 };
@@ -40,26 +80,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "health.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "health.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "health-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "health-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "health.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "health.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "health.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "health-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "health-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "health.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "health.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "health.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "health.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "health.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["fips-us-gov-west-1", "us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "health.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "health.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "health-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "health-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "health.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-healthlake/src/endpoints.ts
+++ b/clients/client-healthlake/src/endpoints.ts
@@ -30,26 +30,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "healthlake.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "healthlake.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "healthlake-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "healthlake-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "healthlake.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "healthlake.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "healthlake.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "healthlake-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "healthlake-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "healthlake.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "healthlake.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "healthlake.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "healthlake.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "healthlake.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "healthlake.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "healthlake.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "healthlake-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "healthlake-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "healthlake.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-honeycode/src/endpoints.ts
+++ b/clients/client-honeycode/src/endpoints.ts
@@ -30,26 +30,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "honeycode.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "honeycode.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "honeycode-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "honeycode-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "honeycode.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "honeycode.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "honeycode.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "honeycode-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "honeycode-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "honeycode.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "honeycode.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "honeycode.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "honeycode.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "honeycode.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "honeycode.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "honeycode.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "honeycode-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "honeycode-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "honeycode.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-iam/src/endpoints.ts
+++ b/clients/client-iam/src/endpoints.ts
@@ -4,38 +4,128 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 const regionHash: RegionHash = {
   "aws-cn-global": {
     hostname: "iam.cn-north-1.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "iam.cn-north-1.amazonaws.com.cn",
+        tags: [],
+      },
+    ],
     signingRegion: "cn-north-1",
   },
   "aws-global": {
     hostname: "iam.amazonaws.com",
+    variants: [
+      {
+        hostname: "iam.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "iam-fips.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
     signingRegion: "us-east-1",
   },
   "aws-global-fips": {
     hostname: "iam-fips.amazonaws.com",
+    variants: [
+      {
+        hostname: "iam-fips.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-1",
   },
   "aws-iso-b-global": {
     hostname: "iam.us-isob-east-1.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "iam.us-isob-east-1.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
     signingRegion: "us-isob-east-1",
   },
   "aws-iso-global": {
     hostname: "iam.us-iso-east-1.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "iam.us-iso-east-1.c2s.ic.gov",
+        tags: [],
+      },
+    ],
     signingRegion: "us-iso-east-1",
   },
   "aws-us-gov-global": {
     hostname: "iam.us-gov.amazonaws.com",
+    variants: [
+      {
+        hostname: "iam.us-gov.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "iam.us-gov.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
     signingRegion: "us-gov-west-1",
   },
   "aws-us-gov-global-fips": {
     hostname: "iam.us-gov.amazonaws.com",
+    variants: [
+      {
+        hostname: "iam.us-gov.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-west-1",
+  },
+  iam: {
+    hostname: "iam.iam.amazonaws.com",
+    variants: [
+      {
+        hostname: "iam.iam.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "iam-fips.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+    signingRegion: "us-east-1",
   },
   "iam-fips": {
     hostname: "iam-fips.amazonaws.com",
+    variants: [
+      {
+        hostname: "iam-fips.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-1",
+  },
+  "iam-govcloud": {
+    hostname: "iam.iam-govcloud.amazonaws.com",
+    variants: [
+      {
+        hostname: "iam.iam-govcloud.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "iam.us-gov.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+    signingRegion: "us-gov-west-1",
   },
   "iam-govcloud-fips": {
     hostname: "iam.us-gov.amazonaws.com",
+    variants: [
+      {
+        hostname: "iam.us-gov.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-west-1",
   },
 };
@@ -70,21 +160,73 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
+    hostname: "iam.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "iam.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "iam-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "iam-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "iam.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
     endpoint: "aws-global",
   },
   "aws-cn": {
     regions: ["aws-cn-global", "cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
+    hostname: "iam.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "iam.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "iam-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "iam-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "iam.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
     endpoint: "aws-cn-global",
   },
   "aws-iso": {
     regions: ["aws-iso-global", "us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
+    hostname: "iam.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "iam.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
     endpoint: "aws-iso-global",
   },
   "aws-iso-b": {
     regions: ["aws-iso-b-global", "us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
+    hostname: "iam.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "iam.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
     endpoint: "aws-iso-b-global",
   },
   "aws-us-gov": {
@@ -97,6 +239,25 @@ const partitionHash: PartitionHash = {
       "us-gov-west-1",
     ],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
+    hostname: "iam.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "iam.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "iam-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "iam-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "iam.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
     endpoint: "aws-us-gov-global",
   },
 };

--- a/clients/client-identitystore/src/endpoints.ts
+++ b/clients/client-identitystore/src/endpoints.ts
@@ -4,7 +4,26 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 const regionHash: RegionHash = {
   "fips-us-gov-west-1": {
     hostname: "identitystore.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "identitystore.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-west-1",
+  },
+  "us-gov-west-1": {
+    hostname: "identitystore.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "identitystore.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "identitystore.us-gov-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
 };
 
@@ -35,26 +54,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "identitystore.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "identitystore.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "identitystore-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "identitystore-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "identitystore.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "identitystore.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "identitystore.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "identitystore-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "identitystore-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "identitystore.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "identitystore.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "identitystore.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "identitystore.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "identitystore.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["fips-us-gov-west-1", "us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "identitystore.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "identitystore.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "identitystore-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "identitystore-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "identitystore.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-imagebuilder/src/endpoints.ts
+++ b/clients/client-imagebuilder/src/endpoints.ts
@@ -30,26 +30,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "imagebuilder.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "imagebuilder.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "imagebuilder-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "imagebuilder-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "imagebuilder.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "imagebuilder.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "imagebuilder.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "imagebuilder-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "imagebuilder-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "imagebuilder.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "imagebuilder.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "imagebuilder.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "imagebuilder.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "imagebuilder.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "imagebuilder.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "imagebuilder.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "imagebuilder-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "imagebuilder-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "imagebuilder.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-inspector/src/endpoints.ts
+++ b/clients/client-inspector/src/endpoints.ts
@@ -4,27 +4,141 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 const regionHash: RegionHash = {
   "fips-us-east-1": {
     hostname: "inspector-fips.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "inspector-fips.us-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-1",
   },
   "fips-us-east-2": {
     hostname: "inspector-fips.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "inspector-fips.us-east-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-2",
   },
   "fips-us-gov-east-1": {
     hostname: "inspector-fips.us-gov-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "inspector-fips.us-gov-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-east-1",
   },
   "fips-us-gov-west-1": {
     hostname: "inspector-fips.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "inspector-fips.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-west-1",
   },
   "fips-us-west-1": {
     hostname: "inspector-fips.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "inspector-fips.us-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-1",
   },
   "fips-us-west-2": {
     hostname: "inspector-fips.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "inspector-fips.us-west-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-2",
+  },
+  "us-east-1": {
+    hostname: "inspector.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "inspector.us-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "inspector-fips.us-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-east-2": {
+    hostname: "inspector.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "inspector.us-east-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "inspector-fips.us-east-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-gov-east-1": {
+    hostname: "inspector.us-gov-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "inspector.us-gov-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "inspector-fips.us-gov-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-gov-west-1": {
+    hostname: "inspector.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "inspector.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "inspector-fips.us-gov-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-west-1": {
+    hostname: "inspector.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "inspector.us-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "inspector-fips.us-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-west-2": {
+    hostname: "inspector.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "inspector.us-west-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "inspector-fips.us-west-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
 };
 
@@ -59,26 +173,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "inspector.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "inspector.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "inspector-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "inspector-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "inspector.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "inspector.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "inspector.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "inspector-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "inspector-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "inspector.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "inspector.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "inspector.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "inspector.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "inspector.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["fips-us-gov-east-1", "fips-us-gov-west-1", "us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "inspector.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "inspector.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "inspector-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "inspector-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "inspector.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-iot-1click-devices-service/src/endpoints.ts
+++ b/clients/client-iot-1click-devices-service/src/endpoints.ts
@@ -30,26 +30,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "devices.iot1click.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "devices.iot1click.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "devices.iot1click-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "devices.iot1click-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "devices.iot1click.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "devices.iot1click.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "devices.iot1click.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "devices.iot1click-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "devices.iot1click-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "devices.iot1click.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "devices.iot1click.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "devices.iot1click.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "devices.iot1click.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "devices.iot1click.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "devices.iot1click.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "devices.iot1click.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "devices.iot1click-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "devices.iot1click-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "devices.iot1click.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-iot-1click-projects/src/endpoints.ts
+++ b/clients/client-iot-1click-projects/src/endpoints.ts
@@ -30,26 +30,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "projects.iot1click.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "projects.iot1click.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "projects.iot1click-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "projects.iot1click-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "projects.iot1click.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "projects.iot1click.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "projects.iot1click.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "projects.iot1click-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "projects.iot1click-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "projects.iot1click.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "projects.iot1click.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "projects.iot1click.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "projects.iot1click.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "projects.iot1click.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "projects.iot1click.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "projects.iot1click.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "projects.iot1click-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "projects.iot1click-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "projects.iot1click.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-iot-data-plane/src/endpoints.ts
+++ b/clients/client-iot-data-plane/src/endpoints.ts
@@ -2,33 +2,166 @@ import { getRegionInfo, PartitionHash, RegionHash } from "@aws-sdk/config-resolv
 import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
+  "ca-central-1": {
+    hostname: "data.iot.ca-central-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "data.iot.ca-central-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "data.iot-fips.ca-central-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
   "fips-ca-central-1": {
     hostname: "data.iot-fips.ca-central-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "data.iot-fips.ca-central-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingService: "iotdata",
   },
   "fips-us-east-1": {
     hostname: "data.iot-fips.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "data.iot-fips.us-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingService: "iotdata",
   },
   "fips-us-east-2": {
     hostname: "data.iot-fips.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "data.iot-fips.us-east-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingService: "iotdata",
   },
   "fips-us-gov-east-1": {
     hostname: "data.iot-fips.us-gov-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "data.iot-fips.us-gov-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingService: "iotdata",
   },
   "fips-us-gov-west-1": {
     hostname: "data.iot-fips.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "data.iot-fips.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingService: "iotdata",
   },
   "fips-us-west-1": {
     hostname: "data.iot-fips.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "data.iot-fips.us-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingService: "iotdata",
   },
   "fips-us-west-2": {
     hostname: "data.iot-fips.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "data.iot-fips.us-west-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingService: "iotdata",
+  },
+  "us-east-1": {
+    hostname: "data.iot.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "data.iot.us-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "data.iot-fips.us-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-east-2": {
+    hostname: "data.iot.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "data.iot.us-east-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "data.iot-fips.us-east-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-gov-east-1": {
+    hostname: "data.iot.us-gov-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "data.iot.us-gov-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "data.iot-fips.us-gov-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-gov-west-1": {
+    hostname: "data.iot.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "data.iot.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "data.iot-fips.us-gov-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-west-1": {
+    hostname: "data.iot.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "data.iot.us-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "data.iot-fips.us-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-west-2": {
+    hostname: "data.iot.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "data.iot.us-west-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "data.iot-fips.us-west-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
 };
 
@@ -64,26 +197,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "data.iot.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "data.iot.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "data.iot-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "data.iot-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "data.iot.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "data.iot.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "data.iot.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "data.iot-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "data.iot-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "data.iot.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "data.iot.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "data.iot.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "data.iot.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "data.iot.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["fips-us-gov-east-1", "fips-us-gov-west-1", "us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "data.iot.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "data.iot.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "data.iot-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "data.iot-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "data.iot.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-iot-events-data/src/endpoints.ts
+++ b/clients/client-iot-events-data/src/endpoints.ts
@@ -30,26 +30,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "data.iotevents.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "data.iotevents.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "data.iotevents-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "data.iotevents-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "data.iotevents.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "data.iotevents.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "data.iotevents.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "data.iotevents-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "data.iotevents-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "data.iotevents.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "data.iotevents.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "data.iotevents.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "data.iotevents.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "data.iotevents.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "data.iotevents.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "data.iotevents.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "data.iotevents-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "data.iotevents-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "data.iotevents.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-iot-events/src/endpoints.ts
+++ b/clients/client-iot-events/src/endpoints.ts
@@ -30,26 +30,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "iotevents.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "iotevents.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "iotevents-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "iotevents-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "iotevents.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "iotevents.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "iotevents.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "iotevents-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "iotevents-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "iotevents.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "iotevents.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "iotevents.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "iotevents.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "iotevents.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "iotevents.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "iotevents.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "iotevents-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "iotevents-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "iotevents.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-iot-jobs-data-plane/src/endpoints.ts
+++ b/clients/client-iot-jobs-data-plane/src/endpoints.ts
@@ -2,33 +2,166 @@ import { getRegionInfo, PartitionHash, RegionHash } from "@aws-sdk/config-resolv
 import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
+  "ca-central-1": {
+    hostname: "data.jobs.iot.ca-central-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "data.jobs.iot.ca-central-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "data.jobs.iot-fips.ca-central-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
   "fips-ca-central-1": {
     hostname: "data.jobs.iot-fips.ca-central-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "data.jobs.iot-fips.ca-central-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "ca-central-1",
   },
   "fips-us-east-1": {
     hostname: "data.jobs.iot-fips.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "data.jobs.iot-fips.us-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-1",
   },
   "fips-us-east-2": {
     hostname: "data.jobs.iot-fips.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "data.jobs.iot-fips.us-east-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-2",
   },
   "fips-us-gov-east-1": {
     hostname: "data.jobs.iot-fips.us-gov-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "data.jobs.iot-fips.us-gov-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-east-1",
   },
   "fips-us-gov-west-1": {
     hostname: "data.jobs.iot-fips.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "data.jobs.iot-fips.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-west-1",
   },
   "fips-us-west-1": {
     hostname: "data.jobs.iot-fips.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "data.jobs.iot-fips.us-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-1",
   },
   "fips-us-west-2": {
     hostname: "data.jobs.iot-fips.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "data.jobs.iot-fips.us-west-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-2",
+  },
+  "us-east-1": {
+    hostname: "data.jobs.iot.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "data.jobs.iot.us-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "data.jobs.iot-fips.us-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-east-2": {
+    hostname: "data.jobs.iot.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "data.jobs.iot.us-east-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "data.jobs.iot-fips.us-east-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-gov-east-1": {
+    hostname: "data.jobs.iot.us-gov-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "data.jobs.iot.us-gov-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "data.jobs.iot-fips.us-gov-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-gov-west-1": {
+    hostname: "data.jobs.iot.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "data.jobs.iot.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "data.jobs.iot-fips.us-gov-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-west-1": {
+    hostname: "data.jobs.iot.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "data.jobs.iot.us-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "data.jobs.iot-fips.us-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-west-2": {
+    hostname: "data.jobs.iot.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "data.jobs.iot.us-west-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "data.jobs.iot-fips.us-west-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
 };
 
@@ -64,26 +197,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "data.jobs.iot.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "data.jobs.iot.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "data.jobs.iot-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "data.jobs.iot-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "data.jobs.iot.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "data.jobs.iot.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "data.jobs.iot.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "data.jobs.iot-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "data.jobs.iot-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "data.jobs.iot.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "data.jobs.iot.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "data.jobs.iot.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "data.jobs.iot.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "data.jobs.iot.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["fips-us-gov-east-1", "fips-us-gov-west-1", "us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "data.jobs.iot.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "data.jobs.iot.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "data.jobs.iot-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "data.jobs.iot-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "data.jobs.iot.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-iot-wireless/src/endpoints.ts
+++ b/clients/client-iot-wireless/src/endpoints.ts
@@ -30,26 +30,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "api.iotwireless.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "api.iotwireless.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "api.iotwireless-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "api.iotwireless-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "api.iotwireless.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "api.iotwireless.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "api.iotwireless.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "api.iotwireless-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "api.iotwireless-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "api.iotwireless.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "api.iotwireless.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "api.iotwireless.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "api.iotwireless.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "api.iotwireless.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "api.iotwireless.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "api.iotwireless.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "api.iotwireless-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "api.iotwireless-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "api.iotwireless.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-iot/src/endpoints.ts
+++ b/clients/client-iot/src/endpoints.ts
@@ -2,33 +2,166 @@ import { getRegionInfo, PartitionHash, RegionHash } from "@aws-sdk/config-resolv
 import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
+  "ca-central-1": {
+    hostname: "iot.ca-central-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "iot.ca-central-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "iot-fips.ca-central-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
   "fips-ca-central-1": {
     hostname: "iot-fips.ca-central-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "iot-fips.ca-central-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingService: "execute-api",
   },
   "fips-us-east-1": {
     hostname: "iot-fips.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "iot-fips.us-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingService: "execute-api",
   },
   "fips-us-east-2": {
     hostname: "iot-fips.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "iot-fips.us-east-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingService: "execute-api",
   },
   "fips-us-gov-east-1": {
     hostname: "iot-fips.us-gov-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "iot-fips.us-gov-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingService: "execute-api",
   },
   "fips-us-gov-west-1": {
     hostname: "iot-fips.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "iot-fips.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingService: "execute-api",
   },
   "fips-us-west-1": {
     hostname: "iot-fips.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "iot-fips.us-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingService: "execute-api",
   },
   "fips-us-west-2": {
     hostname: "iot-fips.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "iot-fips.us-west-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingService: "execute-api",
+  },
+  "us-east-1": {
+    hostname: "iot.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "iot.us-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "iot-fips.us-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-east-2": {
+    hostname: "iot.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "iot.us-east-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "iot-fips.us-east-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-gov-east-1": {
+    hostname: "iot.us-gov-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "iot.us-gov-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "iot-fips.us-gov-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-gov-west-1": {
+    hostname: "iot.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "iot.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "iot-fips.us-gov-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-west-1": {
+    hostname: "iot.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "iot.us-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "iot-fips.us-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-west-2": {
+    hostname: "iot.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "iot.us-west-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "iot-fips.us-west-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
 };
 
@@ -64,26 +197,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "iot.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "iot.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "iot-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "iot-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "iot.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "iot.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "iot.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "iot-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "iot-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "iot.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "iot.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "iot.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "iot.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "iot.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["fips-us-gov-east-1", "fips-us-gov-west-1", "us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "iot.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "iot.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "iot-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "iot-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "iot.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-iotanalytics/src/endpoints.ts
+++ b/clients/client-iotanalytics/src/endpoints.ts
@@ -30,26 +30,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "iotanalytics.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "iotanalytics.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "iotanalytics-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "iotanalytics-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "iotanalytics.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "iotanalytics.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "iotanalytics.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "iotanalytics-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "iotanalytics-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "iotanalytics.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "iotanalytics.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "iotanalytics.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "iotanalytics.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "iotanalytics.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "iotanalytics.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "iotanalytics.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "iotanalytics-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "iotanalytics-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "iotanalytics.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-iotdeviceadvisor/src/endpoints.ts
+++ b/clients/client-iotdeviceadvisor/src/endpoints.ts
@@ -30,26 +30,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "api.iotdeviceadvisor.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "api.iotdeviceadvisor.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "api.iotdeviceadvisor-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "api.iotdeviceadvisor-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "api.iotdeviceadvisor.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "api.iotdeviceadvisor.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "api.iotdeviceadvisor.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "api.iotdeviceadvisor-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "api.iotdeviceadvisor-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "api.iotdeviceadvisor.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "api.iotdeviceadvisor.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "api.iotdeviceadvisor.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "api.iotdeviceadvisor.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "api.iotdeviceadvisor.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "api.iotdeviceadvisor.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "api.iotdeviceadvisor.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "api.iotdeviceadvisor-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "api.iotdeviceadvisor-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "api.iotdeviceadvisor.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-iotfleethub/src/endpoints.ts
+++ b/clients/client-iotfleethub/src/endpoints.ts
@@ -2,21 +2,97 @@ import { getRegionInfo, PartitionHash, RegionHash } from "@aws-sdk/config-resolv
 import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
+  "ca-central-1": {
+    hostname: "api.fleethub.iot.ca-central-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "api.fleethub.iot.ca-central-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "api.fleethub.iot-fips.ca-central-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
   "fips-ca-central-1": {
     hostname: "api.fleethub.iot-fips.ca-central-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "api.fleethub.iot-fips.ca-central-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "ca-central-1",
   },
   "fips-us-east-1": {
     hostname: "api.fleethub.iot-fips.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "api.fleethub.iot-fips.us-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-1",
   },
   "fips-us-east-2": {
     hostname: "api.fleethub.iot-fips.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "api.fleethub.iot-fips.us-east-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-2",
   },
   "fips-us-west-2": {
     hostname: "api.fleethub.iot-fips.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "api.fleethub.iot-fips.us-west-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-2",
+  },
+  "us-east-1": {
+    hostname: "api.fleethub.iot.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "api.fleethub.iot.us-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "api.fleethub.iot-fips.us-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-east-2": {
+    hostname: "api.fleethub.iot.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "api.fleethub.iot.us-east-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "api.fleethub.iot-fips.us-east-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-west-2": {
+    hostname: "api.fleethub.iot.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "api.fleethub.iot.us-west-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "api.fleethub.iot-fips.us-west-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
 };
 
@@ -51,26 +127,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "api.fleethub.iot.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "api.fleethub.iot.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "api.fleethub.iot-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "api.fleethub.iot-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "api.fleethub.iot.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "api.fleethub.iot.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "api.fleethub.iot.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "api.fleethub.iot-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "api.fleethub.iot-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "api.fleethub.iot.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "api.fleethub.iot.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "api.fleethub.iot.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "api.fleethub.iot.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "api.fleethub.iot.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "api.fleethub.iot.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "api.fleethub.iot.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "api.fleethub.iot-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "api.fleethub.iot-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "api.fleethub.iot.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-iotsecuretunneling/src/endpoints.ts
+++ b/clients/client-iotsecuretunneling/src/endpoints.ts
@@ -30,26 +30,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "api.tunneling.iot.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "api.tunneling.iot.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "api.tunneling.iot-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "api.tunneling.iot-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "api.tunneling.iot.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "api.tunneling.iot.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "api.tunneling.iot.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "api.tunneling.iot-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "api.tunneling.iot-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "api.tunneling.iot.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "api.tunneling.iot.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "api.tunneling.iot.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "api.tunneling.iot.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "api.tunneling.iot.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "api.tunneling.iot.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "api.tunneling.iot.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "api.tunneling.iot-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "api.tunneling.iot-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "api.tunneling.iot.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-iotsitewise/src/endpoints.ts
+++ b/clients/client-iotsitewise/src/endpoints.ts
@@ -30,26 +30,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "iotsitewise.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "iotsitewise.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "iotsitewise-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "iotsitewise-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "iotsitewise.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "iotsitewise.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "iotsitewise.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "iotsitewise-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "iotsitewise-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "iotsitewise.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "iotsitewise.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "iotsitewise.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "iotsitewise.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "iotsitewise.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "iotsitewise.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "iotsitewise.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "iotsitewise-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "iotsitewise-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "iotsitewise.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-iotthingsgraph/src/endpoints.ts
+++ b/clients/client-iotthingsgraph/src/endpoints.ts
@@ -30,26 +30,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "iotthingsgraph.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "iotthingsgraph.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "iotthingsgraph-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "iotthingsgraph-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "iotthingsgraph.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "iotthingsgraph.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "iotthingsgraph.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "iotthingsgraph-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "iotthingsgraph-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "iotthingsgraph.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "iotthingsgraph.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "iotthingsgraph.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "iotthingsgraph.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "iotthingsgraph.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "iotthingsgraph.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "iotthingsgraph.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "iotthingsgraph-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "iotthingsgraph-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "iotthingsgraph.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-ivs/src/endpoints.ts
+++ b/clients/client-ivs/src/endpoints.ts
@@ -30,26 +30,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "ivs.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "ivs.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "ivs-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "ivs-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "ivs.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "ivs.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "ivs.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "ivs-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "ivs-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "ivs.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "ivs.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "ivs.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "ivs.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "ivs.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "ivs.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "ivs.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "ivs-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "ivs-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "ivs.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-kafka/src/endpoints.ts
+++ b/clients/client-kafka/src/endpoints.ts
@@ -30,26 +30,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "kafka.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "kafka.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "kafka-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "kafka-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "kafka.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "kafka.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "kafka.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "kafka-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "kafka-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "kafka.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "kafka.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "kafka.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "kafka.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "kafka.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "kafka.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "kafka.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "kafka-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "kafka-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "kafka.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-kafkaconnect/src/endpoints.ts
+++ b/clients/client-kafkaconnect/src/endpoints.ts
@@ -30,26 +30,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "kafkaconnect.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "kafkaconnect.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "kafkaconnect-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "kafkaconnect-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "kafkaconnect.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "kafkaconnect.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "kafkaconnect.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "kafkaconnect-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "kafkaconnect-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "kafkaconnect.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "kafkaconnect.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "kafkaconnect.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "kafkaconnect.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "kafkaconnect.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "kafkaconnect.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "kafkaconnect.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "kafkaconnect-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "kafkaconnect-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "kafkaconnect.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-kendra/src/endpoints.ts
+++ b/clients/client-kendra/src/endpoints.ts
@@ -4,19 +4,95 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 const regionHash: RegionHash = {
   "fips-us-east-1": {
     hostname: "kendra-fips.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "kendra-fips.us-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-1",
   },
   "fips-us-east-2": {
     hostname: "kendra-fips.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "kendra-fips.us-east-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-2",
   },
   "fips-us-gov-west-1": {
     hostname: "kendra-fips.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "kendra-fips.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-west-1",
   },
   "fips-us-west-2": {
     hostname: "kendra-fips.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "kendra-fips.us-west-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-2",
+  },
+  "us-east-1": {
+    hostname: "kendra.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "kendra.us-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "kendra-fips.us-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-east-2": {
+    hostname: "kendra.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "kendra.us-east-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "kendra-fips.us-east-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-gov-west-1": {
+    hostname: "kendra.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "kendra.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "kendra-fips.us-gov-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-west-2": {
+    hostname: "kendra.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "kendra.us-west-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "kendra-fips.us-west-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
 };
 
@@ -50,26 +126,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "kendra.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "kendra.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "kendra-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "kendra-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "kendra.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "kendra.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "kendra.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "kendra-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "kendra-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "kendra.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "kendra.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "kendra.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "kendra.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "kendra.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["fips-us-gov-west-1", "us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "kendra.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "kendra.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "kendra-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "kendra-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "kendra.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-kinesis-analytics-v2/src/endpoints.ts
+++ b/clients/client-kinesis-analytics-v2/src/endpoints.ts
@@ -30,26 +30,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "kinesisanalytics.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "kinesisanalytics.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "kinesisanalytics-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "kinesisanalytics-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "kinesisanalytics.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "kinesisanalytics.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "kinesisanalytics.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "kinesisanalytics-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "kinesisanalytics-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "kinesisanalytics.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "kinesisanalytics.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "kinesisanalytics.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "kinesisanalytics.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "kinesisanalytics.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "kinesisanalytics.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "kinesisanalytics.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "kinesisanalytics-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "kinesisanalytics-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "kinesisanalytics.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-kinesis-analytics/src/endpoints.ts
+++ b/clients/client-kinesis-analytics/src/endpoints.ts
@@ -30,26 +30,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "kinesisanalytics.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "kinesisanalytics.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "kinesisanalytics-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "kinesisanalytics-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "kinesisanalytics.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "kinesisanalytics.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "kinesisanalytics.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "kinesisanalytics-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "kinesisanalytics-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "kinesisanalytics.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "kinesisanalytics.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "kinesisanalytics.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "kinesisanalytics.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "kinesisanalytics.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "kinesisanalytics.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "kinesisanalytics.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "kinesisanalytics-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "kinesisanalytics-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "kinesisanalytics.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-kinesis-video-archived-media/src/endpoints.ts
+++ b/clients/client-kinesis-video-archived-media/src/endpoints.ts
@@ -30,26 +30,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "kinesisvideo.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "kinesisvideo.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "kinesisvideo-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "kinesisvideo-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "kinesisvideo.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "kinesisvideo.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "kinesisvideo.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "kinesisvideo-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "kinesisvideo-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "kinesisvideo.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "kinesisvideo.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "kinesisvideo.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "kinesisvideo.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "kinesisvideo.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "kinesisvideo.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "kinesisvideo.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "kinesisvideo-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "kinesisvideo-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "kinesisvideo.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-kinesis-video-media/src/endpoints.ts
+++ b/clients/client-kinesis-video-media/src/endpoints.ts
@@ -30,26 +30,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "kinesisvideo.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "kinesisvideo.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "kinesisvideo-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "kinesisvideo-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "kinesisvideo.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "kinesisvideo.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "kinesisvideo.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "kinesisvideo-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "kinesisvideo-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "kinesisvideo.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "kinesisvideo.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "kinesisvideo.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "kinesisvideo.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "kinesisvideo.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "kinesisvideo.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "kinesisvideo.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "kinesisvideo-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "kinesisvideo-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "kinesisvideo.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-kinesis-video-signaling/src/endpoints.ts
+++ b/clients/client-kinesis-video-signaling/src/endpoints.ts
@@ -30,26 +30,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "kinesisvideo.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "kinesisvideo.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "kinesisvideo-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "kinesisvideo-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "kinesisvideo.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "kinesisvideo.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "kinesisvideo.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "kinesisvideo-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "kinesisvideo-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "kinesisvideo.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "kinesisvideo.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "kinesisvideo.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "kinesisvideo.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "kinesisvideo.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "kinesisvideo.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "kinesisvideo.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "kinesisvideo-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "kinesisvideo-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "kinesisvideo.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-kinesis-video/src/endpoints.ts
+++ b/clients/client-kinesis-video/src/endpoints.ts
@@ -30,26 +30,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "kinesisvideo.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "kinesisvideo.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "kinesisvideo-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "kinesisvideo-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "kinesisvideo.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "kinesisvideo.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "kinesisvideo.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "kinesisvideo-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "kinesisvideo-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "kinesisvideo.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "kinesisvideo.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "kinesisvideo.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "kinesisvideo.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "kinesisvideo.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "kinesisvideo.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "kinesisvideo.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "kinesisvideo-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "kinesisvideo-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "kinesisvideo.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-kinesis/src/endpoints.ts
+++ b/clients/client-kinesis/src/endpoints.ts
@@ -4,27 +4,115 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 const regionHash: RegionHash = {
   "fips-us-east-1": {
     hostname: "kinesis-fips.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "kinesis-fips.us-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-1",
   },
   "fips-us-east-2": {
     hostname: "kinesis-fips.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "kinesis-fips.us-east-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-2",
   },
   "fips-us-west-1": {
     hostname: "kinesis-fips.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "kinesis-fips.us-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-1",
   },
   "fips-us-west-2": {
     hostname: "kinesis-fips.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "kinesis-fips.us-west-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-2",
+  },
+  "us-east-1": {
+    hostname: "kinesis.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "kinesis.us-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "kinesis-fips.us-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-east-2": {
+    hostname: "kinesis.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "kinesis.us-east-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "kinesis-fips.us-east-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "us-gov-east-1": {
     hostname: "kinesis.us-gov-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "kinesis.us-gov-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-east-1",
   },
   "us-gov-west-1": {
     hostname: "kinesis.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "kinesis.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-west-1",
+  },
+  "us-west-1": {
+    hostname: "kinesis.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "kinesis.us-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "kinesis-fips.us-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-west-2": {
+    hostname: "kinesis.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "kinesis.us-west-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "kinesis-fips.us-west-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
 };
 
@@ -59,26 +147,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "kinesis.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "kinesis.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "kinesis-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "kinesis-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "kinesis.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "kinesis.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "kinesis.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "kinesis-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "kinesis-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "kinesis.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "kinesis.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "kinesis.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "kinesis.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "kinesis.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "kinesis.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "kinesis.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "kinesis-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "kinesis-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "kinesis.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-kms/src/endpoints.ts
+++ b/clients/client-kms/src/endpoints.ts
@@ -4,110 +4,610 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 const regionHash: RegionHash = {
   ProdFips: {
     hostname: "kms-fips.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "kms-fips.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-west-1",
+  },
+  "af-south-1": {
+    hostname: "kms.af-south-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "kms.af-south-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "kms-fips.af-south-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "af-south-1-fips": {
     hostname: "kms-fips.af-south-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "kms-fips.af-south-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "af-south-1",
+  },
+  "ap-east-1": {
+    hostname: "kms.ap-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "kms.ap-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "kms-fips.ap-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "ap-east-1-fips": {
     hostname: "kms-fips.ap-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "kms-fips.ap-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "ap-east-1",
+  },
+  "ap-northeast-1": {
+    hostname: "kms.ap-northeast-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "kms.ap-northeast-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "kms-fips.ap-northeast-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "ap-northeast-1-fips": {
     hostname: "kms-fips.ap-northeast-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "kms-fips.ap-northeast-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "ap-northeast-1",
+  },
+  "ap-northeast-2": {
+    hostname: "kms.ap-northeast-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "kms.ap-northeast-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "kms-fips.ap-northeast-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "ap-northeast-2-fips": {
     hostname: "kms-fips.ap-northeast-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "kms-fips.ap-northeast-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "ap-northeast-2",
+  },
+  "ap-northeast-3": {
+    hostname: "kms.ap-northeast-3.amazonaws.com",
+    variants: [
+      {
+        hostname: "kms.ap-northeast-3.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "kms-fips.ap-northeast-3.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "ap-northeast-3-fips": {
     hostname: "kms-fips.ap-northeast-3.amazonaws.com",
+    variants: [
+      {
+        hostname: "kms-fips.ap-northeast-3.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "ap-northeast-3",
+  },
+  "ap-south-1": {
+    hostname: "kms.ap-south-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "kms.ap-south-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "kms-fips.ap-south-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "ap-south-1-fips": {
     hostname: "kms-fips.ap-south-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "kms-fips.ap-south-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "ap-south-1",
+  },
+  "ap-southeast-1": {
+    hostname: "kms.ap-southeast-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "kms.ap-southeast-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "kms-fips.ap-southeast-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "ap-southeast-1-fips": {
     hostname: "kms-fips.ap-southeast-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "kms-fips.ap-southeast-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "ap-southeast-1",
+  },
+  "ap-southeast-2": {
+    hostname: "kms.ap-southeast-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "kms.ap-southeast-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "kms-fips.ap-southeast-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "ap-southeast-2-fips": {
     hostname: "kms-fips.ap-southeast-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "kms-fips.ap-southeast-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "ap-southeast-2",
+  },
+  "ca-central-1": {
+    hostname: "kms.ca-central-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "kms.ca-central-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "kms-fips.ca-central-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "ca-central-1-fips": {
     hostname: "kms-fips.ca-central-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "kms-fips.ca-central-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "ca-central-1",
+  },
+  "eu-central-1": {
+    hostname: "kms.eu-central-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "kms.eu-central-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "kms-fips.eu-central-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "eu-central-1-fips": {
     hostname: "kms-fips.eu-central-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "kms-fips.eu-central-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "eu-central-1",
+  },
+  "eu-north-1": {
+    hostname: "kms.eu-north-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "kms.eu-north-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "kms-fips.eu-north-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "eu-north-1-fips": {
     hostname: "kms-fips.eu-north-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "kms-fips.eu-north-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "eu-north-1",
+  },
+  "eu-south-1": {
+    hostname: "kms.eu-south-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "kms.eu-south-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "kms-fips.eu-south-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "eu-south-1-fips": {
     hostname: "kms-fips.eu-south-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "kms-fips.eu-south-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "eu-south-1",
+  },
+  "eu-west-1": {
+    hostname: "kms.eu-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "kms.eu-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "kms-fips.eu-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "eu-west-1-fips": {
     hostname: "kms-fips.eu-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "kms-fips.eu-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "eu-west-1",
+  },
+  "eu-west-2": {
+    hostname: "kms.eu-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "kms.eu-west-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "kms-fips.eu-west-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "eu-west-2-fips": {
     hostname: "kms-fips.eu-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "kms-fips.eu-west-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "eu-west-2",
+  },
+  "eu-west-3": {
+    hostname: "kms.eu-west-3.amazonaws.com",
+    variants: [
+      {
+        hostname: "kms.eu-west-3.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "kms-fips.eu-west-3.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "eu-west-3-fips": {
     hostname: "kms-fips.eu-west-3.amazonaws.com",
+    variants: [
+      {
+        hostname: "kms-fips.eu-west-3.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "eu-west-3",
+  },
+  "me-south-1": {
+    hostname: "kms.me-south-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "kms.me-south-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "kms-fips.me-south-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "me-south-1-fips": {
     hostname: "kms-fips.me-south-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "kms-fips.me-south-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "me-south-1",
+  },
+  "sa-east-1": {
+    hostname: "kms.sa-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "kms.sa-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "kms-fips.sa-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "sa-east-1-fips": {
     hostname: "kms-fips.sa-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "kms-fips.sa-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "sa-east-1",
+  },
+  "us-east-1": {
+    hostname: "kms.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "kms.us-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "kms-fips.us-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "us-east-1-fips": {
     hostname: "kms-fips.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "kms-fips.us-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-1",
+  },
+  "us-east-2": {
+    hostname: "kms.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "kms.us-east-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "kms-fips.us-east-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "us-east-2-fips": {
     hostname: "kms-fips.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "kms-fips.us-east-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-2",
+  },
+  "us-gov-east-1": {
+    hostname: "kms.us-gov-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "kms.us-gov-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "kms-fips.us-gov-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "us-gov-east-1-fips": {
     hostname: "kms-fips.us-gov-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "kms-fips.us-gov-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-east-1",
+  },
+  "us-gov-west-1": {
+    hostname: "kms.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "kms.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "kms-fips.us-gov-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "us-gov-west-1-fips": {
     hostname: "kms-fips.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "kms-fips.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-west-1",
+  },
+  "us-iso-east-1": {
+    hostname: "kms.us-iso-east-1.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "kms.us-iso-east-1.c2s.ic.gov",
+        tags: [],
+      },
+      {
+        hostname: "kms-fips.us-iso-east-1.c2s.ic.gov",
+        tags: ["fips"],
+      },
+    ],
   },
   "us-iso-east-1-fips": {
     hostname: "kms-fips.us-iso-east-1.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "kms-fips.us-iso-east-1.c2s.ic.gov",
+        tags: [],
+      },
+    ],
     signingRegion: "us-iso-east-1",
+  },
+  "us-iso-west-1": {
+    hostname: "kms.us-iso-west-1.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "kms.us-iso-west-1.c2s.ic.gov",
+        tags: [],
+      },
+      {
+        hostname: "kms-fips.us-iso-west-1.c2s.ic.gov",
+        tags: ["fips"],
+      },
+    ],
   },
   "us-iso-west-1-fips": {
     hostname: "kms-fips.us-iso-west-1.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "kms-fips.us-iso-west-1.c2s.ic.gov",
+        tags: [],
+      },
+    ],
     signingRegion: "us-iso-west-1",
+  },
+  "us-isob-east-1": {
+    hostname: "kms.us-isob-east-1.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "kms.us-isob-east-1.sc2s.sgov.gov",
+        tags: [],
+      },
+      {
+        hostname: "kms-fips.us-isob-east-1.sc2s.sgov.gov",
+        tags: ["fips"],
+      },
+    ],
   },
   "us-isob-east-1-fips": {
     hostname: "kms-fips.us-isob-east-1.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "kms-fips.us-isob-east-1.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
     signingRegion: "us-isob-east-1",
+  },
+  "us-west-1": {
+    hostname: "kms.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "kms.us-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "kms-fips.us-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "us-west-1-fips": {
     hostname: "kms-fips.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "kms-fips.us-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-1",
+  },
+  "us-west-2": {
+    hostname: "kms.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "kms.us-west-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "kms-fips.us-west-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "us-west-2-fips": {
     hostname: "kms-fips.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "kms-fips.us-west-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-2",
   },
 };
@@ -160,26 +660,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "kms.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "kms.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "kms-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "kms-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "kms.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "kms.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "kms.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "kms-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "kms-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "kms.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["ProdFips", "us-iso-east-1", "us-iso-east-1-fips", "us-iso-west-1", "us-iso-west-1-fips"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "kms.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "kms.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["ProdFips", "us-isob-east-1", "us-isob-east-1-fips"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "kms.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "kms.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["ProdFips", "us-gov-east-1", "us-gov-east-1-fips", "us-gov-west-1", "us-gov-west-1-fips"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "kms.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "kms.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "kms-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "kms-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "kms.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-lakeformation/src/endpoints.ts
+++ b/clients/client-lakeformation/src/endpoints.ts
@@ -4,23 +4,118 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 const regionHash: RegionHash = {
   "fips-us-east-1": {
     hostname: "lakeformation-fips.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "lakeformation-fips.us-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-1",
   },
   "fips-us-east-2": {
     hostname: "lakeformation-fips.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "lakeformation-fips.us-east-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-2",
   },
   "fips-us-gov-west-1": {
     hostname: "lakeformation-fips.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "lakeformation-fips.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-west-1",
   },
   "fips-us-west-1": {
     hostname: "lakeformation-fips.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "lakeformation-fips.us-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-1",
   },
   "fips-us-west-2": {
     hostname: "lakeformation-fips.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "lakeformation-fips.us-west-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-2",
+  },
+  "us-east-1": {
+    hostname: "lakeformation.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "lakeformation.us-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "lakeformation-fips.us-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-east-2": {
+    hostname: "lakeformation.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "lakeformation.us-east-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "lakeformation-fips.us-east-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-gov-west-1": {
+    hostname: "lakeformation.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "lakeformation.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "lakeformation-fips.us-gov-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-west-1": {
+    hostname: "lakeformation.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "lakeformation.us-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "lakeformation-fips.us-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-west-2": {
+    hostname: "lakeformation.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "lakeformation.us-west-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "lakeformation-fips.us-west-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
 };
 
@@ -55,26 +150,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "lakeformation.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "lakeformation.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "lakeformation-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "lakeformation-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "lakeformation.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "lakeformation.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "lakeformation.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "lakeformation-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "lakeformation-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "lakeformation.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "lakeformation.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "lakeformation.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "lakeformation.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "lakeformation.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["fips-us-gov-west-1", "us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "lakeformation.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "lakeformation.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "lakeformation-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "lakeformation-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "lakeformation.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-lambda/src/endpoints.ts
+++ b/clients/client-lambda/src/endpoints.ts
@@ -4,27 +4,141 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 const regionHash: RegionHash = {
   "fips-us-east-1": {
     hostname: "lambda-fips.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "lambda-fips.us-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-1",
   },
   "fips-us-east-2": {
     hostname: "lambda-fips.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "lambda-fips.us-east-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-2",
   },
   "fips-us-gov-east-1": {
     hostname: "lambda-fips.us-gov-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "lambda-fips.us-gov-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-east-1",
   },
   "fips-us-gov-west-1": {
     hostname: "lambda-fips.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "lambda-fips.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-west-1",
   },
   "fips-us-west-1": {
     hostname: "lambda-fips.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "lambda-fips.us-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-1",
   },
   "fips-us-west-2": {
     hostname: "lambda-fips.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "lambda-fips.us-west-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-2",
+  },
+  "us-east-1": {
+    hostname: "lambda.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "lambda.us-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "lambda-fips.us-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-east-2": {
+    hostname: "lambda.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "lambda.us-east-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "lambda-fips.us-east-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-gov-east-1": {
+    hostname: "lambda.us-gov-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "lambda.us-gov-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "lambda-fips.us-gov-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-gov-west-1": {
+    hostname: "lambda.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "lambda.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "lambda-fips.us-gov-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-west-1": {
+    hostname: "lambda.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "lambda.us-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "lambda-fips.us-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-west-2": {
+    hostname: "lambda.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "lambda.us-west-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "lambda-fips.us-west-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
 };
 
@@ -59,26 +173,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "lambda.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "lambda.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "lambda-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "lambda-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "lambda.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "lambda.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "lambda.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "lambda-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "lambda-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "lambda.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "lambda.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "lambda.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "lambda.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "lambda.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["fips-us-gov-east-1", "fips-us-gov-west-1", "us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "lambda.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "lambda.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "lambda-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "lambda-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "lambda.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-lex-model-building-service/src/endpoints.ts
+++ b/clients/client-lex-model-building-service/src/endpoints.ts
@@ -2,16 +2,73 @@ import { getRegionInfo, PartitionHash, RegionHash } from "@aws-sdk/config-resolv
 import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
+  "us-east-1": {
+    hostname: "models.lex.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "models.lex.us-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "models-fips.lex.us-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
   "us-east-1-fips": {
     hostname: "models-fips.lex.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "models-fips.lex.us-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-1",
+  },
+  "us-gov-west-1": {
+    hostname: "models.lex.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "models.lex.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "models-fips.lex.us-gov-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "us-gov-west-1-fips": {
     hostname: "models-fips.lex.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "models-fips.lex.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-west-1",
+  },
+  "us-west-2": {
+    hostname: "models.lex.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "models.lex.us-west-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "models-fips.lex.us-west-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "us-west-2-fips": {
     hostname: "models-fips.lex.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "models-fips.lex.us-west-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-2",
   },
 };
@@ -45,26 +102,76 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "models.lex.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "models.lex.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "models-fips.lex.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "models.lex.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "models.lex.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "models.lex-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "models.lex-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "models.lex.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "models.lex.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "models.lex.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "models.lex.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "models.lex.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1", "us-gov-west-1-fips"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "models.lex.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "models.lex.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "models-fips.lex.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
 };
 

--- a/clients/client-lex-models-v2/src/endpoints.ts
+++ b/clients/client-lex-models-v2/src/endpoints.ts
@@ -30,26 +30,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "models-v2-lex.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "models-v2-lex.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "models-v2-lex-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "models-v2-lex-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "models-v2-lex.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "models-v2-lex.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "models-v2-lex.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "models-v2-lex-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "models-v2-lex-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "models-v2-lex.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "models-v2-lex.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "models-v2-lex.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "models-v2-lex.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "models-v2-lex.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "models-v2-lex.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "models-v2-lex.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "models-v2-lex-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "models-v2-lex-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "models-v2-lex.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-lex-runtime-service/src/endpoints.ts
+++ b/clients/client-lex-runtime-service/src/endpoints.ts
@@ -2,16 +2,73 @@ import { getRegionInfo, PartitionHash, RegionHash } from "@aws-sdk/config-resolv
 import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
+  "us-east-1": {
+    hostname: "runtime.lex.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "runtime.lex.us-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "runtime-fips.lex.us-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
   "us-east-1-fips": {
     hostname: "runtime-fips.lex.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "runtime-fips.lex.us-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-1",
+  },
+  "us-gov-west-1": {
+    hostname: "runtime.lex.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "runtime.lex.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "runtime-fips.lex.us-gov-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "us-gov-west-1-fips": {
     hostname: "runtime-fips.lex.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "runtime-fips.lex.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-west-1",
+  },
+  "us-west-2": {
+    hostname: "runtime.lex.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "runtime.lex.us-west-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "runtime-fips.lex.us-west-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "us-west-2-fips": {
     hostname: "runtime-fips.lex.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "runtime-fips.lex.us-west-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-2",
   },
 };
@@ -45,26 +102,76 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "runtime.lex.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "runtime.lex.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "runtime-fips.lex.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "runtime.lex.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "runtime.lex.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "runtime.lex-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "runtime.lex-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "runtime.lex.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "runtime.lex.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "runtime.lex.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "runtime.lex.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "runtime.lex.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1", "us-gov-west-1-fips"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "runtime.lex.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "runtime.lex.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "runtime-fips.lex.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
 };
 

--- a/clients/client-lex-runtime-v2/src/endpoints.ts
+++ b/clients/client-lex-runtime-v2/src/endpoints.ts
@@ -30,26 +30,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "runtime-v2-lex.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "runtime-v2-lex.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "runtime-v2-lex-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "runtime-v2-lex-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "runtime-v2-lex.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "runtime-v2-lex.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "runtime-v2-lex.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "runtime-v2-lex-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "runtime-v2-lex-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "runtime-v2-lex.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "runtime-v2-lex.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "runtime-v2-lex.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "runtime-v2-lex.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "runtime-v2-lex.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "runtime-v2-lex.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "runtime-v2-lex.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "runtime-v2-lex-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "runtime-v2-lex-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "runtime-v2-lex.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-license-manager/src/endpoints.ts
+++ b/clients/client-license-manager/src/endpoints.ts
@@ -4,27 +4,141 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 const regionHash: RegionHash = {
   "fips-us-east-1": {
     hostname: "license-manager-fips.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "license-manager-fips.us-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-1",
   },
   "fips-us-east-2": {
     hostname: "license-manager-fips.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "license-manager-fips.us-east-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-2",
   },
   "fips-us-gov-east-1": {
     hostname: "license-manager-fips.us-gov-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "license-manager-fips.us-gov-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-east-1",
   },
   "fips-us-gov-west-1": {
     hostname: "license-manager-fips.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "license-manager-fips.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-west-1",
   },
   "fips-us-west-1": {
     hostname: "license-manager-fips.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "license-manager-fips.us-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-1",
   },
   "fips-us-west-2": {
     hostname: "license-manager-fips.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "license-manager-fips.us-west-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-2",
+  },
+  "us-east-1": {
+    hostname: "license-manager.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "license-manager.us-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "license-manager-fips.us-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-east-2": {
+    hostname: "license-manager.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "license-manager.us-east-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "license-manager-fips.us-east-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-gov-east-1": {
+    hostname: "license-manager.us-gov-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "license-manager.us-gov-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "license-manager-fips.us-gov-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-gov-west-1": {
+    hostname: "license-manager.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "license-manager.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "license-manager-fips.us-gov-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-west-1": {
+    hostname: "license-manager.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "license-manager.us-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "license-manager-fips.us-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-west-2": {
+    hostname: "license-manager.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "license-manager.us-west-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "license-manager-fips.us-west-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
 };
 
@@ -59,26 +173,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "license-manager.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "license-manager.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "license-manager-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "license-manager-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "license-manager.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "license-manager.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "license-manager.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "license-manager-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "license-manager-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "license-manager.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "license-manager.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "license-manager.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "license-manager.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "license-manager.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["fips-us-gov-east-1", "fips-us-gov-west-1", "us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "license-manager.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "license-manager.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "license-manager-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "license-manager-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "license-manager.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-lightsail/src/endpoints.ts
+++ b/clients/client-lightsail/src/endpoints.ts
@@ -30,26 +30,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "lightsail.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "lightsail.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "lightsail-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "lightsail-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "lightsail.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "lightsail.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "lightsail.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "lightsail-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "lightsail-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "lightsail.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "lightsail.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "lightsail.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "lightsail.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "lightsail.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "lightsail.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "lightsail.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "lightsail-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "lightsail-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "lightsail.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-location/src/endpoints.ts
+++ b/clients/client-location/src/endpoints.ts
@@ -30,26 +30,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "geo.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "geo.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "geo-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "geo-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "geo.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "geo.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "geo.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "geo-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "geo-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "geo.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "geo.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "geo.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "geo.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "geo.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "geo.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "geo.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "geo-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "geo-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "geo.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-lookoutequipment/src/endpoints.ts
+++ b/clients/client-lookoutequipment/src/endpoints.ts
@@ -30,26 +30,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "lookoutequipment.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "lookoutequipment.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "lookoutequipment-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "lookoutequipment-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "lookoutequipment.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "lookoutequipment.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "lookoutequipment.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "lookoutequipment-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "lookoutequipment-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "lookoutequipment.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "lookoutequipment.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "lookoutequipment.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "lookoutequipment.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "lookoutequipment.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "lookoutequipment.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "lookoutequipment.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "lookoutequipment-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "lookoutequipment-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "lookoutequipment.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-lookoutmetrics/src/endpoints.ts
+++ b/clients/client-lookoutmetrics/src/endpoints.ts
@@ -30,26 +30,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "lookoutmetrics.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "lookoutmetrics.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "lookoutmetrics-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "lookoutmetrics-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "lookoutmetrics.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "lookoutmetrics.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "lookoutmetrics.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "lookoutmetrics-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "lookoutmetrics-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "lookoutmetrics.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "lookoutmetrics.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "lookoutmetrics.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "lookoutmetrics.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "lookoutmetrics.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "lookoutmetrics.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "lookoutmetrics.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "lookoutmetrics-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "lookoutmetrics-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "lookoutmetrics.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-lookoutvision/src/endpoints.ts
+++ b/clients/client-lookoutvision/src/endpoints.ts
@@ -30,26 +30,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "lookoutvision.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "lookoutvision.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "lookoutvision-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "lookoutvision-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "lookoutvision.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "lookoutvision.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "lookoutvision.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "lookoutvision-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "lookoutvision-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "lookoutvision.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "lookoutvision.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "lookoutvision.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "lookoutvision.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "lookoutvision.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "lookoutvision.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "lookoutvision.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "lookoutvision-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "lookoutvision-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "lookoutvision.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-machine-learning/src/endpoints.ts
+++ b/clients/client-machine-learning/src/endpoints.ts
@@ -30,26 +30,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "machinelearning.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "machinelearning.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "machinelearning-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "machinelearning-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "machinelearning.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "machinelearning.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "machinelearning.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "machinelearning-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "machinelearning-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "machinelearning.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "machinelearning.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "machinelearning.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "machinelearning.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "machinelearning.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "machinelearning.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "machinelearning.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "machinelearning-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "machinelearning-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "machinelearning.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-macie/src/endpoints.ts
+++ b/clients/client-macie/src/endpoints.ts
@@ -4,11 +4,49 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 const regionHash: RegionHash = {
   "fips-us-east-1": {
     hostname: "macie-fips.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "macie-fips.us-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-1",
   },
   "fips-us-west-2": {
     hostname: "macie-fips.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "macie-fips.us-west-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-2",
+  },
+  "us-east-1": {
+    hostname: "macie.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "macie.us-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "macie-fips.us-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-west-2": {
+    hostname: "macie.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "macie.us-west-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "macie-fips.us-west-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
 };
 
@@ -41,26 +79,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "macie.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "macie.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "macie-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "macie-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "macie.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "macie.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "macie.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "macie-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "macie-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "macie.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "macie.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "macie.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "macie.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "macie.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "macie.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "macie.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "macie-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "macie-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "macie.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-macie2/src/endpoints.ts
+++ b/clients/client-macie2/src/endpoints.ts
@@ -4,19 +4,95 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 const regionHash: RegionHash = {
   "fips-us-east-1": {
     hostname: "macie2-fips.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "macie2-fips.us-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-1",
   },
   "fips-us-east-2": {
     hostname: "macie2-fips.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "macie2-fips.us-east-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-2",
   },
   "fips-us-west-1": {
     hostname: "macie2-fips.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "macie2-fips.us-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-1",
   },
   "fips-us-west-2": {
     hostname: "macie2-fips.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "macie2-fips.us-west-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-2",
+  },
+  "us-east-1": {
+    hostname: "macie2.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "macie2.us-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "macie2-fips.us-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-east-2": {
+    hostname: "macie2.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "macie2.us-east-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "macie2-fips.us-east-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-west-1": {
+    hostname: "macie2.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "macie2.us-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "macie2-fips.us-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-west-2": {
+    hostname: "macie2.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "macie2.us-west-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "macie2-fips.us-west-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
 };
 
@@ -51,26 +127,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "macie2.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "macie2.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "macie2-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "macie2-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "macie2.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "macie2.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "macie2.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "macie2-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "macie2-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "macie2.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "macie2.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "macie2.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "macie2.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "macie2.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "macie2.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "macie2.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "macie2-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "macie2-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "macie2.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-managedblockchain/src/endpoints.ts
+++ b/clients/client-managedblockchain/src/endpoints.ts
@@ -30,26 +30,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "managedblockchain.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "managedblockchain.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "managedblockchain-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "managedblockchain-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "managedblockchain.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "managedblockchain.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "managedblockchain.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "managedblockchain-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "managedblockchain-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "managedblockchain.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "managedblockchain.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "managedblockchain.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "managedblockchain.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "managedblockchain.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "managedblockchain.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "managedblockchain.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "managedblockchain-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "managedblockchain-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "managedblockchain.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-marketplace-catalog/src/endpoints.ts
+++ b/clients/client-marketplace-catalog/src/endpoints.ts
@@ -30,26 +30,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "catalog.marketplace.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "catalog.marketplace.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "catalog.marketplace-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "catalog.marketplace-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "catalog.marketplace.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "catalog.marketplace.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "catalog.marketplace.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "catalog.marketplace-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "catalog.marketplace-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "catalog.marketplace.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "catalog.marketplace.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "catalog.marketplace.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "catalog.marketplace.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "catalog.marketplace.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "catalog.marketplace.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "catalog.marketplace.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "catalog.marketplace-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "catalog.marketplace-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "catalog.marketplace.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-marketplace-commerce-analytics/src/endpoints.ts
+++ b/clients/client-marketplace-commerce-analytics/src/endpoints.ts
@@ -30,26 +30,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "marketplacecommerceanalytics.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "marketplacecommerceanalytics.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "marketplacecommerceanalytics-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "marketplacecommerceanalytics-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "marketplacecommerceanalytics.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "marketplacecommerceanalytics.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "marketplacecommerceanalytics.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "marketplacecommerceanalytics-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "marketplacecommerceanalytics-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "marketplacecommerceanalytics.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "marketplacecommerceanalytics.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "marketplacecommerceanalytics.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "marketplacecommerceanalytics.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "marketplacecommerceanalytics.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "marketplacecommerceanalytics.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "marketplacecommerceanalytics.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "marketplacecommerceanalytics-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "marketplacecommerceanalytics-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "marketplacecommerceanalytics.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-marketplace-entitlement-service/src/endpoints.ts
+++ b/clients/client-marketplace-entitlement-service/src/endpoints.ts
@@ -30,26 +30,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "entitlement.marketplace.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "entitlement.marketplace.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "entitlement.marketplace-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "entitlement.marketplace-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "entitlement.marketplace.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "entitlement.marketplace.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "entitlement.marketplace.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "entitlement.marketplace-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "entitlement.marketplace-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "entitlement.marketplace.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "entitlement.marketplace.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "entitlement.marketplace.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "entitlement.marketplace.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "entitlement.marketplace.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "entitlement.marketplace.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "entitlement.marketplace.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "entitlement.marketplace-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "entitlement.marketplace-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "entitlement.marketplace.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-marketplace-metering/src/endpoints.ts
+++ b/clients/client-marketplace-metering/src/endpoints.ts
@@ -30,26 +30,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "metering.marketplace.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "metering.marketplace.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "metering.marketplace-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "metering.marketplace-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "metering.marketplace.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "metering.marketplace.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "metering.marketplace.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "metering.marketplace-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "metering.marketplace-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "metering.marketplace.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "metering.marketplace.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "metering.marketplace.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "metering.marketplace.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "metering.marketplace.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "metering.marketplace.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "metering.marketplace.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "metering.marketplace-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "metering.marketplace-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "metering.marketplace.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-mediaconnect/src/endpoints.ts
+++ b/clients/client-mediaconnect/src/endpoints.ts
@@ -30,26 +30,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "mediaconnect.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "mediaconnect.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "mediaconnect-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "mediaconnect-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "mediaconnect.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "mediaconnect.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "mediaconnect.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "mediaconnect-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "mediaconnect-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "mediaconnect.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "mediaconnect.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "mediaconnect.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "mediaconnect.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "mediaconnect.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "mediaconnect.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "mediaconnect.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "mediaconnect-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "mediaconnect-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "mediaconnect.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-mediaconvert/src/endpoints.ts
+++ b/clients/client-mediaconvert/src/endpoints.ts
@@ -2,33 +2,140 @@ import { getRegionInfo, PartitionHash, RegionHash } from "@aws-sdk/config-resolv
 import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
+  "ca-central-1": {
+    hostname: "mediaconvert.ca-central-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "mediaconvert.ca-central-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "mediaconvert-fips.ca-central-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
   "cn-northwest-1": {
     hostname: "subscribe.mediaconvert.cn-northwest-1.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "subscribe.mediaconvert.cn-northwest-1.amazonaws.com.cn",
+        tags: [],
+      },
+    ],
     signingRegion: "cn-northwest-1",
   },
   "fips-ca-central-1": {
     hostname: "mediaconvert-fips.ca-central-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "mediaconvert-fips.ca-central-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "ca-central-1",
   },
   "fips-us-east-1": {
     hostname: "mediaconvert-fips.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "mediaconvert-fips.us-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-1",
   },
   "fips-us-east-2": {
     hostname: "mediaconvert-fips.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "mediaconvert-fips.us-east-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-2",
   },
   "fips-us-west-1": {
     hostname: "mediaconvert-fips.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "mediaconvert-fips.us-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-1",
   },
   "fips-us-west-2": {
     hostname: "mediaconvert-fips.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "mediaconvert-fips.us-west-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-2",
+  },
+  "us-east-1": {
+    hostname: "mediaconvert.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "mediaconvert.us-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "mediaconvert-fips.us-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-east-2": {
+    hostname: "mediaconvert.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "mediaconvert.us-east-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "mediaconvert-fips.us-east-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "us-gov-west-1": {
     hostname: "mediaconvert.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "mediaconvert.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-west-1",
+  },
+  "us-west-1": {
+    hostname: "mediaconvert.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "mediaconvert.us-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "mediaconvert-fips.us-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-west-2": {
+    hostname: "mediaconvert.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "mediaconvert.us-west-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "mediaconvert-fips.us-west-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
 };
 
@@ -64,26 +171,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "mediaconvert.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "mediaconvert.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "mediaconvert-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "mediaconvert-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "mediaconvert.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "mediaconvert.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "mediaconvert.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "mediaconvert-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "mediaconvert-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "mediaconvert.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "mediaconvert.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "mediaconvert.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "mediaconvert.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "mediaconvert.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "mediaconvert.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "mediaconvert.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "mediaconvert-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "mediaconvert-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "mediaconvert.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-medialive/src/endpoints.ts
+++ b/clients/client-medialive/src/endpoints.ts
@@ -4,15 +4,72 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 const regionHash: RegionHash = {
   "fips-us-east-1": {
     hostname: "medialive-fips.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "medialive-fips.us-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-1",
   },
   "fips-us-east-2": {
     hostname: "medialive-fips.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "medialive-fips.us-east-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-2",
   },
   "fips-us-west-2": {
     hostname: "medialive-fips.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "medialive-fips.us-west-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-2",
+  },
+  "us-east-1": {
+    hostname: "medialive.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "medialive.us-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "medialive-fips.us-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-east-2": {
+    hostname: "medialive.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "medialive.us-east-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "medialive-fips.us-east-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-west-2": {
+    hostname: "medialive.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "medialive.us-west-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "medialive-fips.us-west-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
 };
 
@@ -46,26 +103,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "medialive.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "medialive.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "medialive-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "medialive-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "medialive.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "medialive.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "medialive.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "medialive-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "medialive-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "medialive.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "medialive.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "medialive.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "medialive.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "medialive.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "medialive.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "medialive.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "medialive-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "medialive-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "medialive.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-mediapackage-vod/src/endpoints.ts
+++ b/clients/client-mediapackage-vod/src/endpoints.ts
@@ -30,26 +30,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "mediapackage-vod.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "mediapackage-vod.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "mediapackage-vod-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "mediapackage-vod-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "mediapackage-vod.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "mediapackage-vod.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "mediapackage-vod.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "mediapackage-vod-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "mediapackage-vod-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "mediapackage-vod.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "mediapackage-vod.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "mediapackage-vod.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "mediapackage-vod.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "mediapackage-vod.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "mediapackage-vod.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "mediapackage-vod.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "mediapackage-vod-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "mediapackage-vod-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "mediapackage-vod.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-mediapackage/src/endpoints.ts
+++ b/clients/client-mediapackage/src/endpoints.ts
@@ -30,26 +30,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "mediapackage.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "mediapackage.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "mediapackage-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "mediapackage-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "mediapackage.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "mediapackage.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "mediapackage.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "mediapackage-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "mediapackage-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "mediapackage.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "mediapackage.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "mediapackage.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "mediapackage.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "mediapackage.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "mediapackage.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "mediapackage.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "mediapackage-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "mediapackage-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "mediapackage.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-mediastore-data/src/endpoints.ts
+++ b/clients/client-mediastore-data/src/endpoints.ts
@@ -30,26 +30,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "data.mediastore.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "data.mediastore.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "data.mediastore-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "data.mediastore-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "data.mediastore.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "data.mediastore.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "data.mediastore.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "data.mediastore-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "data.mediastore-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "data.mediastore.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "data.mediastore.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "data.mediastore.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "data.mediastore.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "data.mediastore.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "data.mediastore.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "data.mediastore.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "data.mediastore-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "data.mediastore-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "data.mediastore.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-mediastore/src/endpoints.ts
+++ b/clients/client-mediastore/src/endpoints.ts
@@ -30,26 +30,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "mediastore.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "mediastore.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "mediastore-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "mediastore-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "mediastore.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "mediastore.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "mediastore.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "mediastore-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "mediastore-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "mediastore.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "mediastore.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "mediastore.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "mediastore.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "mediastore.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "mediastore.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "mediastore.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "mediastore-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "mediastore-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "mediastore.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-mediatailor/src/endpoints.ts
+++ b/clients/client-mediatailor/src/endpoints.ts
@@ -30,26 +30,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "api.mediatailor.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "api.mediatailor.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "api.mediatailor-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "api.mediatailor-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "api.mediatailor.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "api.mediatailor.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "api.mediatailor.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "api.mediatailor-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "api.mediatailor-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "api.mediatailor.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "api.mediatailor.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "api.mediatailor.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "api.mediatailor.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "api.mediatailor.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "api.mediatailor.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "api.mediatailor.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "api.mediatailor-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "api.mediatailor-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "api.mediatailor.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-memorydb/src/endpoints.ts
+++ b/clients/client-memorydb/src/endpoints.ts
@@ -30,26 +30,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "memory-db.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "memory-db.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "memory-db-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "memory-db-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "memory-db.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "memory-db.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "memory-db.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "memory-db-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "memory-db-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "memory-db.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "memory-db.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "memory-db.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "memory-db.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "memory-db.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "memory-db.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "memory-db.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "memory-db-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "memory-db-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "memory-db.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-mgn/src/endpoints.ts
+++ b/clients/client-mgn/src/endpoints.ts
@@ -30,26 +30,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "mgn.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "mgn.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "mgn-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "mgn-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "mgn.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "mgn.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "mgn.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "mgn-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "mgn-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "mgn.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "mgn.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "mgn.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "mgn.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "mgn.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "mgn.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "mgn.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "mgn-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "mgn-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "mgn.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-migration-hub/src/endpoints.ts
+++ b/clients/client-migration-hub/src/endpoints.ts
@@ -30,26 +30,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "mgh.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "mgh.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "mgh-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "mgh-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "mgh.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "mgh.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "mgh.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "mgh-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "mgh-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "mgh.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "mgh.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "mgh.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "mgh.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "mgh.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "mgh.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "mgh.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "mgh-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "mgh-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "mgh.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-migrationhub-config/src/endpoints.ts
+++ b/clients/client-migrationhub-config/src/endpoints.ts
@@ -30,26 +30,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "migrationhub-config.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "migrationhub-config.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "migrationhub-config-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "migrationhub-config-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "migrationhub-config.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "migrationhub-config.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "migrationhub-config.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "migrationhub-config-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "migrationhub-config-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "migrationhub-config.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "migrationhub-config.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "migrationhub-config.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "migrationhub-config.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "migrationhub-config.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "migrationhub-config.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "migrationhub-config.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "migrationhub-config-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "migrationhub-config-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "migrationhub-config.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-mobile/src/endpoints.ts
+++ b/clients/client-mobile/src/endpoints.ts
@@ -30,26 +30,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "mobile.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "mobile.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "mobile-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "mobile-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "mobile.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "mobile.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "mobile.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "mobile-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "mobile-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "mobile.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "mobile.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "mobile.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "mobile.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "mobile.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "mobile.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "mobile.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "mobile-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "mobile-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "mobile.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-mq/src/endpoints.ts
+++ b/clients/client-mq/src/endpoints.ts
@@ -4,27 +4,141 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 const regionHash: RegionHash = {
   "fips-us-east-1": {
     hostname: "mq-fips.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "mq-fips.us-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-1",
   },
   "fips-us-east-2": {
     hostname: "mq-fips.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "mq-fips.us-east-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-2",
   },
   "fips-us-gov-east-1": {
     hostname: "mq-fips.us-gov-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "mq-fips.us-gov-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-east-1",
   },
   "fips-us-gov-west-1": {
     hostname: "mq-fips.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "mq-fips.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-west-1",
   },
   "fips-us-west-1": {
     hostname: "mq-fips.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "mq-fips.us-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-1",
   },
   "fips-us-west-2": {
     hostname: "mq-fips.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "mq-fips.us-west-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-2",
+  },
+  "us-east-1": {
+    hostname: "mq.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "mq.us-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "mq-fips.us-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-east-2": {
+    hostname: "mq.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "mq.us-east-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "mq-fips.us-east-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-gov-east-1": {
+    hostname: "mq.us-gov-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "mq.us-gov-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "mq-fips.us-gov-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-gov-west-1": {
+    hostname: "mq.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "mq.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "mq-fips.us-gov-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-west-1": {
+    hostname: "mq.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "mq.us-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "mq-fips.us-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-west-2": {
+    hostname: "mq.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "mq.us-west-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "mq-fips.us-west-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
 };
 
@@ -59,26 +173,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "mq.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "mq.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "mq-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "mq-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "mq.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "mq.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "mq.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "mq-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "mq-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "mq.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "mq.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "mq.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "mq.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "mq.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["fips-us-gov-east-1", "fips-us-gov-west-1", "us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "mq.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "mq.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "mq-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "mq-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "mq.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-mturk/src/endpoints.ts
+++ b/clients/client-mturk/src/endpoints.ts
@@ -4,6 +4,12 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 const regionHash: RegionHash = {
   sandbox: {
     hostname: "mturk-requester-sandbox.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "mturk-requester-sandbox.us-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
   },
 };
 
@@ -35,26 +41,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "mturk-requester.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "mturk-requester.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "mturk-requester-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "mturk-requester-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "mturk-requester.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "mturk-requester.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "mturk-requester.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "mturk-requester-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "mturk-requester-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "mturk-requester.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "mturk-requester.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "mturk-requester.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "mturk-requester.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "mturk-requester.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "mturk-requester.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "mturk-requester.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "mturk-requester-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "mturk-requester-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "mturk-requester.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-mwaa/src/endpoints.ts
+++ b/clients/client-mwaa/src/endpoints.ts
@@ -30,26 +30,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "airflow.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "airflow.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "airflow-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "airflow-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "airflow.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "airflow.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "airflow.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "airflow-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "airflow-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "airflow.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "airflow.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "airflow.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "airflow.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "airflow.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "airflow.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "airflow.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "airflow-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "airflow-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "airflow.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-neptune/src/endpoints.ts
+++ b/clients/client-neptune/src/endpoints.ts
@@ -2,60 +2,305 @@ import { getRegionInfo, PartitionHash, RegionHash } from "@aws-sdk/config-resolv
 import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
+  "ca-central-1": {
+    hostname: "rds.ca-central-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "rds.ca-central-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "rds-fips.ca-central-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
   "ca-central-1-fips": {
     hostname: "rds-fips.ca-central-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "rds-fips.ca-central-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "ca-central-1",
   },
   "rds-fips.ca-central-1": {
     hostname: "rds-fips.ca-central-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "rds-fips.ca-central-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "ca-central-1",
   },
   "rds-fips.us-east-1": {
     hostname: "rds-fips.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "rds-fips.us-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-1",
   },
   "rds-fips.us-east-2": {
     hostname: "rds-fips.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "rds-fips.us-east-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-2",
   },
   "rds-fips.us-west-1": {
     hostname: "rds-fips.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "rds-fips.us-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-1",
   },
   "rds-fips.us-west-2": {
     hostname: "rds-fips.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "rds-fips.us-west-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-2",
+  },
+  "rds.ca-central-1": {
+    hostname: "rds.rds.ca-central-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "rds.rds.ca-central-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "rds-fips.ca-central-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+    signingRegion: "ca-central-1",
+  },
+  "rds.us-east-1": {
+    hostname: "rds.rds.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "rds.rds.us-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "rds-fips.us-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+    signingRegion: "us-east-1",
+  },
+  "rds.us-east-2": {
+    hostname: "rds.rds.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "rds.rds.us-east-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "rds-fips.us-east-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+    signingRegion: "us-east-2",
   },
   "rds.us-gov-east-1": {
     hostname: "rds.us-gov-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "rds.us-gov-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-east-1",
   },
   "rds.us-gov-west-1": {
     hostname: "rds.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "rds.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-west-1",
+  },
+  "rds.us-west-1": {
+    hostname: "rds.rds.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "rds.rds.us-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "rds-fips.us-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+    signingRegion: "us-west-1",
+  },
+  "rds.us-west-2": {
+    hostname: "rds.rds.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "rds.rds.us-west-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "rds-fips.us-west-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+    signingRegion: "us-west-2",
+  },
+  "us-east-1": {
+    hostname: "rds.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "rds.us-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "rds-fips.us-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "us-east-1-fips": {
     hostname: "rds-fips.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "rds-fips.us-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-1",
+  },
+  "us-east-2": {
+    hostname: "rds.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "rds.us-east-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "rds-fips.us-east-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "us-east-2-fips": {
     hostname: "rds-fips.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "rds-fips.us-east-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-2",
+  },
+  "us-gov-east-1": {
+    hostname: "rds.us-gov-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "rds.us-gov-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "rds.us-gov-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "us-gov-east-1-fips": {
     hostname: "rds.us-gov-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "rds.us-gov-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-east-1",
+  },
+  "us-gov-west-1": {
+    hostname: "rds.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "rds.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "rds.us-gov-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "us-gov-west-1-fips": {
     hostname: "rds.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "rds.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-west-1",
+  },
+  "us-west-1": {
+    hostname: "rds.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "rds.us-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "rds-fips.us-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "us-west-1-fips": {
     hostname: "rds-fips.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "rds-fips.us-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-1",
+  },
+  "us-west-2": {
+    hostname: "rds.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "rds.us-west-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "rds-fips.us-west-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "us-west-2-fips": {
     hostname: "rds-fips.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "rds-fips.us-west-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-2",
   },
 };
@@ -102,21 +347,69 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "rds.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "rds.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "rds-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "rds-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "rds.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "rds.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "rds.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "rds-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "rds-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "rds.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "rds.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "rds.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "rds.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "rds.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: [
@@ -129,6 +422,24 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "rds.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "rds.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "rds-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "rds-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "rds.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-network-firewall/src/endpoints.ts
+++ b/clients/client-network-firewall/src/endpoints.ts
@@ -2,33 +2,166 @@ import { getRegionInfo, PartitionHash, RegionHash } from "@aws-sdk/config-resolv
 import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
+  "ca-central-1": {
+    hostname: "network-firewall.ca-central-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "network-firewall.ca-central-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "network-firewall-fips.ca-central-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
   "fips-ca-central-1": {
     hostname: "network-firewall-fips.ca-central-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "network-firewall-fips.ca-central-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "ca-central-1",
   },
   "fips-us-east-1": {
     hostname: "network-firewall-fips.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "network-firewall-fips.us-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-1",
   },
   "fips-us-east-2": {
     hostname: "network-firewall-fips.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "network-firewall-fips.us-east-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-2",
   },
   "fips-us-gov-east-1": {
     hostname: "network-firewall-fips.us-gov-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "network-firewall-fips.us-gov-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-east-1",
   },
   "fips-us-gov-west-1": {
     hostname: "network-firewall-fips.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "network-firewall-fips.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-west-1",
   },
   "fips-us-west-1": {
     hostname: "network-firewall-fips.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "network-firewall-fips.us-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-1",
   },
   "fips-us-west-2": {
     hostname: "network-firewall-fips.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "network-firewall-fips.us-west-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-2",
+  },
+  "us-east-1": {
+    hostname: "network-firewall.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "network-firewall.us-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "network-firewall-fips.us-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-east-2": {
+    hostname: "network-firewall.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "network-firewall.us-east-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "network-firewall-fips.us-east-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-gov-east-1": {
+    hostname: "network-firewall.us-gov-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "network-firewall.us-gov-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "network-firewall-fips.us-gov-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-gov-west-1": {
+    hostname: "network-firewall.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "network-firewall.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "network-firewall-fips.us-gov-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-west-1": {
+    hostname: "network-firewall.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "network-firewall.us-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "network-firewall-fips.us-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-west-2": {
+    hostname: "network-firewall.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "network-firewall.us-west-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "network-firewall-fips.us-west-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
 };
 
@@ -64,26 +197,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "network-firewall.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "network-firewall.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "network-firewall-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "network-firewall-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "network-firewall.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "network-firewall.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "network-firewall.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "network-firewall-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "network-firewall-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "network-firewall.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "network-firewall.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "network-firewall.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "network-firewall.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "network-firewall.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["fips-us-gov-east-1", "fips-us-gov-west-1", "us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "network-firewall.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "network-firewall.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "network-firewall-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "network-firewall-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "network-firewall.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-networkmanager/src/endpoints.ts
+++ b/clients/client-networkmanager/src/endpoints.ts
@@ -4,10 +4,22 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 const regionHash: RegionHash = {
   "aws-global": {
     hostname: "networkmanager.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "networkmanager.us-west-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-2",
   },
   "aws-us-gov-global": {
     hostname: "networkmanager.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "networkmanager.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-west-1",
   },
 };
@@ -39,26 +51,94 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
+    hostname: "networkmanager.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "networkmanager.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "networkmanager-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "networkmanager-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "networkmanager.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
     endpoint: "aws-global",
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "networkmanager.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "networkmanager.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "networkmanager-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "networkmanager-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "networkmanager.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "networkmanager.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "networkmanager.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "networkmanager.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "networkmanager.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["aws-us-gov-global", "us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
+    hostname: "networkmanager.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "networkmanager.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "networkmanager-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "networkmanager-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "networkmanager.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
     endpoint: "aws-us-gov-global",
   },
 };

--- a/clients/client-nimble/src/endpoints.ts
+++ b/clients/client-nimble/src/endpoints.ts
@@ -30,26 +30,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "nimble.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "nimble.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "nimble-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "nimble-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "nimble.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "nimble.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "nimble.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "nimble-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "nimble-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "nimble.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "nimble.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "nimble.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "nimble.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "nimble.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "nimble.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "nimble.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "nimble-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "nimble-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "nimble.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-opensearch/src/endpoints.ts
+++ b/clients/client-opensearch/src/endpoints.ts
@@ -4,30 +4,150 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 const regionHash: RegionHash = {
   fips: {
     hostname: "es-fips.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "es-fips.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-west-1",
+  },
+  "us-east-1": {
+    hostname: "es.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "es.us-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "es-fips.us-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "us-east-1-fips": {
     hostname: "es-fips.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "es-fips.us-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-1",
+  },
+  "us-east-2": {
+    hostname: "es.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "es.us-east-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "es-fips.us-east-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "us-east-2-fips": {
     hostname: "es-fips.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "es-fips.us-east-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-2",
+  },
+  "us-gov-east-1": {
+    hostname: "es.us-gov-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "es.us-gov-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "es-fips.us-gov-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "us-gov-east-1-fips": {
     hostname: "es-fips.us-gov-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "es-fips.us-gov-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-east-1",
+  },
+  "us-gov-west-1": {
+    hostname: "es.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "es.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "es-fips.us-gov-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "us-gov-west-1-fips": {
     hostname: "es-fips.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "es-fips.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-west-1",
+  },
+  "us-west-1": {
+    hostname: "es.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "es.us-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "es-fips.us-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "us-west-1-fips": {
     hostname: "es-fips.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "es-fips.us-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-1",
+  },
+  "us-west-2": {
+    hostname: "es.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "es.us-west-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "es-fips.us-west-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "us-west-2-fips": {
     hostname: "es-fips.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "es-fips.us-west-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-2",
   },
 };
@@ -64,26 +184,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "es.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "es.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "es-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "es-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "es.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "es.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "es.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "es-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "es-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "es.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "es.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "es.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "es.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "es.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["fips", "us-gov-east-1", "us-gov-east-1-fips", "us-gov-west-1", "us-gov-west-1-fips"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "es.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "es.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "es-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "es-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "es.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-opsworks/src/endpoints.ts
+++ b/clients/client-opsworks/src/endpoints.ts
@@ -30,26 +30,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "opsworks.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "opsworks.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "opsworks-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "opsworks-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "opsworks.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "opsworks.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "opsworks.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "opsworks-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "opsworks-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "opsworks.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "opsworks.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "opsworks.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "opsworks.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "opsworks.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "opsworks.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "opsworks.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "opsworks-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "opsworks-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "opsworks.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-opsworkscm/src/endpoints.ts
+++ b/clients/client-opsworkscm/src/endpoints.ts
@@ -30,26 +30,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "opsworks-cm.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "opsworks-cm.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "opsworks-cm-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "opsworks-cm-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "opsworks-cm.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "opsworks-cm.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "opsworks-cm.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "opsworks-cm-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "opsworks-cm-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "opsworks-cm.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "opsworks-cm.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "opsworks-cm.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "opsworks-cm.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "opsworks-cm.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "opsworks-cm.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "opsworks-cm.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "opsworks-cm-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "opsworks-cm-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "opsworks-cm.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-organizations/src/endpoints.ts
+++ b/clients/client-organizations/src/endpoints.ts
@@ -4,22 +4,60 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 const regionHash: RegionHash = {
   "aws-cn-global": {
     hostname: "organizations.cn-northwest-1.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "organizations.cn-northwest-1.amazonaws.com.cn",
+        tags: [],
+      },
+    ],
     signingRegion: "cn-northwest-1",
   },
   "aws-global": {
     hostname: "organizations.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "organizations.us-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "organizations-fips.us-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
     signingRegion: "us-east-1",
   },
   "aws-us-gov-global": {
     hostname: "organizations.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "organizations.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "organizations.us-gov-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
     signingRegion: "us-gov-west-1",
   },
   "fips-aws-global": {
     hostname: "organizations-fips.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "organizations-fips.us-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-1",
   },
   "fips-aws-us-gov-global": {
     hostname: "organizations.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "organizations.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-west-1",
   },
 };
@@ -52,26 +90,95 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
+    hostname: "organizations.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "organizations.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "organizations-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "organizations-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "organizations.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
     endpoint: "aws-global",
   },
   "aws-cn": {
     regions: ["aws-cn-global", "cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
+    hostname: "organizations.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "organizations.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "organizations-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "organizations-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "organizations.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
     endpoint: "aws-cn-global",
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "organizations.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "organizations.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "organizations.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "organizations.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["aws-us-gov-global", "fips-aws-us-gov-global", "us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
+    hostname: "organizations.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "organizations.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "organizations-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "organizations-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "organizations.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
     endpoint: "aws-us-gov-global",
   },
 };

--- a/clients/client-outposts/src/endpoints.ts
+++ b/clients/client-outposts/src/endpoints.ts
@@ -2,33 +2,140 @@ import { getRegionInfo, PartitionHash, RegionHash } from "@aws-sdk/config-resolv
 import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
+  "ca-central-1": {
+    hostname: "outposts.ca-central-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "outposts.ca-central-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "outposts-fips.ca-central-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
   "fips-ca-central-1": {
     hostname: "outposts-fips.ca-central-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "outposts-fips.ca-central-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "ca-central-1",
   },
   "fips-us-east-1": {
     hostname: "outposts-fips.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "outposts-fips.us-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-1",
   },
   "fips-us-east-2": {
     hostname: "outposts-fips.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "outposts-fips.us-east-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-2",
   },
   "fips-us-west-1": {
     hostname: "outposts-fips.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "outposts-fips.us-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-1",
   },
   "fips-us-west-2": {
     hostname: "outposts-fips.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "outposts-fips.us-west-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-2",
+  },
+  "us-east-1": {
+    hostname: "outposts.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "outposts.us-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "outposts-fips.us-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-east-2": {
+    hostname: "outposts.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "outposts.us-east-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "outposts-fips.us-east-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "us-gov-east-1": {
     hostname: "outposts.us-gov-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "outposts.us-gov-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-east-1",
   },
   "us-gov-west-1": {
     hostname: "outposts.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "outposts.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-west-1",
+  },
+  "us-west-1": {
+    hostname: "outposts.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "outposts.us-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "outposts-fips.us-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-west-2": {
+    hostname: "outposts.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "outposts.us-west-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "outposts-fips.us-west-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
 };
 
@@ -64,26 +171,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "outposts.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "outposts.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "outposts-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "outposts-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "outposts.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "outposts.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "outposts.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "outposts-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "outposts-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "outposts.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "outposts.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "outposts.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "outposts.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "outposts.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "outposts.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "outposts.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "outposts-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "outposts-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "outposts.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-panorama/src/endpoints.ts
+++ b/clients/client-panorama/src/endpoints.ts
@@ -30,26 +30,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "panorama.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "panorama.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "panorama-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "panorama-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "panorama.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "panorama.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "panorama.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "panorama-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "panorama-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "panorama.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "panorama.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "panorama.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "panorama.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "panorama.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "panorama.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "panorama.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "panorama-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "panorama-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "panorama.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-personalize-events/src/endpoints.ts
+++ b/clients/client-personalize-events/src/endpoints.ts
@@ -30,26 +30,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "personalize-events.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "personalize-events.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "personalize-events-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "personalize-events-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "personalize-events.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "personalize-events.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "personalize-events.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "personalize-events-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "personalize-events-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "personalize-events.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "personalize-events.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "personalize-events.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "personalize-events.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "personalize-events.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "personalize-events.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "personalize-events.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "personalize-events-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "personalize-events-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "personalize-events.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-personalize-runtime/src/endpoints.ts
+++ b/clients/client-personalize-runtime/src/endpoints.ts
@@ -30,26 +30,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "personalize-runtime.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "personalize-runtime.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "personalize-runtime-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "personalize-runtime-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "personalize-runtime.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "personalize-runtime.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "personalize-runtime.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "personalize-runtime-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "personalize-runtime-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "personalize-runtime.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "personalize-runtime.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "personalize-runtime.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "personalize-runtime.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "personalize-runtime.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "personalize-runtime.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "personalize-runtime.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "personalize-runtime-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "personalize-runtime-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "personalize-runtime.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-personalize/src/endpoints.ts
+++ b/clients/client-personalize/src/endpoints.ts
@@ -30,26 +30,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "personalize.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "personalize.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "personalize-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "personalize-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "personalize.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "personalize.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "personalize.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "personalize-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "personalize-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "personalize.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "personalize.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "personalize.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "personalize.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "personalize.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "personalize.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "personalize.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "personalize-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "personalize-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "personalize.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-pi/src/endpoints.ts
+++ b/clients/client-pi/src/endpoints.ts
@@ -30,26 +30,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "pi.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "pi.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "pi-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "pi-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "pi.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "pi.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "pi.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "pi-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "pi-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "pi.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "pi.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "pi.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "pi.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "pi.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "pi.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "pi.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "pi-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "pi-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "pi.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-pinpoint-email/src/endpoints.ts
+++ b/clients/client-pinpoint-email/src/endpoints.ts
@@ -4,7 +4,26 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 const regionHash: RegionHash = {
   "fips-us-gov-west-1": {
     hostname: "email-fips.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "email-fips.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-west-1",
+  },
+  "us-gov-west-1": {
+    hostname: "email.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "email.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "email-fips.us-gov-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
 };
 
@@ -35,26 +54,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "email.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "email.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "email-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "email-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "email.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "email.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "email.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "email-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "email-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "email.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "email.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "email.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "email.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "email.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["fips-us-gov-west-1", "us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "email.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "email.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "email-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "email-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "email.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-pinpoint-sms-voice/src/endpoints.ts
+++ b/clients/client-pinpoint-sms-voice/src/endpoints.ts
@@ -30,26 +30,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "sms-voice.pinpoint.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "sms-voice.pinpoint.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "sms-voice.pinpoint-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "sms-voice.pinpoint-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "sms-voice.pinpoint.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "sms-voice.pinpoint.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "sms-voice.pinpoint.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "sms-voice.pinpoint-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "sms-voice.pinpoint-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "sms-voice.pinpoint.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "sms-voice.pinpoint.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "sms-voice.pinpoint.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "sms-voice.pinpoint.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "sms-voice.pinpoint.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "sms-voice.pinpoint.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "sms-voice.pinpoint.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "sms-voice.pinpoint-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "sms-voice.pinpoint-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "sms-voice.pinpoint.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-pinpoint/src/endpoints.ts
+++ b/clients/client-pinpoint/src/endpoints.ts
@@ -4,26 +4,74 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 const regionHash: RegionHash = {
   "fips-us-east-1": {
     hostname: "pinpoint-fips.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "pinpoint-fips.us-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-1",
   },
   "fips-us-gov-west-1": {
     hostname: "pinpoint-fips.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "pinpoint-fips.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-west-1",
   },
   "fips-us-west-2": {
     hostname: "pinpoint-fips.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "pinpoint-fips.us-west-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-2",
   },
   "us-east-1": {
     hostname: "pinpoint.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "pinpoint.us-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "pinpoint-fips.us-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
     signingRegion: "us-east-1",
   },
   "us-gov-west-1": {
     hostname: "pinpoint.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "pinpoint.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "pinpoint-fips.us-gov-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
     signingRegion: "us-gov-west-1",
   },
   "us-west-2": {
     hostname: "pinpoint.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "pinpoint.us-west-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "pinpoint-fips.us-west-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
     signingRegion: "us-west-2",
   },
 };
@@ -57,26 +105,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "pinpoint.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "pinpoint.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "pinpoint-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "pinpoint-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "pinpoint.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "pinpoint.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "pinpoint.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "pinpoint-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "pinpoint-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "pinpoint.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "pinpoint.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "pinpoint.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "pinpoint.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "pinpoint.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["fips-us-gov-west-1", "us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "pinpoint.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "pinpoint.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "pinpoint-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "pinpoint-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "pinpoint.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-polly/src/endpoints.ts
+++ b/clients/client-polly/src/endpoints.ts
@@ -4,23 +4,118 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 const regionHash: RegionHash = {
   "fips-us-east-1": {
     hostname: "polly-fips.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "polly-fips.us-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-1",
   },
   "fips-us-east-2": {
     hostname: "polly-fips.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "polly-fips.us-east-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-2",
   },
   "fips-us-gov-west-1": {
     hostname: "polly-fips.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "polly-fips.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-west-1",
   },
   "fips-us-west-1": {
     hostname: "polly-fips.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "polly-fips.us-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-1",
   },
   "fips-us-west-2": {
     hostname: "polly-fips.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "polly-fips.us-west-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-2",
+  },
+  "us-east-1": {
+    hostname: "polly.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "polly.us-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "polly-fips.us-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-east-2": {
+    hostname: "polly.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "polly.us-east-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "polly-fips.us-east-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-gov-west-1": {
+    hostname: "polly.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "polly.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "polly-fips.us-gov-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-west-1": {
+    hostname: "polly.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "polly.us-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "polly-fips.us-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-west-2": {
+    hostname: "polly.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "polly.us-west-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "polly-fips.us-west-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
 };
 
@@ -55,26 +150,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "polly.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "polly.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "polly-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "polly-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "polly.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "polly.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "polly.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "polly-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "polly-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "polly.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "polly.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "polly.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "polly.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "polly.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["fips-us-gov-west-1", "us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "polly.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "polly.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "polly-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "polly-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "polly.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-pricing/src/endpoints.ts
+++ b/clients/client-pricing/src/endpoints.ts
@@ -30,26 +30,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "api.pricing.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "api.pricing.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "api.pricing-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "api.pricing-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "api.pricing.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "api.pricing.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "api.pricing.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "api.pricing-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "api.pricing-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "api.pricing.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "api.pricing.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "api.pricing.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "api.pricing.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "api.pricing.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "api.pricing.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "api.pricing.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "api.pricing-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "api.pricing-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "api.pricing.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-proton/src/endpoints.ts
+++ b/clients/client-proton/src/endpoints.ts
@@ -30,26 +30,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "proton.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "proton.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "proton-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "proton-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "proton.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "proton.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "proton.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "proton-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "proton-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "proton.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "proton.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "proton.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "proton.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "proton.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "proton.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "proton.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "proton-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "proton-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "proton.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-qldb-session/src/endpoints.ts
+++ b/clients/client-qldb-session/src/endpoints.ts
@@ -4,15 +4,72 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 const regionHash: RegionHash = {
   "fips-us-east-1": {
     hostname: "session.qldb-fips.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "session.qldb-fips.us-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-1",
   },
   "fips-us-east-2": {
     hostname: "session.qldb-fips.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "session.qldb-fips.us-east-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-2",
   },
   "fips-us-west-2": {
     hostname: "session.qldb-fips.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "session.qldb-fips.us-west-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-2",
+  },
+  "us-east-1": {
+    hostname: "session.qldb.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "session.qldb.us-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "session.qldb-fips.us-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-east-2": {
+    hostname: "session.qldb.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "session.qldb.us-east-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "session.qldb-fips.us-east-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-west-2": {
+    hostname: "session.qldb.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "session.qldb.us-west-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "session.qldb-fips.us-west-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
 };
 
@@ -46,26 +103,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "session.qldb.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "session.qldb.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "session.qldb-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "session.qldb-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "session.qldb.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "session.qldb.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "session.qldb.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "session.qldb-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "session.qldb-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "session.qldb.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "session.qldb.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "session.qldb.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "session.qldb.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "session.qldb.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "session.qldb.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "session.qldb.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "session.qldb-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "session.qldb-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "session.qldb.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-qldb/src/endpoints.ts
+++ b/clients/client-qldb/src/endpoints.ts
@@ -4,15 +4,72 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 const regionHash: RegionHash = {
   "fips-us-east-1": {
     hostname: "qldb-fips.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "qldb-fips.us-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-1",
   },
   "fips-us-east-2": {
     hostname: "qldb-fips.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "qldb-fips.us-east-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-2",
   },
   "fips-us-west-2": {
     hostname: "qldb-fips.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "qldb-fips.us-west-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-2",
+  },
+  "us-east-1": {
+    hostname: "qldb.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "qldb.us-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "qldb-fips.us-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-east-2": {
+    hostname: "qldb.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "qldb.us-east-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "qldb-fips.us-east-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-west-2": {
+    hostname: "qldb.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "qldb.us-west-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "qldb-fips.us-west-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
 };
 
@@ -46,26 +103,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "qldb.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "qldb.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "qldb-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "qldb-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "qldb.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "qldb.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "qldb.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "qldb-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "qldb-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "qldb.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "qldb.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "qldb.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "qldb.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "qldb.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "qldb.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "qldb.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "qldb-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "qldb-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "qldb.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-quicksight/src/endpoints.ts
+++ b/clients/client-quicksight/src/endpoints.ts
@@ -31,26 +31,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "quicksight.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "quicksight.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "quicksight-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "quicksight-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "quicksight.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "quicksight.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "quicksight.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "quicksight-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "quicksight-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "quicksight.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "quicksight.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "quicksight.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "quicksight.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "quicksight.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["api", "us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "quicksight.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "quicksight.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "quicksight-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "quicksight-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "quicksight.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-ram/src/endpoints.ts
+++ b/clients/client-ram/src/endpoints.ts
@@ -2,33 +2,140 @@ import { getRegionInfo, PartitionHash, RegionHash } from "@aws-sdk/config-resolv
 import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
+  "ca-central-1": {
+    hostname: "ram.ca-central-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "ram.ca-central-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "ram-fips.ca-central-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
   "fips-ca-central-1": {
     hostname: "ram-fips.ca-central-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "ram-fips.ca-central-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "ca-central-1",
   },
   "fips-us-east-1": {
     hostname: "ram-fips.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "ram-fips.us-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-1",
   },
   "fips-us-east-2": {
     hostname: "ram-fips.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "ram-fips.us-east-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-2",
   },
   "fips-us-west-1": {
     hostname: "ram-fips.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "ram-fips.us-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-1",
   },
   "fips-us-west-2": {
     hostname: "ram-fips.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "ram-fips.us-west-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-2",
+  },
+  "us-east-1": {
+    hostname: "ram.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "ram.us-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "ram-fips.us-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-east-2": {
+    hostname: "ram.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "ram.us-east-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "ram-fips.us-east-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "us-gov-east-1": {
     hostname: "ram.us-gov-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "ram.us-gov-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-east-1",
   },
   "us-gov-west-1": {
     hostname: "ram.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "ram.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-west-1",
+  },
+  "us-west-1": {
+    hostname: "ram.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "ram.us-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "ram-fips.us-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-west-2": {
+    hostname: "ram.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "ram.us-west-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "ram-fips.us-west-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
 };
 
@@ -64,26 +171,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "ram.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "ram.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "ram-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "ram-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "ram.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "ram.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "ram.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "ram-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "ram-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "ram.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "ram.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "ram.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "ram.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "ram.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "ram.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "ram.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "ram-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "ram-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "ram.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-rds-data/src/endpoints.ts
+++ b/clients/client-rds-data/src/endpoints.ts
@@ -30,26 +30,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "rds-data.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "rds-data.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "rds-data-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "rds-data-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "rds-data.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "rds-data.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "rds-data.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "rds-data-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "rds-data-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "rds-data.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "rds-data.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "rds-data.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "rds-data.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "rds-data.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "rds-data.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "rds-data.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "rds-data-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "rds-data-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "rds-data.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-rds/src/endpoints.ts
+++ b/clients/client-rds/src/endpoints.ts
@@ -2,60 +2,305 @@ import { getRegionInfo, PartitionHash, RegionHash } from "@aws-sdk/config-resolv
 import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
+  "ca-central-1": {
+    hostname: "rds.ca-central-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "rds.ca-central-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "rds-fips.ca-central-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
   "ca-central-1-fips": {
     hostname: "rds-fips.ca-central-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "rds-fips.ca-central-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "ca-central-1",
   },
   "rds-fips.ca-central-1": {
     hostname: "rds-fips.ca-central-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "rds-fips.ca-central-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "ca-central-1",
   },
   "rds-fips.us-east-1": {
     hostname: "rds-fips.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "rds-fips.us-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-1",
   },
   "rds-fips.us-east-2": {
     hostname: "rds-fips.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "rds-fips.us-east-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-2",
   },
   "rds-fips.us-west-1": {
     hostname: "rds-fips.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "rds-fips.us-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-1",
   },
   "rds-fips.us-west-2": {
     hostname: "rds-fips.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "rds-fips.us-west-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-2",
+  },
+  "rds.ca-central-1": {
+    hostname: "rds.rds.ca-central-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "rds.rds.ca-central-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "rds-fips.ca-central-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+    signingRegion: "ca-central-1",
+  },
+  "rds.us-east-1": {
+    hostname: "rds.rds.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "rds.rds.us-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "rds-fips.us-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+    signingRegion: "us-east-1",
+  },
+  "rds.us-east-2": {
+    hostname: "rds.rds.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "rds.rds.us-east-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "rds-fips.us-east-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+    signingRegion: "us-east-2",
   },
   "rds.us-gov-east-1": {
     hostname: "rds.us-gov-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "rds.us-gov-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-east-1",
   },
   "rds.us-gov-west-1": {
     hostname: "rds.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "rds.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-west-1",
+  },
+  "rds.us-west-1": {
+    hostname: "rds.rds.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "rds.rds.us-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "rds-fips.us-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+    signingRegion: "us-west-1",
+  },
+  "rds.us-west-2": {
+    hostname: "rds.rds.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "rds.rds.us-west-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "rds-fips.us-west-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+    signingRegion: "us-west-2",
+  },
+  "us-east-1": {
+    hostname: "rds.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "rds.us-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "rds-fips.us-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "us-east-1-fips": {
     hostname: "rds-fips.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "rds-fips.us-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-1",
+  },
+  "us-east-2": {
+    hostname: "rds.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "rds.us-east-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "rds-fips.us-east-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "us-east-2-fips": {
     hostname: "rds-fips.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "rds-fips.us-east-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-2",
+  },
+  "us-gov-east-1": {
+    hostname: "rds.us-gov-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "rds.us-gov-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "rds.us-gov-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "us-gov-east-1-fips": {
     hostname: "rds.us-gov-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "rds.us-gov-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-east-1",
+  },
+  "us-gov-west-1": {
+    hostname: "rds.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "rds.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "rds.us-gov-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "us-gov-west-1-fips": {
     hostname: "rds.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "rds.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-west-1",
+  },
+  "us-west-1": {
+    hostname: "rds.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "rds.us-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "rds-fips.us-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "us-west-1-fips": {
     hostname: "rds-fips.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "rds-fips.us-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-1",
+  },
+  "us-west-2": {
+    hostname: "rds.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "rds.us-west-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "rds-fips.us-west-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "us-west-2-fips": {
     hostname: "rds-fips.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "rds-fips.us-west-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-2",
   },
 };
@@ -102,21 +347,69 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "rds.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "rds.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "rds-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "rds-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "rds.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "rds.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "rds.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "rds-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "rds-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "rds.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "rds.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "rds.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "rds.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "rds.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: [
@@ -129,6 +422,24 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "rds.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "rds.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "rds-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "rds-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "rds.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-redshift-data/src/endpoints.ts
+++ b/clients/client-redshift-data/src/endpoints.ts
@@ -30,26 +30,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "redshift-data.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "redshift-data.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "redshift-data-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "redshift-data-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "redshift-data.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "redshift-data.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "redshift-data.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "redshift-data-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "redshift-data-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "redshift-data.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "redshift-data.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "redshift-data.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "redshift-data.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "redshift-data.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "redshift-data.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "redshift-data.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "redshift-data-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "redshift-data-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "redshift-data.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-redshift/src/endpoints.ts
+++ b/clients/client-redshift/src/endpoints.ts
@@ -2,33 +2,140 @@ import { getRegionInfo, PartitionHash, RegionHash } from "@aws-sdk/config-resolv
 import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
+  "ca-central-1": {
+    hostname: "redshift.ca-central-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "redshift.ca-central-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "redshift-fips.ca-central-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
   "fips-ca-central-1": {
     hostname: "redshift-fips.ca-central-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "redshift-fips.ca-central-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "ca-central-1",
   },
   "fips-us-east-1": {
     hostname: "redshift-fips.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "redshift-fips.us-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-1",
   },
   "fips-us-east-2": {
     hostname: "redshift-fips.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "redshift-fips.us-east-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-2",
   },
   "fips-us-west-1": {
     hostname: "redshift-fips.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "redshift-fips.us-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-1",
   },
   "fips-us-west-2": {
     hostname: "redshift-fips.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "redshift-fips.us-west-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-2",
+  },
+  "us-east-1": {
+    hostname: "redshift.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "redshift.us-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "redshift-fips.us-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-east-2": {
+    hostname: "redshift.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "redshift.us-east-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "redshift-fips.us-east-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "us-gov-east-1": {
     hostname: "redshift.us-gov-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "redshift.us-gov-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-east-1",
   },
   "us-gov-west-1": {
     hostname: "redshift.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "redshift.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-west-1",
+  },
+  "us-west-1": {
+    hostname: "redshift.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "redshift.us-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "redshift-fips.us-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-west-2": {
+    hostname: "redshift.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "redshift.us-west-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "redshift-fips.us-west-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
 };
 
@@ -64,26 +171,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "redshift.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "redshift.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "redshift-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "redshift-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "redshift.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "redshift.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "redshift.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "redshift-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "redshift-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "redshift.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "redshift.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "redshift.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "redshift.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "redshift.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "redshift.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "redshift.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "redshift-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "redshift-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "redshift.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-rekognition/src/endpoints.ts
+++ b/clients/client-rekognition/src/endpoints.ts
@@ -2,52 +2,286 @@ import { getRegionInfo, PartitionHash, RegionHash } from "@aws-sdk/config-resolv
 import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
+  "ca-central-1": {
+    hostname: "rekognition.ca-central-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "rekognition.ca-central-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "rekognition-fips.ca-central-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
   "ca-central-1-fips": {
     hostname: "rekognition-fips.ca-central-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "rekognition-fips.ca-central-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "ca-central-1",
   },
   "rekognition-fips.ca-central-1": {
     hostname: "rekognition-fips.ca-central-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "rekognition-fips.ca-central-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "ca-central-1",
   },
   "rekognition-fips.us-east-1": {
     hostname: "rekognition-fips.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "rekognition-fips.us-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-1",
   },
   "rekognition-fips.us-east-2": {
     hostname: "rekognition-fips.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "rekognition-fips.us-east-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-2",
   },
   "rekognition-fips.us-gov-west-1": {
     hostname: "rekognition-fips.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "rekognition-fips.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-west-1",
   },
   "rekognition-fips.us-west-1": {
     hostname: "rekognition-fips.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "rekognition-fips.us-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-1",
   },
   "rekognition-fips.us-west-2": {
     hostname: "rekognition-fips.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "rekognition-fips.us-west-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-2",
+  },
+  "rekognition.ca-central-1": {
+    hostname: "rekognition.rekognition.ca-central-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "rekognition.rekognition.ca-central-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "rekognition-fips.ca-central-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+    signingRegion: "ca-central-1",
+  },
+  "rekognition.us-east-1": {
+    hostname: "rekognition.rekognition.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "rekognition.rekognition.us-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "rekognition-fips.us-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+    signingRegion: "us-east-1",
+  },
+  "rekognition.us-east-2": {
+    hostname: "rekognition.rekognition.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "rekognition.rekognition.us-east-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "rekognition-fips.us-east-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+    signingRegion: "us-east-2",
+  },
+  "rekognition.us-gov-west-1": {
+    hostname: "rekognition.rekognition.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "rekognition.rekognition.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "rekognition-fips.us-gov-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+    signingRegion: "us-gov-west-1",
+  },
+  "rekognition.us-west-1": {
+    hostname: "rekognition.rekognition.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "rekognition.rekognition.us-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "rekognition-fips.us-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+    signingRegion: "us-west-1",
+  },
+  "rekognition.us-west-2": {
+    hostname: "rekognition.rekognition.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "rekognition.rekognition.us-west-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "rekognition-fips.us-west-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+    signingRegion: "us-west-2",
+  },
+  "us-east-1": {
+    hostname: "rekognition.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "rekognition.us-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "rekognition-fips.us-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "us-east-1-fips": {
     hostname: "rekognition-fips.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "rekognition-fips.us-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-1",
+  },
+  "us-east-2": {
+    hostname: "rekognition.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "rekognition.us-east-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "rekognition-fips.us-east-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "us-east-2-fips": {
     hostname: "rekognition-fips.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "rekognition-fips.us-east-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-2",
+  },
+  "us-gov-west-1": {
+    hostname: "rekognition.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "rekognition.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "rekognition-fips.us-gov-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "us-gov-west-1-fips": {
     hostname: "rekognition-fips.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "rekognition-fips.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-west-1",
+  },
+  "us-west-1": {
+    hostname: "rekognition.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "rekognition.us-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "rekognition-fips.us-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "us-west-1-fips": {
     hostname: "rekognition-fips.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "rekognition-fips.us-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-1",
+  },
+  "us-west-2": {
+    hostname: "rekognition.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "rekognition.us-west-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "rekognition-fips.us-west-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "us-west-2-fips": {
     hostname: "rekognition-fips.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "rekognition-fips.us-west-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-2",
   },
 };
@@ -94,21 +328,69 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "rekognition.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "rekognition.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "rekognition-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "rekognition-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "rekognition.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "rekognition.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "rekognition.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "rekognition-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "rekognition-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "rekognition.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "rekognition.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "rekognition.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "rekognition.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "rekognition.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: [
@@ -120,6 +402,24 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "rekognition.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "rekognition.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "rekognition-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "rekognition-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "rekognition.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-resource-groups-tagging-api/src/endpoints.ts
+++ b/clients/client-resource-groups-tagging-api/src/endpoints.ts
@@ -30,26 +30,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "tagging.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "tagging.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "tagging-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "tagging-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "tagging.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "tagging.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "tagging.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "tagging-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "tagging-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "tagging.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "tagging.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "tagging.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "tagging.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "tagging.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "tagging.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "tagging.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "tagging-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "tagging-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "tagging.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-resource-groups/src/endpoints.ts
+++ b/clients/client-resource-groups/src/endpoints.ts
@@ -4,27 +4,141 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 const regionHash: RegionHash = {
   "fips-us-east-1": {
     hostname: "resource-groups-fips.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "resource-groups-fips.us-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-1",
   },
   "fips-us-east-2": {
     hostname: "resource-groups-fips.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "resource-groups-fips.us-east-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-2",
   },
   "fips-us-gov-east-1": {
     hostname: "resource-groups.us-gov-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "resource-groups.us-gov-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-east-1",
   },
   "fips-us-gov-west-1": {
     hostname: "resource-groups.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "resource-groups.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-west-1",
   },
   "fips-us-west-1": {
     hostname: "resource-groups-fips.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "resource-groups-fips.us-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-1",
   },
   "fips-us-west-2": {
     hostname: "resource-groups-fips.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "resource-groups-fips.us-west-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-2",
+  },
+  "us-east-1": {
+    hostname: "resource-groups.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "resource-groups.us-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "resource-groups-fips.us-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-east-2": {
+    hostname: "resource-groups.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "resource-groups.us-east-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "resource-groups-fips.us-east-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-gov-east-1": {
+    hostname: "resource-groups.us-gov-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "resource-groups.us-gov-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "resource-groups.us-gov-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-gov-west-1": {
+    hostname: "resource-groups.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "resource-groups.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "resource-groups.us-gov-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-west-1": {
+    hostname: "resource-groups.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "resource-groups.us-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "resource-groups-fips.us-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-west-2": {
+    hostname: "resource-groups.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "resource-groups.us-west-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "resource-groups-fips.us-west-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
 };
 
@@ -59,26 +173,84 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "resource-groups.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "resource-groups.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "resource-groups-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "resource-groups-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "resource-groups.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "resource-groups.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "resource-groups.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "resource-groups-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "resource-groups-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "resource-groups.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "resource-groups.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "resource-groups.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "resource-groups.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "resource-groups.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["fips-us-gov-east-1", "fips-us-gov-west-1", "us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "resource-groups.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "resource-groups.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "resource-groups.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
 };
 

--- a/clients/client-robomaker/src/endpoints.ts
+++ b/clients/client-robomaker/src/endpoints.ts
@@ -30,26 +30,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "robomaker.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "robomaker.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "robomaker-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "robomaker-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "robomaker.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "robomaker.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "robomaker.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "robomaker-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "robomaker-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "robomaker.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "robomaker.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "robomaker.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "robomaker.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "robomaker.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "robomaker.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "robomaker.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "robomaker-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "robomaker-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "robomaker.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-route-53-domains/src/endpoints.ts
+++ b/clients/client-route-53-domains/src/endpoints.ts
@@ -30,26 +30,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "route53domains.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "route53domains.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "route53domains-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "route53domains-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "route53domains.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "route53domains.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "route53domains.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "route53domains-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "route53domains-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "route53domains.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "route53domains.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "route53domains.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "route53domains.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "route53domains.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "route53domains.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "route53domains.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "route53domains-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "route53domains-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "route53domains.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-route-53/src/endpoints.ts
+++ b/clients/client-route-53/src/endpoints.ts
@@ -4,30 +4,80 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 const regionHash: RegionHash = {
   "aws-cn-global": {
     hostname: "route53.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "route53.amazonaws.com.cn",
+        tags: [],
+      },
+    ],
     signingRegion: "cn-northwest-1",
   },
   "aws-global": {
     hostname: "route53.amazonaws.com",
+    variants: [
+      {
+        hostname: "route53.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "route53-fips.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
     signingRegion: "us-east-1",
   },
   "aws-iso-b-global": {
     hostname: "route53.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "route53.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
     signingRegion: "us-isob-east-1",
   },
   "aws-iso-global": {
     hostname: "route53.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "route53.c2s.ic.gov",
+        tags: [],
+      },
+    ],
     signingRegion: "us-iso-east-1",
   },
   "aws-us-gov-global": {
     hostname: "route53.us-gov.amazonaws.com",
+    variants: [
+      {
+        hostname: "route53.us-gov.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "route53.us-gov.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
     signingRegion: "us-gov-west-1",
   },
   "fips-aws-global": {
     hostname: "route53-fips.amazonaws.com",
+    variants: [
+      {
+        hostname: "route53-fips.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-1",
   },
   "fips-aws-us-gov-global": {
     hostname: "route53.us-gov.amazonaws.com",
+    variants: [
+      {
+        hostname: "route53.us-gov.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-west-1",
   },
 };
@@ -60,26 +110,97 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
+    hostname: "route53.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "route53.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "route53-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "route53-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "route53.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
     endpoint: "aws-global",
   },
   "aws-cn": {
     regions: ["aws-cn-global", "cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
+    hostname: "route53.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "route53.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "route53-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "route53-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "route53.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
     endpoint: "aws-cn-global",
   },
   "aws-iso": {
     regions: ["aws-iso-global", "us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
+    hostname: "route53.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "route53.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
     endpoint: "aws-iso-global",
   },
   "aws-iso-b": {
     regions: ["aws-iso-b-global", "us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
+    hostname: "route53.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "route53.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
     endpoint: "aws-iso-b-global",
   },
   "aws-us-gov": {
     regions: ["aws-us-gov-global", "fips-aws-us-gov-global", "us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
+    hostname: "route53.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "route53.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "route53-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "route53-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "route53.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
     endpoint: "aws-us-gov-global",
   },
 };

--- a/clients/client-route53-recovery-cluster/src/endpoints.ts
+++ b/clients/client-route53-recovery-cluster/src/endpoints.ts
@@ -30,26 +30,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "route53-recovery-cluster.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "route53-recovery-cluster.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "route53-recovery-cluster-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "route53-recovery-cluster-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "route53-recovery-cluster.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "route53-recovery-cluster.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "route53-recovery-cluster.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "route53-recovery-cluster-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "route53-recovery-cluster-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "route53-recovery-cluster.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "route53-recovery-cluster.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "route53-recovery-cluster.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "route53-recovery-cluster.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "route53-recovery-cluster.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "route53-recovery-cluster.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "route53-recovery-cluster.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "route53-recovery-cluster-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "route53-recovery-cluster-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "route53-recovery-cluster.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-route53-recovery-control-config/src/endpoints.ts
+++ b/clients/client-route53-recovery-control-config/src/endpoints.ts
@@ -4,6 +4,12 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 const regionHash: RegionHash = {
   "aws-global": {
     hostname: "route53-recovery-control-config.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "route53-recovery-control-config.us-west-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-2",
   },
 };
@@ -36,26 +42,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "route53-recovery-control-config.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "route53-recovery-control-config.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "route53-recovery-control-config-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "route53-recovery-control-config-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "route53-recovery-control-config.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "route53-recovery-control-config.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "route53-recovery-control-config.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "route53-recovery-control-config-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "route53-recovery-control-config-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "route53-recovery-control-config.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "route53-recovery-control-config.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "route53-recovery-control-config.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "route53-recovery-control-config.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "route53-recovery-control-config.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "route53-recovery-control-config.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "route53-recovery-control-config.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "route53-recovery-control-config-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "route53-recovery-control-config-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "route53-recovery-control-config.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-route53-recovery-readiness/src/endpoints.ts
+++ b/clients/client-route53-recovery-readiness/src/endpoints.ts
@@ -30,26 +30,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "route53-recovery-readiness.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "route53-recovery-readiness.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "route53-recovery-readiness-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "route53-recovery-readiness-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "route53-recovery-readiness.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "route53-recovery-readiness.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "route53-recovery-readiness.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "route53-recovery-readiness-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "route53-recovery-readiness-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "route53-recovery-readiness.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "route53-recovery-readiness.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "route53-recovery-readiness.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "route53-recovery-readiness.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "route53-recovery-readiness.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "route53-recovery-readiness.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "route53-recovery-readiness.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "route53-recovery-readiness-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "route53-recovery-readiness-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "route53-recovery-readiness.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-route53resolver/src/endpoints.ts
+++ b/clients/client-route53resolver/src/endpoints.ts
@@ -30,26 +30,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "route53resolver.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "route53resolver.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "route53resolver-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "route53resolver-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "route53resolver.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "route53resolver.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "route53resolver.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "route53resolver-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "route53resolver-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "route53resolver.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "route53resolver.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "route53resolver.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "route53resolver.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "route53resolver.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "route53resolver.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "route53resolver.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "route53resolver-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "route53resolver-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "route53resolver.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-s3-control/src/endpoints.ts
+++ b/clients/client-s3-control/src/endpoints.ts
@@ -4,114 +4,422 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 const regionHash: RegionHash = {
   "ap-northeast-1": {
     hostname: "s3-control.ap-northeast-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "s3-control.ap-northeast-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "s3-control.dualstack.ap-northeast-1.amazonaws.com",
+        tags: ["dualstack"],
+      },
+    ],
     signingRegion: "ap-northeast-1",
   },
   "ap-northeast-2": {
     hostname: "s3-control.ap-northeast-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "s3-control.ap-northeast-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "s3-control.dualstack.ap-northeast-2.amazonaws.com",
+        tags: ["dualstack"],
+      },
+    ],
     signingRegion: "ap-northeast-2",
   },
   "ap-northeast-3": {
     hostname: "s3-control.ap-northeast-3.amazonaws.com",
+    variants: [
+      {
+        hostname: "s3-control.ap-northeast-3.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "s3-control.dualstack.ap-northeast-3.amazonaws.com",
+        tags: ["dualstack"],
+      },
+    ],
     signingRegion: "ap-northeast-3",
   },
   "ap-south-1": {
     hostname: "s3-control.ap-south-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "s3-control.ap-south-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "s3-control.dualstack.ap-south-1.amazonaws.com",
+        tags: ["dualstack"],
+      },
+    ],
     signingRegion: "ap-south-1",
   },
   "ap-southeast-1": {
     hostname: "s3-control.ap-southeast-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "s3-control.ap-southeast-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "s3-control.dualstack.ap-southeast-1.amazonaws.com",
+        tags: ["dualstack"],
+      },
+    ],
     signingRegion: "ap-southeast-1",
   },
   "ap-southeast-2": {
     hostname: "s3-control.ap-southeast-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "s3-control.ap-southeast-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "s3-control.dualstack.ap-southeast-2.amazonaws.com",
+        tags: ["dualstack"],
+      },
+    ],
     signingRegion: "ap-southeast-2",
   },
   "ca-central-1": {
     hostname: "s3-control.ca-central-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "s3-control.ca-central-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "s3-control-fips.ca-central-1.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "s3-control-fips.dualstack.ca-central-1.amazonaws.com",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "s3-control.dualstack.ca-central-1.amazonaws.com",
+        tags: ["dualstack"],
+      },
+    ],
     signingRegion: "ca-central-1",
   },
   "ca-central-1-fips": {
     hostname: "s3-control-fips.ca-central-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "s3-control-fips.ca-central-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "ca-central-1",
   },
   "cn-north-1": {
     hostname: "s3-control.cn-north-1.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "s3-control.cn-north-1.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "s3-control.dualstack.cn-north-1.amazonaws.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
     signingRegion: "cn-north-1",
   },
   "cn-northwest-1": {
     hostname: "s3-control.cn-northwest-1.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "s3-control.cn-northwest-1.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "s3-control.dualstack.cn-northwest-1.amazonaws.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
     signingRegion: "cn-northwest-1",
   },
   "eu-central-1": {
     hostname: "s3-control.eu-central-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "s3-control.eu-central-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "s3-control.dualstack.eu-central-1.amazonaws.com",
+        tags: ["dualstack"],
+      },
+    ],
     signingRegion: "eu-central-1",
   },
   "eu-north-1": {
     hostname: "s3-control.eu-north-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "s3-control.eu-north-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "s3-control.dualstack.eu-north-1.amazonaws.com",
+        tags: ["dualstack"],
+      },
+    ],
     signingRegion: "eu-north-1",
   },
   "eu-west-1": {
     hostname: "s3-control.eu-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "s3-control.eu-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "s3-control.dualstack.eu-west-1.amazonaws.com",
+        tags: ["dualstack"],
+      },
+    ],
     signingRegion: "eu-west-1",
   },
   "eu-west-2": {
     hostname: "s3-control.eu-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "s3-control.eu-west-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "s3-control.dualstack.eu-west-2.amazonaws.com",
+        tags: ["dualstack"],
+      },
+    ],
     signingRegion: "eu-west-2",
   },
   "eu-west-3": {
     hostname: "s3-control.eu-west-3.amazonaws.com",
+    variants: [
+      {
+        hostname: "s3-control.eu-west-3.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "s3-control.dualstack.eu-west-3.amazonaws.com",
+        tags: ["dualstack"],
+      },
+    ],
     signingRegion: "eu-west-3",
   },
   "sa-east-1": {
     hostname: "s3-control.sa-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "s3-control.sa-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "s3-control.dualstack.sa-east-1.amazonaws.com",
+        tags: ["dualstack"],
+      },
+    ],
     signingRegion: "sa-east-1",
   },
   "us-east-1": {
     hostname: "s3-control.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "s3-control.us-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "s3-control-fips.dualstack.us-east-1.amazonaws.com",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "s3-control-fips.us-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "s3-control.dualstack.us-east-1.amazonaws.com",
+        tags: ["dualstack"],
+      },
+    ],
     signingRegion: "us-east-1",
   },
   "us-east-1-fips": {
     hostname: "s3-control-fips.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "s3-control-fips.us-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-1",
   },
   "us-east-2": {
     hostname: "s3-control.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "s3-control.us-east-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "s3-control-fips.dualstack.us-east-2.amazonaws.com",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "s3-control-fips.us-east-2.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "s3-control.dualstack.us-east-2.amazonaws.com",
+        tags: ["dualstack"],
+      },
+    ],
     signingRegion: "us-east-2",
   },
   "us-east-2-fips": {
     hostname: "s3-control-fips.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "s3-control-fips.us-east-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-2",
   },
   "us-gov-east-1": {
     hostname: "s3-control.us-gov-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "s3-control.us-gov-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "s3-control-fips.dualstack.us-gov-east-1.amazonaws.com",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "s3-control-fips.us-gov-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "s3-control.dualstack.us-gov-east-1.amazonaws.com",
+        tags: ["dualstack"],
+      },
+    ],
     signingRegion: "us-gov-east-1",
   },
   "us-gov-east-1-fips": {
     hostname: "s3-control-fips.us-gov-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "s3-control-fips.us-gov-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-east-1",
   },
   "us-gov-west-1": {
     hostname: "s3-control.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "s3-control.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "s3-control-fips.dualstack.us-gov-west-1.amazonaws.com",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "s3-control-fips.us-gov-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "s3-control.dualstack.us-gov-west-1.amazonaws.com",
+        tags: ["dualstack"],
+      },
+    ],
     signingRegion: "us-gov-west-1",
   },
   "us-gov-west-1-fips": {
     hostname: "s3-control-fips.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "s3-control-fips.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-west-1",
   },
   "us-west-1": {
     hostname: "s3-control.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "s3-control.us-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "s3-control-fips.dualstack.us-west-1.amazonaws.com",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "s3-control-fips.us-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "s3-control.dualstack.us-west-1.amazonaws.com",
+        tags: ["dualstack"],
+      },
+    ],
     signingRegion: "us-west-1",
   },
   "us-west-1-fips": {
     hostname: "s3-control-fips.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "s3-control-fips.us-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-1",
   },
   "us-west-2": {
     hostname: "s3-control.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "s3-control.us-west-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "s3-control-fips.dualstack.us-west-2.amazonaws.com",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "s3-control-fips.us-west-2.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "s3-control.dualstack.us-west-2.amazonaws.com",
+        tags: ["dualstack"],
+      },
+    ],
     signingRegion: "us-west-2",
   },
   "us-west-2-fips": {
     hostname: "s3-control-fips.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "s3-control-fips.us-west-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-2",
   },
 };
@@ -148,26 +456,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "s3-control.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "s3-control.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "s3-control-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "s3-control-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "s3-control.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "s3-control.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "s3-control.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "s3-control-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "s3-control-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "s3-control.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "s3-control.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "s3-control.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "s3-control.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "s3-control.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-east-1-fips", "us-gov-west-1", "us-gov-west-1-fips"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "s3-control.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "s3-control.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "s3-control-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "s3-control-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "s3-control.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-s3/src/endpoints.ts
+++ b/clients/client-s3/src/endpoints.ts
@@ -2,71 +2,468 @@ import { getRegionInfo, PartitionHash, RegionHash } from "@aws-sdk/config-resolv
 import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
+  "af-south-1": {
+    hostname: "s3.af-south-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "s3.af-south-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "s3.dualstack.af-south-1.amazonaws.com",
+        tags: ["dualstack"],
+      },
+    ],
+  },
+  "ap-east-1": {
+    hostname: "s3.ap-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "s3.ap-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "s3.dualstack.ap-east-1.amazonaws.com",
+        tags: ["dualstack"],
+      },
+    ],
+  },
   "ap-northeast-1": {
     hostname: "s3.ap-northeast-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "s3.ap-northeast-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "s3.dualstack.ap-northeast-1.amazonaws.com",
+        tags: ["dualstack"],
+      },
+    ],
+  },
+  "ap-northeast-2": {
+    hostname: "s3.ap-northeast-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "s3.ap-northeast-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "s3.dualstack.ap-northeast-2.amazonaws.com",
+        tags: ["dualstack"],
+      },
+    ],
+  },
+  "ap-northeast-3": {
+    hostname: "s3.ap-northeast-3.amazonaws.com",
+    variants: [
+      {
+        hostname: "s3.ap-northeast-3.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "s3.dualstack.ap-northeast-3.amazonaws.com",
+        tags: ["dualstack"],
+      },
+    ],
+  },
+  "ap-south-1": {
+    hostname: "s3.ap-south-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "s3.ap-south-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "s3.dualstack.ap-south-1.amazonaws.com",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "ap-southeast-1": {
     hostname: "s3.ap-southeast-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "s3.ap-southeast-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "s3.dualstack.ap-southeast-1.amazonaws.com",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "ap-southeast-2": {
     hostname: "s3.ap-southeast-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "s3.ap-southeast-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "s3.dualstack.ap-southeast-2.amazonaws.com",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-global": {
     hostname: "s3.amazonaws.com",
+    variants: [
+      {
+        hostname: "s3.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-1",
+  },
+  "ca-central-1": {
+    hostname: "s3.ca-central-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "s3.ca-central-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "s3-fips.ca-central-1.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "s3-fips.dualstack.ca-central-1.amazonaws.com",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "s3.dualstack.ca-central-1.amazonaws.com",
+        tags: ["dualstack"],
+      },
+    ],
+  },
+  "cn-north-1": {
+    hostname: "s3.cn-north-1.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "s3.cn-north-1.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "s3.dualstack.cn-north-1.amazonaws.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
+  },
+  "cn-northwest-1": {
+    hostname: "s3.cn-northwest-1.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "s3.cn-northwest-1.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "s3.dualstack.cn-northwest-1.amazonaws.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
+  },
+  "eu-central-1": {
+    hostname: "s3.eu-central-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "s3.eu-central-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "s3.dualstack.eu-central-1.amazonaws.com",
+        tags: ["dualstack"],
+      },
+    ],
+  },
+  "eu-north-1": {
+    hostname: "s3.eu-north-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "s3.eu-north-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "s3.dualstack.eu-north-1.amazonaws.com",
+        tags: ["dualstack"],
+      },
+    ],
+  },
+  "eu-south-1": {
+    hostname: "s3.eu-south-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "s3.eu-south-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "s3.dualstack.eu-south-1.amazonaws.com",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "eu-west-1": {
     hostname: "s3.eu-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "s3.eu-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "s3.dualstack.eu-west-1.amazonaws.com",
+        tags: ["dualstack"],
+      },
+    ],
+  },
+  "eu-west-2": {
+    hostname: "s3.eu-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "s3.eu-west-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "s3.dualstack.eu-west-2.amazonaws.com",
+        tags: ["dualstack"],
+      },
+    ],
+  },
+  "eu-west-3": {
+    hostname: "s3.eu-west-3.amazonaws.com",
+    variants: [
+      {
+        hostname: "s3.eu-west-3.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "s3.dualstack.eu-west-3.amazonaws.com",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "fips-ca-central-1": {
     hostname: "s3-fips.ca-central-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "s3-fips.ca-central-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "ca-central-1",
   },
   "fips-us-east-1": {
     hostname: "s3-fips.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "s3-fips.us-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-1",
   },
   "fips-us-east-2": {
     hostname: "s3-fips.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "s3-fips.us-east-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-2",
   },
   "fips-us-gov-east-1": {
     hostname: "s3-fips.us-gov-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "s3-fips.us-gov-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-east-1",
   },
   "fips-us-gov-west-1": {
     hostname: "s3-fips.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "s3-fips.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-west-1",
   },
   "fips-us-west-1": {
     hostname: "s3-fips.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "s3-fips.us-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-1",
   },
   "fips-us-west-2": {
     hostname: "s3-fips.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "s3-fips.us-west-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-2",
+  },
+  "me-south-1": {
+    hostname: "s3.me-south-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "s3.me-south-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "s3.dualstack.me-south-1.amazonaws.com",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "s3-external-1": {
     hostname: "s3-external-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "s3-external-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-1",
   },
   "sa-east-1": {
     hostname: "s3.sa-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "s3.sa-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "s3.dualstack.sa-east-1.amazonaws.com",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "us-east-1": {
     hostname: "s3.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "s3.us-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "s3-fips.dualstack.us-east-1.amazonaws.com",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "s3-fips.us-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "s3.dualstack.us-east-1.amazonaws.com",
+        tags: ["dualstack"],
+      },
+    ],
+  },
+  "us-east-2": {
+    hostname: "s3.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "s3.us-east-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "s3-fips.dualstack.us-east-2.amazonaws.com",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "s3-fips.us-east-2.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "s3.dualstack.us-east-2.amazonaws.com",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "us-gov-east-1": {
     hostname: "s3.us-gov-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "s3.us-gov-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "s3-fips.us-gov-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "s3.dualstack.us-gov-east-1.amazonaws.com",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "us-gov-west-1": {
     hostname: "s3.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "s3.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "s3-fips.us-gov-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "s3.dualstack.us-gov-west-1.amazonaws.com",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "us-west-1": {
     hostname: "s3.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "s3.us-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "s3-fips.dualstack.us-west-1.amazonaws.com",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "s3-fips.us-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "s3.dualstack.us-west-1.amazonaws.com",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "us-west-2": {
     hostname: "s3.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "s3.us-west-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "s3-fips.dualstack.us-west-2.amazonaws.com",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "s3-fips.us-west-2.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "s3.dualstack.us-west-2.amazonaws.com",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 
@@ -104,26 +501,76 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "s3.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "s3.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "s3-fips.dualstack.{region}.amazonaws.com",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "s3.dualstack.{region}.amazonaws.com",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "s3.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "s3.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "s3.dualstack.{region}.amazonaws.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "s3.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "s3.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "s3.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "s3.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["fips-us-gov-east-1", "fips-us-gov-west-1", "us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "s3.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "s3.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "s3-fips.dualstack.{region}.amazonaws.com",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "s3.dualstack.{region}.amazonaws.com",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-s3outposts/src/endpoints.ts
+++ b/clients/client-s3outposts/src/endpoints.ts
@@ -30,26 +30,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "s3-outposts.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "s3-outposts.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "s3-outposts-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "s3-outposts-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "s3-outposts.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "s3-outposts.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "s3-outposts.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "s3-outposts-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "s3-outposts-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "s3-outposts.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "s3-outposts.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "s3-outposts.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "s3-outposts.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "s3-outposts.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "s3-outposts.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "s3-outposts.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "s3-outposts-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "s3-outposts-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "s3-outposts.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-sagemaker-a2i-runtime/src/endpoints.ts
+++ b/clients/client-sagemaker-a2i-runtime/src/endpoints.ts
@@ -30,26 +30,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "a2i-runtime.sagemaker.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "a2i-runtime.sagemaker.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "a2i-runtime.sagemaker-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "a2i-runtime.sagemaker-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "a2i-runtime.sagemaker.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "a2i-runtime.sagemaker.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "a2i-runtime.sagemaker.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "a2i-runtime.sagemaker-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "a2i-runtime.sagemaker-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "a2i-runtime.sagemaker.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "a2i-runtime.sagemaker.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "a2i-runtime.sagemaker.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "a2i-runtime.sagemaker.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "a2i-runtime.sagemaker.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "a2i-runtime.sagemaker.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "a2i-runtime.sagemaker.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "a2i-runtime.sagemaker-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "a2i-runtime.sagemaker-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "a2i-runtime.sagemaker.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-sagemaker-edge/src/endpoints.ts
+++ b/clients/client-sagemaker-edge/src/endpoints.ts
@@ -30,26 +30,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "edge.sagemaker.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "edge.sagemaker.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "edge.sagemaker-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "edge.sagemaker-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "edge.sagemaker.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "edge.sagemaker.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "edge.sagemaker.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "edge.sagemaker-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "edge.sagemaker-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "edge.sagemaker.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "edge.sagemaker.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "edge.sagemaker.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "edge.sagemaker.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "edge.sagemaker.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "edge.sagemaker.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "edge.sagemaker.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "edge.sagemaker-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "edge.sagemaker-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "edge.sagemaker.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-sagemaker-featurestore-runtime/src/endpoints.ts
+++ b/clients/client-sagemaker-featurestore-runtime/src/endpoints.ts
@@ -30,26 +30,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "featurestore-runtime.sagemaker.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "featurestore-runtime.sagemaker.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "featurestore-runtime.sagemaker-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "featurestore-runtime.sagemaker-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "featurestore-runtime.sagemaker.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "featurestore-runtime.sagemaker.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "featurestore-runtime.sagemaker.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "featurestore-runtime.sagemaker-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "featurestore-runtime.sagemaker-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "featurestore-runtime.sagemaker.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "featurestore-runtime.sagemaker.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "featurestore-runtime.sagemaker.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "featurestore-runtime.sagemaker.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "featurestore-runtime.sagemaker.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "featurestore-runtime.sagemaker.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "featurestore-runtime.sagemaker.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "featurestore-runtime.sagemaker-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "featurestore-runtime.sagemaker-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "featurestore-runtime.sagemaker.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-sagemaker-runtime/src/endpoints.ts
+++ b/clients/client-sagemaker-runtime/src/endpoints.ts
@@ -2,24 +2,119 @@ import { getRegionInfo, PartitionHash, RegionHash } from "@aws-sdk/config-resolv
 import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
+  "us-east-1": {
+    hostname: "runtime.sagemaker.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "runtime.sagemaker.us-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "runtime-fips.sagemaker.us-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
   "us-east-1-fips": {
     hostname: "runtime-fips.sagemaker.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "runtime-fips.sagemaker.us-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-1",
+  },
+  "us-east-2": {
+    hostname: "runtime.sagemaker.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "runtime.sagemaker.us-east-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "runtime-fips.sagemaker.us-east-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "us-east-2-fips": {
     hostname: "runtime-fips.sagemaker.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "runtime-fips.sagemaker.us-east-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-2",
+  },
+  "us-gov-west-1": {
+    hostname: "runtime.sagemaker.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "runtime.sagemaker.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "runtime.sagemaker.us-gov-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "us-gov-west-1-fips": {
     hostname: "runtime.sagemaker.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "runtime.sagemaker.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-west-1",
+  },
+  "us-west-1": {
+    hostname: "runtime.sagemaker.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "runtime.sagemaker.us-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "runtime-fips.sagemaker.us-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "us-west-1-fips": {
     hostname: "runtime-fips.sagemaker.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "runtime-fips.sagemaker.us-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-1",
+  },
+  "us-west-2": {
+    hostname: "runtime.sagemaker.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "runtime.sagemaker.us-west-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "runtime-fips.sagemaker.us-west-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "us-west-2-fips": {
     hostname: "runtime-fips.sagemaker.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "runtime-fips.sagemaker.us-west-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-2",
   },
 };
@@ -55,26 +150,84 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "runtime.sagemaker.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "runtime.sagemaker.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "runtime-fips.sagemaker.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "runtime.sagemaker.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "runtime.sagemaker.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "runtime.sagemaker-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "runtime.sagemaker-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "runtime.sagemaker.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "runtime.sagemaker.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "runtime.sagemaker.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "runtime.sagemaker.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "runtime.sagemaker.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1", "us-gov-west-1-fips"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "runtime.sagemaker.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "runtime.sagemaker.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "runtime.sagemaker-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "runtime.sagemaker-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "runtime.sagemaker.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-sagemaker/src/endpoints.ts
+++ b/clients/client-sagemaker/src/endpoints.ts
@@ -2,28 +2,143 @@ import { getRegionInfo, PartitionHash, RegionHash } from "@aws-sdk/config-resolv
 import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
+  "us-east-1": {
+    hostname: "api.sagemaker.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "api.sagemaker.us-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "api-fips.sagemaker.us-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
   "us-east-1-fips": {
     hostname: "api-fips.sagemaker.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "api-fips.sagemaker.us-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-1",
+  },
+  "us-east-2": {
+    hostname: "api.sagemaker.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "api.sagemaker.us-east-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "api-fips.sagemaker.us-east-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "us-east-2-fips": {
     hostname: "api-fips.sagemaker.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "api-fips.sagemaker.us-east-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-2",
+  },
+  "us-gov-west-1": {
+    hostname: "api.sagemaker.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "api.sagemaker.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "api-fips.sagemaker.us-gov-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "us-gov-west-1-fips": {
     hostname: "api-fips.sagemaker.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "api-fips.sagemaker.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-west-1",
   },
   "us-gov-west-1-fips-secondary": {
     hostname: "api.sagemaker.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "api.sagemaker.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-west-1",
+  },
+  "us-gov-west-1-secondary": {
+    hostname: "api.sagemaker.us-gov-west-1-secondary.amazonaws.com",
+    variants: [
+      {
+        hostname: "api.sagemaker.us-gov-west-1-secondary.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "api.sagemaker.us-gov-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+    signingRegion: "us-gov-west-1",
+  },
+  "us-west-1": {
+    hostname: "api.sagemaker.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "api.sagemaker.us-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "api-fips.sagemaker.us-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "us-west-1-fips": {
     hostname: "api-fips.sagemaker.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "api-fips.sagemaker.us-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-1",
+  },
+  "us-west-2": {
+    hostname: "api.sagemaker.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "api.sagemaker.us-west-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "api-fips.sagemaker.us-west-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "us-west-2-fips": {
     hostname: "api-fips.sagemaker.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "api-fips.sagemaker.us-west-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-2",
   },
 };
@@ -59,21 +174,61 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "api.sagemaker.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "api.sagemaker.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "api-fips.sagemaker.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "api.sagemaker.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "api.sagemaker.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "api.sagemaker-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "api.sagemaker-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "api.sagemaker.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "api.sagemaker.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "api.sagemaker.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "api.sagemaker.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "api.sagemaker.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: [
@@ -85,6 +240,16 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "api.sagemaker.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "api.sagemaker.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "api-fips.sagemaker.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
 };
 

--- a/clients/client-savingsplans/src/endpoints.ts
+++ b/clients/client-savingsplans/src/endpoints.ts
@@ -4,6 +4,12 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 const regionHash: RegionHash = {
   "aws-global": {
     hostname: "savingsplans.amazonaws.com",
+    variants: [
+      {
+        hostname: "savingsplans.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-1",
   },
 };
@@ -35,27 +41,94 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
+    hostname: "savingsplans.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "savingsplans.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "savingsplans-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "savingsplans-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "savingsplans.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
     endpoint: "aws-global",
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "savingsplans.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "savingsplans.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "savingsplans-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "savingsplans-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "savingsplans.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "savingsplans.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "savingsplans.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "savingsplans.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "savingsplans.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "savingsplans.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "savingsplans.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "savingsplans-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "savingsplans-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "savingsplans.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-schemas/src/endpoints.ts
+++ b/clients/client-schemas/src/endpoints.ts
@@ -30,26 +30,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "schemas.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "schemas.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "schemas-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "schemas-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "schemas.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "schemas.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "schemas.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "schemas-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "schemas-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "schemas.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "schemas.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "schemas.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "schemas.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "schemas.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "schemas.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "schemas.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "schemas-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "schemas-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "schemas.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-secrets-manager/src/endpoints.ts
+++ b/clients/client-secrets-manager/src/endpoints.ts
@@ -2,28 +2,142 @@ import { getRegionInfo, PartitionHash, RegionHash } from "@aws-sdk/config-resolv
 import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
+  "us-east-1": {
+    hostname: "secretsmanager.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "secretsmanager.us-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "secretsmanager-fips.us-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
   "us-east-1-fips": {
     hostname: "secretsmanager-fips.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "secretsmanager-fips.us-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-1",
+  },
+  "us-east-2": {
+    hostname: "secretsmanager.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "secretsmanager.us-east-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "secretsmanager-fips.us-east-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "us-east-2-fips": {
     hostname: "secretsmanager-fips.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "secretsmanager-fips.us-east-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-2",
+  },
+  "us-gov-east-1": {
+    hostname: "secretsmanager.us-gov-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "secretsmanager.us-gov-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "secretsmanager-fips.us-gov-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "us-gov-east-1-fips": {
     hostname: "secretsmanager-fips.us-gov-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "secretsmanager-fips.us-gov-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-east-1",
+  },
+  "us-gov-west-1": {
+    hostname: "secretsmanager.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "secretsmanager.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "secretsmanager-fips.us-gov-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "us-gov-west-1-fips": {
     hostname: "secretsmanager-fips.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "secretsmanager-fips.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-west-1",
+  },
+  "us-west-1": {
+    hostname: "secretsmanager.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "secretsmanager.us-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "secretsmanager-fips.us-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "us-west-1-fips": {
     hostname: "secretsmanager-fips.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "secretsmanager-fips.us-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-1",
+  },
+  "us-west-2": {
+    hostname: "secretsmanager.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "secretsmanager.us-west-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "secretsmanager-fips.us-west-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "us-west-2-fips": {
     hostname: "secretsmanager-fips.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "secretsmanager-fips.us-west-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-2",
   },
 };
@@ -59,26 +173,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "secretsmanager.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "secretsmanager.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "secretsmanager-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "secretsmanager-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "secretsmanager.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "secretsmanager.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "secretsmanager.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "secretsmanager-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "secretsmanager-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "secretsmanager.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "secretsmanager.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "secretsmanager.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "secretsmanager.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "secretsmanager.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-east-1-fips", "us-gov-west-1", "us-gov-west-1-fips"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "secretsmanager.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "secretsmanager.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "secretsmanager-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "secretsmanager-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "secretsmanager.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-securityhub/src/endpoints.ts
+++ b/clients/client-securityhub/src/endpoints.ts
@@ -4,27 +4,141 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 const regionHash: RegionHash = {
   "fips-us-east-1": {
     hostname: "securityhub-fips.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "securityhub-fips.us-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-1",
   },
   "fips-us-east-2": {
     hostname: "securityhub-fips.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "securityhub-fips.us-east-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-2",
   },
   "fips-us-gov-east-1": {
     hostname: "securityhub-fips.us-gov-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "securityhub-fips.us-gov-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-east-1",
   },
   "fips-us-gov-west-1": {
     hostname: "securityhub-fips.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "securityhub-fips.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-west-1",
   },
   "fips-us-west-1": {
     hostname: "securityhub-fips.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "securityhub-fips.us-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-1",
   },
   "fips-us-west-2": {
     hostname: "securityhub-fips.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "securityhub-fips.us-west-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-2",
+  },
+  "us-east-1": {
+    hostname: "securityhub.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "securityhub.us-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "securityhub-fips.us-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-east-2": {
+    hostname: "securityhub.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "securityhub.us-east-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "securityhub-fips.us-east-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-gov-east-1": {
+    hostname: "securityhub.us-gov-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "securityhub.us-gov-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "securityhub-fips.us-gov-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-gov-west-1": {
+    hostname: "securityhub.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "securityhub.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "securityhub-fips.us-gov-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-west-1": {
+    hostname: "securityhub.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "securityhub.us-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "securityhub-fips.us-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-west-2": {
+    hostname: "securityhub.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "securityhub.us-west-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "securityhub-fips.us-west-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
 };
 
@@ -59,26 +173,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "securityhub.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "securityhub.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "securityhub-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "securityhub-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "securityhub.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "securityhub.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "securityhub.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "securityhub-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "securityhub-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "securityhub.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "securityhub.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "securityhub.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "securityhub.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "securityhub.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["fips-us-gov-east-1", "fips-us-gov-west-1", "us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "securityhub.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "securityhub.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "securityhub-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "securityhub-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "securityhub.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-serverlessapplicationrepository/src/endpoints.ts
+++ b/clients/client-serverlessapplicationrepository/src/endpoints.ts
@@ -4,10 +4,22 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 const regionHash: RegionHash = {
   "us-gov-east-1": {
     hostname: "serverlessrepo.us-gov-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "serverlessrepo.us-gov-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-east-1",
   },
   "us-gov-west-1": {
     hostname: "serverlessrepo.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "serverlessrepo.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-west-1",
   },
 };
@@ -39,26 +51,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "serverlessrepo.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "serverlessrepo.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "serverlessrepo-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "serverlessrepo-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "serverlessrepo.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "serverlessrepo.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "serverlessrepo.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "serverlessrepo-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "serverlessrepo-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "serverlessrepo.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "serverlessrepo.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "serverlessrepo.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "serverlessrepo.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "serverlessrepo.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "serverlessrepo.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "serverlessrepo.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "serverlessrepo-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "serverlessrepo-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "serverlessrepo.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-service-catalog-appregistry/src/endpoints.ts
+++ b/clients/client-service-catalog-appregistry/src/endpoints.ts
@@ -2,33 +2,166 @@ import { getRegionInfo, PartitionHash, RegionHash } from "@aws-sdk/config-resolv
 import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
+  "ca-central-1": {
+    hostname: "servicecatalog-appregistry.ca-central-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "servicecatalog-appregistry.ca-central-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "servicecatalog-appregistry-fips.ca-central-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
   "fips-ca-central-1": {
     hostname: "servicecatalog-appregistry-fips.ca-central-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "servicecatalog-appregistry-fips.ca-central-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "ca-central-1",
   },
   "fips-us-east-1": {
     hostname: "servicecatalog-appregistry-fips.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "servicecatalog-appregistry-fips.us-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-1",
   },
   "fips-us-east-2": {
     hostname: "servicecatalog-appregistry-fips.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "servicecatalog-appregistry-fips.us-east-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-2",
   },
   "fips-us-gov-east-1": {
     hostname: "servicecatalog-appregistry.us-gov-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "servicecatalog-appregistry.us-gov-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-east-1",
   },
   "fips-us-gov-west-1": {
     hostname: "servicecatalog-appregistry.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "servicecatalog-appregistry.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-west-1",
   },
   "fips-us-west-1": {
     hostname: "servicecatalog-appregistry-fips.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "servicecatalog-appregistry-fips.us-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-1",
   },
   "fips-us-west-2": {
     hostname: "servicecatalog-appregistry-fips.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "servicecatalog-appregistry-fips.us-west-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-2",
+  },
+  "us-east-1": {
+    hostname: "servicecatalog-appregistry.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "servicecatalog-appregistry.us-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "servicecatalog-appregistry-fips.us-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-east-2": {
+    hostname: "servicecatalog-appregistry.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "servicecatalog-appregistry.us-east-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "servicecatalog-appregistry-fips.us-east-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-gov-east-1": {
+    hostname: "servicecatalog-appregistry.us-gov-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "servicecatalog-appregistry.us-gov-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "servicecatalog-appregistry.us-gov-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-gov-west-1": {
+    hostname: "servicecatalog-appregistry.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "servicecatalog-appregistry.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "servicecatalog-appregistry.us-gov-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-west-1": {
+    hostname: "servicecatalog-appregistry.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "servicecatalog-appregistry.us-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "servicecatalog-appregistry-fips.us-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-west-2": {
+    hostname: "servicecatalog-appregistry.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "servicecatalog-appregistry.us-west-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "servicecatalog-appregistry-fips.us-west-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
 };
 
@@ -64,26 +197,84 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "servicecatalog-appregistry.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "servicecatalog-appregistry.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "servicecatalog-appregistry-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "servicecatalog-appregistry-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "servicecatalog-appregistry.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "servicecatalog-appregistry.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "servicecatalog-appregistry.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "servicecatalog-appregistry-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "servicecatalog-appregistry-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "servicecatalog-appregistry.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "servicecatalog-appregistry.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "servicecatalog-appregistry.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "servicecatalog-appregistry.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "servicecatalog-appregistry.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["fips-us-gov-east-1", "fips-us-gov-west-1", "us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "servicecatalog-appregistry.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "servicecatalog-appregistry.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "servicecatalog-appregistry.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
 };
 

--- a/clients/client-service-catalog/src/endpoints.ts
+++ b/clients/client-service-catalog/src/endpoints.ts
@@ -2,28 +2,142 @@ import { getRegionInfo, PartitionHash, RegionHash } from "@aws-sdk/config-resolv
 import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
+  "us-east-1": {
+    hostname: "servicecatalog.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "servicecatalog.us-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "servicecatalog-fips.us-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
   "us-east-1-fips": {
     hostname: "servicecatalog-fips.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "servicecatalog-fips.us-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-1",
+  },
+  "us-east-2": {
+    hostname: "servicecatalog.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "servicecatalog.us-east-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "servicecatalog-fips.us-east-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "us-east-2-fips": {
     hostname: "servicecatalog-fips.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "servicecatalog-fips.us-east-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-2",
+  },
+  "us-gov-east-1": {
+    hostname: "servicecatalog.us-gov-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "servicecatalog.us-gov-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "servicecatalog-fips.us-gov-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "us-gov-east-1-fips": {
     hostname: "servicecatalog-fips.us-gov-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "servicecatalog-fips.us-gov-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-east-1",
+  },
+  "us-gov-west-1": {
+    hostname: "servicecatalog.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "servicecatalog.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "servicecatalog-fips.us-gov-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "us-gov-west-1-fips": {
     hostname: "servicecatalog-fips.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "servicecatalog-fips.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-west-1",
+  },
+  "us-west-1": {
+    hostname: "servicecatalog.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "servicecatalog.us-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "servicecatalog-fips.us-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "us-west-1-fips": {
     hostname: "servicecatalog-fips.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "servicecatalog-fips.us-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-1",
+  },
+  "us-west-2": {
+    hostname: "servicecatalog.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "servicecatalog.us-west-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "servicecatalog-fips.us-west-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "us-west-2-fips": {
     hostname: "servicecatalog-fips.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "servicecatalog-fips.us-west-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-2",
   },
 };
@@ -59,26 +173,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "servicecatalog.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "servicecatalog.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "servicecatalog-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "servicecatalog-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "servicecatalog.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "servicecatalog.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "servicecatalog.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "servicecatalog-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "servicecatalog-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "servicecatalog.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "servicecatalog.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "servicecatalog.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "servicecatalog.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "servicecatalog.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-east-1-fips", "us-gov-west-1", "us-gov-west-1-fips"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "servicecatalog.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "servicecatalog.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "servicecatalog-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "servicecatalog-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "servicecatalog.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-service-quotas/src/endpoints.ts
+++ b/clients/client-service-quotas/src/endpoints.ts
@@ -4,11 +4,49 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 const regionHash: RegionHash = {
   "fips-us-gov-east-1": {
     hostname: "servicequotas.us-gov-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "servicequotas.us-gov-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-east-1",
   },
   "fips-us-gov-west-1": {
     hostname: "servicequotas.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "servicequotas.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-west-1",
+  },
+  "us-gov-east-1": {
+    hostname: "servicequotas.us-gov-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "servicequotas.us-gov-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "servicequotas.us-gov-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-gov-west-1": {
+    hostname: "servicequotas.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "servicequotas.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "servicequotas.us-gov-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
 };
 
@@ -39,26 +77,84 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "servicequotas.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "servicequotas.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "servicequotas-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "servicequotas-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "servicequotas.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "servicequotas.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "servicequotas.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "servicequotas-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "servicequotas-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "servicequotas.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "servicequotas.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "servicequotas.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "servicequotas.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "servicequotas.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["fips-us-gov-east-1", "fips-us-gov-west-1", "us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "servicequotas.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "servicequotas.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "servicequotas.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
 };
 

--- a/clients/client-servicediscovery/src/endpoints.ts
+++ b/clients/client-servicediscovery/src/endpoints.ts
@@ -2,36 +2,189 @@ import { getRegionInfo, PartitionHash, RegionHash } from "@aws-sdk/config-resolv
 import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
+  "ca-central-1": {
+    hostname: "servicediscovery.ca-central-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "servicediscovery.ca-central-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "servicediscovery-fips.ca-central-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
   "ca-central-1-fips": {
     hostname: "servicediscovery-fips.ca-central-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "servicediscovery-fips.ca-central-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "ca-central-1",
+  },
+  servicediscovery: {
+    hostname: "servicediscovery.servicediscovery.amazonaws.com",
+    variants: [
+      {
+        hostname: "servicediscovery.servicediscovery.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "servicediscovery-fips.us-gov-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+    signingRegion: "us-gov-west-1",
   },
   "servicediscovery-fips": {
     hostname: "servicediscovery-fips.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "servicediscovery-fips.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-west-1",
+  },
+  "us-east-1": {
+    hostname: "servicediscovery.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "servicediscovery.us-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "servicediscovery-fips.us-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "us-east-1-fips": {
     hostname: "servicediscovery-fips.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "servicediscovery-fips.us-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-1",
+  },
+  "us-east-2": {
+    hostname: "servicediscovery.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "servicediscovery.us-east-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "servicediscovery-fips.us-east-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "us-east-2-fips": {
     hostname: "servicediscovery-fips.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "servicediscovery-fips.us-east-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-2",
+  },
+  "us-gov-east-1": {
+    hostname: "servicediscovery.us-gov-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "servicediscovery.us-gov-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "servicediscovery-fips.us-gov-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "us-gov-east-1-fips": {
     hostname: "servicediscovery-fips.us-gov-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "servicediscovery-fips.us-gov-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-east-1",
+  },
+  "us-gov-west-1": {
+    hostname: "servicediscovery.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "servicediscovery.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "servicediscovery-fips.us-gov-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "us-gov-west-1-fips": {
     hostname: "servicediscovery-fips.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "servicediscovery-fips.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-west-1",
+  },
+  "us-west-1": {
+    hostname: "servicediscovery.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "servicediscovery.us-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "servicediscovery-fips.us-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "us-west-1-fips": {
     hostname: "servicediscovery-fips.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "servicediscovery-fips.us-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-1",
+  },
+  "us-west-2": {
+    hostname: "servicediscovery.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "servicediscovery.us-west-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "servicediscovery-fips.us-west-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "us-west-2-fips": {
     hostname: "servicediscovery-fips.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "servicediscovery-fips.us-west-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-2",
   },
 };
@@ -70,21 +223,69 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "servicediscovery.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "servicediscovery.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "servicediscovery-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "servicediscovery-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "servicediscovery.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "servicediscovery.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "servicediscovery.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "servicediscovery-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "servicediscovery-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "servicediscovery.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "servicediscovery.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "servicediscovery.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "servicediscovery.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "servicediscovery.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: [
@@ -97,6 +298,24 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "servicediscovery.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "servicediscovery.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "servicediscovery-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "servicediscovery-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "servicediscovery.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-ses/src/endpoints.ts
+++ b/clients/client-ses/src/endpoints.ts
@@ -4,7 +4,26 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 const regionHash: RegionHash = {
   "fips-us-gov-west-1": {
     hostname: "email-fips.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "email-fips.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-west-1",
+  },
+  "us-gov-west-1": {
+    hostname: "email.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "email.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "email-fips.us-gov-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
 };
 
@@ -35,26 +54,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "email.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "email.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "email-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "email-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "email.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "email.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "email.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "email-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "email-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "email.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "email.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "email.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "email.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "email.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["fips-us-gov-west-1", "us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "email.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "email.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "email-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "email-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "email.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-sesv2/src/endpoints.ts
+++ b/clients/client-sesv2/src/endpoints.ts
@@ -4,7 +4,26 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 const regionHash: RegionHash = {
   "fips-us-gov-west-1": {
     hostname: "email-fips.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "email-fips.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-west-1",
+  },
+  "us-gov-west-1": {
+    hostname: "email.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "email.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "email-fips.us-gov-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
 };
 
@@ -35,26 +54,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "email.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "email.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "email-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "email-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "email.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "email.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "email.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "email-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "email-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "email.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "email.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "email.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "email.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "email.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["fips-us-gov-west-1", "us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "email.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "email.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "email-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "email-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "email.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-sfn/src/endpoints.ts
+++ b/clients/client-sfn/src/endpoints.ts
@@ -4,27 +4,141 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 const regionHash: RegionHash = {
   "fips-us-east-1": {
     hostname: "states-fips.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "states-fips.us-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-1",
   },
   "fips-us-east-2": {
     hostname: "states-fips.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "states-fips.us-east-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-2",
   },
   "fips-us-gov-east-1": {
     hostname: "states-fips.us-gov-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "states-fips.us-gov-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-east-1",
   },
   "fips-us-gov-west-1": {
     hostname: "states.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "states.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-west-1",
   },
   "fips-us-west-1": {
     hostname: "states-fips.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "states-fips.us-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-1",
   },
   "fips-us-west-2": {
     hostname: "states-fips.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "states-fips.us-west-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-2",
+  },
+  "us-east-1": {
+    hostname: "states.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "states.us-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "states-fips.us-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-east-2": {
+    hostname: "states.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "states.us-east-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "states-fips.us-east-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-gov-east-1": {
+    hostname: "states.us-gov-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "states.us-gov-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "states-fips.us-gov-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-gov-west-1": {
+    hostname: "states.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "states.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "states.us-gov-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-west-1": {
+    hostname: "states.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "states.us-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "states-fips.us-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-west-2": {
+    hostname: "states.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "states.us-west-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "states-fips.us-west-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
 };
 
@@ -59,26 +173,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "states.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "states.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "states-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "states-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "states.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "states.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "states.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "states-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "states-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "states.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "states.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "states.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "states.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "states.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["fips-us-gov-east-1", "fips-us-gov-west-1", "us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "states.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "states.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "states-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "states-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "states.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-shield/src/endpoints.ts
+++ b/clients/client-shield/src/endpoints.ts
@@ -4,10 +4,26 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 const regionHash: RegionHash = {
   "aws-global": {
     hostname: "shield.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "shield.us-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "shield-fips.us-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
     signingRegion: "us-east-1",
   },
   "fips-aws-global": {
     hostname: "shield-fips.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "shield-fips.us-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-1",
   },
 };
@@ -40,27 +56,94 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
+    hostname: "shield.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "shield.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "shield-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "shield-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "shield.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
     endpoint: "aws-global",
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "shield.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "shield.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "shield-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "shield-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "shield.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "shield.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "shield.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "shield.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "shield.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "shield.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "shield.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "shield-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "shield-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "shield.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-signer/src/endpoints.ts
+++ b/clients/client-signer/src/endpoints.ts
@@ -30,26 +30,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "signer.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "signer.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "signer-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "signer-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "signer.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "signer.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "signer.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "signer-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "signer-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "signer.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "signer.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "signer.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "signer.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "signer.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "signer.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "signer.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "signer-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "signer-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "signer.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-sms/src/endpoints.ts
+++ b/clients/client-sms/src/endpoints.ts
@@ -4,27 +4,141 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 const regionHash: RegionHash = {
   "fips-us-east-1": {
     hostname: "sms-fips.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "sms-fips.us-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-1",
   },
   "fips-us-east-2": {
     hostname: "sms-fips.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "sms-fips.us-east-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-2",
   },
   "fips-us-gov-east-1": {
     hostname: "sms-fips.us-gov-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "sms-fips.us-gov-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-east-1",
   },
   "fips-us-gov-west-1": {
     hostname: "sms-fips.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "sms-fips.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-west-1",
   },
   "fips-us-west-1": {
     hostname: "sms-fips.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "sms-fips.us-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-1",
   },
   "fips-us-west-2": {
     hostname: "sms-fips.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "sms-fips.us-west-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-2",
+  },
+  "us-east-1": {
+    hostname: "sms.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "sms.us-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "sms-fips.us-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-east-2": {
+    hostname: "sms.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "sms.us-east-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "sms-fips.us-east-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-gov-east-1": {
+    hostname: "sms.us-gov-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "sms.us-gov-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "sms-fips.us-gov-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-gov-west-1": {
+    hostname: "sms.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "sms.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "sms-fips.us-gov-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-west-1": {
+    hostname: "sms.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "sms.us-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "sms-fips.us-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-west-2": {
+    hostname: "sms.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "sms.us-west-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "sms-fips.us-west-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
 };
 
@@ -59,26 +173,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "sms.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "sms.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "sms-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "sms-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "sms.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "sms.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "sms.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "sms-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "sms-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "sms.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "sms.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "sms.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "sms.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "sms.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["fips-us-gov-east-1", "fips-us-gov-west-1", "us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "sms.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "sms.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "sms-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "sms-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "sms.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-snow-device-management/src/endpoints.ts
+++ b/clients/client-snow-device-management/src/endpoints.ts
@@ -30,26 +30,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "snow-device-management.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "snow-device-management.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "snow-device-management-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "snow-device-management-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "snow-device-management.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "snow-device-management.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "snow-device-management.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "snow-device-management-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "snow-device-management-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "snow-device-management.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "snow-device-management.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "snow-device-management.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "snow-device-management.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "snow-device-management.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "snow-device-management.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "snow-device-management.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "snow-device-management-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "snow-device-management-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "snow-device-management.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-snowball/src/endpoints.ts
+++ b/clients/client-snowball/src/endpoints.ts
@@ -2,85 +2,465 @@ import { getRegionInfo, PartitionHash, RegionHash } from "@aws-sdk/config-resolv
 import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
+  "ap-northeast-1": {
+    hostname: "snowball.ap-northeast-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "snowball.ap-northeast-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "snowball-fips.ap-northeast-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "ap-northeast-2": {
+    hostname: "snowball.ap-northeast-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "snowball.ap-northeast-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "snowball-fips.ap-northeast-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "ap-northeast-3": {
+    hostname: "snowball.ap-northeast-3.amazonaws.com",
+    variants: [
+      {
+        hostname: "snowball.ap-northeast-3.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "snowball-fips.ap-northeast-3.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "ap-south-1": {
+    hostname: "snowball.ap-south-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "snowball.ap-south-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "snowball-fips.ap-south-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "ap-southeast-1": {
+    hostname: "snowball.ap-southeast-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "snowball.ap-southeast-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "snowball-fips.ap-southeast-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "ap-southeast-2": {
+    hostname: "snowball.ap-southeast-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "snowball.ap-southeast-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "snowball-fips.ap-southeast-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "ca-central-1": {
+    hostname: "snowball.ca-central-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "snowball.ca-central-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "snowball-fips.ca-central-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "cn-north-1": {
+    hostname: "snowball.cn-north-1.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "snowball.cn-north-1.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "snowball-fips.cn-north-1.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "cn-northwest-1": {
+    hostname: "snowball.cn-northwest-1.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "snowball.cn-northwest-1.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "snowball-fips.cn-northwest-1.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "eu-central-1": {
+    hostname: "snowball.eu-central-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "snowball.eu-central-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "snowball-fips.eu-central-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "eu-west-1": {
+    hostname: "snowball.eu-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "snowball.eu-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "snowball-fips.eu-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "eu-west-2": {
+    hostname: "snowball.eu-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "snowball.eu-west-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "snowball-fips.eu-west-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "eu-west-3": {
+    hostname: "snowball.eu-west-3.amazonaws.com",
+    variants: [
+      {
+        hostname: "snowball.eu-west-3.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "snowball-fips.eu-west-3.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
   "fips-ap-northeast-1": {
     hostname: "snowball-fips.ap-northeast-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "snowball-fips.ap-northeast-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "ap-northeast-1",
   },
   "fips-ap-northeast-2": {
     hostname: "snowball-fips.ap-northeast-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "snowball-fips.ap-northeast-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "ap-northeast-2",
   },
   "fips-ap-northeast-3": {
     hostname: "snowball-fips.ap-northeast-3.amazonaws.com",
+    variants: [
+      {
+        hostname: "snowball-fips.ap-northeast-3.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "ap-northeast-3",
   },
   "fips-ap-south-1": {
     hostname: "snowball-fips.ap-south-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "snowball-fips.ap-south-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "ap-south-1",
   },
   "fips-ap-southeast-1": {
     hostname: "snowball-fips.ap-southeast-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "snowball-fips.ap-southeast-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "ap-southeast-1",
   },
   "fips-ap-southeast-2": {
     hostname: "snowball-fips.ap-southeast-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "snowball-fips.ap-southeast-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "ap-southeast-2",
   },
   "fips-ca-central-1": {
     hostname: "snowball-fips.ca-central-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "snowball-fips.ca-central-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "ca-central-1",
   },
   "fips-cn-north-1": {
     hostname: "snowball-fips.cn-north-1.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "snowball-fips.cn-north-1.amazonaws.com.cn",
+        tags: [],
+      },
+    ],
     signingRegion: "cn-north-1",
   },
   "fips-cn-northwest-1": {
     hostname: "snowball-fips.cn-northwest-1.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "snowball-fips.cn-northwest-1.amazonaws.com.cn",
+        tags: [],
+      },
+    ],
     signingRegion: "cn-northwest-1",
   },
   "fips-eu-central-1": {
     hostname: "snowball-fips.eu-central-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "snowball-fips.eu-central-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "eu-central-1",
   },
   "fips-eu-west-1": {
     hostname: "snowball-fips.eu-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "snowball-fips.eu-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "eu-west-1",
   },
   "fips-eu-west-2": {
     hostname: "snowball-fips.eu-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "snowball-fips.eu-west-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "eu-west-2",
   },
   "fips-eu-west-3": {
     hostname: "snowball-fips.eu-west-3.amazonaws.com",
+    variants: [
+      {
+        hostname: "snowball-fips.eu-west-3.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "eu-west-3",
   },
   "fips-sa-east-1": {
     hostname: "snowball-fips.sa-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "snowball-fips.sa-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "sa-east-1",
   },
   "fips-us-east-1": {
     hostname: "snowball-fips.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "snowball-fips.us-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-1",
   },
   "fips-us-east-2": {
     hostname: "snowball-fips.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "snowball-fips.us-east-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-2",
   },
   "fips-us-gov-east-1": {
     hostname: "snowball-fips.us-gov-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "snowball-fips.us-gov-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-east-1",
   },
   "fips-us-gov-west-1": {
     hostname: "snowball-fips.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "snowball-fips.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-west-1",
   },
   "fips-us-west-1": {
     hostname: "snowball-fips.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "snowball-fips.us-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-1",
   },
   "fips-us-west-2": {
     hostname: "snowball-fips.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "snowball-fips.us-west-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-2",
+  },
+  "sa-east-1": {
+    hostname: "snowball.sa-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "snowball.sa-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "snowball-fips.sa-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-east-1": {
+    hostname: "snowball.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "snowball.us-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "snowball-fips.us-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-east-2": {
+    hostname: "snowball.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "snowball.us-east-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "snowball-fips.us-east-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-gov-east-1": {
+    hostname: "snowball.us-gov-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "snowball.us-gov-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "snowball-fips.us-gov-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-gov-west-1": {
+    hostname: "snowball.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "snowball.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "snowball-fips.us-gov-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-west-1": {
+    hostname: "snowball.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "snowball.us-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "snowball-fips.us-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-west-2": {
+    hostname: "snowball.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "snowball.us-west-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "snowball-fips.us-west-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
 };
 
@@ -127,26 +507,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "snowball.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "snowball.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "snowball-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "snowball-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "snowball.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1", "fips-cn-north-1", "fips-cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "snowball.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "snowball.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "snowball-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "snowball-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "snowball.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "snowball.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "snowball.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "snowball.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "snowball.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["fips-us-gov-east-1", "fips-us-gov-west-1", "us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "snowball.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "snowball.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "snowball-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "snowball-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "snowball.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-sns/src/endpoints.ts
+++ b/clients/client-sns/src/endpoints.ts
@@ -4,27 +4,115 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 const regionHash: RegionHash = {
   "fips-us-east-1": {
     hostname: "sns-fips.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "sns-fips.us-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-1",
   },
   "fips-us-east-2": {
     hostname: "sns-fips.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "sns-fips.us-east-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-2",
   },
   "fips-us-west-1": {
     hostname: "sns-fips.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "sns-fips.us-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-1",
   },
   "fips-us-west-2": {
     hostname: "sns-fips.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "sns-fips.us-west-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-2",
+  },
+  "us-east-1": {
+    hostname: "sns.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "sns.us-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "sns-fips.us-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-east-2": {
+    hostname: "sns.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "sns.us-east-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "sns-fips.us-east-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "us-gov-east-1": {
     hostname: "sns.us-gov-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "sns.us-gov-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-east-1",
   },
   "us-gov-west-1": {
     hostname: "sns.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "sns.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-west-1",
+  },
+  "us-west-1": {
+    hostname: "sns.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "sns.us-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "sns-fips.us-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-west-2": {
+    hostname: "sns.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "sns.us-west-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "sns-fips.us-west-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
 };
 
@@ -59,26 +147,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "sns.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "sns.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "sns-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "sns-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "sns.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "sns.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "sns.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "sns-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "sns-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "sns.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "sns.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "sns.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "sns.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "sns.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "sns.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "sns.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "sns-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "sns-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "sns.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-sqs/src/endpoints.ts
+++ b/clients/client-sqs/src/endpoints.ts
@@ -4,27 +4,115 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 const regionHash: RegionHash = {
   "fips-us-east-1": {
     hostname: "sqs-fips.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "sqs-fips.us-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-1",
   },
   "fips-us-east-2": {
     hostname: "sqs-fips.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "sqs-fips.us-east-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-2",
   },
   "fips-us-west-1": {
     hostname: "sqs-fips.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "sqs-fips.us-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-1",
   },
   "fips-us-west-2": {
     hostname: "sqs-fips.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "sqs-fips.us-west-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-2",
+  },
+  "us-east-1": {
+    hostname: "sqs.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "sqs.us-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "sqs-fips.us-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-east-2": {
+    hostname: "sqs.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "sqs.us-east-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "sqs-fips.us-east-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "us-gov-east-1": {
     hostname: "sqs.us-gov-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "sqs.us-gov-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-east-1",
   },
   "us-gov-west-1": {
     hostname: "sqs.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "sqs.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-west-1",
+  },
+  "us-west-1": {
+    hostname: "sqs.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "sqs.us-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "sqs-fips.us-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-west-2": {
+    hostname: "sqs.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "sqs.us-west-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "sqs-fips.us-west-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
 };
 
@@ -59,26 +147,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "sqs.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "sqs.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "sqs-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "sqs-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "sqs.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "sqs.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "sqs.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "sqs-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "sqs-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "sqs.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "sqs.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "sqs.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "sqs.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "sqs.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "sqs.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "sqs.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "sqs-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "sqs-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "sqs.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-ssm-contacts/src/endpoints.ts
+++ b/clients/client-ssm-contacts/src/endpoints.ts
@@ -30,26 +30,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "ssm-contacts.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "ssm-contacts.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "ssm-contacts-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "ssm-contacts-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "ssm-contacts.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "ssm-contacts.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "ssm-contacts.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "ssm-contacts-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "ssm-contacts-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "ssm-contacts.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "ssm-contacts.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "ssm-contacts.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "ssm-contacts.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "ssm-contacts.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "ssm-contacts.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "ssm-contacts.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "ssm-contacts-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "ssm-contacts-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "ssm-contacts.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-ssm-incidents/src/endpoints.ts
+++ b/clients/client-ssm-incidents/src/endpoints.ts
@@ -30,26 +30,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "ssm-incidents.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "ssm-incidents.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "ssm-incidents-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "ssm-incidents-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "ssm-incidents.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "ssm-incidents.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "ssm-incidents.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "ssm-incidents-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "ssm-incidents-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "ssm-incidents.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "ssm-incidents.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "ssm-incidents.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "ssm-incidents.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "ssm-incidents.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "ssm-incidents.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "ssm-incidents.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "ssm-incidents-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "ssm-incidents-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "ssm-incidents.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-ssm/src/endpoints.ts
+++ b/clients/client-ssm/src/endpoints.ts
@@ -2,33 +2,166 @@ import { getRegionInfo, PartitionHash, RegionHash } from "@aws-sdk/config-resolv
 import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
+  "ca-central-1": {
+    hostname: "ssm.ca-central-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "ssm.ca-central-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "ssm-fips.ca-central-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
   "fips-ca-central-1": {
     hostname: "ssm-fips.ca-central-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "ssm-fips.ca-central-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "ca-central-1",
   },
   "fips-us-east-1": {
     hostname: "ssm-fips.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "ssm-fips.us-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-1",
   },
   "fips-us-east-2": {
     hostname: "ssm-fips.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "ssm-fips.us-east-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-2",
   },
   "fips-us-gov-east-1": {
     hostname: "ssm.us-gov-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "ssm.us-gov-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-east-1",
   },
   "fips-us-gov-west-1": {
     hostname: "ssm.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "ssm.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-west-1",
   },
   "fips-us-west-1": {
     hostname: "ssm-fips.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "ssm-fips.us-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-1",
   },
   "fips-us-west-2": {
     hostname: "ssm-fips.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "ssm-fips.us-west-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-2",
+  },
+  "us-east-1": {
+    hostname: "ssm.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "ssm.us-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "ssm-fips.us-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-east-2": {
+    hostname: "ssm.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "ssm.us-east-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "ssm-fips.us-east-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-gov-east-1": {
+    hostname: "ssm.us-gov-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "ssm.us-gov-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "ssm.us-gov-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-gov-west-1": {
+    hostname: "ssm.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "ssm.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "ssm.us-gov-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-west-1": {
+    hostname: "ssm.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "ssm.us-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "ssm-fips.us-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-west-2": {
+    hostname: "ssm.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "ssm.us-west-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "ssm-fips.us-west-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
 };
 
@@ -64,26 +197,84 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "ssm.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "ssm.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "ssm-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "ssm-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "ssm.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "ssm.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "ssm.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "ssm-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "ssm-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "ssm.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "ssm.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "ssm.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "ssm.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "ssm.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["fips-us-gov-east-1", "fips-us-gov-west-1", "us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "ssm.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "ssm.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "ssm.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
 };
 

--- a/clients/client-sso-admin/src/endpoints.ts
+++ b/clients/client-sso-admin/src/endpoints.ts
@@ -30,26 +30,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "sso.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "sso.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "sso-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "sso-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "sso.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "sso.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "sso.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "sso-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "sso-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "sso.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "sso.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "sso.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "sso.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "sso.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "sso.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "sso.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "sso-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "sso-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "sso.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-sso-oidc/src/endpoints.ts
+++ b/clients/client-sso-oidc/src/endpoints.ts
@@ -4,66 +4,162 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 const regionHash: RegionHash = {
   "ap-northeast-1": {
     hostname: "oidc.ap-northeast-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "oidc.ap-northeast-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "ap-northeast-1",
   },
   "ap-northeast-2": {
     hostname: "oidc.ap-northeast-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "oidc.ap-northeast-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "ap-northeast-2",
   },
   "ap-south-1": {
     hostname: "oidc.ap-south-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "oidc.ap-south-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "ap-south-1",
   },
   "ap-southeast-1": {
     hostname: "oidc.ap-southeast-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "oidc.ap-southeast-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "ap-southeast-1",
   },
   "ap-southeast-2": {
     hostname: "oidc.ap-southeast-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "oidc.ap-southeast-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "ap-southeast-2",
   },
   "ca-central-1": {
     hostname: "oidc.ca-central-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "oidc.ca-central-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "ca-central-1",
   },
   "eu-central-1": {
     hostname: "oidc.eu-central-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "oidc.eu-central-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "eu-central-1",
   },
   "eu-north-1": {
     hostname: "oidc.eu-north-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "oidc.eu-north-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "eu-north-1",
   },
   "eu-west-1": {
     hostname: "oidc.eu-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "oidc.eu-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "eu-west-1",
   },
   "eu-west-2": {
     hostname: "oidc.eu-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "oidc.eu-west-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "eu-west-2",
   },
   "eu-west-3": {
     hostname: "oidc.eu-west-3.amazonaws.com",
+    variants: [
+      {
+        hostname: "oidc.eu-west-3.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "eu-west-3",
   },
   "sa-east-1": {
     hostname: "oidc.sa-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "oidc.sa-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "sa-east-1",
   },
   "us-east-1": {
     hostname: "oidc.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "oidc.us-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-1",
   },
   "us-east-2": {
     hostname: "oidc.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "oidc.us-east-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-2",
   },
   "us-gov-west-1": {
     hostname: "oidc.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "oidc.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-west-1",
   },
   "us-west-2": {
     hostname: "oidc.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "oidc.us-west-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-2",
   },
 };
@@ -95,26 +191,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "oidc.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "oidc.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "oidc-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "oidc-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "oidc.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "oidc.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "oidc.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "oidc-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "oidc-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "oidc.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "oidc.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "oidc.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "oidc.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "oidc.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "oidc.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "oidc.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "oidc-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "oidc-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "oidc.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-sso/src/endpoints.ts
+++ b/clients/client-sso/src/endpoints.ts
@@ -4,66 +4,162 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 const regionHash: RegionHash = {
   "ap-northeast-1": {
     hostname: "portal.sso.ap-northeast-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "portal.sso.ap-northeast-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "ap-northeast-1",
   },
   "ap-northeast-2": {
     hostname: "portal.sso.ap-northeast-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "portal.sso.ap-northeast-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "ap-northeast-2",
   },
   "ap-south-1": {
     hostname: "portal.sso.ap-south-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "portal.sso.ap-south-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "ap-south-1",
   },
   "ap-southeast-1": {
     hostname: "portal.sso.ap-southeast-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "portal.sso.ap-southeast-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "ap-southeast-1",
   },
   "ap-southeast-2": {
     hostname: "portal.sso.ap-southeast-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "portal.sso.ap-southeast-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "ap-southeast-2",
   },
   "ca-central-1": {
     hostname: "portal.sso.ca-central-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "portal.sso.ca-central-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "ca-central-1",
   },
   "eu-central-1": {
     hostname: "portal.sso.eu-central-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "portal.sso.eu-central-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "eu-central-1",
   },
   "eu-north-1": {
     hostname: "portal.sso.eu-north-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "portal.sso.eu-north-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "eu-north-1",
   },
   "eu-west-1": {
     hostname: "portal.sso.eu-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "portal.sso.eu-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "eu-west-1",
   },
   "eu-west-2": {
     hostname: "portal.sso.eu-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "portal.sso.eu-west-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "eu-west-2",
   },
   "eu-west-3": {
     hostname: "portal.sso.eu-west-3.amazonaws.com",
+    variants: [
+      {
+        hostname: "portal.sso.eu-west-3.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "eu-west-3",
   },
   "sa-east-1": {
     hostname: "portal.sso.sa-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "portal.sso.sa-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "sa-east-1",
   },
   "us-east-1": {
     hostname: "portal.sso.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "portal.sso.us-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-1",
   },
   "us-east-2": {
     hostname: "portal.sso.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "portal.sso.us-east-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-2",
   },
   "us-gov-west-1": {
     hostname: "portal.sso.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "portal.sso.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-west-1",
   },
   "us-west-2": {
     hostname: "portal.sso.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "portal.sso.us-west-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-2",
   },
 };
@@ -95,26 +191,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "portal.sso.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "portal.sso.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "portal.sso-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "portal.sso-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "portal.sso.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "portal.sso.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "portal.sso.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "portal.sso-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "portal.sso-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "portal.sso.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "portal.sso.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "portal.sso.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "portal.sso.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "portal.sso.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "portal.sso.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "portal.sso.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "portal.sso-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "portal.sso-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "portal.sso.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-storage-gateway/src/endpoints.ts
+++ b/clients/client-storage-gateway/src/endpoints.ts
@@ -2,36 +2,175 @@ import { getRegionInfo, PartitionHash, RegionHash } from "@aws-sdk/config-resolv
 import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
+  "ca-central-1": {
+    hostname: "storagegateway.ca-central-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "storagegateway.ca-central-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "storagegateway-fips.ca-central-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
   "ca-central-1-fips": {
     hostname: "storagegateway-fips.ca-central-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "storagegateway-fips.ca-central-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "ca-central-1",
   },
   fips: {
     hostname: "storagegateway-fips.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "storagegateway-fips.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-west-1",
+  },
+  "us-east-1": {
+    hostname: "storagegateway.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "storagegateway.us-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "storagegateway-fips.us-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "us-east-1-fips": {
     hostname: "storagegateway-fips.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "storagegateway-fips.us-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-1",
+  },
+  "us-east-2": {
+    hostname: "storagegateway.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "storagegateway.us-east-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "storagegateway-fips.us-east-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "us-east-2-fips": {
     hostname: "storagegateway-fips.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "storagegateway-fips.us-east-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-2",
+  },
+  "us-gov-east-1": {
+    hostname: "storagegateway.us-gov-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "storagegateway.us-gov-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "storagegateway-fips.us-gov-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "us-gov-east-1-fips": {
     hostname: "storagegateway-fips.us-gov-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "storagegateway-fips.us-gov-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-east-1",
+  },
+  "us-gov-west-1": {
+    hostname: "storagegateway.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "storagegateway.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "storagegateway-fips.us-gov-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "us-gov-west-1-fips": {
     hostname: "storagegateway-fips.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "storagegateway-fips.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-west-1",
+  },
+  "us-west-1": {
+    hostname: "storagegateway.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "storagegateway.us-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "storagegateway-fips.us-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "us-west-1-fips": {
     hostname: "storagegateway-fips.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "storagegateway-fips.us-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-1",
+  },
+  "us-west-2": {
+    hostname: "storagegateway.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "storagegateway.us-west-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "storagegateway-fips.us-west-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "us-west-2-fips": {
     hostname: "storagegateway-fips.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "storagegateway-fips.us-west-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-2",
   },
 };
@@ -69,26 +208,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "storagegateway.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "storagegateway.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "storagegateway-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "storagegateway-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "storagegateway.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "storagegateway.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "storagegateway.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "storagegateway-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "storagegateway-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "storagegateway.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "storagegateway.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "storagegateway.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "storagegateway.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "storagegateway.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["fips", "us-gov-east-1", "us-gov-east-1-fips", "us-gov-west-1", "us-gov-west-1-fips"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "storagegateway.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "storagegateway.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "storagegateway-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "storagegateway-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "storagegateway.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-sts/src/endpoints.ts
+++ b/clients/client-sts/src/endpoints.ts
@@ -4,30 +4,150 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 const regionHash: RegionHash = {
   "aws-global": {
     hostname: "sts.amazonaws.com",
+    variants: [
+      {
+        hostname: "sts.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-1",
+  },
+  "us-east-1": {
+    hostname: "sts.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "sts.us-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "sts-fips.us-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "us-east-1-fips": {
     hostname: "sts-fips.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "sts-fips.us-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-1",
+  },
+  "us-east-2": {
+    hostname: "sts.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "sts.us-east-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "sts-fips.us-east-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "us-east-2-fips": {
     hostname: "sts-fips.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "sts-fips.us-east-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-2",
+  },
+  "us-gov-east-1": {
+    hostname: "sts.us-gov-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "sts.us-gov-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "sts.us-gov-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "us-gov-east-1-fips": {
     hostname: "sts.us-gov-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "sts.us-gov-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-east-1",
+  },
+  "us-gov-west-1": {
+    hostname: "sts.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "sts.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "sts.us-gov-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "us-gov-west-1-fips": {
     hostname: "sts.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "sts.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-west-1",
+  },
+  "us-west-1": {
+    hostname: "sts.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "sts.us-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "sts-fips.us-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "us-west-1-fips": {
     hostname: "sts-fips.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "sts-fips.us-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-1",
+  },
+  "us-west-2": {
+    hostname: "sts.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "sts.us-west-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "sts-fips.us-west-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "us-west-2-fips": {
     hostname: "sts-fips.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "sts-fips.us-west-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-2",
   },
 };
@@ -64,26 +184,84 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "sts.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "sts.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "sts-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "sts-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "sts.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "sts.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "sts.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "sts-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "sts-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "sts.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "sts.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "sts.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "sts.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "sts.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-east-1-fips", "us-gov-west-1", "us-gov-west-1-fips"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "sts.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "sts.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "sts.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
 };
 

--- a/clients/client-support/src/endpoints.ts
+++ b/clients/client-support/src/endpoints.ts
@@ -4,26 +4,76 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 const regionHash: RegionHash = {
   "aws-cn-global": {
     hostname: "support.cn-north-1.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "support.cn-north-1.amazonaws.com.cn",
+        tags: [],
+      },
+    ],
     signingRegion: "cn-north-1",
   },
   "aws-global": {
     hostname: "support.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "support.us-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-1",
   },
   "aws-iso-b-global": {
     hostname: "support.us-isob-east-1.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "support.us-isob-east-1.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
     signingRegion: "us-isob-east-1",
   },
   "aws-iso-global": {
     hostname: "support.us-iso-east-1.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "support.us-iso-east-1.c2s.ic.gov",
+        tags: [],
+      },
+    ],
     signingRegion: "us-iso-east-1",
   },
   "aws-us-gov-global": {
     hostname: "support.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "support.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-west-1",
   },
   "fips-us-gov-west-1": {
     hostname: "support.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "support.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
+    signingRegion: "us-gov-west-1",
+  },
+  "us-gov-west-1": {
+    hostname: "support.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "support.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "support.us-gov-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
     signingRegion: "us-gov-west-1",
   },
 };
@@ -56,26 +106,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "support.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "support.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "support-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "support-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "support.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["aws-cn-global", "cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "support.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "support.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "support-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "support-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "support.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["aws-iso-global", "us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "support.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "support.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["aws-iso-b-global", "us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "support.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "support.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["aws-us-gov-global", "fips-us-gov-west-1", "us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "support.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "support.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "support-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "support-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "support.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-swf/src/endpoints.ts
+++ b/clients/client-swf/src/endpoints.ts
@@ -4,27 +4,115 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 const regionHash: RegionHash = {
   "fips-us-east-1": {
     hostname: "swf-fips.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "swf-fips.us-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-1",
   },
   "fips-us-east-2": {
     hostname: "swf-fips.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "swf-fips.us-east-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-2",
   },
   "fips-us-west-1": {
     hostname: "swf-fips.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "swf-fips.us-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-1",
   },
   "fips-us-west-2": {
     hostname: "swf-fips.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "swf-fips.us-west-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-2",
+  },
+  "us-east-1": {
+    hostname: "swf.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "swf.us-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "swf-fips.us-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-east-2": {
+    hostname: "swf.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "swf.us-east-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "swf-fips.us-east-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "us-gov-east-1": {
     hostname: "swf.us-gov-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "swf.us-gov-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-east-1",
   },
   "us-gov-west-1": {
     hostname: "swf.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "swf.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-west-1",
+  },
+  "us-west-1": {
+    hostname: "swf.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "swf.us-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "swf-fips.us-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-west-2": {
+    hostname: "swf.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "swf.us-west-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "swf-fips.us-west-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
 };
 
@@ -59,26 +147,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "swf.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "swf.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "swf-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "swf-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "swf.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "swf.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "swf.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "swf-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "swf-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "swf.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "swf.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "swf.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "swf.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "swf.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "swf.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "swf.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "swf-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "swf-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "swf.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-synthetics/src/endpoints.ts
+++ b/clients/client-synthetics/src/endpoints.ts
@@ -30,26 +30,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "synthetics.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "synthetics.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "synthetics-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "synthetics-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "synthetics.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "synthetics.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "synthetics.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "synthetics-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "synthetics-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "synthetics.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "synthetics.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "synthetics.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "synthetics.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "synthetics.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "synthetics.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "synthetics.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "synthetics-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "synthetics-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "synthetics.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-textract/src/endpoints.ts
+++ b/clients/client-textract/src/endpoints.ts
@@ -2,33 +2,166 @@ import { getRegionInfo, PartitionHash, RegionHash } from "@aws-sdk/config-resolv
 import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
+  "ca-central-1": {
+    hostname: "textract.ca-central-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "textract.ca-central-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "textract-fips.ca-central-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
   "fips-ca-central-1": {
     hostname: "textract-fips.ca-central-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "textract-fips.ca-central-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "ca-central-1",
   },
   "fips-us-east-1": {
     hostname: "textract-fips.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "textract-fips.us-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-1",
   },
   "fips-us-east-2": {
     hostname: "textract-fips.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "textract-fips.us-east-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-2",
   },
   "fips-us-gov-east-1": {
     hostname: "textract-fips.us-gov-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "textract-fips.us-gov-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-east-1",
   },
   "fips-us-gov-west-1": {
     hostname: "textract-fips.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "textract-fips.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-west-1",
   },
   "fips-us-west-1": {
     hostname: "textract-fips.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "textract-fips.us-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-1",
   },
   "fips-us-west-2": {
     hostname: "textract-fips.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "textract-fips.us-west-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-2",
+  },
+  "us-east-1": {
+    hostname: "textract.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "textract.us-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "textract-fips.us-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-east-2": {
+    hostname: "textract.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "textract.us-east-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "textract-fips.us-east-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-gov-east-1": {
+    hostname: "textract.us-gov-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "textract.us-gov-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "textract-fips.us-gov-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-gov-west-1": {
+    hostname: "textract.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "textract.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "textract-fips.us-gov-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-west-1": {
+    hostname: "textract.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "textract.us-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "textract-fips.us-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-west-2": {
+    hostname: "textract.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "textract.us-west-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "textract-fips.us-west-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
 };
 
@@ -64,26 +197,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "textract.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "textract.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "textract-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "textract-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "textract.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "textract.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "textract.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "textract-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "textract-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "textract.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "textract.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "textract.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "textract.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "textract.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["fips-us-gov-east-1", "fips-us-gov-west-1", "us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "textract.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "textract.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "textract-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "textract-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "textract.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-timestream-query/src/endpoints.ts
+++ b/clients/client-timestream-query/src/endpoints.ts
@@ -30,26 +30,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "query.timestream.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "query.timestream.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "query.timestream-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "query.timestream-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "query.timestream.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "query.timestream.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "query.timestream.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "query.timestream-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "query.timestream-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "query.timestream.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "query.timestream.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "query.timestream.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "query.timestream.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "query.timestream.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "query.timestream.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "query.timestream.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "query.timestream-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "query.timestream-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "query.timestream.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-timestream-write/src/endpoints.ts
+++ b/clients/client-timestream-write/src/endpoints.ts
@@ -30,26 +30,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "ingest.timestream.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "ingest.timestream.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "ingest.timestream-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "ingest.timestream-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "ingest.timestream.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "ingest.timestream.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "ingest.timestream.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "ingest.timestream-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "ingest.timestream-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "ingest.timestream.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "ingest.timestream.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "ingest.timestream.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "ingest.timestream.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "ingest.timestream.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "ingest.timestream.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "ingest.timestream.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "ingest.timestream-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "ingest.timestream-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "ingest.timestream.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-transcribe-streaming/src/endpoints.ts
+++ b/clients/client-transcribe-streaming/src/endpoints.ts
@@ -2,20 +2,100 @@ import { getRegionInfo, PartitionHash, RegionHash } from "@aws-sdk/config-resolv
 import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
+  "transcribestreaming-ca-central-1": {
+    hostname: "transcribestreaming.transcribestreaming-ca-central-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "transcribestreaming.transcribestreaming-ca-central-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "transcribestreaming-fips.ca-central-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+    signingRegion: "ca-central-1",
+  },
   "transcribestreaming-fips-ca-central-1": {
     hostname: "transcribestreaming-fips.ca-central-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "transcribestreaming-fips.ca-central-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "ca-central-1",
   },
   "transcribestreaming-fips-us-east-1": {
     hostname: "transcribestreaming-fips.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "transcribestreaming-fips.us-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-1",
   },
   "transcribestreaming-fips-us-east-2": {
     hostname: "transcribestreaming-fips.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "transcribestreaming-fips.us-east-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-2",
   },
   "transcribestreaming-fips-us-west-2": {
     hostname: "transcribestreaming-fips.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "transcribestreaming-fips.us-west-2.amazonaws.com",
+        tags: [],
+      },
+    ],
+    signingRegion: "us-west-2",
+  },
+  "transcribestreaming-us-east-1": {
+    hostname: "transcribestreaming.transcribestreaming-us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "transcribestreaming.transcribestreaming-us-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "transcribestreaming-fips.us-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+    signingRegion: "us-east-1",
+  },
+  "transcribestreaming-us-east-2": {
+    hostname: "transcribestreaming.transcribestreaming-us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "transcribestreaming.transcribestreaming-us-east-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "transcribestreaming-fips.us-east-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+    signingRegion: "us-east-2",
+  },
+  "transcribestreaming-us-west-2": {
+    hostname: "transcribestreaming.transcribestreaming-us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "transcribestreaming.transcribestreaming-us-west-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "transcribestreaming-fips.us-west-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
     signingRegion: "us-west-2",
   },
 };
@@ -55,26 +135,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "transcribestreaming.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "transcribestreaming.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "transcribestreaming-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "transcribestreaming-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "transcribestreaming.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "transcribestreaming.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "transcribestreaming.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "transcribestreaming-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "transcribestreaming-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "transcribestreaming.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "transcribestreaming.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "transcribestreaming.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "transcribestreaming.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "transcribestreaming.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "transcribestreaming.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "transcribestreaming.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "transcribestreaming-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "transcribestreaming-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "transcribestreaming.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-transcribe/src/endpoints.ts
+++ b/clients/client-transcribe/src/endpoints.ts
@@ -4,35 +4,161 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 const regionHash: RegionHash = {
   "cn-north-1": {
     hostname: "cn.transcribe.cn-north-1.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "cn.transcribe.cn-north-1.amazonaws.com.cn",
+        tags: [],
+      },
+    ],
     signingRegion: "cn-north-1",
   },
   "cn-northwest-1": {
     hostname: "cn.transcribe.cn-northwest-1.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "cn.transcribe.cn-northwest-1.amazonaws.com.cn",
+        tags: [],
+      },
+    ],
     signingRegion: "cn-northwest-1",
   },
   "fips-us-east-1": {
     hostname: "fips.transcribe.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "fips.transcribe.us-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-1",
   },
   "fips-us-east-2": {
     hostname: "fips.transcribe.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "fips.transcribe.us-east-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-2",
   },
   "fips-us-gov-east-1": {
     hostname: "fips.transcribe.us-gov-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "fips.transcribe.us-gov-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-east-1",
   },
   "fips-us-gov-west-1": {
     hostname: "fips.transcribe.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "fips.transcribe.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-west-1",
   },
   "fips-us-west-1": {
     hostname: "fips.transcribe.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "fips.transcribe.us-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-1",
   },
   "fips-us-west-2": {
     hostname: "fips.transcribe.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "fips.transcribe.us-west-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-2",
+  },
+  "us-east-1": {
+    hostname: "transcribe.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "transcribe.us-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "fips.transcribe.us-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-east-2": {
+    hostname: "transcribe.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "transcribe.us-east-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "fips.transcribe.us-east-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-gov-east-1": {
+    hostname: "transcribe.us-gov-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "transcribe.us-gov-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "fips.transcribe.us-gov-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-gov-west-1": {
+    hostname: "transcribe.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "transcribe.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "fips.transcribe.us-gov-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-west-1": {
+    hostname: "transcribe.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "transcribe.us-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "fips.transcribe.us-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-west-2": {
+    hostname: "transcribe.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "transcribe.us-west-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "fips.transcribe.us-west-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
 };
 
@@ -67,26 +193,76 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "transcribe.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "transcribe.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "fips.transcribe.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "transcribe.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "transcribe.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "transcribe-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "transcribe-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "transcribe.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "transcribe.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "transcribe.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "transcribe.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "transcribe.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["fips-us-gov-east-1", "fips-us-gov-west-1", "us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "transcribe.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "transcribe.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "fips.transcribe.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
 };
 

--- a/clients/client-transfer/src/endpoints.ts
+++ b/clients/client-transfer/src/endpoints.ts
@@ -2,33 +2,166 @@ import { getRegionInfo, PartitionHash, RegionHash } from "@aws-sdk/config-resolv
 import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
+  "ca-central-1": {
+    hostname: "transfer.ca-central-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "transfer.ca-central-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "transfer-fips.ca-central-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
   "fips-ca-central-1": {
     hostname: "transfer-fips.ca-central-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "transfer-fips.ca-central-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "ca-central-1",
   },
   "fips-us-east-1": {
     hostname: "transfer-fips.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "transfer-fips.us-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-1",
   },
   "fips-us-east-2": {
     hostname: "transfer-fips.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "transfer-fips.us-east-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-2",
   },
   "fips-us-gov-east-1": {
     hostname: "transfer-fips.us-gov-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "transfer-fips.us-gov-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-east-1",
   },
   "fips-us-gov-west-1": {
     hostname: "transfer-fips.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "transfer-fips.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-west-1",
   },
   "fips-us-west-1": {
     hostname: "transfer-fips.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "transfer-fips.us-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-1",
   },
   "fips-us-west-2": {
     hostname: "transfer-fips.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "transfer-fips.us-west-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-2",
+  },
+  "us-east-1": {
+    hostname: "transfer.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "transfer.us-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "transfer-fips.us-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-east-2": {
+    hostname: "transfer.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "transfer.us-east-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "transfer-fips.us-east-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-gov-east-1": {
+    hostname: "transfer.us-gov-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "transfer.us-gov-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "transfer-fips.us-gov-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-gov-west-1": {
+    hostname: "transfer.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "transfer.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "transfer-fips.us-gov-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-west-1": {
+    hostname: "transfer.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "transfer.us-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "transfer-fips.us-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-west-2": {
+    hostname: "transfer.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "transfer.us-west-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "transfer-fips.us-west-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
 };
 
@@ -64,26 +197,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "transfer.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "transfer.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "transfer-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "transfer-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "transfer.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "transfer.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "transfer.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "transfer-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "transfer-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "transfer.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "transfer.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "transfer.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "transfer.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "transfer.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["fips-us-gov-east-1", "fips-us-gov-west-1", "us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "transfer.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "transfer.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "transfer-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "transfer-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "transfer.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-translate/src/endpoints.ts
+++ b/clients/client-translate/src/endpoints.ts
@@ -2,20 +2,96 @@ import { getRegionInfo, PartitionHash, RegionHash } from "@aws-sdk/config-resolv
 import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
+  "us-east-1": {
+    hostname: "translate.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "translate.us-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "translate-fips.us-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
   "us-east-1-fips": {
     hostname: "translate-fips.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "translate-fips.us-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-1",
+  },
+  "us-east-2": {
+    hostname: "translate.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "translate.us-east-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "translate-fips.us-east-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "us-east-2-fips": {
     hostname: "translate-fips.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "translate-fips.us-east-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-2",
+  },
+  "us-gov-west-1": {
+    hostname: "translate.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "translate.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "translate-fips.us-gov-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "us-gov-west-1-fips": {
     hostname: "translate-fips.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "translate-fips.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-west-1",
+  },
+  "us-west-2": {
+    hostname: "translate.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "translate.us-west-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "translate-fips.us-west-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
   "us-west-2-fips": {
     hostname: "translate-fips.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "translate-fips.us-west-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-2",
   },
 };
@@ -50,26 +126,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "translate.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "translate.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "translate-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "translate-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "translate.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "translate.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "translate.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "translate-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "translate-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "translate.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "translate.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "translate.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "translate.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "translate.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1", "us-gov-west-1-fips"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "translate.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "translate.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "translate-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "translate-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "translate.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-voice-id/src/endpoints.ts
+++ b/clients/client-voice-id/src/endpoints.ts
@@ -30,26 +30,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "voiceid.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "voiceid.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "voiceid-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "voiceid-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "voiceid.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "voiceid.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "voiceid.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "voiceid-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "voiceid-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "voiceid.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "voiceid.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "voiceid.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "voiceid.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "voiceid.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "voiceid.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "voiceid.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "voiceid-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "voiceid-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "voiceid.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-waf-regional/src/endpoints.ts
+++ b/clients/client-waf-regional/src/endpoints.ts
@@ -4,202 +4,602 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 const regionHash: RegionHash = {
   "af-south-1": {
     hostname: "waf-regional.af-south-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "waf-regional.af-south-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "waf-regional-fips.af-south-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
     signingRegion: "af-south-1",
   },
   "ap-east-1": {
     hostname: "waf-regional.ap-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "waf-regional.ap-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "waf-regional-fips.ap-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
     signingRegion: "ap-east-1",
   },
   "ap-northeast-1": {
     hostname: "waf-regional.ap-northeast-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "waf-regional.ap-northeast-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "waf-regional-fips.ap-northeast-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
     signingRegion: "ap-northeast-1",
   },
   "ap-northeast-2": {
     hostname: "waf-regional.ap-northeast-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "waf-regional.ap-northeast-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "waf-regional-fips.ap-northeast-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
     signingRegion: "ap-northeast-2",
   },
   "ap-northeast-3": {
     hostname: "waf-regional.ap-northeast-3.amazonaws.com",
+    variants: [
+      {
+        hostname: "waf-regional.ap-northeast-3.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "waf-regional-fips.ap-northeast-3.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
     signingRegion: "ap-northeast-3",
   },
   "ap-south-1": {
     hostname: "waf-regional.ap-south-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "waf-regional.ap-south-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "waf-regional-fips.ap-south-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
     signingRegion: "ap-south-1",
   },
   "ap-southeast-1": {
     hostname: "waf-regional.ap-southeast-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "waf-regional.ap-southeast-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "waf-regional-fips.ap-southeast-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
     signingRegion: "ap-southeast-1",
   },
   "ap-southeast-2": {
     hostname: "waf-regional.ap-southeast-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "waf-regional.ap-southeast-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "waf-regional-fips.ap-southeast-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
     signingRegion: "ap-southeast-2",
   },
   "ca-central-1": {
     hostname: "waf-regional.ca-central-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "waf-regional.ca-central-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "waf-regional-fips.ca-central-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
     signingRegion: "ca-central-1",
   },
   "cn-north-1": {
     hostname: "waf-regional.cn-north-1.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "waf-regional.cn-north-1.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "waf-regional-fips.cn-north-1.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+    ],
     signingRegion: "cn-north-1",
   },
   "cn-northwest-1": {
     hostname: "waf-regional.cn-northwest-1.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "waf-regional.cn-northwest-1.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "waf-regional-fips.cn-northwest-1.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+    ],
     signingRegion: "cn-northwest-1",
   },
   "eu-central-1": {
     hostname: "waf-regional.eu-central-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "waf-regional.eu-central-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "waf-regional-fips.eu-central-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
     signingRegion: "eu-central-1",
   },
   "eu-north-1": {
     hostname: "waf-regional.eu-north-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "waf-regional.eu-north-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "waf-regional-fips.eu-north-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
     signingRegion: "eu-north-1",
   },
   "eu-south-1": {
     hostname: "waf-regional.eu-south-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "waf-regional.eu-south-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "waf-regional-fips.eu-south-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
     signingRegion: "eu-south-1",
   },
   "eu-west-1": {
     hostname: "waf-regional.eu-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "waf-regional.eu-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "waf-regional-fips.eu-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
     signingRegion: "eu-west-1",
   },
   "eu-west-2": {
     hostname: "waf-regional.eu-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "waf-regional.eu-west-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "waf-regional-fips.eu-west-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
     signingRegion: "eu-west-2",
   },
   "eu-west-3": {
     hostname: "waf-regional.eu-west-3.amazonaws.com",
+    variants: [
+      {
+        hostname: "waf-regional.eu-west-3.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "waf-regional-fips.eu-west-3.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
     signingRegion: "eu-west-3",
   },
   "fips-af-south-1": {
     hostname: "waf-regional-fips.af-south-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "waf-regional-fips.af-south-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "af-south-1",
   },
   "fips-ap-east-1": {
     hostname: "waf-regional-fips.ap-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "waf-regional-fips.ap-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "ap-east-1",
   },
   "fips-ap-northeast-1": {
     hostname: "waf-regional-fips.ap-northeast-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "waf-regional-fips.ap-northeast-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "ap-northeast-1",
   },
   "fips-ap-northeast-2": {
     hostname: "waf-regional-fips.ap-northeast-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "waf-regional-fips.ap-northeast-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "ap-northeast-2",
   },
   "fips-ap-northeast-3": {
     hostname: "waf-regional-fips.ap-northeast-3.amazonaws.com",
+    variants: [
+      {
+        hostname: "waf-regional-fips.ap-northeast-3.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "ap-northeast-3",
   },
   "fips-ap-south-1": {
     hostname: "waf-regional-fips.ap-south-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "waf-regional-fips.ap-south-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "ap-south-1",
   },
   "fips-ap-southeast-1": {
     hostname: "waf-regional-fips.ap-southeast-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "waf-regional-fips.ap-southeast-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "ap-southeast-1",
   },
   "fips-ap-southeast-2": {
     hostname: "waf-regional-fips.ap-southeast-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "waf-regional-fips.ap-southeast-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "ap-southeast-2",
   },
   "fips-ca-central-1": {
     hostname: "waf-regional-fips.ca-central-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "waf-regional-fips.ca-central-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "ca-central-1",
   },
   "fips-cn-north-1": {
     hostname: "waf-regional-fips.cn-north-1.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "waf-regional-fips.cn-north-1.amazonaws.com.cn",
+        tags: [],
+      },
+    ],
     signingRegion: "cn-north-1",
   },
   "fips-cn-northwest-1": {
     hostname: "waf-regional-fips.cn-northwest-1.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "waf-regional-fips.cn-northwest-1.amazonaws.com.cn",
+        tags: [],
+      },
+    ],
     signingRegion: "cn-northwest-1",
   },
   "fips-eu-central-1": {
     hostname: "waf-regional-fips.eu-central-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "waf-regional-fips.eu-central-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "eu-central-1",
   },
   "fips-eu-north-1": {
     hostname: "waf-regional-fips.eu-north-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "waf-regional-fips.eu-north-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "eu-north-1",
   },
   "fips-eu-south-1": {
     hostname: "waf-regional-fips.eu-south-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "waf-regional-fips.eu-south-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "eu-south-1",
   },
   "fips-eu-west-1": {
     hostname: "waf-regional-fips.eu-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "waf-regional-fips.eu-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "eu-west-1",
   },
   "fips-eu-west-2": {
     hostname: "waf-regional-fips.eu-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "waf-regional-fips.eu-west-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "eu-west-2",
   },
   "fips-eu-west-3": {
     hostname: "waf-regional-fips.eu-west-3.amazonaws.com",
+    variants: [
+      {
+        hostname: "waf-regional-fips.eu-west-3.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "eu-west-3",
   },
   "fips-me-south-1": {
     hostname: "waf-regional-fips.me-south-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "waf-regional-fips.me-south-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "me-south-1",
   },
   "fips-sa-east-1": {
     hostname: "waf-regional-fips.sa-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "waf-regional-fips.sa-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "sa-east-1",
   },
   "fips-us-east-1": {
     hostname: "waf-regional-fips.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "waf-regional-fips.us-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-1",
   },
   "fips-us-east-2": {
     hostname: "waf-regional-fips.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "waf-regional-fips.us-east-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-2",
   },
   "fips-us-gov-east-1": {
     hostname: "waf-regional-fips.us-gov-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "waf-regional-fips.us-gov-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-east-1",
   },
   "fips-us-gov-west-1": {
     hostname: "waf-regional-fips.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "waf-regional-fips.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-west-1",
   },
   "fips-us-west-1": {
     hostname: "waf-regional-fips.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "waf-regional-fips.us-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-1",
   },
   "fips-us-west-2": {
     hostname: "waf-regional-fips.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "waf-regional-fips.us-west-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-2",
   },
   "me-south-1": {
     hostname: "waf-regional.me-south-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "waf-regional.me-south-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "waf-regional-fips.me-south-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
     signingRegion: "me-south-1",
   },
   "sa-east-1": {
     hostname: "waf-regional.sa-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "waf-regional.sa-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "waf-regional-fips.sa-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
     signingRegion: "sa-east-1",
   },
   "us-east-1": {
     hostname: "waf-regional.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "waf-regional.us-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "waf-regional-fips.us-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
     signingRegion: "us-east-1",
   },
   "us-east-2": {
     hostname: "waf-regional.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "waf-regional.us-east-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "waf-regional-fips.us-east-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
     signingRegion: "us-east-2",
   },
   "us-gov-east-1": {
     hostname: "waf-regional.us-gov-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "waf-regional.us-gov-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "waf-regional-fips.us-gov-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
     signingRegion: "us-gov-east-1",
   },
   "us-gov-west-1": {
     hostname: "waf-regional.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "waf-regional.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "waf-regional-fips.us-gov-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
     signingRegion: "us-gov-west-1",
   },
   "us-west-1": {
     hostname: "waf-regional.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "waf-regional.us-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "waf-regional-fips.us-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
     signingRegion: "us-west-1",
   },
   "us-west-2": {
     hostname: "waf-regional.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "waf-regional.us-west-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "waf-regional-fips.us-west-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
     signingRegion: "us-west-2",
   },
 };
@@ -252,26 +652,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "waf-regional.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "waf-regional.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "waf-regional-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "waf-regional-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "waf-regional.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1", "fips-cn-north-1", "fips-cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "waf-regional.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "waf-regional.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "waf-regional-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "waf-regional-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "waf-regional.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "waf-regional.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "waf-regional.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "waf-regional.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "waf-regional.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["fips-us-gov-east-1", "fips-us-gov-west-1", "us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "waf-regional.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "waf-regional.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "waf-regional-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "waf-regional-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "waf-regional.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-waf/src/endpoints.ts
+++ b/clients/client-waf/src/endpoints.ts
@@ -2,16 +2,52 @@ import { getRegionInfo, PartitionHash, RegionHash } from "@aws-sdk/config-resolv
 import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
+  aws: {
+    hostname: "waf.aws.amazonaws.com",
+    variants: [
+      {
+        hostname: "waf.aws.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "waf-fips.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+    signingRegion: "us-east-1",
+  },
   "aws-fips": {
     hostname: "waf-fips.amazonaws.com",
+    variants: [
+      {
+        hostname: "waf-fips.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-1",
   },
   "aws-global": {
     hostname: "waf.amazonaws.com",
+    variants: [
+      {
+        hostname: "waf.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "waf-fips.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
     signingRegion: "us-east-1",
   },
   "aws-global-fips": {
     hostname: "waf-fips.amazonaws.com",
+    variants: [
+      {
+        hostname: "waf-fips.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-1",
   },
 };
@@ -46,27 +82,94 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
+    hostname: "waf.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "waf.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "waf-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "waf-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "waf.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
     endpoint: "aws-global",
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "waf.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "waf.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "waf-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "waf-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "waf.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "waf.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "waf.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "waf.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "waf.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "waf.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "waf.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "waf-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "waf-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "waf.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-wafv2/src/endpoints.ts
+++ b/clients/client-wafv2/src/endpoints.ts
@@ -30,26 +30,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "wafv2.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "wafv2.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "wafv2-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "wafv2-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "wafv2.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "wafv2.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "wafv2.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "wafv2-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "wafv2-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "wafv2.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "wafv2.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "wafv2.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "wafv2.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "wafv2.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "wafv2.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "wafv2.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "wafv2-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "wafv2-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "wafv2.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-wellarchitected/src/endpoints.ts
+++ b/clients/client-wellarchitected/src/endpoints.ts
@@ -30,26 +30,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "wellarchitected.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "wellarchitected.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "wellarchitected-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "wellarchitected-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "wellarchitected.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "wellarchitected.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "wellarchitected.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "wellarchitected-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "wellarchitected-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "wellarchitected.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "wellarchitected.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "wellarchitected.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "wellarchitected.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "wellarchitected.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "wellarchitected.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "wellarchitected.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "wellarchitected-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "wellarchitected-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "wellarchitected.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-wisdom/src/endpoints.ts
+++ b/clients/client-wisdom/src/endpoints.ts
@@ -30,26 +30,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "wisdom.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "wisdom.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "wisdom-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "wisdom-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "wisdom.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "wisdom.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "wisdom.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "wisdom-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "wisdom-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "wisdom.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "wisdom.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "wisdom.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "wisdom.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "wisdom.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "wisdom.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "wisdom.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "wisdom-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "wisdom-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "wisdom.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-workdocs/src/endpoints.ts
+++ b/clients/client-workdocs/src/endpoints.ts
@@ -4,11 +4,49 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 const regionHash: RegionHash = {
   "fips-us-east-1": {
     hostname: "workdocs-fips.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "workdocs-fips.us-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-1",
   },
   "fips-us-west-2": {
     hostname: "workdocs-fips.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "workdocs-fips.us-west-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-2",
+  },
+  "us-east-1": {
+    hostname: "workdocs.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "workdocs.us-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "workdocs-fips.us-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-west-2": {
+    hostname: "workdocs.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "workdocs.us-west-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "workdocs-fips.us-west-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
 };
 
@@ -41,26 +79,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "workdocs.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "workdocs.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "workdocs-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "workdocs-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "workdocs.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "workdocs.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "workdocs.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "workdocs-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "workdocs-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "workdocs.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "workdocs.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "workdocs.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "workdocs.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "workdocs.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "workdocs.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "workdocs.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "workdocs-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "workdocs-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "workdocs.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-worklink/src/endpoints.ts
+++ b/clients/client-worklink/src/endpoints.ts
@@ -30,26 +30,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "worklink.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "worklink.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "worklink-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "worklink-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "worklink.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "worklink.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "worklink.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "worklink-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "worklink-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "worklink.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "worklink.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "worklink.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "worklink.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "worklink.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "worklink.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "worklink.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "worklink-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "worklink-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "worklink.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-workmail/src/endpoints.ts
+++ b/clients/client-workmail/src/endpoints.ts
@@ -30,26 +30,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "workmail.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "workmail.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "workmail-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "workmail-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "workmail.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "workmail.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "workmail.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "workmail-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "workmail-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "workmail.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "workmail.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "workmail.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "workmail.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "workmail.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "workmail.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "workmail.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "workmail-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "workmail-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "workmail.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-workmailmessageflow/src/endpoints.ts
+++ b/clients/client-workmailmessageflow/src/endpoints.ts
@@ -30,26 +30,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "workmailmessageflow.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "workmailmessageflow.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "workmailmessageflow-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "workmailmessageflow-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "workmailmessageflow.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "workmailmessageflow.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "workmailmessageflow.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "workmailmessageflow-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "workmailmessageflow-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "workmailmessageflow.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "workmailmessageflow.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "workmailmessageflow.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "workmailmessageflow.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "workmailmessageflow.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "workmailmessageflow.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "workmailmessageflow.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "workmailmessageflow-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "workmailmessageflow-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "workmailmessageflow.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-workspaces/src/endpoints.ts
+++ b/clients/client-workspaces/src/endpoints.ts
@@ -4,15 +4,72 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 const regionHash: RegionHash = {
   "fips-us-east-1": {
     hostname: "workspaces-fips.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "workspaces-fips.us-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-1",
   },
   "fips-us-gov-west-1": {
     hostname: "workspaces-fips.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "workspaces-fips.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-west-1",
   },
   "fips-us-west-2": {
     hostname: "workspaces-fips.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "workspaces-fips.us-west-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-2",
+  },
+  "us-east-1": {
+    hostname: "workspaces.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "workspaces.us-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "workspaces-fips.us-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-gov-west-1": {
+    hostname: "workspaces.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "workspaces.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "workspaces-fips.us-gov-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-west-2": {
+    hostname: "workspaces.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "workspaces.us-west-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "workspaces-fips.us-west-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
 };
 
@@ -45,26 +102,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "workspaces.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "workspaces.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "workspaces-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "workspaces-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "workspaces.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "workspaces.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "workspaces.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "workspaces-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "workspaces-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "workspaces.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "workspaces.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "workspaces.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "workspaces.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "workspaces.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["fips-us-gov-west-1", "us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "workspaces.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "workspaces.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "workspaces-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "workspaces-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "workspaces.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/clients/client-xray/src/endpoints.ts
+++ b/clients/client-xray/src/endpoints.ts
@@ -4,27 +4,141 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 const regionHash: RegionHash = {
   "fips-us-east-1": {
     hostname: "xray-fips.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "xray-fips.us-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-1",
   },
   "fips-us-east-2": {
     hostname: "xray-fips.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "xray-fips.us-east-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-east-2",
   },
   "fips-us-gov-east-1": {
     hostname: "xray-fips.us-gov-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "xray-fips.us-gov-east-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-east-1",
   },
   "fips-us-gov-west-1": {
     hostname: "xray-fips.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "xray-fips.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-gov-west-1",
   },
   "fips-us-west-1": {
     hostname: "xray-fips.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "xray-fips.us-west-1.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-1",
   },
   "fips-us-west-2": {
     hostname: "xray-fips.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "xray-fips.us-west-2.amazonaws.com",
+        tags: [],
+      },
+    ],
     signingRegion: "us-west-2",
+  },
+  "us-east-1": {
+    hostname: "xray.us-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "xray.us-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "xray-fips.us-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-east-2": {
+    hostname: "xray.us-east-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "xray.us-east-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "xray-fips.us-east-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-gov-east-1": {
+    hostname: "xray.us-gov-east-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "xray.us-gov-east-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "xray-fips.us-gov-east-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-gov-west-1": {
+    hostname: "xray.us-gov-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "xray.us-gov-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "xray-fips.us-gov-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-west-1": {
+    hostname: "xray.us-west-1.amazonaws.com",
+    variants: [
+      {
+        hostname: "xray.us-west-1.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "xray-fips.us-west-1.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
+  },
+  "us-west-2": {
+    hostname: "xray.us-west-2.amazonaws.com",
+    variants: [
+      {
+        hostname: "xray.us-west-2.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "xray-fips.us-west-2.amazonaws.com",
+        tags: ["fips"],
+      },
+    ],
   },
 };
 
@@ -59,26 +173,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "xray.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "xray.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "xray-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "xray-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "xray.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "xray.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "xray.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "xray-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "xray-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "xray.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "xray.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "xray.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "xray.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "xray.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["fips-us-gov-east-1", "fips-us-gov-west-1", "us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "xray.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "xray.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "xray-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "xray-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "xray.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/packages/config-resolver/src/regionInfo/EndpointVariant.ts
+++ b/packages/config-resolver/src/regionInfo/EndpointVariant.ts
@@ -1,0 +1,9 @@
+import { EndpointVariantTag } from "./EndpointVariantTag";
+
+/**
+ * Provides hostname information for specific host label.
+ */
+export type EndpointVariant = {
+  hostname: string;
+  tags: EndpointVariantTag[];
+};

--- a/packages/config-resolver/src/regionInfo/EndpointVariantTag.ts
+++ b/packages/config-resolver/src/regionInfo/EndpointVariantTag.ts
@@ -1,0 +1,5 @@
+/**
+ * The tag which mentions which area variant is providing information for.
+ * Can be either "fips" or "dualstack".
+ */
+export type EndpointVariantTag = "fips" | "dualstack";

--- a/packages/config-resolver/src/regionInfo/PartitionHash.ts
+++ b/packages/config-resolver/src/regionInfo/PartitionHash.ts
@@ -1,8 +1,17 @@
+import { EndpointVariant } from "./EndpointVariant";
+
 /**
  * The hash of partition with the information specific to that partition.
  * The information includes the list of regions belonging to that partition,
  * and the hostname to be used for the partition.
  */
 export type PartitionHash = {
-  [key: string]: { regions: string[]; regionRegex: string; hostname?: string; endpoint?: string };
+  [key: string]: {
+    regions: string[];
+    regionRegex: string;
+    // TODO: Remove hostname after fully switching to variants.
+    hostname: string;
+    variants: EndpointVariant[];
+    endpoint?: string;
+  };
 };

--- a/packages/config-resolver/src/regionInfo/RegionHash.ts
+++ b/packages/config-resolver/src/regionInfo/RegionHash.ts
@@ -1,7 +1,15 @@
-import { RegionInfo } from "@aws-sdk/types";
+import { EndpointVariant } from "./EndpointVariant";
 
 /**
  * The hash of region with the information specific to that region.
  * The information can include hostname, signingService and signingRegion.
  */
-export type RegionHash = { [key: string]: Partial<Omit<RegionInfo, "partition" | "path">> };
+export type RegionHash = {
+  [key: string]: {
+    // TODO: Remove hostname after fully switching to variants.
+    hostname: string;
+    variants: EndpointVariant[];
+    signingService?: string;
+    signingRegion?: string;
+  };
+};

--- a/packages/config-resolver/src/regionInfo/getRegionInfo.spec.ts
+++ b/packages/config-resolver/src/regionInfo/getRegionInfo.spec.ts
@@ -29,11 +29,13 @@ describe(getRegionInfo.name, () => {
     ...((regionCase === RegionCase.REGION || regionCase === RegionCase.REGION_AND_ENDPOINT) && {
       [mockRegion]: {
         hostname: mockHostname,
+        variants: [{ hostname: mockHostname, tags: [] }],
       },
     }),
     ...((regionCase === RegionCase.ENDPOINT || regionCase === RegionCase.REGION_AND_ENDPOINT) && {
       [mockEndpointRegion]: {
         hostname: mockEndpointHostname,
+        variants: [{ hostname: mockEndpointHostname, tags: [] }],
       },
     }),
   });
@@ -42,9 +44,8 @@ describe(getRegionInfo.name, () => {
     [mockPartition]: {
       regions: [mockRegion, `${mockRegion}2`, `${mockRegion}3`],
       regionRegex: mockRegionRegex,
-      ...((regionCase === RegionCase.REGION || regionCase === RegionCase.REGION_AND_ENDPOINT) && {
-        hostname: mockHostname,
-      }),
+      hostname: mockHostname,
+      variants: [{ hostname: mockHostname, tags: [] }],
       ...((regionCase === RegionCase.ENDPOINT || regionCase === RegionCase.REGION_AND_ENDPOINT) && {
         endpoint: mockEndpointRegion,
       }),

--- a/packages/config-resolver/src/regionInfo/getResolvedPartition.spec.ts
+++ b/packages/config-resolver/src/regionInfo/getResolvedPartition.spec.ts
@@ -13,6 +13,7 @@ describe(getResolvedPartition.name, () => {
         regions: [mockRegion, `${mockRegion}2`, `${mockRegion}3`],
         regionRegex: mockRegionRegex,
         hostname: mockHostname,
+        variants: [{ hostname: mockHostname, tags: [] }],
       },
     };
     expect(getResolvedPartition(mockRegion, { partitionHash: mockPartitionHash })).toBe(mockPartition);
@@ -24,6 +25,7 @@ describe(getResolvedPartition.name, () => {
         regions: [`${mockRegion}2`, `${mockRegion}3`],
         regionRegex: mockRegionRegex,
         hostname: mockHostname,
+        variants: [{ hostname: mockHostname, tags: [] }],
       },
     };
     expect(getResolvedPartition(mockRegion, { partitionHash: mockPartitionHash })).toBe("aws");

--- a/private/aws-protocoltests-ec2/src/endpoints.ts
+++ b/private/aws-protocoltests-ec2/src/endpoints.ts
@@ -30,26 +30,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "awsec2.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "awsec2.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "awsec2-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "awsec2-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "awsec2.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "awsec2.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "awsec2.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "awsec2-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "awsec2-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "awsec2.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "awsec2.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "awsec2.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "awsec2.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "awsec2.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "awsec2.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "awsec2.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "awsec2-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "awsec2-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "awsec2.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/private/aws-protocoltests-json-10/src/endpoints.ts
+++ b/private/aws-protocoltests-json-10/src/endpoints.ts
@@ -30,26 +30,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "jsonrpc10.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "jsonrpc10.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "jsonrpc10-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "jsonrpc10-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "jsonrpc10.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "jsonrpc10.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "jsonrpc10.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "jsonrpc10-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "jsonrpc10-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "jsonrpc10.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "jsonrpc10.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "jsonrpc10.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "jsonrpc10.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "jsonrpc10.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "jsonrpc10.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "jsonrpc10.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "jsonrpc10-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "jsonrpc10-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "jsonrpc10.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/private/aws-protocoltests-json/src/endpoints.ts
+++ b/private/aws-protocoltests-json/src/endpoints.ts
@@ -30,26 +30,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "jsonprotocol.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "jsonprotocol.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "jsonprotocol-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "jsonprotocol-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "jsonprotocol.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "jsonprotocol.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "jsonprotocol.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "jsonprotocol-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "jsonprotocol-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "jsonprotocol.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "jsonprotocol.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "jsonprotocol.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "jsonprotocol.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "jsonprotocol.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "jsonprotocol.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "jsonprotocol.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "jsonprotocol-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "jsonprotocol-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "jsonprotocol.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/private/aws-protocoltests-query/src/endpoints.ts
+++ b/private/aws-protocoltests-query/src/endpoints.ts
@@ -30,26 +30,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "awsquery.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "awsquery.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "awsquery-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "awsquery-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "awsquery.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "awsquery.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "awsquery.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "awsquery-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "awsquery-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "awsquery.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "awsquery.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "awsquery.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "awsquery.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "awsquery.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "awsquery.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "awsquery.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "awsquery-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "awsquery-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "awsquery.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/private/aws-protocoltests-restjson/src/endpoints.ts
+++ b/private/aws-protocoltests-restjson/src/endpoints.ts
@@ -30,26 +30,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "restjson.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "restjson.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "restjson-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "restjson-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "restjson.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "restjson.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "restjson.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "restjson-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "restjson-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "restjson.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "restjson.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "restjson.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "restjson.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "restjson.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "restjson.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "restjson.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "restjson-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "restjson-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "restjson.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 

--- a/private/aws-protocoltests-restxml/src/endpoints.ts
+++ b/private/aws-protocoltests-restxml/src/endpoints.ts
@@ -30,26 +30,92 @@ const partitionHash: PartitionHash = {
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
     hostname: "restxml.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "restxml.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "restxml-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "restxml-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "restxml.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
     hostname: "restxml.{region}.amazonaws.com.cn",
+    variants: [
+      {
+        hostname: "restxml.{region}.amazonaws.com.cn",
+        tags: [],
+      },
+      {
+        hostname: "restxml-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "restxml-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "restxml.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack"],
+      },
+    ],
   },
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
     hostname: "restxml.{region}.c2s.ic.gov",
+    variants: [
+      {
+        hostname: "restxml.{region}.c2s.ic.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
     hostname: "restxml.{region}.sc2s.sgov.gov",
+    variants: [
+      {
+        hostname: "restxml.{region}.sc2s.sgov.gov",
+        tags: [],
+      },
+    ],
   },
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
     hostname: "restxml.{region}.amazonaws.com",
+    variants: [
+      {
+        hostname: "restxml.{region}.amazonaws.com",
+        tags: [],
+      },
+      {
+        hostname: "restxml-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
+        hostname: "restxml-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "restxml.{region}.api.aws",
+        tags: ["dualstack"],
+      },
+    ],
   },
 };
 


### PR DESCRIPTION
### Issue
Internal JS-2908

Follow-up to #2947
Cleaned up PR of #2962

~~Note: This PR will be rebased from main and made ready after #2962 is merged.~~ PR is ready!

### Description
Populates variants in endpoints hashes:
* The `hostname` and `variants` are now compulsory keys for RegionHash and PartitionHash.
  * The hostname can be removed, after we’ve completely switched to variants.
* The variants array is populated with default hostname with no tags.
  * This will make utilities in config-resolver simpler, as we can ignore hostname and process just the variants.

### Testing
N/A as variants are additive. The functional tests are successful.
The follow-up PRs will update unit tests in config-resolver, and affected middleware packages.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
