### PR TITLE
Bump code generators to 0.7.0

### DIFF
--- a/codegen/CHANGELOG.md
+++ b/codegen/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Smithy AWS Typescript Codegen Changelog
 
+## 0.7.0 (2021-11-03)
+
+### Features
+
+* Updated set deserialization to reject duplicates. ([#2764](https://github.com/aws/aws-sdk-js-v3/pull/2764))
+* Updated collection deserialization to reject null in non-sparse collections. ([#2771](https://github.com/aws/aws-sdk-js-v3/pull/2771))
+* Moved source files to `src` folder. ([#2844](https://github.com/aws/aws-sdk-js-v3/pull/2844))
+* packageInfo imports from user agent module are now automatically ignored. ([#2875](https://github.com/aws/aws-sdk-js-v3/pull/2875))
+* Updated Smithy version to `1.12.0`. ([#2878](https://github.com/aws/aws-sdk-js-v3/pull/2878))
+
 ## 0.6.0 (2021-09-02)
 
 ### Features

--- a/codegen/build.gradle.kts
+++ b/codegen/build.gradle.kts
@@ -28,7 +28,7 @@ allprojects {
         mavenCentral()
     }
     group = "software.amazon.smithy.typescript"
-    version = "0.6.0"
+    version = "0.7.0"
 }
 
 // The root project doesn't produce a JAR.

--- a/codegen/smithy-aws-typescript-codegen/build.gradle.kts
+++ b/codegen/smithy-aws-typescript-codegen/build.gradle.kts
@@ -35,7 +35,7 @@ dependencies {
     api("software.amazon.smithy:smithy-waiters:[1.12.0, 1.13.0[")
     api("software.amazon.smithy:smithy-aws-iam-traits:[1.12.0, 1.13.0[")
     api("software.amazon.smithy:smithy-protocol-test-traits:[1.12.0, 1.13.0[")
-    api("software.amazon.smithy.typescript:smithy-typescript-codegen:0.6.0")
+    api("software.amazon.smithy.typescript:smithy-typescript-codegen:0.7.0")
 }
 
 tasks.register("set-aws-sdk-versions") {


### PR DESCRIPTION
### Description
Bumps the smithy-typescript-aws-codegen version to 0.7.0 and picks up the 0.7.0 update of smithy-typescript-codegen - https://github.com/awslabs/smithy-typescript/pull/461

### Testing
```
cd codegen
gradle build publishToMavenLocal
cd ../
yarn install
yarn generate-clients
```

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
