### PR TITLE
chore: pass fips/dualstack config to regionInfoProvider

### DIFF
--- a/packages/config-resolver/src/endpointsConfig/resolveEndpointsConfig.ts
+++ b/packages/config-resolver/src/endpointsConfig/resolveEndpointsConfig.ts
@@ -57,13 +57,17 @@ export interface EndpointsResolvedConfig extends Required<EndpointsInputConfig> 
 
 export const resolveEndpointsConfig = <T>(
   input: T & EndpointsInputConfig & PreviouslyResolved
-): T & EndpointsResolvedConfig => ({
-  ...input,
-  tls: input.tls ?? true,
-  endpoint: input.endpoint
-    ? normalizeEndpoint({ ...input, endpoint: input.endpoint })
-    : () => getEndpointFromRegion(input),
-  isCustomEndpoint: input.endpoint ? true : false,
-  useDualstackEndpoint: normalizeBoolean(input.useDualstackEndpoint!),
-  useFipsEndpoint: normalizeBoolean(input.useFipsEndpoint!),
-});
+): T & EndpointsResolvedConfig => {
+  const useDualstackEndpoint = normalizeBoolean(input.useDualstackEndpoint!);
+  const useFipsEndpoint = normalizeBoolean(input.useFipsEndpoint!);
+  return {
+    ...input,
+    tls: input.tls ?? true,
+    endpoint: input.endpoint
+      ? normalizeEndpoint({ ...input, endpoint: input.endpoint })
+      : () => getEndpointFromRegion({ ...input, useDualstackEndpoint, useFipsEndpoint }),
+    isCustomEndpoint: input.endpoint ? true : false,
+    useDualstackEndpoint,
+    useFipsEndpoint,
+  };
+};

--- a/packages/config-resolver/src/endpointsConfig/utils/getEndpointFromRegion.spec.ts
+++ b/packages/config-resolver/src/endpointsConfig/utils/getEndpointFromRegion.spec.ts
@@ -4,8 +4,16 @@ describe(getEndpointFromRegion.name, () => {
   const mockRegion = jest.fn();
   const mockUrlParser = jest.fn();
   const mockRegionInfoProvider = jest.fn();
+  const mockUseFipsEndpoint = jest.fn();
+  const mockUseDualstackEndpoint = jest.fn();
 
-  const mockInput = { region: mockRegion, urlParser: mockUrlParser, regionInfoProvider: mockRegionInfoProvider };
+  const mockInput = {
+    region: mockRegion,
+    urlParser: mockUrlParser,
+    regionInfoProvider: mockRegionInfoProvider,
+    useDualstackEndpoint: mockUseDualstackEndpoint,
+    useFipsEndpoint: mockUseFipsEndpoint,
+  };
 
   const mockRegionValue = "mockRegion";
   const mockEndpoint = {
@@ -19,6 +27,8 @@ describe(getEndpointFromRegion.name, () => {
     mockRegion.mockResolvedValue(mockRegionValue);
     mockUrlParser.mockResolvedValue(mockEndpoint);
     mockRegionInfoProvider.mockResolvedValue(mockRegionInfo);
+    mockUseFipsEndpoint.mockResolvedValue(false);
+    mockUseDualstackEndpoint.mockResolvedValue(false);
   });
 
   afterEach(() => {
@@ -28,7 +38,10 @@ describe(getEndpointFromRegion.name, () => {
 
   describe("tls", () => {
     afterEach(() => {
-      expect(mockRegionInfoProvider).toHaveBeenCalledWith(mockRegionValue);
+      expect(mockRegionInfoProvider).toHaveBeenCalledWith(mockRegionValue, {
+        useDualstackEndpoint: false,
+        useFipsEndpoint: false,
+      });
     });
 
     it("uses protocol https when not defined", async () => {
@@ -81,14 +94,20 @@ describe(getEndpointFromRegion.name, () => {
     } catch (error) {
       expect(error.message).toEqual(errorMsg);
     }
-    expect(mockRegionInfoProvider).toHaveBeenCalledWith(mockRegionValue);
+    expect(mockRegionInfoProvider).toHaveBeenCalledWith(mockRegionValue, {
+      useDualstackEndpoint: false,
+      useFipsEndpoint: false,
+    });
     expect(mockUrlParser).not.toHaveBeenCalled();
   });
 
   it("returns parsed endpoint", async () => {
     const endpoint = await getEndpointFromRegion(mockInput);
     expect(endpoint).toEqual(mockEndpoint);
-    expect(mockRegionInfoProvider).toHaveBeenCalledWith(mockRegionValue);
+    expect(mockRegionInfoProvider).toHaveBeenCalledWith(mockRegionValue, {
+      useDualstackEndpoint: false,
+      useFipsEndpoint: false,
+    });
     expect(mockUrlParser).toHaveBeenCalledWith(`https://${mockRegionInfo.hostname}`);
   });
 });

--- a/packages/config-resolver/src/endpointsConfig/utils/getEndpointFromRegion.ts
+++ b/packages/config-resolver/src/endpointsConfig/utils/getEndpointFromRegion.ts
@@ -5,6 +5,8 @@ interface GetEndpointFromRegionOptions {
   tls?: boolean;
   regionInfoProvider: RegionInfoProvider;
   urlParser: UrlParser;
+  useDualstackEndpoint: Provider<boolean>;
+  useFipsEndpoint: Provider<boolean>;
 }
 
 export const getEndpointFromRegion = async (input: GetEndpointFromRegionOptions) => {
@@ -16,7 +18,9 @@ export const getEndpointFromRegion = async (input: GetEndpointFromRegionOptions)
     throw new Error("Invalid region in client config");
   }
 
-  const { hostname } = (await input.regionInfoProvider(region)) ?? {};
+  const useDualstackEndpoint = await input.useDualstackEndpoint();
+  const useFipsEndpoint = await input.useFipsEndpoint();
+  const { hostname } = (await input.regionInfoProvider(region, { useDualstackEndpoint, useFipsEndpoint })) ?? {};
   if (!hostname) {
     throw new Error("Cannot resolve hostname from client config");
   }

--- a/packages/middleware-bucket-endpoint/src/bucketEndpointMiddleware.spec.ts
+++ b/packages/middleware-bucket-endpoint/src/bucketEndpointMiddleware.spec.ts
@@ -34,6 +34,7 @@ describe("bucketEndpointMiddleware", () => {
       .fn()
       .mockResolvedValue({ hostname: "foo.us-foo-2.amazonaws.com", partition: "aws-foo", signingRegion: mockRegion }),
     useArnRegion: jest.fn().mockResolvedValue(false),
+    useFipsEndpoint: () => Promise.resolve(false),
     useDualstackEndpoint: () => Promise.resolve(false),
   };
 

--- a/packages/middleware-bucket-endpoint/src/bucketEndpointMiddleware.ts
+++ b/packages/middleware-bucket-endpoint/src/bucketEndpointMiddleware.ts
@@ -31,9 +31,11 @@ export const bucketEndpointMiddleware =
       } else if (validateArn(bucketName)) {
         const bucketArn = parseArn(bucketName);
         const clientRegion = getPseudoRegion(await options.region());
-        const { partition, signingRegion = clientRegion } = (await options.regionInfoProvider(clientRegion)) || {};
+        const useDualstackEndpoint = await options.useDualstackEndpoint();
+        const useFipsEndpoint = await options.useFipsEndpoint();
+        const { partition, signingRegion = clientRegion } =
+          (await options.regionInfoProvider(clientRegion, { useDualstackEndpoint, useFipsEndpoint })) || {};
         const useArnRegion = await options.useArnRegion();
-        const dualstackEndpoint = await options.useDualstackEndpoint();
         const {
           hostname,
           bucketEndpoint,
@@ -43,7 +45,7 @@ export const bucketEndpointMiddleware =
           bucketName: bucketArn,
           baseHostname: request.hostname,
           accelerateEndpoint: options.useAccelerateEndpoint,
-          dualstackEndpoint,
+          dualstackEndpoint: useDualstackEndpoint,
           pathStyleEndpoint: options.forcePathStyle,
           tlsCompatible: request.protocol === "https:",
           useArnRegion,

--- a/packages/middleware-bucket-endpoint/src/configurations.ts
+++ b/packages/middleware-bucket-endpoint/src/configurations.ts
@@ -28,6 +28,7 @@ interface PreviouslyResolved {
   isCustomEndpoint: boolean;
   region: Provider<string>;
   regionInfoProvider: RegionInfoProvider;
+  useFipsEndpoint: Provider<boolean>;
   useDualstackEndpoint: Provider<boolean>;
 }
 
@@ -49,6 +50,10 @@ export interface BucketEndpointResolvedConfig {
    * Resolved value for input config {@link BucketEndpointInputConfig.useAccelerateEndpoint}
    */
   useAccelerateEndpoint: boolean;
+  /**
+   * Enables FIPS compatible endpoints.
+   */
+  useFipsEndpoint: Provider<boolean>;
   /**
    * Enables IPv6/IPv4 dualstack endpoint.
    */

--- a/packages/middleware-sdk-s3-control/src/configurations.ts
+++ b/packages/middleware-sdk-s3-control/src/configurations.ts
@@ -12,6 +12,7 @@ interface PreviouslyResolved {
   isCustomEndpoint: boolean;
   region: Provider<string>;
   regionInfoProvider: RegionInfoProvider;
+  useFipsEndpoint: Provider<boolean>;
   useDualstackEndpoint: Provider<boolean>;
 }
 
@@ -21,6 +22,10 @@ export interface S3ControlResolvedConfig {
    * @internal
    */
   isCustomEndpoint: boolean;
+  /**
+   * Enables FIPS compatible endpoints.
+   */
+  useFipsEndpoint: Provider<boolean>;
   /**
    * Enables IPv6/IPv4 dualstack endpoint.
    */

--- a/packages/middleware-sdk-s3-control/src/process-arnables-plugin/parse-outpost-arnables.ts
+++ b/packages/middleware-sdk-s3-control/src/process-arnables-plugin/parse-outpost-arnables.ts
@@ -36,11 +36,14 @@ export const parseOutpostArnablesMiddleaware =
     if (!parameter) return next(args);
 
     const clientRegion = await options.region();
-    const { regionInfoProvider } = options;
     const useArnRegion = await options.useArnRegion();
+    const useFipsEndpoint = await options.useFipsEndpoint();
     const useDualstackEndpoint = await options.useDualstackEndpoint();
     const baseRegion = getPseudoRegion(clientRegion);
-    const { partition: clientPartition, signingRegion = baseRegion } = (await regionInfoProvider(baseRegion))!;
+    const { partition: clientPartition, signingRegion = baseRegion } = (await options.regionInfoProvider(baseRegion, {
+      useFipsEndpoint,
+      useDualstackEndpoint,
+    }))!;
     const validatorOptions: ValidateOutpostsArnOptions = {
       useDualstackEndpoint,
       clientRegion,

--- a/packages/middleware-sdk-s3-control/src/process-arnables-plugin/plugin.spec.ts
+++ b/packages/middleware-sdk-s3-control/src/process-arnables-plugin/plugin.spec.ts
@@ -10,11 +10,13 @@ describe("getProcessArnablesMiddleware", () => {
     region: string;
     regionInfoProvider?: Provider<RegionInfo>;
     useAccelerateEndpoint?: boolean;
+    useFipsEndpoint?: Provider<boolean>;
     useDualstackEndpoint?: Provider<boolean>;
     useArnRegion?: boolean;
   };
   const setupPluginOptions = (options: FakeOptions): S3ControlResolvedConfig => {
     return {
+      useFipsEndpoint: () => Promise.resolve(false),
       useDualstackEndpoint: () => Promise.resolve(false),
       ...options,
       regionInfoProvider: options.regionInfoProvider ?? jest.fn().mockResolvedValue({ partition: "aws" }),

--- a/packages/middleware-sdk-sts/src/index.ts
+++ b/packages/middleware-sdk-sts/src/index.ts
@@ -2,6 +2,7 @@ import { AwsAuthInputConfig, AwsAuthResolvedConfig, resolveAwsAuthConfig } from 
 import { Client, Credentials, HashConstructor, Pluggable, Provider, RegionInfoProvider } from "@aws-sdk/types";
 
 export interface StsAuthInputConfig extends AwsAuthInputConfig {}
+
 interface PreviouslyResolved {
   credentialDefaultProvider: (input: any) => Provider<Credentials>;
   region: string | Provider<string>;
@@ -9,7 +10,10 @@ interface PreviouslyResolved {
   signingName?: string;
   serviceId: string;
   sha256: HashConstructor;
+  useFipsEndpoint: Provider<boolean>;
+  useDualstackEndpoint: Provider<boolean>;
 }
+
 export interface StsAuthResolvedConfig extends AwsAuthResolvedConfig {
   /**
    * Reference to STSClient class constructor.

--- a/packages/middleware-signing/src/configuration.spec.ts
+++ b/packages/middleware-signing/src/configuration.spec.ts
@@ -3,7 +3,6 @@ import { HttpRequest } from "@aws-sdk/protocol-http";
 import { resolveAwsAuthConfig, resolveSigV4AuthConfig } from "./configurations";
 
 describe("AuthConfig", () => {
-
   describe("resolveAwsAuthConfig", () => {
     const inputParams = {
       credentialDefaultProvider: () => () => Promise.resolve({ accessKeyId: "key", secretAccessKey: "secret" }),
@@ -15,6 +14,8 @@ describe("AuthConfig", () => {
         digest: jest.fn().mockReturnValue("SHA256 hash"),
       }),
       credentials: jest.fn().mockResolvedValue({ accessKeyId: "key", secretAccessKey: "secret" }),
+      useFipsEndpoint: () => Promise.resolve(false),
+      useDualstackEndpoint: () => Promise.resolve(false),
     };
 
     beforeEach(() => {


### PR DESCRIPTION
### Issue
PR for follow-up to https://github.com/aws/aws-sdk-js-v3/pull/2980

### Description
Passes fips/dualstack configuration while resolving regionInfo from following packages:
* config-resolver
* middleware-bucket-endpoint
* middleware-sdk-s3-control
* middleware-signing

### Testing
* CI
* Integration tests

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
