### PR TITLE
feat(client-s3-control): support FIPS in S3 Outposts Control Plane

### DIFF
--- a/packages/middleware-sdk-s3-control/src/process-arnables-plugin/getOutpostEndpoint.spec.ts
+++ b/packages/middleware-sdk-s3-control/src/process-arnables-plugin/getOutpostEndpoint.spec.ts
@@ -1,0 +1,31 @@
+import { getOutpostEndpoint } from "./getOutpostEndpoint";
+
+describe(getOutpostEndpoint.name, () => {
+  const mockRegion = "region";
+  const mockDnsSuffix = "mockDnsSuffix";
+  const mockHostname = `s3-control.${mockRegion}.${mockDnsSuffix}`;
+  const mockInput = { isCustomEndpoint: false, useFipsEndpoint: false };
+
+  it("returns hostname if custom endpoint is set", () => {
+    expect(getOutpostEndpoint(mockHostname, { ...mockInput, isCustomEndpoint: true })).toStrictEqual(mockHostname);
+  });
+
+  describe("returns outpost endpoint", () => {
+    it("uses region from hostname if regionOverride if provided", () => {
+      expect(getOutpostEndpoint(mockHostname, mockInput)).toStrictEqual(`s3-outposts.${mockRegion}.${mockDnsSuffix}`);
+    });
+
+    it("uses region from regionOverride if provided", () => {
+      const mockRegionOverride = "mockRegionOverride";
+      expect(getOutpostEndpoint(mockHostname, { ...mockInput, regionOverride: mockRegionOverride })).toStrictEqual(
+        `s3-outposts.${mockRegionOverride}.${mockDnsSuffix}`
+      );
+    });
+
+    it(`adds suffix "-fips" if useFipsEndpoint is set`, () => {
+      expect(getOutpostEndpoint(mockHostname, { ...mockInput, useFipsEndpoint: true })).toStrictEqual(
+        `s3-outposts-fips.${mockRegion}.${mockDnsSuffix}`
+      );
+    });
+  });
+});

--- a/packages/middleware-sdk-s3-control/src/process-arnables-plugin/getOutpostEndpoint.ts
+++ b/packages/middleware-sdk-s3-control/src/process-arnables-plugin/getOutpostEndpoint.ts
@@ -1,0 +1,24 @@
+const REGEX_S3CONTROL_HOSTNAME = /^(.+\.)?s3-control[.-]([a-z0-9-]+)\./;
+
+export interface GetOutpostEndpointOptions {
+  isCustomEndpoint?: boolean;
+  regionOverride?: string;
+  useFipsEndpoint: boolean;
+}
+
+export const getOutpostEndpoint = (
+  hostname: string,
+  { isCustomEndpoint, regionOverride, useFipsEndpoint }: GetOutpostEndpointOptions
+): string => {
+  const [matched, prefix, region] = hostname.match(REGEX_S3CONTROL_HOSTNAME)!;
+  // hostname prefix will be ignored even if presents
+  return isCustomEndpoint
+    ? hostname
+    : [
+        `s3-outposts${useFipsEndpoint ? "-fips" : ""}`,
+        regionOverride || region,
+        hostname.replace(new RegExp(`^${matched}`), ""),
+      ]
+        .filter((part) => part !== undefined)
+        .join(".");
+};

--- a/packages/middleware-sdk-s3-control/src/process-arnables-plugin/index.ts
+++ b/packages/middleware-sdk-s3-control/src/process-arnables-plugin/index.ts
@@ -1,7 +1,4 @@
 export { getProcessArnablesPlugin } from "./plugin";
 export { parseOutpostArnablesMiddleaware, parseOutpostArnablesMiddleawareOptions } from "./parse-outpost-arnables";
-export {
-  updateArnablesRequestMiddleware,
-  updateArnablesRequestMiddlewareOptions,
-  getOutpostEndpoint,
-} from "./update-arnables-request";
+export { updateArnablesRequestMiddleware, updateArnablesRequestMiddlewareOptions } from "./update-arnables-request";
+export { getOutpostEndpoint } from "./getOutpostEndpoint";

--- a/packages/middleware-sdk-s3-control/src/process-arnables-plugin/parse-outpost-arnables.ts
+++ b/packages/middleware-sdk-s3-control/src/process-arnables-plugin/parse-outpost-arnables.ts
@@ -3,7 +3,6 @@ import {
   getPseudoRegion,
   validateAccountId,
   validateNoDualstack,
-  validateNoFIPS,
   validateOutpostService,
   validatePartition,
   validateRegion,
@@ -114,7 +113,6 @@ const validateOutpostsArn = (
     clientSigningRegion: signingRegion,
   });
   validateNoDualstack(useDualstackEndpoint);
-  if (!useArnRegion) validateNoFIPS(clientRegion);
 };
 
 const parseOutpostsAccessPointArnResource = (

--- a/packages/middleware-sdk-s3-control/src/process-arnables-plugin/plugin.spec.ts
+++ b/packages/middleware-sdk-s3-control/src/process-arnables-plugin/plugin.spec.ts
@@ -169,27 +169,6 @@ describe("getProcessArnablesMiddleware", () => {
       expect(context).toMatchObject({ signing_service: "s3-outposts", signing_region: "us-gov-east-1" });
     });
 
-    it("should validate when client region is fips region", async () => {
-      expect.assertions(1);
-      const clientRegion = "fips-us-gov-east-1";
-      const hostname = `s3-control.${clientRegion}.amazonaws.com`;
-      const options = setupPluginOptions({
-        region: clientRegion,
-        regionInfoProvider: () => Promise.resolve({ hostname, partition: "aws-us-gov" }),
-      });
-      const stack = getStack(hostname, options);
-      const handler = stack.resolve((() => {}) as any, {});
-      try {
-        await handler({
-          input: {
-            Name: "arn:aws-us-gov:s3-outposts:us-gov-east-1:123456789012:outpost:op-01234567890123456:accesspoint:myaccesspoint",
-          },
-        });
-      } catch (e) {
-        expect(e.message).toContain("FIPS region is not supported");
-      }
-    });
-
     it("should validate when arn region is fips region", async () => {
       expect.assertions(1);
       const clientRegion = "fips-us-gov-east-1";
@@ -409,28 +388,6 @@ describe("getProcessArnablesMiddleware", () => {
       expect(request.headers).toMatchObject({ "x-amz-outpost-id": "op-01234567890123456" });
       expect(input.AccountId).toBe("123456789012");
       expect(context).toMatchObject({ signing_service: "s3-outposts", signing_region: "us-gov-east-1" });
-    });
-
-    it("should validate when client region is fips region", async () => {
-      expect.assertions(1);
-      const clientRegion = "fips-us-gov-east-1";
-      const hostname = `s3-control.${clientRegion}.amazonaws.com`;
-      const options = setupPluginOptions({
-        region: clientRegion,
-        regionInfoProvider: () => Promise.resolve({ hostname, partition: "aws-us-gov" }),
-      });
-      const stack = getStack(hostname, options);
-      const handler = stack.resolve((() => {}) as any, {});
-      try {
-        await handler({
-          input: {
-            Bucket:
-              "arn:aws-us-gov:s3-outposts:us-gov-east-1:123456789012:outpost:op-01234567890123456:bucket:mybucket",
-          },
-        });
-      } catch (e) {
-        expect(e.message).toContain("FIPS region is not supported");
-      }
     });
 
     it("should validate when arn region is fips region", async () => {

--- a/packages/middleware-sdk-s3-control/src/redirect-from-postid.spec.ts
+++ b/packages/middleware-sdk-s3-control/src/redirect-from-postid.spec.ts
@@ -6,7 +6,13 @@ describe("redirectFromPostIdMiddleware", () => {
   it("should redirect request if Bucket is a valid ARN", async () => {
     const next: any = (args: any) => ({ output: args.request });
     const context: any = {};
-    const { output } = await redirectFromPostIdMiddleware({ isCustomEndpoint: false })(next, context)({
+    const { output } = await redirectFromPostIdMiddleware({
+      isCustomEndpoint: false,
+      useFipsEndpoint: () => Promise.resolve(false),
+    })(
+      next,
+      context
+    )({
       input: { OutpostId: "op-123" },
       request: new HttpRequest({ hostname: "123456789012.s3-control.us-west-2.amazonaws.com" }),
     });

--- a/packages/middleware-sdk-s3-control/src/redirect-from-postid.ts
+++ b/packages/middleware-sdk-s3-control/src/redirect-from-postid.ts
@@ -1,5 +1,5 @@
 import { HttpRequest } from "@aws-sdk/protocol-http";
-import { BuildHandlerOptions, BuildMiddleware, Pluggable } from "@aws-sdk/types";
+import { BuildHandlerOptions, BuildMiddleware, Pluggable, Provider } from "@aws-sdk/types";
 
 import { S3ControlResolvedConfig } from "./configurations";
 import { CONTEXT_SIGNING_SERVICE } from "./constants";
@@ -9,18 +9,25 @@ type InputType = {
   OutpostId?: string;
 };
 
+export interface RedirectFromPostIdMiddlewareConfig {
+  isCustomEndpoint: boolean;
+  useFipsEndpoint: Provider<boolean>;
+}
+
 /**
  * If OutpostId is set, redirect hostname to Outpost one, and change signing service to `s3-outposts`.
  * Applied to S3Control.CreateBucket and S3Control.ListRegionalBuckets
  */
 export const redirectFromPostIdMiddleware =
-  ({ isCustomEndpoint }: { isCustomEndpoint: boolean }): BuildMiddleware<InputType, any> =>
+  (config: RedirectFromPostIdMiddlewareConfig): BuildMiddleware<InputType, any> =>
   (next, context) =>
-  (args) => {
+  async (args) => {
     const { input, request } = args;
     if (!HttpRequest.isInstance(request)) return next(args);
     if (input.OutpostId) {
-      request.hostname = getOutpostEndpoint(request.hostname, { isCustomEndpoint });
+      const { isCustomEndpoint } = config;
+      const useFipsEndpoint = await config.useFipsEndpoint();
+      request.hostname = getOutpostEndpoint(request.hostname, { isCustomEndpoint, useFipsEndpoint });
       context[CONTEXT_SIGNING_SERVICE] = "s3-outposts";
     }
     return next(args);


### PR DESCRIPTION
### Issue
Internal JS-2928

### Description
Adds support for FIPS in S3 Outposts Control Plane

### Testing
Unit testing

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
