### PR TITLE
chore(clients): remove hostname key from endpoint hashes

### DIFF
--- a/clients/client-accessanalyzer/src/endpoints.ts
+++ b/clients/client-accessanalyzer/src/endpoints.ts
@@ -3,7 +3,6 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
   "ca-central-1": {
-    hostname: "access-analyzer.ca-central-1.amazonaws.com",
     variants: [
       {
         hostname: "access-analyzer.ca-central-1.amazonaws.com",
@@ -16,7 +15,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-east-1": {
-    hostname: "access-analyzer.us-east-1.amazonaws.com",
     variants: [
       {
         hostname: "access-analyzer.us-east-1.amazonaws.com",
@@ -29,7 +27,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-east-2": {
-    hostname: "access-analyzer.us-east-2.amazonaws.com",
     variants: [
       {
         hostname: "access-analyzer.us-east-2.amazonaws.com",
@@ -42,7 +39,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-gov-east-1": {
-    hostname: "access-analyzer.us-gov-east-1.amazonaws.com",
     variants: [
       {
         hostname: "access-analyzer.us-gov-east-1.amazonaws.com",
@@ -52,7 +48,6 @@ const regionHash: RegionHash = {
     signingRegion: "us-gov-east-1",
   },
   "us-gov-west-1": {
-    hostname: "access-analyzer.us-gov-west-1.amazonaws.com",
     variants: [
       {
         hostname: "access-analyzer.us-gov-west-1.amazonaws.com",
@@ -62,7 +57,6 @@ const regionHash: RegionHash = {
     signingRegion: "us-gov-west-1",
   },
   "us-west-1": {
-    hostname: "access-analyzer.us-west-1.amazonaws.com",
     variants: [
       {
         hostname: "access-analyzer.us-west-1.amazonaws.com",
@@ -75,7 +69,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-west-2": {
-    hostname: "access-analyzer.us-west-2.amazonaws.com",
     variants: [
       {
         hostname: "access-analyzer.us-west-2.amazonaws.com",
@@ -120,7 +113,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "access-analyzer.{region}.amazonaws.com",
     variants: [
       {
         hostname: "access-analyzer.{region}.amazonaws.com",
@@ -143,7 +135,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "access-analyzer.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "access-analyzer.{region}.amazonaws.com.cn",
@@ -166,7 +157,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "access-analyzer.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "access-analyzer.{region}.c2s.ic.gov",
@@ -177,7 +167,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "access-analyzer.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "access-analyzer.{region}.sc2s.sgov.gov",
@@ -188,7 +177,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "access-analyzer.{region}.amazonaws.com",
     variants: [
       {
         hostname: "access-analyzer.{region}.amazonaws.com",

--- a/clients/client-account/src/endpoints.ts
+++ b/clients/client-account/src/endpoints.ts
@@ -3,7 +3,6 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
   "aws-cn-global": {
-    hostname: "account.cn-northwest-1.amazonaws.com.cn",
     variants: [
       {
         hostname: "account.cn-northwest-1.amazonaws.com.cn",
@@ -13,7 +12,6 @@ const regionHash: RegionHash = {
     signingRegion: "cn-northwest-1",
   },
   "aws-global": {
-    hostname: "account.us-east-1.amazonaws.com",
     variants: [
       {
         hostname: "account.us-east-1.amazonaws.com",
@@ -51,7 +49,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "account.{region}.amazonaws.com",
     variants: [
       {
         hostname: "account.{region}.amazonaws.com",
@@ -75,7 +72,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["aws-cn-global", "cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "account.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "account.{region}.amazonaws.com.cn",
@@ -99,7 +95,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "account.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "account.{region}.c2s.ic.gov",
@@ -110,7 +105,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "account.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "account.{region}.sc2s.sgov.gov",
@@ -121,7 +115,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "account.{region}.amazonaws.com",
     variants: [
       {
         hostname: "account.{region}.amazonaws.com",

--- a/clients/client-acm-pca/src/endpoints.ts
+++ b/clients/client-acm-pca/src/endpoints.ts
@@ -3,7 +3,6 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
   "ca-central-1": {
-    hostname: "acm-pca.ca-central-1.amazonaws.com",
     variants: [
       {
         hostname: "acm-pca.ca-central-1.amazonaws.com",
@@ -16,7 +15,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-east-1": {
-    hostname: "acm-pca.us-east-1.amazonaws.com",
     variants: [
       {
         hostname: "acm-pca.us-east-1.amazonaws.com",
@@ -29,7 +27,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-east-2": {
-    hostname: "acm-pca.us-east-2.amazonaws.com",
     variants: [
       {
         hostname: "acm-pca.us-east-2.amazonaws.com",
@@ -42,7 +39,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-gov-east-1": {
-    hostname: "acm-pca.us-gov-east-1.amazonaws.com",
     variants: [
       {
         hostname: "acm-pca.us-gov-east-1.amazonaws.com",
@@ -55,7 +51,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-gov-west-1": {
-    hostname: "acm-pca.us-gov-west-1.amazonaws.com",
     variants: [
       {
         hostname: "acm-pca.us-gov-west-1.amazonaws.com",
@@ -68,7 +63,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-west-1": {
-    hostname: "acm-pca.us-west-1.amazonaws.com",
     variants: [
       {
         hostname: "acm-pca.us-west-1.amazonaws.com",
@@ -81,7 +75,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-west-2": {
-    hostname: "acm-pca.us-west-2.amazonaws.com",
     variants: [
       {
         hostname: "acm-pca.us-west-2.amazonaws.com",
@@ -126,7 +119,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "acm-pca.{region}.amazonaws.com",
     variants: [
       {
         hostname: "acm-pca.{region}.amazonaws.com",
@@ -149,7 +141,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "acm-pca.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "acm-pca.{region}.amazonaws.com.cn",
@@ -172,7 +163,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "acm-pca.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "acm-pca.{region}.c2s.ic.gov",
@@ -183,7 +173,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "acm-pca.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "acm-pca.{region}.sc2s.sgov.gov",
@@ -194,7 +183,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["fips-us-gov-east-1", "fips-us-gov-west-1", "us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "acm-pca.{region}.amazonaws.com",
     variants: [
       {
         hostname: "acm-pca.{region}.amazonaws.com",

--- a/clients/client-acm/src/endpoints.ts
+++ b/clients/client-acm/src/endpoints.ts
@@ -3,7 +3,6 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
   "ca-central-1": {
-    hostname: "acm.ca-central-1.amazonaws.com",
     variants: [
       {
         hostname: "acm.ca-central-1.amazonaws.com",
@@ -16,7 +15,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-east-1": {
-    hostname: "acm.us-east-1.amazonaws.com",
     variants: [
       {
         hostname: "acm.us-east-1.amazonaws.com",
@@ -29,7 +27,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-east-2": {
-    hostname: "acm.us-east-2.amazonaws.com",
     variants: [
       {
         hostname: "acm.us-east-2.amazonaws.com",
@@ -42,7 +39,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-gov-east-1": {
-    hostname: "acm.us-gov-east-1.amazonaws.com",
     variants: [
       {
         hostname: "acm.us-gov-east-1.amazonaws.com",
@@ -52,7 +48,6 @@ const regionHash: RegionHash = {
     signingRegion: "us-gov-east-1",
   },
   "us-gov-west-1": {
-    hostname: "acm.us-gov-west-1.amazonaws.com",
     variants: [
       {
         hostname: "acm.us-gov-west-1.amazonaws.com",
@@ -62,7 +57,6 @@ const regionHash: RegionHash = {
     signingRegion: "us-gov-west-1",
   },
   "us-west-1": {
-    hostname: "acm.us-west-1.amazonaws.com",
     variants: [
       {
         hostname: "acm.us-west-1.amazonaws.com",
@@ -75,7 +69,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-west-2": {
-    hostname: "acm.us-west-2.amazonaws.com",
     variants: [
       {
         hostname: "acm.us-west-2.amazonaws.com",
@@ -120,7 +113,6 @@ const partitionHash: PartitionHash = {
       "us-west-2-fips",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "acm.{region}.amazonaws.com",
     variants: [
       {
         hostname: "acm.{region}.amazonaws.com",
@@ -143,7 +135,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "acm.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "acm.{region}.amazonaws.com.cn",
@@ -166,7 +157,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "acm.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "acm.{region}.c2s.ic.gov",
@@ -177,7 +167,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "acm.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "acm.{region}.sc2s.sgov.gov",
@@ -188,7 +177,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "acm.{region}.amazonaws.com",
     variants: [
       {
         hostname: "acm.{region}.amazonaws.com",

--- a/clients/client-alexa-for-business/src/endpoints.ts
+++ b/clients/client-alexa-for-business/src/endpoints.ts
@@ -29,7 +29,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "a4b.{region}.amazonaws.com",
     variants: [
       {
         hostname: "a4b.{region}.amazonaws.com",
@@ -52,7 +51,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "a4b.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "a4b.{region}.amazonaws.com.cn",
@@ -75,7 +73,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "a4b.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "a4b.{region}.c2s.ic.gov",
@@ -86,7 +83,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "a4b.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "a4b.{region}.sc2s.sgov.gov",
@@ -97,7 +93,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "a4b.{region}.amazonaws.com",
     variants: [
       {
         hostname: "a4b.{region}.amazonaws.com",

--- a/clients/client-amp/src/endpoints.ts
+++ b/clients/client-amp/src/endpoints.ts
@@ -29,7 +29,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "aps.{region}.amazonaws.com",
     variants: [
       {
         hostname: "aps.{region}.amazonaws.com",
@@ -52,7 +51,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "aps.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "aps.{region}.amazonaws.com.cn",
@@ -75,7 +73,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "aps.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "aps.{region}.c2s.ic.gov",
@@ -86,7 +83,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "aps.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "aps.{region}.sc2s.sgov.gov",
@@ -97,7 +93,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "aps.{region}.amazonaws.com",
     variants: [
       {
         hostname: "aps.{region}.amazonaws.com",

--- a/clients/client-amplify/src/endpoints.ts
+++ b/clients/client-amplify/src/endpoints.ts
@@ -29,7 +29,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "amplify.{region}.amazonaws.com",
     variants: [
       {
         hostname: "amplify.{region}.amazonaws.com",
@@ -52,7 +51,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "amplify.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "amplify.{region}.amazonaws.com.cn",
@@ -75,7 +73,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "amplify.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "amplify.{region}.c2s.ic.gov",
@@ -86,7 +83,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "amplify.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "amplify.{region}.sc2s.sgov.gov",
@@ -97,7 +93,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "amplify.{region}.amazonaws.com",
     variants: [
       {
         hostname: "amplify.{region}.amazonaws.com",

--- a/clients/client-amplifybackend/src/endpoints.ts
+++ b/clients/client-amplifybackend/src/endpoints.ts
@@ -29,7 +29,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "amplifybackend.{region}.amazonaws.com",
     variants: [
       {
         hostname: "amplifybackend.{region}.amazonaws.com",
@@ -52,7 +51,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "amplifybackend.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "amplifybackend.{region}.amazonaws.com.cn",
@@ -75,7 +73,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "amplifybackend.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "amplifybackend.{region}.c2s.ic.gov",
@@ -86,7 +83,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "amplifybackend.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "amplifybackend.{region}.sc2s.sgov.gov",
@@ -97,7 +93,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "amplifybackend.{region}.amazonaws.com",
     variants: [
       {
         hostname: "amplifybackend.{region}.amazonaws.com",

--- a/clients/client-api-gateway/src/endpoints.ts
+++ b/clients/client-api-gateway/src/endpoints.ts
@@ -29,7 +29,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "apigateway.{region}.amazonaws.com",
     variants: [
       {
         hostname: "apigateway.{region}.amazonaws.com",
@@ -52,7 +51,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "apigateway.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "apigateway.{region}.amazonaws.com.cn",
@@ -75,7 +73,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "apigateway.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "apigateway.{region}.c2s.ic.gov",
@@ -86,7 +83,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "apigateway.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "apigateway.{region}.sc2s.sgov.gov",
@@ -97,7 +93,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "apigateway.{region}.amazonaws.com",
     variants: [
       {
         hostname: "apigateway.{region}.amazonaws.com",

--- a/clients/client-apigatewaymanagementapi/src/endpoints.ts
+++ b/clients/client-apigatewaymanagementapi/src/endpoints.ts
@@ -29,7 +29,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "execute-api.{region}.amazonaws.com",
     variants: [
       {
         hostname: "execute-api.{region}.amazonaws.com",
@@ -52,7 +51,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "execute-api.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "execute-api.{region}.amazonaws.com.cn",
@@ -75,7 +73,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "execute-api.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "execute-api.{region}.c2s.ic.gov",
@@ -86,7 +83,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "execute-api.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "execute-api.{region}.sc2s.sgov.gov",
@@ -97,7 +93,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "execute-api.{region}.amazonaws.com",
     variants: [
       {
         hostname: "execute-api.{region}.amazonaws.com",

--- a/clients/client-apigatewayv2/src/endpoints.ts
+++ b/clients/client-apigatewayv2/src/endpoints.ts
@@ -29,7 +29,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "apigateway.{region}.amazonaws.com",
     variants: [
       {
         hostname: "apigateway.{region}.amazonaws.com",
@@ -52,7 +51,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "apigateway.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "apigateway.{region}.amazonaws.com.cn",
@@ -75,7 +73,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "apigateway.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "apigateway.{region}.c2s.ic.gov",
@@ -86,7 +83,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "apigateway.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "apigateway.{region}.sc2s.sgov.gov",
@@ -97,7 +93,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "apigateway.{region}.amazonaws.com",
     variants: [
       {
         hostname: "apigateway.{region}.amazonaws.com",

--- a/clients/client-app-mesh/src/endpoints.ts
+++ b/clients/client-app-mesh/src/endpoints.ts
@@ -29,7 +29,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "appmesh.{region}.amazonaws.com",
     variants: [
       {
         hostname: "appmesh.{region}.amazonaws.com",
@@ -52,7 +51,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "appmesh.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "appmesh.{region}.amazonaws.com.cn",
@@ -75,7 +73,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "appmesh.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "appmesh.{region}.c2s.ic.gov",
@@ -86,7 +83,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "appmesh.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "appmesh.{region}.sc2s.sgov.gov",
@@ -97,7 +93,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "appmesh.{region}.amazonaws.com",
     variants: [
       {
         hostname: "appmesh.{region}.amazonaws.com",

--- a/clients/client-appconfig/src/endpoints.ts
+++ b/clients/client-appconfig/src/endpoints.ts
@@ -29,7 +29,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "appconfig.{region}.amazonaws.com",
     variants: [
       {
         hostname: "appconfig.{region}.amazonaws.com",
@@ -52,7 +51,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "appconfig.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "appconfig.{region}.amazonaws.com.cn",
@@ -75,7 +73,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "appconfig.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "appconfig.{region}.c2s.ic.gov",
@@ -86,7 +83,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "appconfig.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "appconfig.{region}.sc2s.sgov.gov",
@@ -97,7 +93,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "appconfig.{region}.amazonaws.com",
     variants: [
       {
         hostname: "appconfig.{region}.amazonaws.com",

--- a/clients/client-appflow/src/endpoints.ts
+++ b/clients/client-appflow/src/endpoints.ts
@@ -29,7 +29,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "appflow.{region}.amazonaws.com",
     variants: [
       {
         hostname: "appflow.{region}.amazonaws.com",
@@ -52,7 +51,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "appflow.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "appflow.{region}.amazonaws.com.cn",
@@ -75,7 +73,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "appflow.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "appflow.{region}.c2s.ic.gov",
@@ -86,7 +83,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "appflow.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "appflow.{region}.sc2s.sgov.gov",
@@ -97,7 +93,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "appflow.{region}.amazonaws.com",
     variants: [
       {
         hostname: "appflow.{region}.amazonaws.com",

--- a/clients/client-appintegrations/src/endpoints.ts
+++ b/clients/client-appintegrations/src/endpoints.ts
@@ -29,7 +29,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "app-integrations.{region}.amazonaws.com",
     variants: [
       {
         hostname: "app-integrations.{region}.amazonaws.com",
@@ -52,7 +51,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "app-integrations.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "app-integrations.{region}.amazonaws.com.cn",
@@ -75,7 +73,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "app-integrations.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "app-integrations.{region}.c2s.ic.gov",
@@ -86,7 +83,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "app-integrations.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "app-integrations.{region}.sc2s.sgov.gov",
@@ -97,7 +93,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "app-integrations.{region}.amazonaws.com",
     variants: [
       {
         hostname: "app-integrations.{region}.amazonaws.com",

--- a/clients/client-application-auto-scaling/src/endpoints.ts
+++ b/clients/client-application-auto-scaling/src/endpoints.ts
@@ -29,7 +29,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "application-autoscaling.{region}.amazonaws.com",
     variants: [
       {
         hostname: "application-autoscaling.{region}.amazonaws.com",
@@ -52,7 +51,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "application-autoscaling.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "application-autoscaling.{region}.amazonaws.com.cn",
@@ -75,7 +73,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "application-autoscaling.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "application-autoscaling.{region}.c2s.ic.gov",
@@ -86,7 +83,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "application-autoscaling.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "application-autoscaling.{region}.sc2s.sgov.gov",
@@ -97,7 +93,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "application-autoscaling.{region}.amazonaws.com",
     variants: [
       {
         hostname: "application-autoscaling.{region}.amazonaws.com",

--- a/clients/client-application-discovery-service/src/endpoints.ts
+++ b/clients/client-application-discovery-service/src/endpoints.ts
@@ -29,7 +29,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "discovery.{region}.amazonaws.com",
     variants: [
       {
         hostname: "discovery.{region}.amazonaws.com",
@@ -52,7 +51,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "discovery.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "discovery.{region}.amazonaws.com.cn",
@@ -75,7 +73,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "discovery.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "discovery.{region}.c2s.ic.gov",
@@ -86,7 +83,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "discovery.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "discovery.{region}.sc2s.sgov.gov",
@@ -97,7 +93,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "discovery.{region}.amazonaws.com",
     variants: [
       {
         hostname: "discovery.{region}.amazonaws.com",

--- a/clients/client-application-insights/src/endpoints.ts
+++ b/clients/client-application-insights/src/endpoints.ts
@@ -3,7 +3,6 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
   "us-gov-east-1": {
-    hostname: "applicationinsights.us-gov-east-1.amazonaws.com",
     variants: [
       {
         hostname: "applicationinsights.us-gov-east-1.amazonaws.com",
@@ -13,7 +12,6 @@ const regionHash: RegionHash = {
     signingRegion: "us-gov-east-1",
   },
   "us-gov-west-1": {
-    hostname: "applicationinsights.us-gov-west-1.amazonaws.com",
     variants: [
       {
         hostname: "applicationinsights.us-gov-west-1.amazonaws.com",
@@ -50,7 +48,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "applicationinsights.{region}.amazonaws.com",
     variants: [
       {
         hostname: "applicationinsights.{region}.amazonaws.com",
@@ -73,7 +70,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "applicationinsights.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "applicationinsights.{region}.amazonaws.com.cn",
@@ -96,7 +92,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "applicationinsights.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "applicationinsights.{region}.c2s.ic.gov",
@@ -107,7 +102,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "applicationinsights.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "applicationinsights.{region}.sc2s.sgov.gov",
@@ -118,7 +112,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "applicationinsights.{region}.amazonaws.com",
     variants: [
       {
         hostname: "applicationinsights.{region}.amazonaws.com",

--- a/clients/client-applicationcostprofiler/src/endpoints.ts
+++ b/clients/client-applicationcostprofiler/src/endpoints.ts
@@ -29,7 +29,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "application-cost-profiler.{region}.amazonaws.com",
     variants: [
       {
         hostname: "application-cost-profiler.{region}.amazonaws.com",
@@ -52,7 +51,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "application-cost-profiler.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "application-cost-profiler.{region}.amazonaws.com.cn",
@@ -75,7 +73,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "application-cost-profiler.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "application-cost-profiler.{region}.c2s.ic.gov",
@@ -86,7 +83,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "application-cost-profiler.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "application-cost-profiler.{region}.sc2s.sgov.gov",
@@ -97,7 +93,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "application-cost-profiler.{region}.amazonaws.com",
     variants: [
       {
         hostname: "application-cost-profiler.{region}.amazonaws.com",

--- a/clients/client-apprunner/src/endpoints.ts
+++ b/clients/client-apprunner/src/endpoints.ts
@@ -29,7 +29,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "apprunner.{region}.amazonaws.com",
     variants: [
       {
         hostname: "apprunner.{region}.amazonaws.com",
@@ -52,7 +51,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "apprunner.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "apprunner.{region}.amazonaws.com.cn",
@@ -75,7 +73,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "apprunner.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "apprunner.{region}.c2s.ic.gov",
@@ -86,7 +83,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "apprunner.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "apprunner.{region}.sc2s.sgov.gov",
@@ -97,7 +93,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "apprunner.{region}.amazonaws.com",
     variants: [
       {
         hostname: "apprunner.{region}.amazonaws.com",

--- a/clients/client-appstream/src/endpoints.ts
+++ b/clients/client-appstream/src/endpoints.ts
@@ -3,7 +3,6 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
   "us-east-1": {
-    hostname: "appstream2.us-east-1.amazonaws.com",
     variants: [
       {
         hostname: "appstream2.us-east-1.amazonaws.com",
@@ -16,7 +15,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-gov-west-1": {
-    hostname: "appstream2.us-gov-west-1.amazonaws.com",
     variants: [
       {
         hostname: "appstream2.us-gov-west-1.amazonaws.com",
@@ -29,7 +27,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-west-2": {
-    hostname: "appstream2.us-west-2.amazonaws.com",
     variants: [
       {
         hostname: "appstream2.us-west-2.amazonaws.com",
@@ -72,7 +69,6 @@ const partitionHash: PartitionHash = {
       "us-west-2-fips",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "appstream2.{region}.amazonaws.com",
     variants: [
       {
         hostname: "appstream2.{region}.amazonaws.com",
@@ -95,7 +91,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "appstream2.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "appstream2.{region}.amazonaws.com.cn",
@@ -118,7 +113,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "appstream2.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "appstream2.{region}.c2s.ic.gov",
@@ -129,7 +123,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "appstream2.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "appstream2.{region}.sc2s.sgov.gov",
@@ -140,7 +133,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["fips", "us-gov-east-1", "us-gov-west-1", "us-gov-west-1-fips"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "appstream2.{region}.amazonaws.com",
     variants: [
       {
         hostname: "appstream2.{region}.amazonaws.com",

--- a/clients/client-appsync/src/endpoints.ts
+++ b/clients/client-appsync/src/endpoints.ts
@@ -29,7 +29,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "appsync.{region}.amazonaws.com",
     variants: [
       {
         hostname: "appsync.{region}.amazonaws.com",
@@ -52,7 +51,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "appsync.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "appsync.{region}.amazonaws.com.cn",
@@ -75,7 +73,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "appsync.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "appsync.{region}.c2s.ic.gov",
@@ -86,7 +83,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "appsync.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "appsync.{region}.sc2s.sgov.gov",
@@ -97,7 +93,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "appsync.{region}.amazonaws.com",
     variants: [
       {
         hostname: "appsync.{region}.amazonaws.com",

--- a/clients/client-athena/src/endpoints.ts
+++ b/clients/client-athena/src/endpoints.ts
@@ -3,7 +3,6 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
   "us-east-1": {
-    hostname: "athena.us-east-1.amazonaws.com",
     variants: [
       {
         hostname: "athena.us-east-1.amazonaws.com",
@@ -16,7 +15,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-east-2": {
-    hostname: "athena.us-east-2.amazonaws.com",
     variants: [
       {
         hostname: "athena.us-east-2.amazonaws.com",
@@ -29,7 +27,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-gov-east-1": {
-    hostname: "athena.us-gov-east-1.amazonaws.com",
     variants: [
       {
         hostname: "athena.us-gov-east-1.amazonaws.com",
@@ -42,7 +39,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-gov-west-1": {
-    hostname: "athena.us-gov-west-1.amazonaws.com",
     variants: [
       {
         hostname: "athena.us-gov-west-1.amazonaws.com",
@@ -55,7 +51,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-west-1": {
-    hostname: "athena.us-west-1.amazonaws.com",
     variants: [
       {
         hostname: "athena.us-west-1.amazonaws.com",
@@ -68,7 +63,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-west-2": {
-    hostname: "athena.us-west-2.amazonaws.com",
     variants: [
       {
         hostname: "athena.us-west-2.amazonaws.com",
@@ -112,7 +106,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "athena.{region}.amazonaws.com",
     variants: [
       {
         hostname: "athena.{region}.amazonaws.com",
@@ -135,7 +128,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "athena.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "athena.{region}.amazonaws.com.cn",
@@ -158,7 +150,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "athena.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "athena.{region}.c2s.ic.gov",
@@ -169,7 +160,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "athena.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "athena.{region}.sc2s.sgov.gov",
@@ -180,7 +170,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["fips-us-gov-east-1", "fips-us-gov-west-1", "us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "athena.{region}.amazonaws.com",
     variants: [
       {
         hostname: "athena.{region}.amazonaws.com",

--- a/clients/client-auditmanager/src/endpoints.ts
+++ b/clients/client-auditmanager/src/endpoints.ts
@@ -29,7 +29,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "auditmanager.{region}.amazonaws.com",
     variants: [
       {
         hostname: "auditmanager.{region}.amazonaws.com",
@@ -52,7 +51,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "auditmanager.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "auditmanager.{region}.amazonaws.com.cn",
@@ -75,7 +73,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "auditmanager.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "auditmanager.{region}.c2s.ic.gov",
@@ -86,7 +83,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "auditmanager.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "auditmanager.{region}.sc2s.sgov.gov",
@@ -97,7 +93,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "auditmanager.{region}.amazonaws.com",
     variants: [
       {
         hostname: "auditmanager.{region}.amazonaws.com",

--- a/clients/client-auto-scaling-plans/src/endpoints.ts
+++ b/clients/client-auto-scaling-plans/src/endpoints.ts
@@ -29,7 +29,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "autoscaling-plans.{region}.amazonaws.com",
     variants: [
       {
         hostname: "autoscaling-plans.{region}.amazonaws.com",
@@ -52,7 +51,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "autoscaling-plans.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "autoscaling-plans.{region}.amazonaws.com.cn",
@@ -75,7 +73,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "autoscaling-plans.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "autoscaling-plans.{region}.c2s.ic.gov",
@@ -86,7 +83,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "autoscaling-plans.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "autoscaling-plans.{region}.sc2s.sgov.gov",
@@ -97,7 +93,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "autoscaling-plans.{region}.amazonaws.com",
     variants: [
       {
         hostname: "autoscaling-plans.{region}.amazonaws.com",

--- a/clients/client-auto-scaling/src/endpoints.ts
+++ b/clients/client-auto-scaling/src/endpoints.ts
@@ -29,7 +29,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "autoscaling.{region}.amazonaws.com",
     variants: [
       {
         hostname: "autoscaling.{region}.amazonaws.com",
@@ -52,7 +51,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "autoscaling.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "autoscaling.{region}.amazonaws.com.cn",
@@ -75,7 +73,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "autoscaling.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "autoscaling.{region}.c2s.ic.gov",
@@ -86,7 +83,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "autoscaling.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "autoscaling.{region}.sc2s.sgov.gov",
@@ -97,7 +93,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "autoscaling.{region}.amazonaws.com",
     variants: [
       {
         hostname: "autoscaling.{region}.amazonaws.com",

--- a/clients/client-backup/src/endpoints.ts
+++ b/clients/client-backup/src/endpoints.ts
@@ -29,7 +29,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "backup.{region}.amazonaws.com",
     variants: [
       {
         hostname: "backup.{region}.amazonaws.com",
@@ -52,7 +51,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "backup.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "backup.{region}.amazonaws.com.cn",
@@ -75,7 +73,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "backup.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "backup.{region}.c2s.ic.gov",
@@ -86,7 +83,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "backup.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "backup.{region}.sc2s.sgov.gov",
@@ -97,7 +93,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "backup.{region}.amazonaws.com",
     variants: [
       {
         hostname: "backup.{region}.amazonaws.com",

--- a/clients/client-batch/src/endpoints.ts
+++ b/clients/client-batch/src/endpoints.ts
@@ -3,7 +3,6 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
   "us-east-1": {
-    hostname: "batch.us-east-1.amazonaws.com",
     variants: [
       {
         hostname: "batch.us-east-1.amazonaws.com",
@@ -16,7 +15,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-east-2": {
-    hostname: "batch.us-east-2.amazonaws.com",
     variants: [
       {
         hostname: "batch.us-east-2.amazonaws.com",
@@ -29,7 +27,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-gov-east-1": {
-    hostname: "batch.us-gov-east-1.amazonaws.com",
     variants: [
       {
         hostname: "batch.us-gov-east-1.amazonaws.com",
@@ -42,7 +39,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-gov-west-1": {
-    hostname: "batch.us-gov-west-1.amazonaws.com",
     variants: [
       {
         hostname: "batch.us-gov-west-1.amazonaws.com",
@@ -55,7 +51,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-west-1": {
-    hostname: "batch.us-west-1.amazonaws.com",
     variants: [
       {
         hostname: "batch.us-west-1.amazonaws.com",
@@ -68,7 +63,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-west-2": {
-    hostname: "batch.us-west-2.amazonaws.com",
     variants: [
       {
         hostname: "batch.us-west-2.amazonaws.com",
@@ -112,7 +106,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "batch.{region}.amazonaws.com",
     variants: [
       {
         hostname: "batch.{region}.amazonaws.com",
@@ -127,7 +120,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "batch.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "batch.{region}.amazonaws.com.cn",
@@ -150,7 +142,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "batch.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "batch.{region}.c2s.ic.gov",
@@ -161,7 +152,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "batch.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "batch.{region}.sc2s.sgov.gov",
@@ -172,7 +162,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["fips-us-gov-east-1", "fips-us-gov-west-1", "us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "batch.{region}.amazonaws.com",
     variants: [
       {
         hostname: "batch.{region}.amazonaws.com",

--- a/clients/client-braket/src/endpoints.ts
+++ b/clients/client-braket/src/endpoints.ts
@@ -29,7 +29,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "braket.{region}.amazonaws.com",
     variants: [
       {
         hostname: "braket.{region}.amazonaws.com",
@@ -52,7 +51,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "braket.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "braket.{region}.amazonaws.com.cn",
@@ -75,7 +73,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "braket.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "braket.{region}.c2s.ic.gov",
@@ -86,7 +83,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "braket.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "braket.{region}.sc2s.sgov.gov",
@@ -97,7 +93,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "braket.{region}.amazonaws.com",
     variants: [
       {
         hostname: "braket.{region}.amazonaws.com",

--- a/clients/client-budgets/src/endpoints.ts
+++ b/clients/client-budgets/src/endpoints.ts
@@ -3,7 +3,6 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
   "aws-cn-global": {
-    hostname: "budgets.amazonaws.com.cn",
     variants: [
       {
         hostname: "budgets.amazonaws.com.cn",
@@ -13,7 +12,6 @@ const regionHash: RegionHash = {
     signingRegion: "cn-northwest-1",
   },
   "aws-global": {
-    hostname: "budgets.amazonaws.com",
     variants: [
       {
         hostname: "budgets.amazonaws.com",
@@ -51,7 +49,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "budgets.{region}.amazonaws.com",
     variants: [
       {
         hostname: "budgets.{region}.amazonaws.com",
@@ -75,7 +72,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["aws-cn-global", "cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "budgets.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "budgets.{region}.amazonaws.com.cn",
@@ -99,7 +95,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "budgets.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "budgets.{region}.c2s.ic.gov",
@@ -110,7 +105,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "budgets.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "budgets.{region}.sc2s.sgov.gov",
@@ -121,7 +115,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "budgets.{region}.amazonaws.com",
     variants: [
       {
         hostname: "budgets.{region}.amazonaws.com",

--- a/clients/client-chime-sdk-identity/src/endpoints.ts
+++ b/clients/client-chime-sdk-identity/src/endpoints.ts
@@ -3,7 +3,6 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
   "us-east-1": {
-    hostname: "identity-chime.us-east-1.amazonaws.com",
     variants: [
       {
         hostname: "identity-chime.us-east-1.amazonaws.com",
@@ -44,7 +43,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "identity-chime.{region}.amazonaws.com",
     variants: [
       {
         hostname: "identity-chime.{region}.amazonaws.com",
@@ -67,7 +65,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "identity-chime.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "identity-chime.{region}.amazonaws.com.cn",
@@ -90,7 +87,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "identity-chime.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "identity-chime.{region}.c2s.ic.gov",
@@ -101,7 +97,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "identity-chime.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "identity-chime.{region}.sc2s.sgov.gov",
@@ -112,7 +107,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "identity-chime.{region}.amazonaws.com",
     variants: [
       {
         hostname: "identity-chime.{region}.amazonaws.com",

--- a/clients/client-chime-sdk-messaging/src/endpoints.ts
+++ b/clients/client-chime-sdk-messaging/src/endpoints.ts
@@ -3,7 +3,6 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
   "us-east-1": {
-    hostname: "messaging-chime.us-east-1.amazonaws.com",
     variants: [
       {
         hostname: "messaging-chime.us-east-1.amazonaws.com",
@@ -44,7 +43,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "messaging-chime.{region}.amazonaws.com",
     variants: [
       {
         hostname: "messaging-chime.{region}.amazonaws.com",
@@ -67,7 +65,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "messaging-chime.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "messaging-chime.{region}.amazonaws.com.cn",
@@ -90,7 +87,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "messaging-chime.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "messaging-chime.{region}.c2s.ic.gov",
@@ -101,7 +97,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "messaging-chime.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "messaging-chime.{region}.sc2s.sgov.gov",
@@ -112,7 +107,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "messaging-chime.{region}.amazonaws.com",
     variants: [
       {
         hostname: "messaging-chime.{region}.amazonaws.com",

--- a/clients/client-chime/src/endpoints.ts
+++ b/clients/client-chime/src/endpoints.ts
@@ -3,7 +3,6 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
   "aws-global": {
-    hostname: "chime.us-east-1.amazonaws.com",
     variants: [
       {
         hostname: "chime.us-east-1.amazonaws.com",
@@ -41,7 +40,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "chime.{region}.amazonaws.com",
     variants: [
       {
         hostname: "chime.{region}.amazonaws.com",
@@ -65,7 +63,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "chime.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "chime.{region}.amazonaws.com.cn",
@@ -88,7 +85,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "chime.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "chime.{region}.c2s.ic.gov",
@@ -99,7 +95,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "chime.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "chime.{region}.sc2s.sgov.gov",
@@ -110,7 +105,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "chime.{region}.amazonaws.com",
     variants: [
       {
         hostname: "chime.{region}.amazonaws.com",

--- a/clients/client-cloud9/src/endpoints.ts
+++ b/clients/client-cloud9/src/endpoints.ts
@@ -29,7 +29,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "cloud9.{region}.amazonaws.com",
     variants: [
       {
         hostname: "cloud9.{region}.amazonaws.com",
@@ -52,7 +51,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "cloud9.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "cloud9.{region}.amazonaws.com.cn",
@@ -75,7 +73,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "cloud9.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "cloud9.{region}.c2s.ic.gov",
@@ -86,7 +83,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "cloud9.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "cloud9.{region}.sc2s.sgov.gov",
@@ -97,7 +93,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "cloud9.{region}.amazonaws.com",
     variants: [
       {
         hostname: "cloud9.{region}.amazonaws.com",

--- a/clients/client-cloudcontrol/src/endpoints.ts
+++ b/clients/client-cloudcontrol/src/endpoints.ts
@@ -3,7 +3,6 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
   "ca-central-1": {
-    hostname: "cloudcontrolapi.ca-central-1.amazonaws.com",
     variants: [
       {
         hostname: "cloudcontrolapi.ca-central-1.amazonaws.com",
@@ -16,7 +15,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-east-1": {
-    hostname: "cloudcontrolapi.us-east-1.amazonaws.com",
     variants: [
       {
         hostname: "cloudcontrolapi.us-east-1.amazonaws.com",
@@ -29,7 +27,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-east-2": {
-    hostname: "cloudcontrolapi.us-east-2.amazonaws.com",
     variants: [
       {
         hostname: "cloudcontrolapi.us-east-2.amazonaws.com",
@@ -42,7 +39,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-gov-east-1": {
-    hostname: "cloudcontrolapi.us-gov-east-1.amazonaws.com",
     variants: [
       {
         hostname: "cloudcontrolapi.us-gov-east-1.amazonaws.com",
@@ -55,7 +51,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-gov-west-1": {
-    hostname: "cloudcontrolapi.us-gov-west-1.amazonaws.com",
     variants: [
       {
         hostname: "cloudcontrolapi.us-gov-west-1.amazonaws.com",
@@ -68,7 +63,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-west-1": {
-    hostname: "cloudcontrolapi.us-west-1.amazonaws.com",
     variants: [
       {
         hostname: "cloudcontrolapi.us-west-1.amazonaws.com",
@@ -81,7 +75,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-west-2": {
-    hostname: "cloudcontrolapi.us-west-2.amazonaws.com",
     variants: [
       {
         hostname: "cloudcontrolapi.us-west-2.amazonaws.com",
@@ -126,7 +119,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "cloudcontrolapi.{region}.amazonaws.com",
     variants: [
       {
         hostname: "cloudcontrolapi.{region}.amazonaws.com",
@@ -149,7 +141,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "cloudcontrolapi.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "cloudcontrolapi.{region}.amazonaws.com.cn",
@@ -172,7 +163,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "cloudcontrolapi.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "cloudcontrolapi.{region}.c2s.ic.gov",
@@ -183,7 +173,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "cloudcontrolapi.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "cloudcontrolapi.{region}.sc2s.sgov.gov",
@@ -194,7 +183,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["fips-us-gov-east-1", "fips-us-gov-west-1", "us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "cloudcontrolapi.{region}.amazonaws.com",
     variants: [
       {
         hostname: "cloudcontrolapi.{region}.amazonaws.com",

--- a/clients/client-clouddirectory/src/endpoints.ts
+++ b/clients/client-clouddirectory/src/endpoints.ts
@@ -29,7 +29,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "clouddirectory.{region}.amazonaws.com",
     variants: [
       {
         hostname: "clouddirectory.{region}.amazonaws.com",
@@ -52,7 +51,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "clouddirectory.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "clouddirectory.{region}.amazonaws.com.cn",
@@ -75,7 +73,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "clouddirectory.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "clouddirectory.{region}.c2s.ic.gov",
@@ -86,7 +83,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "clouddirectory.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "clouddirectory.{region}.sc2s.sgov.gov",
@@ -97,7 +93,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "clouddirectory.{region}.amazonaws.com",
     variants: [
       {
         hostname: "clouddirectory.{region}.amazonaws.com",

--- a/clients/client-cloudformation/src/endpoints.ts
+++ b/clients/client-cloudformation/src/endpoints.ts
@@ -3,7 +3,6 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
   "us-east-1": {
-    hostname: "cloudformation.us-east-1.amazonaws.com",
     variants: [
       {
         hostname: "cloudformation.us-east-1.amazonaws.com",
@@ -16,7 +15,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-east-2": {
-    hostname: "cloudformation.us-east-2.amazonaws.com",
     variants: [
       {
         hostname: "cloudformation.us-east-2.amazonaws.com",
@@ -29,7 +27,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-gov-east-1": {
-    hostname: "cloudformation.us-gov-east-1.amazonaws.com",
     variants: [
       {
         hostname: "cloudformation.us-gov-east-1.amazonaws.com",
@@ -39,7 +36,6 @@ const regionHash: RegionHash = {
     signingRegion: "us-gov-east-1",
   },
   "us-gov-west-1": {
-    hostname: "cloudformation.us-gov-west-1.amazonaws.com",
     variants: [
       {
         hostname: "cloudformation.us-gov-west-1.amazonaws.com",
@@ -49,7 +45,6 @@ const regionHash: RegionHash = {
     signingRegion: "us-gov-west-1",
   },
   "us-west-1": {
-    hostname: "cloudformation.us-west-1.amazonaws.com",
     variants: [
       {
         hostname: "cloudformation.us-west-1.amazonaws.com",
@@ -62,7 +57,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-west-2": {
-    hostname: "cloudformation.us-west-2.amazonaws.com",
     variants: [
       {
         hostname: "cloudformation.us-west-2.amazonaws.com",
@@ -106,7 +100,6 @@ const partitionHash: PartitionHash = {
       "us-west-2-fips",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "cloudformation.{region}.amazonaws.com",
     variants: [
       {
         hostname: "cloudformation.{region}.amazonaws.com",
@@ -129,7 +122,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "cloudformation.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "cloudformation.{region}.amazonaws.com.cn",
@@ -152,7 +144,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "cloudformation.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "cloudformation.{region}.c2s.ic.gov",
@@ -163,7 +154,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "cloudformation.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "cloudformation.{region}.sc2s.sgov.gov",
@@ -174,7 +164,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "cloudformation.{region}.amazonaws.com",
     variants: [
       {
         hostname: "cloudformation.{region}.amazonaws.com",

--- a/clients/client-cloudfront/src/endpoints.ts
+++ b/clients/client-cloudfront/src/endpoints.ts
@@ -3,7 +3,6 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
   "aws-cn-global": {
-    hostname: "cloudfront.cn-northwest-1.amazonaws.com.cn",
     variants: [
       {
         hostname: "cloudfront.cn-northwest-1.amazonaws.com.cn",
@@ -13,7 +12,6 @@ const regionHash: RegionHash = {
     signingRegion: "cn-northwest-1",
   },
   "aws-global": {
-    hostname: "cloudfront.amazonaws.com",
     variants: [
       {
         hostname: "cloudfront.amazonaws.com",
@@ -51,7 +49,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "cloudfront.{region}.amazonaws.com",
     variants: [
       {
         hostname: "cloudfront.{region}.amazonaws.com",
@@ -75,7 +72,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["aws-cn-global", "cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "cloudfront.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "cloudfront.{region}.amazonaws.com.cn",
@@ -99,7 +95,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "cloudfront.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "cloudfront.{region}.c2s.ic.gov",
@@ -110,7 +105,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "cloudfront.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "cloudfront.{region}.sc2s.sgov.gov",
@@ -121,7 +115,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "cloudfront.{region}.amazonaws.com",
     variants: [
       {
         hostname: "cloudfront.{region}.amazonaws.com",

--- a/clients/client-cloudhsm-v2/src/endpoints.ts
+++ b/clients/client-cloudhsm-v2/src/endpoints.ts
@@ -29,7 +29,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "cloudhsmv2.{region}.amazonaws.com",
     variants: [
       {
         hostname: "cloudhsmv2.{region}.amazonaws.com",
@@ -52,7 +51,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "cloudhsmv2.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "cloudhsmv2.{region}.amazonaws.com.cn",
@@ -75,7 +73,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "cloudhsmv2.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "cloudhsmv2.{region}.c2s.ic.gov",
@@ -86,7 +83,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "cloudhsmv2.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "cloudhsmv2.{region}.sc2s.sgov.gov",
@@ -97,7 +93,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "cloudhsmv2.{region}.amazonaws.com",
     variants: [
       {
         hostname: "cloudhsmv2.{region}.amazonaws.com",

--- a/clients/client-cloudhsm/src/endpoints.ts
+++ b/clients/client-cloudhsm/src/endpoints.ts
@@ -29,7 +29,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "cloudhsm.{region}.amazonaws.com",
     variants: [
       {
         hostname: "cloudhsm.{region}.amazonaws.com",
@@ -52,7 +51,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "cloudhsm.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "cloudhsm.{region}.amazonaws.com.cn",
@@ -75,7 +73,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "cloudhsm.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "cloudhsm.{region}.c2s.ic.gov",
@@ -86,7 +83,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "cloudhsm.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "cloudhsm.{region}.sc2s.sgov.gov",
@@ -97,7 +93,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "cloudhsm.{region}.amazonaws.com",
     variants: [
       {
         hostname: "cloudhsm.{region}.amazonaws.com",

--- a/clients/client-cloudsearch-domain/src/endpoints.ts
+++ b/clients/client-cloudsearch-domain/src/endpoints.ts
@@ -29,7 +29,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "cloudsearchdomain.{region}.amazonaws.com",
     variants: [
       {
         hostname: "cloudsearchdomain.{region}.amazonaws.com",
@@ -52,7 +51,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "cloudsearchdomain.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "cloudsearchdomain.{region}.amazonaws.com.cn",
@@ -75,7 +73,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "cloudsearchdomain.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "cloudsearchdomain.{region}.c2s.ic.gov",
@@ -86,7 +83,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "cloudsearchdomain.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "cloudsearchdomain.{region}.sc2s.sgov.gov",
@@ -97,7 +93,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "cloudsearchdomain.{region}.amazonaws.com",
     variants: [
       {
         hostname: "cloudsearchdomain.{region}.amazonaws.com",

--- a/clients/client-cloudsearch/src/endpoints.ts
+++ b/clients/client-cloudsearch/src/endpoints.ts
@@ -29,7 +29,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "cloudsearch.{region}.amazonaws.com",
     variants: [
       {
         hostname: "cloudsearch.{region}.amazonaws.com",
@@ -52,7 +51,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "cloudsearch.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "cloudsearch.{region}.amazonaws.com.cn",
@@ -75,7 +73,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "cloudsearch.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "cloudsearch.{region}.c2s.ic.gov",
@@ -86,7 +83,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "cloudsearch.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "cloudsearch.{region}.sc2s.sgov.gov",
@@ -97,7 +93,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "cloudsearch.{region}.amazonaws.com",
     variants: [
       {
         hostname: "cloudsearch.{region}.amazonaws.com",

--- a/clients/client-cloudtrail/src/endpoints.ts
+++ b/clients/client-cloudtrail/src/endpoints.ts
@@ -3,7 +3,6 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
   "us-east-1": {
-    hostname: "cloudtrail.us-east-1.amazonaws.com",
     variants: [
       {
         hostname: "cloudtrail.us-east-1.amazonaws.com",
@@ -16,7 +15,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-east-2": {
-    hostname: "cloudtrail.us-east-2.amazonaws.com",
     variants: [
       {
         hostname: "cloudtrail.us-east-2.amazonaws.com",
@@ -29,7 +27,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-gov-east-1": {
-    hostname: "cloudtrail.us-gov-east-1.amazonaws.com",
     variants: [
       {
         hostname: "cloudtrail.us-gov-east-1.amazonaws.com",
@@ -39,7 +36,6 @@ const regionHash: RegionHash = {
     signingRegion: "us-gov-east-1",
   },
   "us-gov-west-1": {
-    hostname: "cloudtrail.us-gov-west-1.amazonaws.com",
     variants: [
       {
         hostname: "cloudtrail.us-gov-west-1.amazonaws.com",
@@ -49,7 +45,6 @@ const regionHash: RegionHash = {
     signingRegion: "us-gov-west-1",
   },
   "us-west-1": {
-    hostname: "cloudtrail.us-west-1.amazonaws.com",
     variants: [
       {
         hostname: "cloudtrail.us-west-1.amazonaws.com",
@@ -62,7 +57,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-west-2": {
-    hostname: "cloudtrail.us-west-2.amazonaws.com",
     variants: [
       {
         hostname: "cloudtrail.us-west-2.amazonaws.com",
@@ -106,7 +100,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "cloudtrail.{region}.amazonaws.com",
     variants: [
       {
         hostname: "cloudtrail.{region}.amazonaws.com",
@@ -129,7 +122,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "cloudtrail.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "cloudtrail.{region}.amazonaws.com.cn",
@@ -152,7 +144,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "cloudtrail.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "cloudtrail.{region}.c2s.ic.gov",
@@ -163,7 +154,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "cloudtrail.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "cloudtrail.{region}.sc2s.sgov.gov",
@@ -174,7 +164,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "cloudtrail.{region}.amazonaws.com",
     variants: [
       {
         hostname: "cloudtrail.{region}.amazonaws.com",

--- a/clients/client-cloudwatch-events/src/endpoints.ts
+++ b/clients/client-cloudwatch-events/src/endpoints.ts
@@ -3,7 +3,6 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
   "us-east-1": {
-    hostname: "events.us-east-1.amazonaws.com",
     variants: [
       {
         hostname: "events.us-east-1.amazonaws.com",
@@ -16,7 +15,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-east-2": {
-    hostname: "events.us-east-2.amazonaws.com",
     variants: [
       {
         hostname: "events.us-east-2.amazonaws.com",
@@ -29,7 +27,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-gov-east-1": {
-    hostname: "events.us-gov-east-1.amazonaws.com",
     variants: [
       {
         hostname: "events.us-gov-east-1.amazonaws.com",
@@ -39,7 +36,6 @@ const regionHash: RegionHash = {
     signingRegion: "us-gov-east-1",
   },
   "us-gov-west-1": {
-    hostname: "events.us-gov-west-1.amazonaws.com",
     variants: [
       {
         hostname: "events.us-gov-west-1.amazonaws.com",
@@ -49,7 +45,6 @@ const regionHash: RegionHash = {
     signingRegion: "us-gov-west-1",
   },
   "us-west-1": {
-    hostname: "events.us-west-1.amazonaws.com",
     variants: [
       {
         hostname: "events.us-west-1.amazonaws.com",
@@ -62,7 +57,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-west-2": {
-    hostname: "events.us-west-2.amazonaws.com",
     variants: [
       {
         hostname: "events.us-west-2.amazonaws.com",
@@ -106,7 +100,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "events.{region}.amazonaws.com",
     variants: [
       {
         hostname: "events.{region}.amazonaws.com",
@@ -129,7 +122,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "events.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "events.{region}.amazonaws.com.cn",
@@ -152,7 +144,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "events.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "events.{region}.c2s.ic.gov",
@@ -163,7 +154,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "events.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "events.{region}.sc2s.sgov.gov",
@@ -174,7 +164,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "events.{region}.amazonaws.com",
     variants: [
       {
         hostname: "events.{region}.amazonaws.com",

--- a/clients/client-cloudwatch-logs/src/endpoints.ts
+++ b/clients/client-cloudwatch-logs/src/endpoints.ts
@@ -3,7 +3,6 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
   "us-east-1": {
-    hostname: "logs.us-east-1.amazonaws.com",
     variants: [
       {
         hostname: "logs.us-east-1.amazonaws.com",
@@ -16,7 +15,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-east-2": {
-    hostname: "logs.us-east-2.amazonaws.com",
     variants: [
       {
         hostname: "logs.us-east-2.amazonaws.com",
@@ -29,7 +27,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-gov-east-1": {
-    hostname: "logs.us-gov-east-1.amazonaws.com",
     variants: [
       {
         hostname: "logs.us-gov-east-1.amazonaws.com",
@@ -39,7 +36,6 @@ const regionHash: RegionHash = {
     signingRegion: "us-gov-east-1",
   },
   "us-gov-west-1": {
-    hostname: "logs.us-gov-west-1.amazonaws.com",
     variants: [
       {
         hostname: "logs.us-gov-west-1.amazonaws.com",
@@ -49,7 +45,6 @@ const regionHash: RegionHash = {
     signingRegion: "us-gov-west-1",
   },
   "us-west-1": {
-    hostname: "logs.us-west-1.amazonaws.com",
     variants: [
       {
         hostname: "logs.us-west-1.amazonaws.com",
@@ -62,7 +57,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-west-2": {
-    hostname: "logs.us-west-2.amazonaws.com",
     variants: [
       {
         hostname: "logs.us-west-2.amazonaws.com",
@@ -106,7 +100,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "logs.{region}.amazonaws.com",
     variants: [
       {
         hostname: "logs.{region}.amazonaws.com",
@@ -129,7 +122,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "logs.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "logs.{region}.amazonaws.com.cn",
@@ -152,7 +144,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "logs.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "logs.{region}.c2s.ic.gov",
@@ -163,7 +154,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "logs.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "logs.{region}.sc2s.sgov.gov",
@@ -174,7 +164,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "logs.{region}.amazonaws.com",
     variants: [
       {
         hostname: "logs.{region}.amazonaws.com",

--- a/clients/client-cloudwatch/src/endpoints.ts
+++ b/clients/client-cloudwatch/src/endpoints.ts
@@ -3,7 +3,6 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
   "us-east-1": {
-    hostname: "monitoring.us-east-1.amazonaws.com",
     variants: [
       {
         hostname: "monitoring.us-east-1.amazonaws.com",
@@ -16,7 +15,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-east-2": {
-    hostname: "monitoring.us-east-2.amazonaws.com",
     variants: [
       {
         hostname: "monitoring.us-east-2.amazonaws.com",
@@ -29,7 +27,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-gov-east-1": {
-    hostname: "monitoring.us-gov-east-1.amazonaws.com",
     variants: [
       {
         hostname: "monitoring.us-gov-east-1.amazonaws.com",
@@ -42,7 +39,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-gov-west-1": {
-    hostname: "monitoring.us-gov-west-1.amazonaws.com",
     variants: [
       {
         hostname: "monitoring.us-gov-west-1.amazonaws.com",
@@ -55,7 +51,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-west-1": {
-    hostname: "monitoring.us-west-1.amazonaws.com",
     variants: [
       {
         hostname: "monitoring.us-west-1.amazonaws.com",
@@ -68,7 +63,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-west-2": {
-    hostname: "monitoring.us-west-2.amazonaws.com",
     variants: [
       {
         hostname: "monitoring.us-west-2.amazonaws.com",
@@ -112,7 +106,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "monitoring.{region}.amazonaws.com",
     variants: [
       {
         hostname: "monitoring.{region}.amazonaws.com",
@@ -135,7 +128,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "monitoring.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "monitoring.{region}.amazonaws.com.cn",
@@ -158,7 +150,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "monitoring.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "monitoring.{region}.c2s.ic.gov",
@@ -169,7 +160,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "monitoring.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "monitoring.{region}.sc2s.sgov.gov",
@@ -180,7 +170,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["fips-us-gov-east-1", "fips-us-gov-west-1", "us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "monitoring.{region}.amazonaws.com",
     variants: [
       {
         hostname: "monitoring.{region}.amazonaws.com",

--- a/clients/client-codeartifact/src/endpoints.ts
+++ b/clients/client-codeartifact/src/endpoints.ts
@@ -29,7 +29,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "codeartifact.{region}.amazonaws.com",
     variants: [
       {
         hostname: "codeartifact.{region}.amazonaws.com",
@@ -52,7 +51,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "codeartifact.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "codeartifact.{region}.amazonaws.com.cn",
@@ -75,7 +73,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "codeartifact.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "codeartifact.{region}.c2s.ic.gov",
@@ -86,7 +83,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "codeartifact.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "codeartifact.{region}.sc2s.sgov.gov",
@@ -97,7 +93,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "codeartifact.{region}.amazonaws.com",
     variants: [
       {
         hostname: "codeartifact.{region}.amazonaws.com",

--- a/clients/client-codebuild/src/endpoints.ts
+++ b/clients/client-codebuild/src/endpoints.ts
@@ -3,7 +3,6 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
   "us-east-1": {
-    hostname: "codebuild.us-east-1.amazonaws.com",
     variants: [
       {
         hostname: "codebuild.us-east-1.amazonaws.com",
@@ -16,7 +15,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-east-2": {
-    hostname: "codebuild.us-east-2.amazonaws.com",
     variants: [
       {
         hostname: "codebuild.us-east-2.amazonaws.com",
@@ -29,7 +27,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-gov-east-1": {
-    hostname: "codebuild.us-gov-east-1.amazonaws.com",
     variants: [
       {
         hostname: "codebuild.us-gov-east-1.amazonaws.com",
@@ -42,7 +39,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-gov-west-1": {
-    hostname: "codebuild.us-gov-west-1.amazonaws.com",
     variants: [
       {
         hostname: "codebuild.us-gov-west-1.amazonaws.com",
@@ -55,7 +51,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-west-1": {
-    hostname: "codebuild.us-west-1.amazonaws.com",
     variants: [
       {
         hostname: "codebuild.us-west-1.amazonaws.com",
@@ -68,7 +63,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-west-2": {
-    hostname: "codebuild.us-west-2.amazonaws.com",
     variants: [
       {
         hostname: "codebuild.us-west-2.amazonaws.com",
@@ -112,7 +106,6 @@ const partitionHash: PartitionHash = {
       "us-west-2-fips",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "codebuild.{region}.amazonaws.com",
     variants: [
       {
         hostname: "codebuild.{region}.amazonaws.com",
@@ -135,7 +128,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "codebuild.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "codebuild.{region}.amazonaws.com.cn",
@@ -158,7 +150,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "codebuild.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "codebuild.{region}.c2s.ic.gov",
@@ -169,7 +160,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "codebuild.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "codebuild.{region}.sc2s.sgov.gov",
@@ -180,7 +170,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-east-1-fips", "us-gov-west-1", "us-gov-west-1-fips"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "codebuild.{region}.amazonaws.com",
     variants: [
       {
         hostname: "codebuild.{region}.amazonaws.com",

--- a/clients/client-codecommit/src/endpoints.ts
+++ b/clients/client-codecommit/src/endpoints.ts
@@ -3,7 +3,6 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
   "ca-central-1": {
-    hostname: "codecommit.ca-central-1.amazonaws.com",
     variants: [
       {
         hostname: "codecommit.ca-central-1.amazonaws.com",
@@ -16,7 +15,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-east-1": {
-    hostname: "codecommit.us-east-1.amazonaws.com",
     variants: [
       {
         hostname: "codecommit.us-east-1.amazonaws.com",
@@ -29,7 +27,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-east-2": {
-    hostname: "codecommit.us-east-2.amazonaws.com",
     variants: [
       {
         hostname: "codecommit.us-east-2.amazonaws.com",
@@ -42,7 +39,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-gov-east-1": {
-    hostname: "codecommit.us-gov-east-1.amazonaws.com",
     variants: [
       {
         hostname: "codecommit.us-gov-east-1.amazonaws.com",
@@ -55,7 +51,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-gov-west-1": {
-    hostname: "codecommit.us-gov-west-1.amazonaws.com",
     variants: [
       {
         hostname: "codecommit.us-gov-west-1.amazonaws.com",
@@ -68,7 +63,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-west-1": {
-    hostname: "codecommit.us-west-1.amazonaws.com",
     variants: [
       {
         hostname: "codecommit.us-west-1.amazonaws.com",
@@ -81,7 +75,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-west-2": {
-    hostname: "codecommit.us-west-2.amazonaws.com",
     variants: [
       {
         hostname: "codecommit.us-west-2.amazonaws.com",
@@ -127,7 +120,6 @@ const partitionHash: PartitionHash = {
       "us-west-2-fips",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "codecommit.{region}.amazonaws.com",
     variants: [
       {
         hostname: "codecommit.{region}.amazonaws.com",
@@ -150,7 +142,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "codecommit.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "codecommit.{region}.amazonaws.com.cn",
@@ -173,7 +164,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "codecommit.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "codecommit.{region}.c2s.ic.gov",
@@ -184,7 +174,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "codecommit.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "codecommit.{region}.sc2s.sgov.gov",
@@ -195,7 +184,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["fips", "us-gov-east-1", "us-gov-east-1-fips", "us-gov-west-1", "us-gov-west-1-fips"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "codecommit.{region}.amazonaws.com",
     variants: [
       {
         hostname: "codecommit.{region}.amazonaws.com",

--- a/clients/client-codedeploy/src/endpoints.ts
+++ b/clients/client-codedeploy/src/endpoints.ts
@@ -3,7 +3,6 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
   "us-east-1": {
-    hostname: "codedeploy.us-east-1.amazonaws.com",
     variants: [
       {
         hostname: "codedeploy.us-east-1.amazonaws.com",
@@ -16,7 +15,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-east-2": {
-    hostname: "codedeploy.us-east-2.amazonaws.com",
     variants: [
       {
         hostname: "codedeploy.us-east-2.amazonaws.com",
@@ -29,7 +27,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-gov-east-1": {
-    hostname: "codedeploy.us-gov-east-1.amazonaws.com",
     variants: [
       {
         hostname: "codedeploy.us-gov-east-1.amazonaws.com",
@@ -42,7 +39,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-gov-west-1": {
-    hostname: "codedeploy.us-gov-west-1.amazonaws.com",
     variants: [
       {
         hostname: "codedeploy.us-gov-west-1.amazonaws.com",
@@ -55,7 +51,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-west-1": {
-    hostname: "codedeploy.us-west-1.amazonaws.com",
     variants: [
       {
         hostname: "codedeploy.us-west-1.amazonaws.com",
@@ -68,7 +63,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-west-2": {
-    hostname: "codedeploy.us-west-2.amazonaws.com",
     variants: [
       {
         hostname: "codedeploy.us-west-2.amazonaws.com",
@@ -112,7 +106,6 @@ const partitionHash: PartitionHash = {
       "us-west-2-fips",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "codedeploy.{region}.amazonaws.com",
     variants: [
       {
         hostname: "codedeploy.{region}.amazonaws.com",
@@ -135,7 +128,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "codedeploy.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "codedeploy.{region}.amazonaws.com.cn",
@@ -158,7 +150,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "codedeploy.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "codedeploy.{region}.c2s.ic.gov",
@@ -169,7 +160,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "codedeploy.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "codedeploy.{region}.sc2s.sgov.gov",
@@ -180,7 +170,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-east-1-fips", "us-gov-west-1", "us-gov-west-1-fips"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "codedeploy.{region}.amazonaws.com",
     variants: [
       {
         hostname: "codedeploy.{region}.amazonaws.com",

--- a/clients/client-codeguru-reviewer/src/endpoints.ts
+++ b/clients/client-codeguru-reviewer/src/endpoints.ts
@@ -29,7 +29,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "codeguru-reviewer.{region}.amazonaws.com",
     variants: [
       {
         hostname: "codeguru-reviewer.{region}.amazonaws.com",
@@ -52,7 +51,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "codeguru-reviewer.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "codeguru-reviewer.{region}.amazonaws.com.cn",
@@ -75,7 +73,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "codeguru-reviewer.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "codeguru-reviewer.{region}.c2s.ic.gov",
@@ -86,7 +83,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "codeguru-reviewer.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "codeguru-reviewer.{region}.sc2s.sgov.gov",
@@ -97,7 +93,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "codeguru-reviewer.{region}.amazonaws.com",
     variants: [
       {
         hostname: "codeguru-reviewer.{region}.amazonaws.com",

--- a/clients/client-codeguruprofiler/src/endpoints.ts
+++ b/clients/client-codeguruprofiler/src/endpoints.ts
@@ -29,7 +29,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "codeguru-profiler.{region}.amazonaws.com",
     variants: [
       {
         hostname: "codeguru-profiler.{region}.amazonaws.com",
@@ -52,7 +51,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "codeguru-profiler.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "codeguru-profiler.{region}.amazonaws.com.cn",
@@ -75,7 +73,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "codeguru-profiler.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "codeguru-profiler.{region}.c2s.ic.gov",
@@ -86,7 +83,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "codeguru-profiler.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "codeguru-profiler.{region}.sc2s.sgov.gov",
@@ -97,7 +93,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "codeguru-profiler.{region}.amazonaws.com",
     variants: [
       {
         hostname: "codeguru-profiler.{region}.amazonaws.com",

--- a/clients/client-codepipeline/src/endpoints.ts
+++ b/clients/client-codepipeline/src/endpoints.ts
@@ -3,7 +3,6 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
   "ca-central-1": {
-    hostname: "codepipeline.ca-central-1.amazonaws.com",
     variants: [
       {
         hostname: "codepipeline.ca-central-1.amazonaws.com",
@@ -16,7 +15,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-east-1": {
-    hostname: "codepipeline.us-east-1.amazonaws.com",
     variants: [
       {
         hostname: "codepipeline.us-east-1.amazonaws.com",
@@ -29,7 +27,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-east-2": {
-    hostname: "codepipeline.us-east-2.amazonaws.com",
     variants: [
       {
         hostname: "codepipeline.us-east-2.amazonaws.com",
@@ -42,7 +39,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-gov-west-1": {
-    hostname: "codepipeline.us-gov-west-1.amazonaws.com",
     variants: [
       {
         hostname: "codepipeline.us-gov-west-1.amazonaws.com",
@@ -55,7 +51,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-west-1": {
-    hostname: "codepipeline.us-west-1.amazonaws.com",
     variants: [
       {
         hostname: "codepipeline.us-west-1.amazonaws.com",
@@ -68,7 +63,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-west-2": {
-    hostname: "codepipeline.us-west-2.amazonaws.com",
     variants: [
       {
         hostname: "codepipeline.us-west-2.amazonaws.com",
@@ -113,7 +107,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "codepipeline.{region}.amazonaws.com",
     variants: [
       {
         hostname: "codepipeline.{region}.amazonaws.com",
@@ -136,7 +129,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "codepipeline.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "codepipeline.{region}.amazonaws.com.cn",
@@ -159,7 +151,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "codepipeline.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "codepipeline.{region}.c2s.ic.gov",
@@ -170,7 +161,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "codepipeline.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "codepipeline.{region}.sc2s.sgov.gov",
@@ -181,7 +171,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["fips-us-gov-west-1", "us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "codepipeline.{region}.amazonaws.com",
     variants: [
       {
         hostname: "codepipeline.{region}.amazonaws.com",

--- a/clients/client-codestar-connections/src/endpoints.ts
+++ b/clients/client-codestar-connections/src/endpoints.ts
@@ -29,7 +29,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "codestar-connections.{region}.amazonaws.com",
     variants: [
       {
         hostname: "codestar-connections.{region}.amazonaws.com",
@@ -52,7 +51,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "codestar-connections.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "codestar-connections.{region}.amazonaws.com.cn",
@@ -75,7 +73,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "codestar-connections.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "codestar-connections.{region}.c2s.ic.gov",
@@ -86,7 +83,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "codestar-connections.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "codestar-connections.{region}.sc2s.sgov.gov",
@@ -97,7 +93,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "codestar-connections.{region}.amazonaws.com",
     variants: [
       {
         hostname: "codestar-connections.{region}.amazonaws.com",

--- a/clients/client-codestar-notifications/src/endpoints.ts
+++ b/clients/client-codestar-notifications/src/endpoints.ts
@@ -29,7 +29,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "codestar-notifications.{region}.amazonaws.com",
     variants: [
       {
         hostname: "codestar-notifications.{region}.amazonaws.com",
@@ -52,7 +51,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "codestar-notifications.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "codestar-notifications.{region}.amazonaws.com.cn",
@@ -75,7 +73,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "codestar-notifications.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "codestar-notifications.{region}.c2s.ic.gov",
@@ -86,7 +83,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "codestar-notifications.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "codestar-notifications.{region}.sc2s.sgov.gov",
@@ -97,7 +93,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "codestar-notifications.{region}.amazonaws.com",
     variants: [
       {
         hostname: "codestar-notifications.{region}.amazonaws.com",

--- a/clients/client-codestar/src/endpoints.ts
+++ b/clients/client-codestar/src/endpoints.ts
@@ -29,7 +29,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "codestar.{region}.amazonaws.com",
     variants: [
       {
         hostname: "codestar.{region}.amazonaws.com",
@@ -52,7 +51,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "codestar.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "codestar.{region}.amazonaws.com.cn",
@@ -75,7 +73,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "codestar.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "codestar.{region}.c2s.ic.gov",
@@ -86,7 +83,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "codestar.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "codestar.{region}.sc2s.sgov.gov",
@@ -97,7 +93,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "codestar.{region}.amazonaws.com",
     variants: [
       {
         hostname: "codestar.{region}.amazonaws.com",

--- a/clients/client-cognito-identity-provider/src/endpoints.ts
+++ b/clients/client-cognito-identity-provider/src/endpoints.ts
@@ -3,7 +3,6 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
   "us-east-1": {
-    hostname: "cognito-idp.us-east-1.amazonaws.com",
     variants: [
       {
         hostname: "cognito-idp.us-east-1.amazonaws.com",
@@ -16,7 +15,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-east-2": {
-    hostname: "cognito-idp.us-east-2.amazonaws.com",
     variants: [
       {
         hostname: "cognito-idp.us-east-2.amazonaws.com",
@@ -29,7 +27,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-gov-west-1": {
-    hostname: "cognito-idp.us-gov-west-1.amazonaws.com",
     variants: [
       {
         hostname: "cognito-idp.us-gov-west-1.amazonaws.com",
@@ -42,7 +39,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-west-1": {
-    hostname: "cognito-idp.us-west-1.amazonaws.com",
     variants: [
       {
         hostname: "cognito-idp.us-west-1.amazonaws.com",
@@ -55,7 +51,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-west-2": {
-    hostname: "cognito-idp.us-west-2.amazonaws.com",
     variants: [
       {
         hostname: "cognito-idp.us-west-2.amazonaws.com",
@@ -99,7 +94,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "cognito-idp.{region}.amazonaws.com",
     variants: [
       {
         hostname: "cognito-idp.{region}.amazonaws.com",
@@ -122,7 +116,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "cognito-idp.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "cognito-idp.{region}.amazonaws.com.cn",
@@ -145,7 +138,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "cognito-idp.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "cognito-idp.{region}.c2s.ic.gov",
@@ -156,7 +148,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "cognito-idp.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "cognito-idp.{region}.sc2s.sgov.gov",
@@ -167,7 +158,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["fips-us-gov-west-1", "us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "cognito-idp.{region}.amazonaws.com",
     variants: [
       {
         hostname: "cognito-idp.{region}.amazonaws.com",

--- a/clients/client-cognito-identity/src/endpoints.ts
+++ b/clients/client-cognito-identity/src/endpoints.ts
@@ -3,7 +3,6 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
   "us-east-1": {
-    hostname: "cognito-identity.us-east-1.amazonaws.com",
     variants: [
       {
         hostname: "cognito-identity.us-east-1.amazonaws.com",
@@ -16,7 +15,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-east-2": {
-    hostname: "cognito-identity.us-east-2.amazonaws.com",
     variants: [
       {
         hostname: "cognito-identity.us-east-2.amazonaws.com",
@@ -29,7 +27,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-gov-west-1": {
-    hostname: "cognito-identity.us-gov-west-1.amazonaws.com",
     variants: [
       {
         hostname: "cognito-identity.us-gov-west-1.amazonaws.com",
@@ -42,7 +39,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-west-2": {
-    hostname: "cognito-identity.us-west-2.amazonaws.com",
     variants: [
       {
         hostname: "cognito-identity.us-west-2.amazonaws.com",
@@ -85,7 +81,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "cognito-identity.{region}.amazonaws.com",
     variants: [
       {
         hostname: "cognito-identity.{region}.amazonaws.com",
@@ -108,7 +103,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "cognito-identity.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "cognito-identity.{region}.amazonaws.com.cn",
@@ -131,7 +125,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "cognito-identity.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "cognito-identity.{region}.c2s.ic.gov",
@@ -142,7 +135,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "cognito-identity.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "cognito-identity.{region}.sc2s.sgov.gov",
@@ -153,7 +145,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["fips-us-gov-west-1", "us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "cognito-identity.{region}.amazonaws.com",
     variants: [
       {
         hostname: "cognito-identity.{region}.amazonaws.com",

--- a/clients/client-cognito-sync/src/endpoints.ts
+++ b/clients/client-cognito-sync/src/endpoints.ts
@@ -29,7 +29,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "cognito-sync.{region}.amazonaws.com",
     variants: [
       {
         hostname: "cognito-sync.{region}.amazonaws.com",
@@ -52,7 +51,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "cognito-sync.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "cognito-sync.{region}.amazonaws.com.cn",
@@ -75,7 +73,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "cognito-sync.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "cognito-sync.{region}.c2s.ic.gov",
@@ -86,7 +83,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "cognito-sync.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "cognito-sync.{region}.sc2s.sgov.gov",
@@ -97,7 +93,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "cognito-sync.{region}.amazonaws.com",
     variants: [
       {
         hostname: "cognito-sync.{region}.amazonaws.com",

--- a/clients/client-comprehend/src/endpoints.ts
+++ b/clients/client-comprehend/src/endpoints.ts
@@ -3,7 +3,6 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
   "us-east-1": {
-    hostname: "comprehend.us-east-1.amazonaws.com",
     variants: [
       {
         hostname: "comprehend.us-east-1.amazonaws.com",
@@ -16,7 +15,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-east-2": {
-    hostname: "comprehend.us-east-2.amazonaws.com",
     variants: [
       {
         hostname: "comprehend.us-east-2.amazonaws.com",
@@ -29,7 +27,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-gov-west-1": {
-    hostname: "comprehend.us-gov-west-1.amazonaws.com",
     variants: [
       {
         hostname: "comprehend.us-gov-west-1.amazonaws.com",
@@ -42,7 +39,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-west-2": {
-    hostname: "comprehend.us-west-2.amazonaws.com",
     variants: [
       {
         hostname: "comprehend.us-west-2.amazonaws.com",
@@ -85,7 +81,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "comprehend.{region}.amazonaws.com",
     variants: [
       {
         hostname: "comprehend.{region}.amazonaws.com",
@@ -108,7 +103,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "comprehend.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "comprehend.{region}.amazonaws.com.cn",
@@ -131,7 +125,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "comprehend.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "comprehend.{region}.c2s.ic.gov",
@@ -142,7 +135,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "comprehend.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "comprehend.{region}.sc2s.sgov.gov",
@@ -153,7 +145,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["fips-us-gov-west-1", "us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "comprehend.{region}.amazonaws.com",
     variants: [
       {
         hostname: "comprehend.{region}.amazonaws.com",

--- a/clients/client-comprehendmedical/src/endpoints.ts
+++ b/clients/client-comprehendmedical/src/endpoints.ts
@@ -3,7 +3,6 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
   "us-east-1": {
-    hostname: "comprehendmedical.us-east-1.amazonaws.com",
     variants: [
       {
         hostname: "comprehendmedical.us-east-1.amazonaws.com",
@@ -16,7 +15,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-east-2": {
-    hostname: "comprehendmedical.us-east-2.amazonaws.com",
     variants: [
       {
         hostname: "comprehendmedical.us-east-2.amazonaws.com",
@@ -29,7 +27,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-gov-west-1": {
-    hostname: "comprehendmedical.us-gov-west-1.amazonaws.com",
     variants: [
       {
         hostname: "comprehendmedical.us-gov-west-1.amazonaws.com",
@@ -42,7 +39,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-west-2": {
-    hostname: "comprehendmedical.us-west-2.amazonaws.com",
     variants: [
       {
         hostname: "comprehendmedical.us-west-2.amazonaws.com",
@@ -85,7 +81,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "comprehendmedical.{region}.amazonaws.com",
     variants: [
       {
         hostname: "comprehendmedical.{region}.amazonaws.com",
@@ -108,7 +103,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "comprehendmedical.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "comprehendmedical.{region}.amazonaws.com.cn",
@@ -131,7 +125,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "comprehendmedical.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "comprehendmedical.{region}.c2s.ic.gov",
@@ -142,7 +135,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "comprehendmedical.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "comprehendmedical.{region}.sc2s.sgov.gov",
@@ -153,7 +145,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["fips-us-gov-west-1", "us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "comprehendmedical.{region}.amazonaws.com",
     variants: [
       {
         hostname: "comprehendmedical.{region}.amazonaws.com",

--- a/clients/client-compute-optimizer/src/endpoints.ts
+++ b/clients/client-compute-optimizer/src/endpoints.ts
@@ -29,7 +29,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "compute-optimizer.{region}.amazonaws.com",
     variants: [
       {
         hostname: "compute-optimizer.{region}.amazonaws.com",
@@ -52,7 +51,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "compute-optimizer.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "compute-optimizer.{region}.amazonaws.com.cn",
@@ -75,7 +73,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "compute-optimizer.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "compute-optimizer.{region}.c2s.ic.gov",
@@ -86,7 +83,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "compute-optimizer.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "compute-optimizer.{region}.sc2s.sgov.gov",
@@ -97,7 +93,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "compute-optimizer.{region}.amazonaws.com",
     variants: [
       {
         hostname: "compute-optimizer.{region}.amazonaws.com",

--- a/clients/client-config-service/src/endpoints.ts
+++ b/clients/client-config-service/src/endpoints.ts
@@ -3,7 +3,6 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
   "us-east-1": {
-    hostname: "config.us-east-1.amazonaws.com",
     variants: [
       {
         hostname: "config.us-east-1.amazonaws.com",
@@ -16,7 +15,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-east-2": {
-    hostname: "config.us-east-2.amazonaws.com",
     variants: [
       {
         hostname: "config.us-east-2.amazonaws.com",
@@ -29,7 +27,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-gov-east-1": {
-    hostname: "config.us-gov-east-1.amazonaws.com",
     variants: [
       {
         hostname: "config.us-gov-east-1.amazonaws.com",
@@ -42,7 +39,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-gov-west-1": {
-    hostname: "config.us-gov-west-1.amazonaws.com",
     variants: [
       {
         hostname: "config.us-gov-west-1.amazonaws.com",
@@ -55,7 +51,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-west-1": {
-    hostname: "config.us-west-1.amazonaws.com",
     variants: [
       {
         hostname: "config.us-west-1.amazonaws.com",
@@ -68,7 +63,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-west-2": {
-    hostname: "config.us-west-2.amazonaws.com",
     variants: [
       {
         hostname: "config.us-west-2.amazonaws.com",
@@ -112,7 +106,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "config.{region}.amazonaws.com",
     variants: [
       {
         hostname: "config.{region}.amazonaws.com",
@@ -135,7 +128,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "config.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "config.{region}.amazonaws.com.cn",
@@ -158,7 +150,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "config.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "config.{region}.c2s.ic.gov",
@@ -169,7 +160,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "config.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "config.{region}.sc2s.sgov.gov",
@@ -180,7 +170,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["fips-us-gov-east-1", "fips-us-gov-west-1", "us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "config.{region}.amazonaws.com",
     variants: [
       {
         hostname: "config.{region}.amazonaws.com",

--- a/clients/client-connect-contact-lens/src/endpoints.ts
+++ b/clients/client-connect-contact-lens/src/endpoints.ts
@@ -29,7 +29,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "contact-lens.{region}.amazonaws.com",
     variants: [
       {
         hostname: "contact-lens.{region}.amazonaws.com",
@@ -52,7 +51,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "contact-lens.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "contact-lens.{region}.amazonaws.com.cn",
@@ -75,7 +73,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "contact-lens.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "contact-lens.{region}.c2s.ic.gov",
@@ -86,7 +83,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "contact-lens.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "contact-lens.{region}.sc2s.sgov.gov",
@@ -97,7 +93,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "contact-lens.{region}.amazonaws.com",
     variants: [
       {
         hostname: "contact-lens.{region}.amazonaws.com",

--- a/clients/client-connect/src/endpoints.ts
+++ b/clients/client-connect/src/endpoints.ts
@@ -29,7 +29,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "connect.{region}.amazonaws.com",
     variants: [
       {
         hostname: "connect.{region}.amazonaws.com",
@@ -52,7 +51,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "connect.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "connect.{region}.amazonaws.com.cn",
@@ -75,7 +73,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "connect.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "connect.{region}.c2s.ic.gov",
@@ -86,7 +83,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "connect.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "connect.{region}.sc2s.sgov.gov",
@@ -97,7 +93,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "connect.{region}.amazonaws.com",
     variants: [
       {
         hostname: "connect.{region}.amazonaws.com",

--- a/clients/client-connectparticipant/src/endpoints.ts
+++ b/clients/client-connectparticipant/src/endpoints.ts
@@ -29,7 +29,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "participant.connect.{region}.amazonaws.com",
     variants: [
       {
         hostname: "participant.connect.{region}.amazonaws.com",
@@ -52,7 +51,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "participant.connect.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "participant.connect.{region}.amazonaws.com.cn",
@@ -75,7 +73,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "participant.connect.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "participant.connect.{region}.c2s.ic.gov",
@@ -86,7 +83,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "participant.connect.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "participant.connect.{region}.sc2s.sgov.gov",
@@ -97,7 +93,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "participant.connect.{region}.amazonaws.com",
     variants: [
       {
         hostname: "participant.connect.{region}.amazonaws.com",

--- a/clients/client-cost-and-usage-report-service/src/endpoints.ts
+++ b/clients/client-cost-and-usage-report-service/src/endpoints.ts
@@ -29,7 +29,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "cur.{region}.amazonaws.com",
     variants: [
       {
         hostname: "cur.{region}.amazonaws.com",
@@ -52,7 +51,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "cur.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "cur.{region}.amazonaws.com.cn",
@@ -75,7 +73,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "cur.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "cur.{region}.c2s.ic.gov",
@@ -86,7 +83,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "cur.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "cur.{region}.sc2s.sgov.gov",
@@ -97,7 +93,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "cur.{region}.amazonaws.com",
     variants: [
       {
         hostname: "cur.{region}.amazonaws.com",

--- a/clients/client-cost-explorer/src/endpoints.ts
+++ b/clients/client-cost-explorer/src/endpoints.ts
@@ -3,7 +3,6 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
   "aws-cn-global": {
-    hostname: "ce.cn-northwest-1.amazonaws.com.cn",
     variants: [
       {
         hostname: "ce.cn-northwest-1.amazonaws.com.cn",
@@ -13,7 +12,6 @@ const regionHash: RegionHash = {
     signingRegion: "cn-northwest-1",
   },
   "aws-global": {
-    hostname: "ce.us-east-1.amazonaws.com",
     variants: [
       {
         hostname: "ce.us-east-1.amazonaws.com",
@@ -51,7 +49,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "ce.{region}.amazonaws.com",
     variants: [
       {
         hostname: "ce.{region}.amazonaws.com",
@@ -75,7 +72,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["aws-cn-global", "cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "ce.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "ce.{region}.amazonaws.com.cn",
@@ -99,7 +95,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "ce.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "ce.{region}.c2s.ic.gov",
@@ -110,7 +105,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "ce.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "ce.{region}.sc2s.sgov.gov",
@@ -121,7 +115,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "ce.{region}.amazonaws.com",
     variants: [
       {
         hostname: "ce.{region}.amazonaws.com",

--- a/clients/client-customer-profiles/src/endpoints.ts
+++ b/clients/client-customer-profiles/src/endpoints.ts
@@ -29,7 +29,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "profile.{region}.amazonaws.com",
     variants: [
       {
         hostname: "profile.{region}.amazonaws.com",
@@ -52,7 +51,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "profile.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "profile.{region}.amazonaws.com.cn",
@@ -75,7 +73,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "profile.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "profile.{region}.c2s.ic.gov",
@@ -86,7 +83,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "profile.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "profile.{region}.sc2s.sgov.gov",
@@ -97,7 +93,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "profile.{region}.amazonaws.com",
     variants: [
       {
         hostname: "profile.{region}.amazonaws.com",

--- a/clients/client-data-pipeline/src/endpoints.ts
+++ b/clients/client-data-pipeline/src/endpoints.ts
@@ -29,7 +29,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "datapipeline.{region}.amazonaws.com",
     variants: [
       {
         hostname: "datapipeline.{region}.amazonaws.com",
@@ -52,7 +51,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "datapipeline.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "datapipeline.{region}.amazonaws.com.cn",
@@ -75,7 +73,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "datapipeline.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "datapipeline.{region}.c2s.ic.gov",
@@ -86,7 +83,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "datapipeline.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "datapipeline.{region}.sc2s.sgov.gov",
@@ -97,7 +93,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "datapipeline.{region}.amazonaws.com",
     variants: [
       {
         hostname: "datapipeline.{region}.amazonaws.com",

--- a/clients/client-database-migration-service/src/endpoints.ts
+++ b/clients/client-database-migration-service/src/endpoints.ts
@@ -3,7 +3,6 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
   "us-east-1": {
-    hostname: "dms.us-east-1.amazonaws.com",
     variants: [
       {
         hostname: "dms.us-east-1.amazonaws.com",
@@ -16,7 +15,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-east-2": {
-    hostname: "dms.us-east-2.amazonaws.com",
     variants: [
       {
         hostname: "dms.us-east-2.amazonaws.com",
@@ -29,7 +27,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-gov-east-1": {
-    hostname: "dms.us-gov-east-1.amazonaws.com",
     variants: [
       {
         hostname: "dms.us-gov-east-1.amazonaws.com",
@@ -42,7 +39,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-gov-west-1": {
-    hostname: "dms.us-gov-west-1.amazonaws.com",
     variants: [
       {
         hostname: "dms.us-gov-west-1.amazonaws.com",
@@ -55,7 +51,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-iso-east-1": {
-    hostname: "dms.us-iso-east-1.c2s.ic.gov",
     variants: [
       {
         hostname: "dms.us-iso-east-1.c2s.ic.gov",
@@ -68,7 +63,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-isob-east-1": {
-    hostname: "dms.us-isob-east-1.sc2s.sgov.gov",
     variants: [
       {
         hostname: "dms.us-isob-east-1.sc2s.sgov.gov",
@@ -81,7 +75,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-west-1": {
-    hostname: "dms.us-west-1.amazonaws.com",
     variants: [
       {
         hostname: "dms.us-west-1.amazonaws.com",
@@ -94,7 +87,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-west-2": {
-    hostname: "dms.us-west-2.amazonaws.com",
     variants: [
       {
         hostname: "dms.us-west-2.amazonaws.com",
@@ -140,7 +132,6 @@ const partitionHash: PartitionHash = {
       "us-west-2-fips",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "dms.{region}.amazonaws.com",
     variants: [
       {
         hostname: "dms.{region}.amazonaws.com",
@@ -163,7 +154,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "dms.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "dms.{region}.amazonaws.com.cn",
@@ -186,7 +176,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["dms", "dms-fips", "us-iso-east-1", "us-iso-east-1-fips", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "dms.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "dms.{region}.c2s.ic.gov",
@@ -201,7 +190,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["dms", "dms-fips", "us-isob-east-1", "us-isob-east-1-fips"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "dms.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "dms.{region}.sc2s.sgov.gov",
@@ -216,7 +204,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["dms", "dms-fips", "us-gov-east-1", "us-gov-east-1-fips", "us-gov-west-1", "us-gov-west-1-fips"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "dms.{region}.amazonaws.com",
     variants: [
       {
         hostname: "dms.{region}.amazonaws.com",

--- a/clients/client-databrew/src/endpoints.ts
+++ b/clients/client-databrew/src/endpoints.ts
@@ -29,7 +29,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "databrew.{region}.amazonaws.com",
     variants: [
       {
         hostname: "databrew.{region}.amazonaws.com",
@@ -52,7 +51,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "databrew.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "databrew.{region}.amazonaws.com.cn",
@@ -75,7 +73,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "databrew.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "databrew.{region}.c2s.ic.gov",
@@ -86,7 +83,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "databrew.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "databrew.{region}.sc2s.sgov.gov",
@@ -97,7 +93,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "databrew.{region}.amazonaws.com",
     variants: [
       {
         hostname: "databrew.{region}.amazonaws.com",

--- a/clients/client-dataexchange/src/endpoints.ts
+++ b/clients/client-dataexchange/src/endpoints.ts
@@ -29,7 +29,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "dataexchange.{region}.amazonaws.com",
     variants: [
       {
         hostname: "dataexchange.{region}.amazonaws.com",
@@ -52,7 +51,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "dataexchange.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "dataexchange.{region}.amazonaws.com.cn",
@@ -75,7 +73,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "dataexchange.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "dataexchange.{region}.c2s.ic.gov",
@@ -86,7 +83,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "dataexchange.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "dataexchange.{region}.sc2s.sgov.gov",
@@ -97,7 +93,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "dataexchange.{region}.amazonaws.com",
     variants: [
       {
         hostname: "dataexchange.{region}.amazonaws.com",

--- a/clients/client-datasync/src/endpoints.ts
+++ b/clients/client-datasync/src/endpoints.ts
@@ -3,7 +3,6 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
   "ca-central-1": {
-    hostname: "datasync.ca-central-1.amazonaws.com",
     variants: [
       {
         hostname: "datasync.ca-central-1.amazonaws.com",
@@ -16,7 +15,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-east-1": {
-    hostname: "datasync.us-east-1.amazonaws.com",
     variants: [
       {
         hostname: "datasync.us-east-1.amazonaws.com",
@@ -29,7 +27,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-east-2": {
-    hostname: "datasync.us-east-2.amazonaws.com",
     variants: [
       {
         hostname: "datasync.us-east-2.amazonaws.com",
@@ -42,7 +39,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-gov-east-1": {
-    hostname: "datasync.us-gov-east-1.amazonaws.com",
     variants: [
       {
         hostname: "datasync.us-gov-east-1.amazonaws.com",
@@ -55,7 +51,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-gov-west-1": {
-    hostname: "datasync.us-gov-west-1.amazonaws.com",
     variants: [
       {
         hostname: "datasync.us-gov-west-1.amazonaws.com",
@@ -68,7 +63,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-west-1": {
-    hostname: "datasync.us-west-1.amazonaws.com",
     variants: [
       {
         hostname: "datasync.us-west-1.amazonaws.com",
@@ -81,7 +75,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-west-2": {
-    hostname: "datasync.us-west-2.amazonaws.com",
     variants: [
       {
         hostname: "datasync.us-west-2.amazonaws.com",
@@ -126,7 +119,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "datasync.{region}.amazonaws.com",
     variants: [
       {
         hostname: "datasync.{region}.amazonaws.com",
@@ -149,7 +141,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "datasync.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "datasync.{region}.amazonaws.com.cn",
@@ -172,7 +163,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "datasync.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "datasync.{region}.c2s.ic.gov",
@@ -183,7 +173,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "datasync.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "datasync.{region}.sc2s.sgov.gov",
@@ -194,7 +183,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["fips-us-gov-east-1", "fips-us-gov-west-1", "us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "datasync.{region}.amazonaws.com",
     variants: [
       {
         hostname: "datasync.{region}.amazonaws.com",

--- a/clients/client-dax/src/endpoints.ts
+++ b/clients/client-dax/src/endpoints.ts
@@ -29,7 +29,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "dax.{region}.amazonaws.com",
     variants: [
       {
         hostname: "dax.{region}.amazonaws.com",
@@ -52,7 +51,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "dax.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "dax.{region}.amazonaws.com.cn",
@@ -75,7 +73,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "dax.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "dax.{region}.c2s.ic.gov",
@@ -86,7 +83,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "dax.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "dax.{region}.sc2s.sgov.gov",
@@ -97,7 +93,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "dax.{region}.amazonaws.com",
     variants: [
       {
         hostname: "dax.{region}.amazonaws.com",

--- a/clients/client-detective/src/endpoints.ts
+++ b/clients/client-detective/src/endpoints.ts
@@ -3,7 +3,6 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
   "us-east-1": {
-    hostname: "api.detective.us-east-1.amazonaws.com",
     variants: [
       {
         hostname: "api.detective.us-east-1.amazonaws.com",
@@ -16,7 +15,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-east-2": {
-    hostname: "api.detective.us-east-2.amazonaws.com",
     variants: [
       {
         hostname: "api.detective.us-east-2.amazonaws.com",
@@ -29,7 +27,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-gov-east-1": {
-    hostname: "api.detective.us-gov-east-1.amazonaws.com",
     variants: [
       {
         hostname: "api.detective.us-gov-east-1.amazonaws.com",
@@ -42,7 +39,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-gov-west-1": {
-    hostname: "api.detective.us-gov-west-1.amazonaws.com",
     variants: [
       {
         hostname: "api.detective.us-gov-west-1.amazonaws.com",
@@ -55,7 +51,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-west-1": {
-    hostname: "api.detective.us-west-1.amazonaws.com",
     variants: [
       {
         hostname: "api.detective.us-west-1.amazonaws.com",
@@ -68,7 +63,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-west-2": {
-    hostname: "api.detective.us-west-2.amazonaws.com",
     variants: [
       {
         hostname: "api.detective.us-west-2.amazonaws.com",
@@ -112,7 +106,6 @@ const partitionHash: PartitionHash = {
       "us-west-2-fips",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "api.detective.{region}.amazonaws.com",
     variants: [
       {
         hostname: "api.detective.{region}.amazonaws.com",
@@ -135,7 +128,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "api.detective.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "api.detective.{region}.amazonaws.com.cn",
@@ -158,7 +150,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "api.detective.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "api.detective.{region}.c2s.ic.gov",
@@ -169,7 +160,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "api.detective.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "api.detective.{region}.sc2s.sgov.gov",
@@ -180,7 +170,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-east-1-fips", "us-gov-west-1", "us-gov-west-1-fips"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "api.detective.{region}.amazonaws.com",
     variants: [
       {
         hostname: "api.detective.{region}.amazonaws.com",

--- a/clients/client-device-farm/src/endpoints.ts
+++ b/clients/client-device-farm/src/endpoints.ts
@@ -29,7 +29,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "devicefarm.{region}.amazonaws.com",
     variants: [
       {
         hostname: "devicefarm.{region}.amazonaws.com",
@@ -52,7 +51,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "devicefarm.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "devicefarm.{region}.amazonaws.com.cn",
@@ -75,7 +73,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "devicefarm.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "devicefarm.{region}.c2s.ic.gov",
@@ -86,7 +83,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "devicefarm.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "devicefarm.{region}.sc2s.sgov.gov",
@@ -97,7 +93,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "devicefarm.{region}.amazonaws.com",
     variants: [
       {
         hostname: "devicefarm.{region}.amazonaws.com",

--- a/clients/client-devops-guru/src/endpoints.ts
+++ b/clients/client-devops-guru/src/endpoints.ts
@@ -29,7 +29,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "devops-guru.{region}.amazonaws.com",
     variants: [
       {
         hostname: "devops-guru.{region}.amazonaws.com",
@@ -52,7 +51,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "devops-guru.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "devops-guru.{region}.amazonaws.com.cn",
@@ -75,7 +73,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "devops-guru.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "devops-guru.{region}.c2s.ic.gov",
@@ -86,7 +83,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "devops-guru.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "devops-guru.{region}.sc2s.sgov.gov",
@@ -97,7 +93,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "devops-guru.{region}.amazonaws.com",
     variants: [
       {
         hostname: "devops-guru.{region}.amazonaws.com",

--- a/clients/client-direct-connect/src/endpoints.ts
+++ b/clients/client-direct-connect/src/endpoints.ts
@@ -3,7 +3,6 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
   "us-east-1": {
-    hostname: "directconnect.us-east-1.amazonaws.com",
     variants: [
       {
         hostname: "directconnect.us-east-1.amazonaws.com",
@@ -16,7 +15,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-east-2": {
-    hostname: "directconnect.us-east-2.amazonaws.com",
     variants: [
       {
         hostname: "directconnect.us-east-2.amazonaws.com",
@@ -29,7 +27,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-gov-east-1": {
-    hostname: "directconnect.us-gov-east-1.amazonaws.com",
     variants: [
       {
         hostname: "directconnect.us-gov-east-1.amazonaws.com",
@@ -39,7 +36,6 @@ const regionHash: RegionHash = {
     signingRegion: "us-gov-east-1",
   },
   "us-gov-west-1": {
-    hostname: "directconnect.us-gov-west-1.amazonaws.com",
     variants: [
       {
         hostname: "directconnect.us-gov-west-1.amazonaws.com",
@@ -49,7 +45,6 @@ const regionHash: RegionHash = {
     signingRegion: "us-gov-west-1",
   },
   "us-west-1": {
-    hostname: "directconnect.us-west-1.amazonaws.com",
     variants: [
       {
         hostname: "directconnect.us-west-1.amazonaws.com",
@@ -62,7 +57,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-west-2": {
-    hostname: "directconnect.us-west-2.amazonaws.com",
     variants: [
       {
         hostname: "directconnect.us-west-2.amazonaws.com",
@@ -106,7 +100,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "directconnect.{region}.amazonaws.com",
     variants: [
       {
         hostname: "directconnect.{region}.amazonaws.com",
@@ -129,7 +122,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "directconnect.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "directconnect.{region}.amazonaws.com.cn",
@@ -152,7 +144,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "directconnect.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "directconnect.{region}.c2s.ic.gov",
@@ -163,7 +154,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "directconnect.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "directconnect.{region}.sc2s.sgov.gov",
@@ -174,7 +164,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "directconnect.{region}.amazonaws.com",
     variants: [
       {
         hostname: "directconnect.{region}.amazonaws.com",

--- a/clients/client-directory-service/src/endpoints.ts
+++ b/clients/client-directory-service/src/endpoints.ts
@@ -3,7 +3,6 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
   "ca-central-1": {
-    hostname: "ds.ca-central-1.amazonaws.com",
     variants: [
       {
         hostname: "ds.ca-central-1.amazonaws.com",
@@ -16,7 +15,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-east-1": {
-    hostname: "ds.us-east-1.amazonaws.com",
     variants: [
       {
         hostname: "ds.us-east-1.amazonaws.com",
@@ -29,7 +27,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-east-2": {
-    hostname: "ds.us-east-2.amazonaws.com",
     variants: [
       {
         hostname: "ds.us-east-2.amazonaws.com",
@@ -42,7 +39,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-gov-east-1": {
-    hostname: "ds.us-gov-east-1.amazonaws.com",
     variants: [
       {
         hostname: "ds.us-gov-east-1.amazonaws.com",
@@ -55,7 +51,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-gov-west-1": {
-    hostname: "ds.us-gov-west-1.amazonaws.com",
     variants: [
       {
         hostname: "ds.us-gov-west-1.amazonaws.com",
@@ -68,7 +63,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-west-1": {
-    hostname: "ds.us-west-1.amazonaws.com",
     variants: [
       {
         hostname: "ds.us-west-1.amazonaws.com",
@@ -81,7 +75,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-west-2": {
-    hostname: "ds.us-west-2.amazonaws.com",
     variants: [
       {
         hostname: "ds.us-west-2.amazonaws.com",
@@ -126,7 +119,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "ds.{region}.amazonaws.com",
     variants: [
       {
         hostname: "ds.{region}.amazonaws.com",
@@ -149,7 +141,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "ds.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "ds.{region}.amazonaws.com.cn",
@@ -172,7 +163,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "ds.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "ds.{region}.c2s.ic.gov",
@@ -183,7 +173,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "ds.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "ds.{region}.sc2s.sgov.gov",
@@ -194,7 +183,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["fips-us-gov-east-1", "fips-us-gov-west-1", "us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "ds.{region}.amazonaws.com",
     variants: [
       {
         hostname: "ds.{region}.amazonaws.com",

--- a/clients/client-dlm/src/endpoints.ts
+++ b/clients/client-dlm/src/endpoints.ts
@@ -29,7 +29,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "dlm.{region}.amazonaws.com",
     variants: [
       {
         hostname: "dlm.{region}.amazonaws.com",
@@ -52,7 +51,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "dlm.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "dlm.{region}.amazonaws.com.cn",
@@ -75,7 +73,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "dlm.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "dlm.{region}.c2s.ic.gov",
@@ -86,7 +83,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "dlm.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "dlm.{region}.sc2s.sgov.gov",
@@ -97,7 +93,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "dlm.{region}.amazonaws.com",
     variants: [
       {
         hostname: "dlm.{region}.amazonaws.com",

--- a/clients/client-docdb/src/endpoints.ts
+++ b/clients/client-docdb/src/endpoints.ts
@@ -3,7 +3,6 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
   "ca-central-1": {
-    hostname: "rds.ca-central-1.amazonaws.com",
     variants: [
       {
         hostname: "rds.ca-central-1.amazonaws.com",
@@ -16,7 +15,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-east-1": {
-    hostname: "rds.us-east-1.amazonaws.com",
     variants: [
       {
         hostname: "rds.us-east-1.amazonaws.com",
@@ -29,7 +27,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-east-2": {
-    hostname: "rds.us-east-2.amazonaws.com",
     variants: [
       {
         hostname: "rds.us-east-2.amazonaws.com",
@@ -42,7 +39,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-gov-east-1": {
-    hostname: "rds.us-gov-east-1.amazonaws.com",
     variants: [
       {
         hostname: "rds.us-gov-east-1.amazonaws.com",
@@ -55,7 +51,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-gov-west-1": {
-    hostname: "rds.us-gov-west-1.amazonaws.com",
     variants: [
       {
         hostname: "rds.us-gov-west-1.amazonaws.com",
@@ -68,7 +63,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-west-1": {
-    hostname: "rds.us-west-1.amazonaws.com",
     variants: [
       {
         hostname: "rds.us-west-1.amazonaws.com",
@@ -81,7 +75,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-west-2": {
-    hostname: "rds.us-west-2.amazonaws.com",
     variants: [
       {
         hostname: "rds.us-west-2.amazonaws.com",
@@ -136,7 +129,6 @@ const partitionHash: PartitionHash = {
       "us-west-2-fips",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "rds.{region}.amazonaws.com",
     variants: [
       {
         hostname: "rds.{region}.amazonaws.com",
@@ -159,7 +151,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "rds.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "rds.{region}.amazonaws.com.cn",
@@ -182,7 +173,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "rds.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "rds.{region}.c2s.ic.gov",
@@ -193,7 +183,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "rds.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "rds.{region}.sc2s.sgov.gov",
@@ -211,7 +200,6 @@ const partitionHash: PartitionHash = {
       "us-gov-west-1-fips",
     ],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "rds.{region}.amazonaws.com",
     variants: [
       {
         hostname: "rds.{region}.amazonaws.com",

--- a/clients/client-dynamodb-streams/src/endpoints.ts
+++ b/clients/client-dynamodb-streams/src/endpoints.ts
@@ -3,7 +3,6 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
   "ca-central-1-fips": {
-    hostname: "dynamodb-fips.ca-central-1.amazonaws.com",
     variants: [
       {
         hostname: "dynamodb-fips.ca-central-1.amazonaws.com",
@@ -13,7 +12,6 @@ const regionHash: RegionHash = {
     signingRegion: "ca-central-1",
   },
   local: {
-    hostname: "localhost:8000",
     variants: [
       {
         hostname: "localhost:8000",
@@ -23,7 +21,6 @@ const regionHash: RegionHash = {
     signingRegion: "us-east-1",
   },
   "us-east-1-fips": {
-    hostname: "dynamodb-fips.us-east-1.amazonaws.com",
     variants: [
       {
         hostname: "dynamodb-fips.us-east-1.amazonaws.com",
@@ -33,7 +30,6 @@ const regionHash: RegionHash = {
     signingRegion: "us-east-1",
   },
   "us-east-2-fips": {
-    hostname: "dynamodb-fips.us-east-2.amazonaws.com",
     variants: [
       {
         hostname: "dynamodb-fips.us-east-2.amazonaws.com",
@@ -43,7 +39,6 @@ const regionHash: RegionHash = {
     signingRegion: "us-east-2",
   },
   "us-gov-east-1-fips": {
-    hostname: "dynamodb.us-gov-east-1.amazonaws.com",
     variants: [
       {
         hostname: "dynamodb.us-gov-east-1.amazonaws.com",
@@ -53,7 +48,6 @@ const regionHash: RegionHash = {
     signingRegion: "us-gov-east-1",
   },
   "us-gov-west-1-fips": {
-    hostname: "dynamodb.us-gov-west-1.amazonaws.com",
     variants: [
       {
         hostname: "dynamodb.us-gov-west-1.amazonaws.com",
@@ -63,7 +57,6 @@ const regionHash: RegionHash = {
     signingRegion: "us-gov-west-1",
   },
   "us-west-1-fips": {
-    hostname: "dynamodb-fips.us-west-1.amazonaws.com",
     variants: [
       {
         hostname: "dynamodb-fips.us-west-1.amazonaws.com",
@@ -73,7 +66,6 @@ const regionHash: RegionHash = {
     signingRegion: "us-west-1",
   },
   "us-west-2-fips": {
-    hostname: "dynamodb-fips.us-west-2.amazonaws.com",
     variants: [
       {
         hostname: "dynamodb-fips.us-west-2.amazonaws.com",
@@ -116,7 +108,6 @@ const partitionHash: PartitionHash = {
       "us-west-2-fips",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "streams.dynamodb.{region}.amazonaws.com",
     variants: [
       {
         hostname: "streams.dynamodb.{region}.amazonaws.com",
@@ -139,7 +130,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "streams.dynamodb.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "streams.dynamodb.{region}.amazonaws.com.cn",
@@ -162,7 +152,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "streams.dynamodb.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "streams.dynamodb.{region}.c2s.ic.gov",
@@ -173,7 +162,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "streams.dynamodb.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "streams.dynamodb.{region}.sc2s.sgov.gov",
@@ -184,7 +172,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-east-1-fips", "us-gov-west-1", "us-gov-west-1-fips"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "streams.dynamodb.{region}.amazonaws.com",
     variants: [
       {
         hostname: "streams.dynamodb.{region}.amazonaws.com",

--- a/clients/client-dynamodb/src/endpoints.ts
+++ b/clients/client-dynamodb/src/endpoints.ts
@@ -3,7 +3,6 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
   "ca-central-1": {
-    hostname: "dynamodb.ca-central-1.amazonaws.com",
     variants: [
       {
         hostname: "dynamodb.ca-central-1.amazonaws.com",
@@ -16,7 +15,6 @@ const regionHash: RegionHash = {
     ],
   },
   local: {
-    hostname: "localhost:8000",
     variants: [
       {
         hostname: "localhost:8000",
@@ -26,7 +24,6 @@ const regionHash: RegionHash = {
     signingRegion: "us-east-1",
   },
   "us-east-1": {
-    hostname: "dynamodb.us-east-1.amazonaws.com",
     variants: [
       {
         hostname: "dynamodb.us-east-1.amazonaws.com",
@@ -39,7 +36,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-east-2": {
-    hostname: "dynamodb.us-east-2.amazonaws.com",
     variants: [
       {
         hostname: "dynamodb.us-east-2.amazonaws.com",
@@ -52,7 +48,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-gov-east-1": {
-    hostname: "dynamodb.us-gov-east-1.amazonaws.com",
     variants: [
       {
         hostname: "dynamodb.us-gov-east-1.amazonaws.com",
@@ -65,7 +60,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-gov-west-1": {
-    hostname: "dynamodb.us-gov-west-1.amazonaws.com",
     variants: [
       {
         hostname: "dynamodb.us-gov-west-1.amazonaws.com",
@@ -78,7 +72,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-west-1": {
-    hostname: "dynamodb.us-west-1.amazonaws.com",
     variants: [
       {
         hostname: "dynamodb.us-west-1.amazonaws.com",
@@ -91,7 +84,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-west-2": {
-    hostname: "dynamodb.us-west-2.amazonaws.com",
     variants: [
       {
         hostname: "dynamodb.us-west-2.amazonaws.com",
@@ -137,7 +129,6 @@ const partitionHash: PartitionHash = {
       "us-west-2-fips",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "dynamodb.{region}.amazonaws.com",
     variants: [
       {
         hostname: "dynamodb.{region}.amazonaws.com",
@@ -160,7 +151,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "dynamodb.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "dynamodb.{region}.amazonaws.com.cn",
@@ -183,7 +173,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "dynamodb.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "dynamodb.{region}.c2s.ic.gov",
@@ -194,7 +183,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "dynamodb.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "dynamodb.{region}.sc2s.sgov.gov",
@@ -205,7 +193,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-east-1-fips", "us-gov-west-1", "us-gov-west-1-fips"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "dynamodb.{region}.amazonaws.com",
     variants: [
       {
         hostname: "dynamodb.{region}.amazonaws.com",

--- a/clients/client-ebs/src/endpoints.ts
+++ b/clients/client-ebs/src/endpoints.ts
@@ -3,7 +3,6 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
   "ca-central-1": {
-    hostname: "ebs.ca-central-1.amazonaws.com",
     variants: [
       {
         hostname: "ebs.ca-central-1.amazonaws.com",
@@ -16,7 +15,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-east-1": {
-    hostname: "ebs.us-east-1.amazonaws.com",
     variants: [
       {
         hostname: "ebs.us-east-1.amazonaws.com",
@@ -29,7 +27,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-east-2": {
-    hostname: "ebs.us-east-2.amazonaws.com",
     variants: [
       {
         hostname: "ebs.us-east-2.amazonaws.com",
@@ -42,7 +39,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-west-1": {
-    hostname: "ebs.us-west-1.amazonaws.com",
     variants: [
       {
         hostname: "ebs.us-west-1.amazonaws.com",
@@ -55,7 +51,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-west-2": {
-    hostname: "ebs.us-west-2.amazonaws.com",
     variants: [
       {
         hostname: "ebs.us-west-2.amazonaws.com",
@@ -100,7 +95,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "ebs.{region}.amazonaws.com",
     variants: [
       {
         hostname: "ebs.{region}.amazonaws.com",
@@ -123,7 +117,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "ebs.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "ebs.{region}.amazonaws.com.cn",
@@ -146,7 +139,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "ebs.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "ebs.{region}.c2s.ic.gov",
@@ -157,7 +149,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "ebs.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "ebs.{region}.sc2s.sgov.gov",
@@ -168,7 +159,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "ebs.{region}.amazonaws.com",
     variants: [
       {
         hostname: "ebs.{region}.amazonaws.com",

--- a/clients/client-ec2-instance-connect/src/endpoints.ts
+++ b/clients/client-ec2-instance-connect/src/endpoints.ts
@@ -29,7 +29,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "ec2-instance-connect.{region}.amazonaws.com",
     variants: [
       {
         hostname: "ec2-instance-connect.{region}.amazonaws.com",
@@ -52,7 +51,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "ec2-instance-connect.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "ec2-instance-connect.{region}.amazonaws.com.cn",
@@ -75,7 +73,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "ec2-instance-connect.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "ec2-instance-connect.{region}.c2s.ic.gov",
@@ -86,7 +83,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "ec2-instance-connect.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "ec2-instance-connect.{region}.sc2s.sgov.gov",
@@ -97,7 +93,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "ec2-instance-connect.{region}.amazonaws.com",
     variants: [
       {
         hostname: "ec2-instance-connect.{region}.amazonaws.com",

--- a/clients/client-ec2/src/endpoints.ts
+++ b/clients/client-ec2/src/endpoints.ts
@@ -3,7 +3,6 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
   "ap-south-1": {
-    hostname: "ec2.ap-south-1.amazonaws.com",
     variants: [
       {
         hostname: "ec2.ap-south-1.amazonaws.com",
@@ -16,7 +15,6 @@ const regionHash: RegionHash = {
     ],
   },
   "ca-central-1": {
-    hostname: "ec2.ca-central-1.amazonaws.com",
     variants: [
       {
         hostname: "ec2.ca-central-1.amazonaws.com",
@@ -29,7 +27,6 @@ const regionHash: RegionHash = {
     ],
   },
   "eu-west-1": {
-    hostname: "ec2.eu-west-1.amazonaws.com",
     variants: [
       {
         hostname: "ec2.eu-west-1.amazonaws.com",
@@ -42,7 +39,6 @@ const regionHash: RegionHash = {
     ],
   },
   "sa-east-1": {
-    hostname: "ec2.sa-east-1.amazonaws.com",
     variants: [
       {
         hostname: "ec2.sa-east-1.amazonaws.com",
@@ -55,7 +51,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-east-1": {
-    hostname: "ec2.us-east-1.amazonaws.com",
     variants: [
       {
         hostname: "ec2.us-east-1.amazonaws.com",
@@ -72,7 +67,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-east-2": {
-    hostname: "ec2.us-east-2.amazonaws.com",
     variants: [
       {
         hostname: "ec2.us-east-2.amazonaws.com",
@@ -89,7 +83,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-gov-east-1": {
-    hostname: "ec2.us-gov-east-1.amazonaws.com",
     variants: [
       {
         hostname: "ec2.us-gov-east-1.amazonaws.com",
@@ -99,7 +92,6 @@ const regionHash: RegionHash = {
     signingRegion: "us-gov-east-1",
   },
   "us-gov-west-1": {
-    hostname: "ec2.us-gov-west-1.amazonaws.com",
     variants: [
       {
         hostname: "ec2.us-gov-west-1.amazonaws.com",
@@ -109,7 +101,6 @@ const regionHash: RegionHash = {
     signingRegion: "us-gov-west-1",
   },
   "us-west-1": {
-    hostname: "ec2.us-west-1.amazonaws.com",
     variants: [
       {
         hostname: "ec2.us-west-1.amazonaws.com",
@@ -122,7 +113,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-west-2": {
-    hostname: "ec2.us-west-2.amazonaws.com",
     variants: [
       {
         hostname: "ec2.us-west-2.amazonaws.com",
@@ -171,7 +161,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "ec2.{region}.amazonaws.com",
     variants: [
       {
         hostname: "ec2.{region}.amazonaws.com",
@@ -194,7 +183,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "ec2.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "ec2.{region}.amazonaws.com.cn",
@@ -217,7 +205,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "ec2.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "ec2.{region}.c2s.ic.gov",
@@ -228,7 +215,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "ec2.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "ec2.{region}.sc2s.sgov.gov",
@@ -239,7 +225,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "ec2.{region}.amazonaws.com",
     variants: [
       {
         hostname: "ec2.{region}.amazonaws.com",

--- a/clients/client-ecr-public/src/endpoints.ts
+++ b/clients/client-ecr-public/src/endpoints.ts
@@ -29,7 +29,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "api.ecr-public.{region}.amazonaws.com",
     variants: [
       {
         hostname: "api.ecr-public.{region}.amazonaws.com",
@@ -52,7 +51,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "api.ecr-public.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "api.ecr-public.{region}.amazonaws.com.cn",
@@ -75,7 +73,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "api.ecr-public.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "api.ecr-public.{region}.c2s.ic.gov",
@@ -86,7 +83,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "api.ecr-public.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "api.ecr-public.{region}.sc2s.sgov.gov",
@@ -97,7 +93,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "api.ecr-public.{region}.amazonaws.com",
     variants: [
       {
         hostname: "api.ecr-public.{region}.amazonaws.com",

--- a/clients/client-ecr/src/endpoints.ts
+++ b/clients/client-ecr/src/endpoints.ts
@@ -3,7 +3,6 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
   "af-south-1": {
-    hostname: "api.ecr.af-south-1.amazonaws.com",
     variants: [
       {
         hostname: "api.ecr.af-south-1.amazonaws.com",
@@ -13,7 +12,6 @@ const regionHash: RegionHash = {
     signingRegion: "af-south-1",
   },
   "ap-east-1": {
-    hostname: "api.ecr.ap-east-1.amazonaws.com",
     variants: [
       {
         hostname: "api.ecr.ap-east-1.amazonaws.com",
@@ -23,7 +21,6 @@ const regionHash: RegionHash = {
     signingRegion: "ap-east-1",
   },
   "ap-northeast-1": {
-    hostname: "api.ecr.ap-northeast-1.amazonaws.com",
     variants: [
       {
         hostname: "api.ecr.ap-northeast-1.amazonaws.com",
@@ -33,7 +30,6 @@ const regionHash: RegionHash = {
     signingRegion: "ap-northeast-1",
   },
   "ap-northeast-2": {
-    hostname: "api.ecr.ap-northeast-2.amazonaws.com",
     variants: [
       {
         hostname: "api.ecr.ap-northeast-2.amazonaws.com",
@@ -43,7 +39,6 @@ const regionHash: RegionHash = {
     signingRegion: "ap-northeast-2",
   },
   "ap-northeast-3": {
-    hostname: "api.ecr.ap-northeast-3.amazonaws.com",
     variants: [
       {
         hostname: "api.ecr.ap-northeast-3.amazonaws.com",
@@ -53,7 +48,6 @@ const regionHash: RegionHash = {
     signingRegion: "ap-northeast-3",
   },
   "ap-south-1": {
-    hostname: "api.ecr.ap-south-1.amazonaws.com",
     variants: [
       {
         hostname: "api.ecr.ap-south-1.amazonaws.com",
@@ -63,7 +57,6 @@ const regionHash: RegionHash = {
     signingRegion: "ap-south-1",
   },
   "ap-southeast-1": {
-    hostname: "api.ecr.ap-southeast-1.amazonaws.com",
     variants: [
       {
         hostname: "api.ecr.ap-southeast-1.amazonaws.com",
@@ -73,7 +66,6 @@ const regionHash: RegionHash = {
     signingRegion: "ap-southeast-1",
   },
   "ap-southeast-2": {
-    hostname: "api.ecr.ap-southeast-2.amazonaws.com",
     variants: [
       {
         hostname: "api.ecr.ap-southeast-2.amazonaws.com",
@@ -83,7 +75,6 @@ const regionHash: RegionHash = {
     signingRegion: "ap-southeast-2",
   },
   "ca-central-1": {
-    hostname: "api.ecr.ca-central-1.amazonaws.com",
     variants: [
       {
         hostname: "api.ecr.ca-central-1.amazonaws.com",
@@ -93,7 +84,6 @@ const regionHash: RegionHash = {
     signingRegion: "ca-central-1",
   },
   "cn-north-1": {
-    hostname: "api.ecr.cn-north-1.amazonaws.com.cn",
     variants: [
       {
         hostname: "api.ecr.cn-north-1.amazonaws.com.cn",
@@ -103,7 +93,6 @@ const regionHash: RegionHash = {
     signingRegion: "cn-north-1",
   },
   "cn-northwest-1": {
-    hostname: "api.ecr.cn-northwest-1.amazonaws.com.cn",
     variants: [
       {
         hostname: "api.ecr.cn-northwest-1.amazonaws.com.cn",
@@ -113,7 +102,6 @@ const regionHash: RegionHash = {
     signingRegion: "cn-northwest-1",
   },
   "eu-central-1": {
-    hostname: "api.ecr.eu-central-1.amazonaws.com",
     variants: [
       {
         hostname: "api.ecr.eu-central-1.amazonaws.com",
@@ -123,7 +111,6 @@ const regionHash: RegionHash = {
     signingRegion: "eu-central-1",
   },
   "eu-north-1": {
-    hostname: "api.ecr.eu-north-1.amazonaws.com",
     variants: [
       {
         hostname: "api.ecr.eu-north-1.amazonaws.com",
@@ -133,7 +120,6 @@ const regionHash: RegionHash = {
     signingRegion: "eu-north-1",
   },
   "eu-south-1": {
-    hostname: "api.ecr.eu-south-1.amazonaws.com",
     variants: [
       {
         hostname: "api.ecr.eu-south-1.amazonaws.com",
@@ -143,7 +129,6 @@ const regionHash: RegionHash = {
     signingRegion: "eu-south-1",
   },
   "eu-west-1": {
-    hostname: "api.ecr.eu-west-1.amazonaws.com",
     variants: [
       {
         hostname: "api.ecr.eu-west-1.amazonaws.com",
@@ -153,7 +138,6 @@ const regionHash: RegionHash = {
     signingRegion: "eu-west-1",
   },
   "eu-west-2": {
-    hostname: "api.ecr.eu-west-2.amazonaws.com",
     variants: [
       {
         hostname: "api.ecr.eu-west-2.amazonaws.com",
@@ -163,7 +147,6 @@ const regionHash: RegionHash = {
     signingRegion: "eu-west-2",
   },
   "eu-west-3": {
-    hostname: "api.ecr.eu-west-3.amazonaws.com",
     variants: [
       {
         hostname: "api.ecr.eu-west-3.amazonaws.com",
@@ -173,7 +156,6 @@ const regionHash: RegionHash = {
     signingRegion: "eu-west-3",
   },
   "me-south-1": {
-    hostname: "api.ecr.me-south-1.amazonaws.com",
     variants: [
       {
         hostname: "api.ecr.me-south-1.amazonaws.com",
@@ -183,7 +165,6 @@ const regionHash: RegionHash = {
     signingRegion: "me-south-1",
   },
   "sa-east-1": {
-    hostname: "api.ecr.sa-east-1.amazonaws.com",
     variants: [
       {
         hostname: "api.ecr.sa-east-1.amazonaws.com",
@@ -193,7 +174,6 @@ const regionHash: RegionHash = {
     signingRegion: "sa-east-1",
   },
   "us-east-1": {
-    hostname: "api.ecr.us-east-1.amazonaws.com",
     variants: [
       {
         hostname: "api.ecr.us-east-1.amazonaws.com",
@@ -207,7 +187,6 @@ const regionHash: RegionHash = {
     signingRegion: "us-east-1",
   },
   "us-east-2": {
-    hostname: "api.ecr.us-east-2.amazonaws.com",
     variants: [
       {
         hostname: "api.ecr.us-east-2.amazonaws.com",
@@ -221,7 +200,6 @@ const regionHash: RegionHash = {
     signingRegion: "us-east-2",
   },
   "us-gov-east-1": {
-    hostname: "api.ecr.us-gov-east-1.amazonaws.com",
     variants: [
       {
         hostname: "api.ecr.us-gov-east-1.amazonaws.com",
@@ -235,7 +213,6 @@ const regionHash: RegionHash = {
     signingRegion: "us-gov-east-1",
   },
   "us-gov-west-1": {
-    hostname: "api.ecr.us-gov-west-1.amazonaws.com",
     variants: [
       {
         hostname: "api.ecr.us-gov-west-1.amazonaws.com",
@@ -249,7 +226,6 @@ const regionHash: RegionHash = {
     signingRegion: "us-gov-west-1",
   },
   "us-iso-east-1": {
-    hostname: "api.ecr.us-iso-east-1.c2s.ic.gov",
     variants: [
       {
         hostname: "api.ecr.us-iso-east-1.c2s.ic.gov",
@@ -259,7 +235,6 @@ const regionHash: RegionHash = {
     signingRegion: "us-iso-east-1",
   },
   "us-iso-west-1": {
-    hostname: "api.ecr.us-iso-west-1.c2s.ic.gov",
     variants: [
       {
         hostname: "api.ecr.us-iso-west-1.c2s.ic.gov",
@@ -269,7 +244,6 @@ const regionHash: RegionHash = {
     signingRegion: "us-iso-west-1",
   },
   "us-isob-east-1": {
-    hostname: "api.ecr.us-isob-east-1.sc2s.sgov.gov",
     variants: [
       {
         hostname: "api.ecr.us-isob-east-1.sc2s.sgov.gov",
@@ -279,7 +253,6 @@ const regionHash: RegionHash = {
     signingRegion: "us-isob-east-1",
   },
   "us-west-1": {
-    hostname: "api.ecr.us-west-1.amazonaws.com",
     variants: [
       {
         hostname: "api.ecr.us-west-1.amazonaws.com",
@@ -293,7 +266,6 @@ const regionHash: RegionHash = {
     signingRegion: "us-west-1",
   },
   "us-west-2": {
-    hostname: "api.ecr.us-west-2.amazonaws.com",
     variants: [
       {
         hostname: "api.ecr.us-west-2.amazonaws.com",
@@ -346,7 +318,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "api.ecr.{region}.amazonaws.com",
     variants: [
       {
         hostname: "api.ecr.{region}.amazonaws.com",
@@ -361,7 +332,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "api.ecr.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "api.ecr.{region}.amazonaws.com.cn",
@@ -384,7 +354,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "api.ecr.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "api.ecr.{region}.c2s.ic.gov",
@@ -395,7 +364,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "api.ecr.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "api.ecr.{region}.sc2s.sgov.gov",
@@ -415,7 +383,6 @@ const partitionHash: PartitionHash = {
       "us-gov-west-1",
     ],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "api.ecr.{region}.amazonaws.com",
     variants: [
       {
         hostname: "api.ecr.{region}.amazonaws.com",

--- a/clients/client-ecs/src/endpoints.ts
+++ b/clients/client-ecs/src/endpoints.ts
@@ -3,7 +3,6 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
   "us-east-1": {
-    hostname: "ecs.us-east-1.amazonaws.com",
     variants: [
       {
         hostname: "ecs.us-east-1.amazonaws.com",
@@ -16,7 +15,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-east-2": {
-    hostname: "ecs.us-east-2.amazonaws.com",
     variants: [
       {
         hostname: "ecs.us-east-2.amazonaws.com",
@@ -29,7 +27,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-gov-east-1": {
-    hostname: "ecs.us-gov-east-1.amazonaws.com",
     variants: [
       {
         hostname: "ecs.us-gov-east-1.amazonaws.com",
@@ -42,7 +39,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-gov-west-1": {
-    hostname: "ecs.us-gov-west-1.amazonaws.com",
     variants: [
       {
         hostname: "ecs.us-gov-west-1.amazonaws.com",
@@ -55,7 +51,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-west-1": {
-    hostname: "ecs.us-west-1.amazonaws.com",
     variants: [
       {
         hostname: "ecs.us-west-1.amazonaws.com",
@@ -68,7 +63,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-west-2": {
-    hostname: "ecs.us-west-2.amazonaws.com",
     variants: [
       {
         hostname: "ecs.us-west-2.amazonaws.com",
@@ -112,7 +106,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "ecs.{region}.amazonaws.com",
     variants: [
       {
         hostname: "ecs.{region}.amazonaws.com",
@@ -135,7 +128,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "ecs.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "ecs.{region}.amazonaws.com.cn",
@@ -158,7 +150,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "ecs.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "ecs.{region}.c2s.ic.gov",
@@ -169,7 +160,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "ecs.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "ecs.{region}.sc2s.sgov.gov",
@@ -180,7 +170,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["fips-us-gov-east-1", "fips-us-gov-west-1", "us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "ecs.{region}.amazonaws.com",
     variants: [
       {
         hostname: "ecs.{region}.amazonaws.com",

--- a/clients/client-efs/src/endpoints.ts
+++ b/clients/client-efs/src/endpoints.ts
@@ -3,7 +3,6 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
   "af-south-1": {
-    hostname: "elasticfilesystem.af-south-1.amazonaws.com",
     variants: [
       {
         hostname: "elasticfilesystem.af-south-1.amazonaws.com",
@@ -16,7 +15,6 @@ const regionHash: RegionHash = {
     ],
   },
   "ap-east-1": {
-    hostname: "elasticfilesystem.ap-east-1.amazonaws.com",
     variants: [
       {
         hostname: "elasticfilesystem.ap-east-1.amazonaws.com",
@@ -29,7 +27,6 @@ const regionHash: RegionHash = {
     ],
   },
   "ap-northeast-1": {
-    hostname: "elasticfilesystem.ap-northeast-1.amazonaws.com",
     variants: [
       {
         hostname: "elasticfilesystem.ap-northeast-1.amazonaws.com",
@@ -42,7 +39,6 @@ const regionHash: RegionHash = {
     ],
   },
   "ap-northeast-2": {
-    hostname: "elasticfilesystem.ap-northeast-2.amazonaws.com",
     variants: [
       {
         hostname: "elasticfilesystem.ap-northeast-2.amazonaws.com",
@@ -55,7 +51,6 @@ const regionHash: RegionHash = {
     ],
   },
   "ap-northeast-3": {
-    hostname: "elasticfilesystem.ap-northeast-3.amazonaws.com",
     variants: [
       {
         hostname: "elasticfilesystem.ap-northeast-3.amazonaws.com",
@@ -68,7 +63,6 @@ const regionHash: RegionHash = {
     ],
   },
   "ap-south-1": {
-    hostname: "elasticfilesystem.ap-south-1.amazonaws.com",
     variants: [
       {
         hostname: "elasticfilesystem.ap-south-1.amazonaws.com",
@@ -81,7 +75,6 @@ const regionHash: RegionHash = {
     ],
   },
   "ap-southeast-1": {
-    hostname: "elasticfilesystem.ap-southeast-1.amazonaws.com",
     variants: [
       {
         hostname: "elasticfilesystem.ap-southeast-1.amazonaws.com",
@@ -94,7 +87,6 @@ const regionHash: RegionHash = {
     ],
   },
   "ap-southeast-2": {
-    hostname: "elasticfilesystem.ap-southeast-2.amazonaws.com",
     variants: [
       {
         hostname: "elasticfilesystem.ap-southeast-2.amazonaws.com",
@@ -107,7 +99,6 @@ const regionHash: RegionHash = {
     ],
   },
   "ca-central-1": {
-    hostname: "elasticfilesystem.ca-central-1.amazonaws.com",
     variants: [
       {
         hostname: "elasticfilesystem.ca-central-1.amazonaws.com",
@@ -120,7 +111,6 @@ const regionHash: RegionHash = {
     ],
   },
   "cn-north-1": {
-    hostname: "elasticfilesystem.cn-north-1.amazonaws.com.cn",
     variants: [
       {
         hostname: "elasticfilesystem.cn-north-1.amazonaws.com.cn",
@@ -133,7 +123,6 @@ const regionHash: RegionHash = {
     ],
   },
   "cn-northwest-1": {
-    hostname: "elasticfilesystem.cn-northwest-1.amazonaws.com.cn",
     variants: [
       {
         hostname: "elasticfilesystem.cn-northwest-1.amazonaws.com.cn",
@@ -146,7 +135,6 @@ const regionHash: RegionHash = {
     ],
   },
   "eu-central-1": {
-    hostname: "elasticfilesystem.eu-central-1.amazonaws.com",
     variants: [
       {
         hostname: "elasticfilesystem.eu-central-1.amazonaws.com",
@@ -159,7 +147,6 @@ const regionHash: RegionHash = {
     ],
   },
   "eu-north-1": {
-    hostname: "elasticfilesystem.eu-north-1.amazonaws.com",
     variants: [
       {
         hostname: "elasticfilesystem.eu-north-1.amazonaws.com",
@@ -172,7 +159,6 @@ const regionHash: RegionHash = {
     ],
   },
   "eu-south-1": {
-    hostname: "elasticfilesystem.eu-south-1.amazonaws.com",
     variants: [
       {
         hostname: "elasticfilesystem.eu-south-1.amazonaws.com",
@@ -185,7 +171,6 @@ const regionHash: RegionHash = {
     ],
   },
   "eu-west-1": {
-    hostname: "elasticfilesystem.eu-west-1.amazonaws.com",
     variants: [
       {
         hostname: "elasticfilesystem.eu-west-1.amazonaws.com",
@@ -198,7 +183,6 @@ const regionHash: RegionHash = {
     ],
   },
   "eu-west-2": {
-    hostname: "elasticfilesystem.eu-west-2.amazonaws.com",
     variants: [
       {
         hostname: "elasticfilesystem.eu-west-2.amazonaws.com",
@@ -211,7 +195,6 @@ const regionHash: RegionHash = {
     ],
   },
   "eu-west-3": {
-    hostname: "elasticfilesystem.eu-west-3.amazonaws.com",
     variants: [
       {
         hostname: "elasticfilesystem.eu-west-3.amazonaws.com",
@@ -224,7 +207,6 @@ const regionHash: RegionHash = {
     ],
   },
   "me-south-1": {
-    hostname: "elasticfilesystem.me-south-1.amazonaws.com",
     variants: [
       {
         hostname: "elasticfilesystem.me-south-1.amazonaws.com",
@@ -237,7 +219,6 @@ const regionHash: RegionHash = {
     ],
   },
   "sa-east-1": {
-    hostname: "elasticfilesystem.sa-east-1.amazonaws.com",
     variants: [
       {
         hostname: "elasticfilesystem.sa-east-1.amazonaws.com",
@@ -250,7 +231,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-east-1": {
-    hostname: "elasticfilesystem.us-east-1.amazonaws.com",
     variants: [
       {
         hostname: "elasticfilesystem.us-east-1.amazonaws.com",
@@ -263,7 +243,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-east-2": {
-    hostname: "elasticfilesystem.us-east-2.amazonaws.com",
     variants: [
       {
         hostname: "elasticfilesystem.us-east-2.amazonaws.com",
@@ -276,7 +255,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-gov-east-1": {
-    hostname: "elasticfilesystem.us-gov-east-1.amazonaws.com",
     variants: [
       {
         hostname: "elasticfilesystem.us-gov-east-1.amazonaws.com",
@@ -289,7 +267,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-gov-west-1": {
-    hostname: "elasticfilesystem.us-gov-west-1.amazonaws.com",
     variants: [
       {
         hostname: "elasticfilesystem.us-gov-west-1.amazonaws.com",
@@ -302,7 +279,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-iso-east-1": {
-    hostname: "elasticfilesystem.us-iso-east-1.c2s.ic.gov",
     variants: [
       {
         hostname: "elasticfilesystem.us-iso-east-1.c2s.ic.gov",
@@ -315,7 +291,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-west-1": {
-    hostname: "elasticfilesystem.us-west-1.amazonaws.com",
     variants: [
       {
         hostname: "elasticfilesystem.us-west-1.amazonaws.com",
@@ -328,7 +303,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-west-2": {
-    hostname: "elasticfilesystem.us-west-2.amazonaws.com",
     variants: [
       {
         hostname: "elasticfilesystem.us-west-2.amazonaws.com",
@@ -389,7 +363,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "elasticfilesystem.{region}.amazonaws.com",
     variants: [
       {
         hostname: "elasticfilesystem.{region}.amazonaws.com",
@@ -412,7 +385,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1", "fips-cn-north-1", "fips-cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "elasticfilesystem.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "elasticfilesystem.{region}.amazonaws.com.cn",
@@ -435,7 +407,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["fips-us-iso-east-1", "us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "elasticfilesystem.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "elasticfilesystem.{region}.c2s.ic.gov",
@@ -446,7 +417,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "elasticfilesystem.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "elasticfilesystem.{region}.sc2s.sgov.gov",
@@ -457,7 +427,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["fips-us-gov-east-1", "fips-us-gov-west-1", "us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "elasticfilesystem.{region}.amazonaws.com",
     variants: [
       {
         hostname: "elasticfilesystem.{region}.amazonaws.com",

--- a/clients/client-eks/src/endpoints.ts
+++ b/clients/client-eks/src/endpoints.ts
@@ -3,7 +3,6 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
   "us-east-1": {
-    hostname: "eks.us-east-1.amazonaws.com",
     variants: [
       {
         hostname: "eks.us-east-1.amazonaws.com",
@@ -16,7 +15,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-east-2": {
-    hostname: "eks.us-east-2.amazonaws.com",
     variants: [
       {
         hostname: "eks.us-east-2.amazonaws.com",
@@ -29,7 +27,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-gov-east-1": {
-    hostname: "eks.us-gov-east-1.amazonaws.com",
     variants: [
       {
         hostname: "eks.us-gov-east-1.amazonaws.com",
@@ -42,7 +39,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-gov-west-1": {
-    hostname: "eks.us-gov-west-1.amazonaws.com",
     variants: [
       {
         hostname: "eks.us-gov-west-1.amazonaws.com",
@@ -55,7 +51,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-west-1": {
-    hostname: "eks.us-west-1.amazonaws.com",
     variants: [
       {
         hostname: "eks.us-west-1.amazonaws.com",
@@ -68,7 +63,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-west-2": {
-    hostname: "eks.us-west-2.amazonaws.com",
     variants: [
       {
         hostname: "eks.us-west-2.amazonaws.com",
@@ -112,7 +106,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "eks.{region}.amazonaws.com",
     variants: [
       {
         hostname: "eks.{region}.amazonaws.com",
@@ -127,7 +120,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "eks.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "eks.{region}.amazonaws.com.cn",
@@ -150,7 +142,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "eks.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "eks.{region}.c2s.ic.gov",
@@ -161,7 +152,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "eks.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "eks.{region}.sc2s.sgov.gov",
@@ -172,7 +162,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["fips-us-gov-east-1", "fips-us-gov-west-1", "us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "eks.{region}.amazonaws.com",
     variants: [
       {
         hostname: "eks.{region}.amazonaws.com",

--- a/clients/client-elastic-beanstalk/src/endpoints.ts
+++ b/clients/client-elastic-beanstalk/src/endpoints.ts
@@ -3,7 +3,6 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
   "us-east-1": {
-    hostname: "elasticbeanstalk.us-east-1.amazonaws.com",
     variants: [
       {
         hostname: "elasticbeanstalk.us-east-1.amazonaws.com",
@@ -16,7 +15,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-east-2": {
-    hostname: "elasticbeanstalk.us-east-2.amazonaws.com",
     variants: [
       {
         hostname: "elasticbeanstalk.us-east-2.amazonaws.com",
@@ -29,7 +27,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-gov-east-1": {
-    hostname: "elasticbeanstalk.us-gov-east-1.amazonaws.com",
     variants: [
       {
         hostname: "elasticbeanstalk.us-gov-east-1.amazonaws.com",
@@ -39,7 +36,6 @@ const regionHash: RegionHash = {
     signingRegion: "us-gov-east-1",
   },
   "us-gov-west-1": {
-    hostname: "elasticbeanstalk.us-gov-west-1.amazonaws.com",
     variants: [
       {
         hostname: "elasticbeanstalk.us-gov-west-1.amazonaws.com",
@@ -49,7 +45,6 @@ const regionHash: RegionHash = {
     signingRegion: "us-gov-west-1",
   },
   "us-west-1": {
-    hostname: "elasticbeanstalk.us-west-1.amazonaws.com",
     variants: [
       {
         hostname: "elasticbeanstalk.us-west-1.amazonaws.com",
@@ -62,7 +57,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-west-2": {
-    hostname: "elasticbeanstalk.us-west-2.amazonaws.com",
     variants: [
       {
         hostname: "elasticbeanstalk.us-west-2.amazonaws.com",
@@ -106,7 +100,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "elasticbeanstalk.{region}.amazonaws.com",
     variants: [
       {
         hostname: "elasticbeanstalk.{region}.amazonaws.com",
@@ -129,7 +122,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "elasticbeanstalk.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "elasticbeanstalk.{region}.amazonaws.com.cn",
@@ -152,7 +144,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "elasticbeanstalk.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "elasticbeanstalk.{region}.c2s.ic.gov",
@@ -163,7 +154,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "elasticbeanstalk.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "elasticbeanstalk.{region}.sc2s.sgov.gov",
@@ -174,7 +164,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "elasticbeanstalk.{region}.amazonaws.com",
     variants: [
       {
         hostname: "elasticbeanstalk.{region}.amazonaws.com",

--- a/clients/client-elastic-inference/src/endpoints.ts
+++ b/clients/client-elastic-inference/src/endpoints.ts
@@ -3,7 +3,6 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
   "ap-northeast-1": {
-    hostname: "api.elastic-inference.ap-northeast-1.amazonaws.com",
     variants: [
       {
         hostname: "api.elastic-inference.ap-northeast-1.amazonaws.com",
@@ -12,7 +11,6 @@ const regionHash: RegionHash = {
     ],
   },
   "ap-northeast-2": {
-    hostname: "api.elastic-inference.ap-northeast-2.amazonaws.com",
     variants: [
       {
         hostname: "api.elastic-inference.ap-northeast-2.amazonaws.com",
@@ -21,7 +19,6 @@ const regionHash: RegionHash = {
     ],
   },
   "eu-west-1": {
-    hostname: "api.elastic-inference.eu-west-1.amazonaws.com",
     variants: [
       {
         hostname: "api.elastic-inference.eu-west-1.amazonaws.com",
@@ -30,7 +27,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-east-1": {
-    hostname: "api.elastic-inference.us-east-1.amazonaws.com",
     variants: [
       {
         hostname: "api.elastic-inference.us-east-1.amazonaws.com",
@@ -39,7 +35,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-east-2": {
-    hostname: "api.elastic-inference.us-east-2.amazonaws.com",
     variants: [
       {
         hostname: "api.elastic-inference.us-east-2.amazonaws.com",
@@ -48,7 +43,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-west-2": {
-    hostname: "api.elastic-inference.us-west-2.amazonaws.com",
     variants: [
       {
         hostname: "api.elastic-inference.us-west-2.amazonaws.com",
@@ -84,7 +78,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "api.elastic-inference.{region}.amazonaws.com",
     variants: [
       {
         hostname: "api.elastic-inference.{region}.amazonaws.com",
@@ -107,7 +100,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "api.elastic-inference.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "api.elastic-inference.{region}.amazonaws.com.cn",
@@ -130,7 +122,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "api.elastic-inference.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "api.elastic-inference.{region}.c2s.ic.gov",
@@ -141,7 +132,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "api.elastic-inference.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "api.elastic-inference.{region}.sc2s.sgov.gov",
@@ -152,7 +142,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "api.elastic-inference.{region}.amazonaws.com",
     variants: [
       {
         hostname: "api.elastic-inference.{region}.amazonaws.com",

--- a/clients/client-elastic-load-balancing-v2/src/endpoints.ts
+++ b/clients/client-elastic-load-balancing-v2/src/endpoints.ts
@@ -3,7 +3,6 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
   "us-east-1": {
-    hostname: "elasticloadbalancing.us-east-1.amazonaws.com",
     variants: [
       {
         hostname: "elasticloadbalancing.us-east-1.amazonaws.com",
@@ -16,7 +15,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-east-2": {
-    hostname: "elasticloadbalancing.us-east-2.amazonaws.com",
     variants: [
       {
         hostname: "elasticloadbalancing.us-east-2.amazonaws.com",
@@ -29,7 +27,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-gov-east-1": {
-    hostname: "elasticloadbalancing.us-gov-east-1.amazonaws.com",
     variants: [
       {
         hostname: "elasticloadbalancing.us-gov-east-1.amazonaws.com",
@@ -42,7 +39,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-gov-west-1": {
-    hostname: "elasticloadbalancing.us-gov-west-1.amazonaws.com",
     variants: [
       {
         hostname: "elasticloadbalancing.us-gov-west-1.amazonaws.com",
@@ -55,7 +51,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-west-1": {
-    hostname: "elasticloadbalancing.us-west-1.amazonaws.com",
     variants: [
       {
         hostname: "elasticloadbalancing.us-west-1.amazonaws.com",
@@ -68,7 +63,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-west-2": {
-    hostname: "elasticloadbalancing.us-west-2.amazonaws.com",
     variants: [
       {
         hostname: "elasticloadbalancing.us-west-2.amazonaws.com",
@@ -112,7 +106,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "elasticloadbalancing.{region}.amazonaws.com",
     variants: [
       {
         hostname: "elasticloadbalancing.{region}.amazonaws.com",
@@ -135,7 +128,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "elasticloadbalancing.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "elasticloadbalancing.{region}.amazonaws.com.cn",
@@ -158,7 +150,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "elasticloadbalancing.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "elasticloadbalancing.{region}.c2s.ic.gov",
@@ -169,7 +160,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "elasticloadbalancing.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "elasticloadbalancing.{region}.sc2s.sgov.gov",
@@ -180,7 +170,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["fips-us-gov-east-1", "fips-us-gov-west-1", "us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "elasticloadbalancing.{region}.amazonaws.com",
     variants: [
       {
         hostname: "elasticloadbalancing.{region}.amazonaws.com",

--- a/clients/client-elastic-load-balancing/src/endpoints.ts
+++ b/clients/client-elastic-load-balancing/src/endpoints.ts
@@ -3,7 +3,6 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
   "us-east-1": {
-    hostname: "elasticloadbalancing.us-east-1.amazonaws.com",
     variants: [
       {
         hostname: "elasticloadbalancing.us-east-1.amazonaws.com",
@@ -16,7 +15,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-east-2": {
-    hostname: "elasticloadbalancing.us-east-2.amazonaws.com",
     variants: [
       {
         hostname: "elasticloadbalancing.us-east-2.amazonaws.com",
@@ -29,7 +27,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-gov-east-1": {
-    hostname: "elasticloadbalancing.us-gov-east-1.amazonaws.com",
     variants: [
       {
         hostname: "elasticloadbalancing.us-gov-east-1.amazonaws.com",
@@ -42,7 +39,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-gov-west-1": {
-    hostname: "elasticloadbalancing.us-gov-west-1.amazonaws.com",
     variants: [
       {
         hostname: "elasticloadbalancing.us-gov-west-1.amazonaws.com",
@@ -55,7 +51,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-west-1": {
-    hostname: "elasticloadbalancing.us-west-1.amazonaws.com",
     variants: [
       {
         hostname: "elasticloadbalancing.us-west-1.amazonaws.com",
@@ -68,7 +63,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-west-2": {
-    hostname: "elasticloadbalancing.us-west-2.amazonaws.com",
     variants: [
       {
         hostname: "elasticloadbalancing.us-west-2.amazonaws.com",
@@ -112,7 +106,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "elasticloadbalancing.{region}.amazonaws.com",
     variants: [
       {
         hostname: "elasticloadbalancing.{region}.amazonaws.com",
@@ -135,7 +128,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "elasticloadbalancing.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "elasticloadbalancing.{region}.amazonaws.com.cn",
@@ -158,7 +150,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "elasticloadbalancing.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "elasticloadbalancing.{region}.c2s.ic.gov",
@@ -169,7 +160,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "elasticloadbalancing.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "elasticloadbalancing.{region}.sc2s.sgov.gov",
@@ -180,7 +170,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["fips-us-gov-east-1", "fips-us-gov-west-1", "us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "elasticloadbalancing.{region}.amazonaws.com",
     variants: [
       {
         hostname: "elasticloadbalancing.{region}.amazonaws.com",

--- a/clients/client-elastic-transcoder/src/endpoints.ts
+++ b/clients/client-elastic-transcoder/src/endpoints.ts
@@ -29,7 +29,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "elastictranscoder.{region}.amazonaws.com",
     variants: [
       {
         hostname: "elastictranscoder.{region}.amazonaws.com",
@@ -52,7 +51,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "elastictranscoder.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "elastictranscoder.{region}.amazonaws.com.cn",
@@ -75,7 +73,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "elastictranscoder.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "elastictranscoder.{region}.c2s.ic.gov",
@@ -86,7 +83,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "elastictranscoder.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "elastictranscoder.{region}.sc2s.sgov.gov",
@@ -97,7 +93,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "elastictranscoder.{region}.amazonaws.com",
     variants: [
       {
         hostname: "elastictranscoder.{region}.amazonaws.com",

--- a/clients/client-elasticache/src/endpoints.ts
+++ b/clients/client-elasticache/src/endpoints.ts
@@ -3,7 +3,6 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
   "us-east-1": {
-    hostname: "elasticache.us-east-1.amazonaws.com",
     variants: [
       {
         hostname: "elasticache.us-east-1.amazonaws.com",
@@ -16,7 +15,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-east-2": {
-    hostname: "elasticache.us-east-2.amazonaws.com",
     variants: [
       {
         hostname: "elasticache.us-east-2.amazonaws.com",
@@ -29,7 +27,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-gov-west-1": {
-    hostname: "elasticache.us-gov-west-1.amazonaws.com",
     variants: [
       {
         hostname: "elasticache.us-gov-west-1.amazonaws.com",
@@ -42,7 +39,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-west-1": {
-    hostname: "elasticache.us-west-1.amazonaws.com",
     variants: [
       {
         hostname: "elasticache.us-west-1.amazonaws.com",
@@ -55,7 +51,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-west-2": {
-    hostname: "elasticache.us-west-2.amazonaws.com",
     variants: [
       {
         hostname: "elasticache.us-west-2.amazonaws.com",
@@ -100,7 +95,6 @@ const partitionHash: PartitionHash = {
       "us-west-2-fips",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "elasticache.{region}.amazonaws.com",
     variants: [
       {
         hostname: "elasticache.{region}.amazonaws.com",
@@ -123,7 +117,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "elasticache.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "elasticache.{region}.amazonaws.com.cn",
@@ -146,7 +139,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "elasticache.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "elasticache.{region}.c2s.ic.gov",
@@ -157,7 +149,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "elasticache.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "elasticache.{region}.sc2s.sgov.gov",
@@ -168,7 +159,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["fips", "us-gov-east-1", "us-gov-west-1", "us-gov-west-1-fips"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "elasticache.{region}.amazonaws.com",
     variants: [
       {
         hostname: "elasticache.{region}.amazonaws.com",

--- a/clients/client-elasticsearch-service/src/endpoints.ts
+++ b/clients/client-elasticsearch-service/src/endpoints.ts
@@ -3,7 +3,6 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
   "us-east-1": {
-    hostname: "es.us-east-1.amazonaws.com",
     variants: [
       {
         hostname: "es.us-east-1.amazonaws.com",
@@ -16,7 +15,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-east-2": {
-    hostname: "es.us-east-2.amazonaws.com",
     variants: [
       {
         hostname: "es.us-east-2.amazonaws.com",
@@ -29,7 +27,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-gov-east-1": {
-    hostname: "es.us-gov-east-1.amazonaws.com",
     variants: [
       {
         hostname: "es.us-gov-east-1.amazonaws.com",
@@ -42,7 +39,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-gov-west-1": {
-    hostname: "es.us-gov-west-1.amazonaws.com",
     variants: [
       {
         hostname: "es.us-gov-west-1.amazonaws.com",
@@ -55,7 +51,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-west-1": {
-    hostname: "es.us-west-1.amazonaws.com",
     variants: [
       {
         hostname: "es.us-west-1.amazonaws.com",
@@ -68,7 +63,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-west-2": {
-    hostname: "es.us-west-2.amazonaws.com",
     variants: [
       {
         hostname: "es.us-west-2.amazonaws.com",
@@ -113,7 +107,6 @@ const partitionHash: PartitionHash = {
       "us-west-2-fips",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "es.{region}.amazonaws.com",
     variants: [
       {
         hostname: "es.{region}.amazonaws.com",
@@ -136,7 +129,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "es.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "es.{region}.amazonaws.com.cn",
@@ -159,7 +151,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "es.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "es.{region}.c2s.ic.gov",
@@ -170,7 +161,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "es.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "es.{region}.sc2s.sgov.gov",
@@ -181,7 +171,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["fips", "us-gov-east-1", "us-gov-east-1-fips", "us-gov-west-1", "us-gov-west-1-fips"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "es.{region}.amazonaws.com",
     variants: [
       {
         hostname: "es.{region}.amazonaws.com",

--- a/clients/client-emr-containers/src/endpoints.ts
+++ b/clients/client-emr-containers/src/endpoints.ts
@@ -3,7 +3,6 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
   "ca-central-1": {
-    hostname: "emr-containers.ca-central-1.amazonaws.com",
     variants: [
       {
         hostname: "emr-containers.ca-central-1.amazonaws.com",
@@ -16,7 +15,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-east-1": {
-    hostname: "emr-containers.us-east-1.amazonaws.com",
     variants: [
       {
         hostname: "emr-containers.us-east-1.amazonaws.com",
@@ -29,7 +27,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-east-2": {
-    hostname: "emr-containers.us-east-2.amazonaws.com",
     variants: [
       {
         hostname: "emr-containers.us-east-2.amazonaws.com",
@@ -42,7 +39,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-west-1": {
-    hostname: "emr-containers.us-west-1.amazonaws.com",
     variants: [
       {
         hostname: "emr-containers.us-west-1.amazonaws.com",
@@ -55,7 +51,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-west-2": {
-    hostname: "emr-containers.us-west-2.amazonaws.com",
     variants: [
       {
         hostname: "emr-containers.us-west-2.amazonaws.com",
@@ -100,7 +95,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "emr-containers.{region}.amazonaws.com",
     variants: [
       {
         hostname: "emr-containers.{region}.amazonaws.com",
@@ -123,7 +117,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "emr-containers.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "emr-containers.{region}.amazonaws.com.cn",
@@ -146,7 +139,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "emr-containers.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "emr-containers.{region}.c2s.ic.gov",
@@ -157,7 +149,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "emr-containers.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "emr-containers.{region}.sc2s.sgov.gov",
@@ -168,7 +159,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "emr-containers.{region}.amazonaws.com",
     variants: [
       {
         hostname: "emr-containers.{region}.amazonaws.com",

--- a/clients/client-emr/src/endpoints.ts
+++ b/clients/client-emr/src/endpoints.ts
@@ -3,7 +3,6 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
   "ca-central-1": {
-    hostname: "elasticmapreduce.ca-central-1.amazonaws.com",
     variants: [
       {
         hostname: "elasticmapreduce.ca-central-1.amazonaws.com",
@@ -16,7 +15,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-east-1": {
-    hostname: "elasticmapreduce.us-east-1.amazonaws.com",
     variants: [
       {
         hostname: "elasticmapreduce.us-east-1.amazonaws.com",
@@ -29,7 +27,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-east-2": {
-    hostname: "elasticmapreduce.us-east-2.amazonaws.com",
     variants: [
       {
         hostname: "elasticmapreduce.us-east-2.amazonaws.com",
@@ -42,7 +39,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-gov-east-1": {
-    hostname: "elasticmapreduce.us-gov-east-1.amazonaws.com",
     variants: [
       {
         hostname: "elasticmapreduce.us-gov-east-1.amazonaws.com",
@@ -55,7 +51,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-gov-west-1": {
-    hostname: "elasticmapreduce.us-gov-west-1.amazonaws.com",
     variants: [
       {
         hostname: "elasticmapreduce.us-gov-west-1.amazonaws.com",
@@ -68,7 +63,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-west-1": {
-    hostname: "elasticmapreduce.us-west-1.amazonaws.com",
     variants: [
       {
         hostname: "elasticmapreduce.us-west-1.amazonaws.com",
@@ -81,7 +75,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-west-2": {
-    hostname: "elasticmapreduce.us-west-2.amazonaws.com",
     variants: [
       {
         hostname: "elasticmapreduce.us-west-2.amazonaws.com",
@@ -126,7 +119,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "elasticmapreduce.{region}.amazonaws.com",
     variants: [
       {
         hostname: "elasticmapreduce.{region}.amazonaws.com",
@@ -149,7 +141,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "elasticmapreduce.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "elasticmapreduce.{region}.amazonaws.com.cn",
@@ -172,7 +163,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "elasticmapreduce.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "elasticmapreduce.{region}.c2s.ic.gov",
@@ -183,7 +173,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "elasticmapreduce.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "elasticmapreduce.{region}.sc2s.sgov.gov",
@@ -194,7 +183,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["fips-us-gov-east-1", "fips-us-gov-west-1", "us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "elasticmapreduce.{region}.amazonaws.com",
     variants: [
       {
         hostname: "elasticmapreduce.{region}.amazonaws.com",

--- a/clients/client-eventbridge/src/endpoints.ts
+++ b/clients/client-eventbridge/src/endpoints.ts
@@ -3,7 +3,6 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
   "us-east-1": {
-    hostname: "events.us-east-1.amazonaws.com",
     variants: [
       {
         hostname: "events.us-east-1.amazonaws.com",
@@ -16,7 +15,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-east-2": {
-    hostname: "events.us-east-2.amazonaws.com",
     variants: [
       {
         hostname: "events.us-east-2.amazonaws.com",
@@ -29,7 +27,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-gov-east-1": {
-    hostname: "events.us-gov-east-1.amazonaws.com",
     variants: [
       {
         hostname: "events.us-gov-east-1.amazonaws.com",
@@ -39,7 +36,6 @@ const regionHash: RegionHash = {
     signingRegion: "us-gov-east-1",
   },
   "us-gov-west-1": {
-    hostname: "events.us-gov-west-1.amazonaws.com",
     variants: [
       {
         hostname: "events.us-gov-west-1.amazonaws.com",
@@ -49,7 +45,6 @@ const regionHash: RegionHash = {
     signingRegion: "us-gov-west-1",
   },
   "us-west-1": {
-    hostname: "events.us-west-1.amazonaws.com",
     variants: [
       {
         hostname: "events.us-west-1.amazonaws.com",
@@ -62,7 +57,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-west-2": {
-    hostname: "events.us-west-2.amazonaws.com",
     variants: [
       {
         hostname: "events.us-west-2.amazonaws.com",
@@ -106,7 +100,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "events.{region}.amazonaws.com",
     variants: [
       {
         hostname: "events.{region}.amazonaws.com",
@@ -129,7 +122,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "events.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "events.{region}.amazonaws.com.cn",
@@ -152,7 +144,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "events.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "events.{region}.c2s.ic.gov",
@@ -163,7 +154,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "events.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "events.{region}.sc2s.sgov.gov",
@@ -174,7 +164,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "events.{region}.amazonaws.com",
     variants: [
       {
         hostname: "events.{region}.amazonaws.com",

--- a/clients/client-finspace-data/src/endpoints.ts
+++ b/clients/client-finspace-data/src/endpoints.ts
@@ -29,7 +29,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "finspace-api.{region}.amazonaws.com",
     variants: [
       {
         hostname: "finspace-api.{region}.amazonaws.com",
@@ -52,7 +51,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "finspace-api.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "finspace-api.{region}.amazonaws.com.cn",
@@ -75,7 +73,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "finspace-api.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "finspace-api.{region}.c2s.ic.gov",
@@ -86,7 +83,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "finspace-api.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "finspace-api.{region}.sc2s.sgov.gov",
@@ -97,7 +93,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "finspace-api.{region}.amazonaws.com",
     variants: [
       {
         hostname: "finspace-api.{region}.amazonaws.com",

--- a/clients/client-finspace/src/endpoints.ts
+++ b/clients/client-finspace/src/endpoints.ts
@@ -29,7 +29,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "finspace.{region}.amazonaws.com",
     variants: [
       {
         hostname: "finspace.{region}.amazonaws.com",
@@ -52,7 +51,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "finspace.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "finspace.{region}.amazonaws.com.cn",
@@ -75,7 +73,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "finspace.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "finspace.{region}.c2s.ic.gov",
@@ -86,7 +83,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "finspace.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "finspace.{region}.sc2s.sgov.gov",
@@ -97,7 +93,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "finspace.{region}.amazonaws.com",
     variants: [
       {
         hostname: "finspace.{region}.amazonaws.com",

--- a/clients/client-firehose/src/endpoints.ts
+++ b/clients/client-firehose/src/endpoints.ts
@@ -3,7 +3,6 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
   "us-east-1": {
-    hostname: "firehose.us-east-1.amazonaws.com",
     variants: [
       {
         hostname: "firehose.us-east-1.amazonaws.com",
@@ -16,7 +15,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-east-2": {
-    hostname: "firehose.us-east-2.amazonaws.com",
     variants: [
       {
         hostname: "firehose.us-east-2.amazonaws.com",
@@ -29,7 +27,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-gov-east-1": {
-    hostname: "firehose.us-gov-east-1.amazonaws.com",
     variants: [
       {
         hostname: "firehose.us-gov-east-1.amazonaws.com",
@@ -42,7 +39,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-gov-west-1": {
-    hostname: "firehose.us-gov-west-1.amazonaws.com",
     variants: [
       {
         hostname: "firehose.us-gov-west-1.amazonaws.com",
@@ -55,7 +51,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-west-1": {
-    hostname: "firehose.us-west-1.amazonaws.com",
     variants: [
       {
         hostname: "firehose.us-west-1.amazonaws.com",
@@ -68,7 +63,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-west-2": {
-    hostname: "firehose.us-west-2.amazonaws.com",
     variants: [
       {
         hostname: "firehose.us-west-2.amazonaws.com",
@@ -112,7 +106,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "firehose.{region}.amazonaws.com",
     variants: [
       {
         hostname: "firehose.{region}.amazonaws.com",
@@ -135,7 +128,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "firehose.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "firehose.{region}.amazonaws.com.cn",
@@ -158,7 +150,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "firehose.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "firehose.{region}.c2s.ic.gov",
@@ -169,7 +160,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "firehose.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "firehose.{region}.sc2s.sgov.gov",
@@ -180,7 +170,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["fips-us-gov-east-1", "fips-us-gov-west-1", "us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "firehose.{region}.amazonaws.com",
     variants: [
       {
         hostname: "firehose.{region}.amazonaws.com",

--- a/clients/client-fis/src/endpoints.ts
+++ b/clients/client-fis/src/endpoints.ts
@@ -29,7 +29,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "fis.{region}.amazonaws.com",
     variants: [
       {
         hostname: "fis.{region}.amazonaws.com",
@@ -52,7 +51,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "fis.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "fis.{region}.amazonaws.com.cn",
@@ -75,7 +73,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "fis.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "fis.{region}.c2s.ic.gov",
@@ -86,7 +83,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "fis.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "fis.{region}.sc2s.sgov.gov",
@@ -97,7 +93,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "fis.{region}.amazonaws.com",
     variants: [
       {
         hostname: "fis.{region}.amazonaws.com",

--- a/clients/client-fms/src/endpoints.ts
+++ b/clients/client-fms/src/endpoints.ts
@@ -3,7 +3,6 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
   "af-south-1": {
-    hostname: "fms.af-south-1.amazonaws.com",
     variants: [
       {
         hostname: "fms.af-south-1.amazonaws.com",
@@ -16,7 +15,6 @@ const regionHash: RegionHash = {
     ],
   },
   "ap-east-1": {
-    hostname: "fms.ap-east-1.amazonaws.com",
     variants: [
       {
         hostname: "fms.ap-east-1.amazonaws.com",
@@ -29,7 +27,6 @@ const regionHash: RegionHash = {
     ],
   },
   "ap-northeast-1": {
-    hostname: "fms.ap-northeast-1.amazonaws.com",
     variants: [
       {
         hostname: "fms.ap-northeast-1.amazonaws.com",
@@ -42,7 +39,6 @@ const regionHash: RegionHash = {
     ],
   },
   "ap-northeast-2": {
-    hostname: "fms.ap-northeast-2.amazonaws.com",
     variants: [
       {
         hostname: "fms.ap-northeast-2.amazonaws.com",
@@ -55,7 +51,6 @@ const regionHash: RegionHash = {
     ],
   },
   "ap-south-1": {
-    hostname: "fms.ap-south-1.amazonaws.com",
     variants: [
       {
         hostname: "fms.ap-south-1.amazonaws.com",
@@ -68,7 +63,6 @@ const regionHash: RegionHash = {
     ],
   },
   "ap-southeast-1": {
-    hostname: "fms.ap-southeast-1.amazonaws.com",
     variants: [
       {
         hostname: "fms.ap-southeast-1.amazonaws.com",
@@ -81,7 +75,6 @@ const regionHash: RegionHash = {
     ],
   },
   "ap-southeast-2": {
-    hostname: "fms.ap-southeast-2.amazonaws.com",
     variants: [
       {
         hostname: "fms.ap-southeast-2.amazonaws.com",
@@ -94,7 +87,6 @@ const regionHash: RegionHash = {
     ],
   },
   "ca-central-1": {
-    hostname: "fms.ca-central-1.amazonaws.com",
     variants: [
       {
         hostname: "fms.ca-central-1.amazonaws.com",
@@ -107,7 +99,6 @@ const regionHash: RegionHash = {
     ],
   },
   "eu-central-1": {
-    hostname: "fms.eu-central-1.amazonaws.com",
     variants: [
       {
         hostname: "fms.eu-central-1.amazonaws.com",
@@ -120,7 +111,6 @@ const regionHash: RegionHash = {
     ],
   },
   "eu-south-1": {
-    hostname: "fms.eu-south-1.amazonaws.com",
     variants: [
       {
         hostname: "fms.eu-south-1.amazonaws.com",
@@ -133,7 +123,6 @@ const regionHash: RegionHash = {
     ],
   },
   "eu-west-1": {
-    hostname: "fms.eu-west-1.amazonaws.com",
     variants: [
       {
         hostname: "fms.eu-west-1.amazonaws.com",
@@ -146,7 +135,6 @@ const regionHash: RegionHash = {
     ],
   },
   "eu-west-2": {
-    hostname: "fms.eu-west-2.amazonaws.com",
     variants: [
       {
         hostname: "fms.eu-west-2.amazonaws.com",
@@ -159,7 +147,6 @@ const regionHash: RegionHash = {
     ],
   },
   "eu-west-3": {
-    hostname: "fms.eu-west-3.amazonaws.com",
     variants: [
       {
         hostname: "fms.eu-west-3.amazonaws.com",
@@ -172,7 +159,6 @@ const regionHash: RegionHash = {
     ],
   },
   "me-south-1": {
-    hostname: "fms.me-south-1.amazonaws.com",
     variants: [
       {
         hostname: "fms.me-south-1.amazonaws.com",
@@ -185,7 +171,6 @@ const regionHash: RegionHash = {
     ],
   },
   "sa-east-1": {
-    hostname: "fms.sa-east-1.amazonaws.com",
     variants: [
       {
         hostname: "fms.sa-east-1.amazonaws.com",
@@ -198,7 +183,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-east-1": {
-    hostname: "fms.us-east-1.amazonaws.com",
     variants: [
       {
         hostname: "fms.us-east-1.amazonaws.com",
@@ -211,7 +195,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-east-2": {
-    hostname: "fms.us-east-2.amazonaws.com",
     variants: [
       {
         hostname: "fms.us-east-2.amazonaws.com",
@@ -224,7 +207,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-gov-east-1": {
-    hostname: "fms.us-gov-east-1.amazonaws.com",
     variants: [
       {
         hostname: "fms.us-gov-east-1.amazonaws.com",
@@ -237,7 +219,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-gov-west-1": {
-    hostname: "fms.us-gov-west-1.amazonaws.com",
     variants: [
       {
         hostname: "fms.us-gov-west-1.amazonaws.com",
@@ -250,7 +231,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-west-1": {
-    hostname: "fms.us-west-1.amazonaws.com",
     variants: [
       {
         hostname: "fms.us-west-1.amazonaws.com",
@@ -263,7 +243,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-west-2": {
-    hostname: "fms.us-west-2.amazonaws.com",
     variants: [
       {
         hostname: "fms.us-west-2.amazonaws.com",
@@ -322,7 +301,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "fms.{region}.amazonaws.com",
     variants: [
       {
         hostname: "fms.{region}.amazonaws.com",
@@ -345,7 +323,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "fms.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "fms.{region}.amazonaws.com.cn",
@@ -368,7 +345,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "fms.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "fms.{region}.c2s.ic.gov",
@@ -379,7 +355,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "fms.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "fms.{region}.sc2s.sgov.gov",
@@ -390,7 +365,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["fips-us-gov-east-1", "fips-us-gov-west-1", "us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "fms.{region}.amazonaws.com",
     variants: [
       {
         hostname: "fms.{region}.amazonaws.com",

--- a/clients/client-forecast/src/endpoints.ts
+++ b/clients/client-forecast/src/endpoints.ts
@@ -3,7 +3,6 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
   "us-east-1": {
-    hostname: "forecast.us-east-1.amazonaws.com",
     variants: [
       {
         hostname: "forecast.us-east-1.amazonaws.com",
@@ -16,7 +15,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-east-2": {
-    hostname: "forecast.us-east-2.amazonaws.com",
     variants: [
       {
         hostname: "forecast.us-east-2.amazonaws.com",
@@ -29,7 +27,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-west-2": {
-    hostname: "forecast.us-west-2.amazonaws.com",
     variants: [
       {
         hostname: "forecast.us-west-2.amazonaws.com",
@@ -72,7 +69,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "forecast.{region}.amazonaws.com",
     variants: [
       {
         hostname: "forecast.{region}.amazonaws.com",
@@ -95,7 +91,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "forecast.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "forecast.{region}.amazonaws.com.cn",
@@ -118,7 +113,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "forecast.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "forecast.{region}.c2s.ic.gov",
@@ -129,7 +123,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "forecast.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "forecast.{region}.sc2s.sgov.gov",
@@ -140,7 +133,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "forecast.{region}.amazonaws.com",
     variants: [
       {
         hostname: "forecast.{region}.amazonaws.com",

--- a/clients/client-forecastquery/src/endpoints.ts
+++ b/clients/client-forecastquery/src/endpoints.ts
@@ -3,7 +3,6 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
   "us-east-1": {
-    hostname: "forecastquery.us-east-1.amazonaws.com",
     variants: [
       {
         hostname: "forecastquery.us-east-1.amazonaws.com",
@@ -16,7 +15,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-east-2": {
-    hostname: "forecastquery.us-east-2.amazonaws.com",
     variants: [
       {
         hostname: "forecastquery.us-east-2.amazonaws.com",
@@ -29,7 +27,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-west-2": {
-    hostname: "forecastquery.us-west-2.amazonaws.com",
     variants: [
       {
         hostname: "forecastquery.us-west-2.amazonaws.com",
@@ -72,7 +69,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "forecastquery.{region}.amazonaws.com",
     variants: [
       {
         hostname: "forecastquery.{region}.amazonaws.com",
@@ -95,7 +91,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "forecastquery.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "forecastquery.{region}.amazonaws.com.cn",
@@ -118,7 +113,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "forecastquery.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "forecastquery.{region}.c2s.ic.gov",
@@ -129,7 +123,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "forecastquery.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "forecastquery.{region}.sc2s.sgov.gov",
@@ -140,7 +133,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "forecastquery.{region}.amazonaws.com",
     variants: [
       {
         hostname: "forecastquery.{region}.amazonaws.com",

--- a/clients/client-frauddetector/src/endpoints.ts
+++ b/clients/client-frauddetector/src/endpoints.ts
@@ -29,7 +29,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "frauddetector.{region}.amazonaws.com",
     variants: [
       {
         hostname: "frauddetector.{region}.amazonaws.com",
@@ -52,7 +51,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "frauddetector.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "frauddetector.{region}.amazonaws.com.cn",
@@ -75,7 +73,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "frauddetector.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "frauddetector.{region}.c2s.ic.gov",
@@ -86,7 +83,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "frauddetector.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "frauddetector.{region}.sc2s.sgov.gov",
@@ -97,7 +93,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "frauddetector.{region}.amazonaws.com",
     variants: [
       {
         hostname: "frauddetector.{region}.amazonaws.com",

--- a/clients/client-fsx/src/endpoints.ts
+++ b/clients/client-fsx/src/endpoints.ts
@@ -3,7 +3,6 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
   "ca-central-1": {
-    hostname: "fsx.ca-central-1.amazonaws.com",
     variants: [
       {
         hostname: "fsx.ca-central-1.amazonaws.com",
@@ -16,7 +15,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-east-1": {
-    hostname: "fsx.us-east-1.amazonaws.com",
     variants: [
       {
         hostname: "fsx.us-east-1.amazonaws.com",
@@ -29,7 +27,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-east-2": {
-    hostname: "fsx.us-east-2.amazonaws.com",
     variants: [
       {
         hostname: "fsx.us-east-2.amazonaws.com",
@@ -42,7 +39,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-gov-east-1": {
-    hostname: "fsx.us-gov-east-1.amazonaws.com",
     variants: [
       {
         hostname: "fsx.us-gov-east-1.amazonaws.com",
@@ -55,7 +51,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-gov-west-1": {
-    hostname: "fsx.us-gov-west-1.amazonaws.com",
     variants: [
       {
         hostname: "fsx.us-gov-west-1.amazonaws.com",
@@ -68,7 +63,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-west-1": {
-    hostname: "fsx.us-west-1.amazonaws.com",
     variants: [
       {
         hostname: "fsx.us-west-1.amazonaws.com",
@@ -81,7 +75,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-west-2": {
-    hostname: "fsx.us-west-2.amazonaws.com",
     variants: [
       {
         hostname: "fsx.us-west-2.amazonaws.com",
@@ -136,7 +129,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "fsx.{region}.amazonaws.com",
     variants: [
       {
         hostname: "fsx.{region}.amazonaws.com",
@@ -159,7 +151,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "fsx.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "fsx.{region}.amazonaws.com.cn",
@@ -182,7 +173,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "fsx.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "fsx.{region}.c2s.ic.gov",
@@ -193,7 +183,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "fsx.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "fsx.{region}.sc2s.sgov.gov",
@@ -213,7 +202,6 @@ const partitionHash: PartitionHash = {
       "us-gov-west-1",
     ],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "fsx.{region}.amazonaws.com",
     variants: [
       {
         hostname: "fsx.{region}.amazonaws.com",

--- a/clients/client-gamelift/src/endpoints.ts
+++ b/clients/client-gamelift/src/endpoints.ts
@@ -29,7 +29,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "gamelift.{region}.amazonaws.com",
     variants: [
       {
         hostname: "gamelift.{region}.amazonaws.com",
@@ -52,7 +51,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "gamelift.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "gamelift.{region}.amazonaws.com.cn",
@@ -75,7 +73,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "gamelift.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "gamelift.{region}.c2s.ic.gov",
@@ -86,7 +83,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "gamelift.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "gamelift.{region}.sc2s.sgov.gov",
@@ -97,7 +93,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "gamelift.{region}.amazonaws.com",
     variants: [
       {
         hostname: "gamelift.{region}.amazonaws.com",

--- a/clients/client-glacier/src/endpoints.ts
+++ b/clients/client-glacier/src/endpoints.ts
@@ -3,7 +3,6 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
   "ca-central-1": {
-    hostname: "glacier.ca-central-1.amazonaws.com",
     variants: [
       {
         hostname: "glacier.ca-central-1.amazonaws.com",
@@ -16,7 +15,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-east-1": {
-    hostname: "glacier.us-east-1.amazonaws.com",
     variants: [
       {
         hostname: "glacier.us-east-1.amazonaws.com",
@@ -29,7 +27,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-east-2": {
-    hostname: "glacier.us-east-2.amazonaws.com",
     variants: [
       {
         hostname: "glacier.us-east-2.amazonaws.com",
@@ -42,7 +39,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-gov-east-1": {
-    hostname: "glacier.us-gov-east-1.amazonaws.com",
     variants: [
       {
         hostname: "glacier.us-gov-east-1.amazonaws.com",
@@ -52,7 +48,6 @@ const regionHash: RegionHash = {
     signingRegion: "us-gov-east-1",
   },
   "us-gov-west-1": {
-    hostname: "glacier.us-gov-west-1.amazonaws.com",
     variants: [
       {
         hostname: "glacier.us-gov-west-1.amazonaws.com",
@@ -62,7 +57,6 @@ const regionHash: RegionHash = {
     signingRegion: "us-gov-west-1",
   },
   "us-west-1": {
-    hostname: "glacier.us-west-1.amazonaws.com",
     variants: [
       {
         hostname: "glacier.us-west-1.amazonaws.com",
@@ -75,7 +69,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-west-2": {
-    hostname: "glacier.us-west-2.amazonaws.com",
     variants: [
       {
         hostname: "glacier.us-west-2.amazonaws.com",
@@ -120,7 +113,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "glacier.{region}.amazonaws.com",
     variants: [
       {
         hostname: "glacier.{region}.amazonaws.com",
@@ -143,7 +135,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "glacier.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "glacier.{region}.amazonaws.com.cn",
@@ -166,7 +157,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "glacier.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "glacier.{region}.c2s.ic.gov",
@@ -177,7 +167,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "glacier.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "glacier.{region}.sc2s.sgov.gov",
@@ -188,7 +177,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "glacier.{region}.amazonaws.com",
     variants: [
       {
         hostname: "glacier.{region}.amazonaws.com",

--- a/clients/client-global-accelerator/src/endpoints.ts
+++ b/clients/client-global-accelerator/src/endpoints.ts
@@ -29,7 +29,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "globalaccelerator.{region}.amazonaws.com",
     variants: [
       {
         hostname: "globalaccelerator.{region}.amazonaws.com",
@@ -52,7 +51,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "globalaccelerator.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "globalaccelerator.{region}.amazonaws.com.cn",
@@ -75,7 +73,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "globalaccelerator.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "globalaccelerator.{region}.c2s.ic.gov",
@@ -86,7 +83,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "globalaccelerator.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "globalaccelerator.{region}.sc2s.sgov.gov",
@@ -97,7 +93,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "globalaccelerator.{region}.amazonaws.com",
     variants: [
       {
         hostname: "globalaccelerator.{region}.amazonaws.com",

--- a/clients/client-glue/src/endpoints.ts
+++ b/clients/client-glue/src/endpoints.ts
@@ -3,7 +3,6 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
   "us-east-1": {
-    hostname: "glue.us-east-1.amazonaws.com",
     variants: [
       {
         hostname: "glue.us-east-1.amazonaws.com",
@@ -16,7 +15,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-east-2": {
-    hostname: "glue.us-east-2.amazonaws.com",
     variants: [
       {
         hostname: "glue.us-east-2.amazonaws.com",
@@ -29,7 +27,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-gov-east-1": {
-    hostname: "glue.us-gov-east-1.amazonaws.com",
     variants: [
       {
         hostname: "glue.us-gov-east-1.amazonaws.com",
@@ -42,7 +39,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-gov-west-1": {
-    hostname: "glue.us-gov-west-1.amazonaws.com",
     variants: [
       {
         hostname: "glue.us-gov-west-1.amazonaws.com",
@@ -55,7 +51,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-west-1": {
-    hostname: "glue.us-west-1.amazonaws.com",
     variants: [
       {
         hostname: "glue.us-west-1.amazonaws.com",
@@ -68,7 +63,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-west-2": {
-    hostname: "glue.us-west-2.amazonaws.com",
     variants: [
       {
         hostname: "glue.us-west-2.amazonaws.com",
@@ -112,7 +106,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "glue.{region}.amazonaws.com",
     variants: [
       {
         hostname: "glue.{region}.amazonaws.com",
@@ -135,7 +128,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "glue.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "glue.{region}.amazonaws.com.cn",
@@ -158,7 +150,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "glue.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "glue.{region}.c2s.ic.gov",
@@ -169,7 +160,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "glue.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "glue.{region}.sc2s.sgov.gov",
@@ -180,7 +170,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["fips-us-gov-east-1", "fips-us-gov-west-1", "us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "glue.{region}.amazonaws.com",
     variants: [
       {
         hostname: "glue.{region}.amazonaws.com",

--- a/clients/client-grafana/src/endpoints.ts
+++ b/clients/client-grafana/src/endpoints.ts
@@ -3,7 +3,6 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
   "ap-northeast-1": {
-    hostname: "grafana.ap-northeast-1.amazonaws.com",
     variants: [
       {
         hostname: "grafana.ap-northeast-1.amazonaws.com",
@@ -13,7 +12,6 @@ const regionHash: RegionHash = {
     signingRegion: "ap-northeast-1",
   },
   "ap-northeast-2": {
-    hostname: "grafana.ap-northeast-2.amazonaws.com",
     variants: [
       {
         hostname: "grafana.ap-northeast-2.amazonaws.com",
@@ -23,7 +21,6 @@ const regionHash: RegionHash = {
     signingRegion: "ap-northeast-2",
   },
   "ap-southeast-1": {
-    hostname: "grafana.ap-southeast-1.amazonaws.com",
     variants: [
       {
         hostname: "grafana.ap-southeast-1.amazonaws.com",
@@ -33,7 +30,6 @@ const regionHash: RegionHash = {
     signingRegion: "ap-southeast-1",
   },
   "ap-southeast-2": {
-    hostname: "grafana.ap-southeast-2.amazonaws.com",
     variants: [
       {
         hostname: "grafana.ap-southeast-2.amazonaws.com",
@@ -43,7 +39,6 @@ const regionHash: RegionHash = {
     signingRegion: "ap-southeast-2",
   },
   "eu-central-1": {
-    hostname: "grafana.eu-central-1.amazonaws.com",
     variants: [
       {
         hostname: "grafana.eu-central-1.amazonaws.com",
@@ -53,7 +48,6 @@ const regionHash: RegionHash = {
     signingRegion: "eu-central-1",
   },
   "eu-west-1": {
-    hostname: "grafana.eu-west-1.amazonaws.com",
     variants: [
       {
         hostname: "grafana.eu-west-1.amazonaws.com",
@@ -63,7 +57,6 @@ const regionHash: RegionHash = {
     signingRegion: "eu-west-1",
   },
   "eu-west-2": {
-    hostname: "grafana.eu-west-2.amazonaws.com",
     variants: [
       {
         hostname: "grafana.eu-west-2.amazonaws.com",
@@ -73,7 +66,6 @@ const regionHash: RegionHash = {
     signingRegion: "eu-west-2",
   },
   "us-east-1": {
-    hostname: "grafana.us-east-1.amazonaws.com",
     variants: [
       {
         hostname: "grafana.us-east-1.amazonaws.com",
@@ -83,7 +75,6 @@ const regionHash: RegionHash = {
     signingRegion: "us-east-1",
   },
   "us-east-2": {
-    hostname: "grafana.us-east-2.amazonaws.com",
     variants: [
       {
         hostname: "grafana.us-east-2.amazonaws.com",
@@ -93,7 +84,6 @@ const regionHash: RegionHash = {
     signingRegion: "us-east-2",
   },
   "us-west-2": {
-    hostname: "grafana.us-west-2.amazonaws.com",
     variants: [
       {
         hostname: "grafana.us-west-2.amazonaws.com",
@@ -130,7 +120,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "grafana.{region}.amazonaws.com",
     variants: [
       {
         hostname: "grafana.{region}.amazonaws.com",
@@ -153,7 +142,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "grafana.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "grafana.{region}.amazonaws.com.cn",
@@ -176,7 +164,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "grafana.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "grafana.{region}.c2s.ic.gov",
@@ -187,7 +174,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "grafana.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "grafana.{region}.sc2s.sgov.gov",
@@ -198,7 +184,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "grafana.{region}.amazonaws.com",
     variants: [
       {
         hostname: "grafana.{region}.amazonaws.com",

--- a/clients/client-greengrass/src/endpoints.ts
+++ b/clients/client-greengrass/src/endpoints.ts
@@ -3,7 +3,6 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
   "dataplane-us-gov-east-1": {
-    hostname: "greengrass-ats.iot.us-gov-east-1.amazonaws.com",
     variants: [
       {
         hostname: "greengrass-ats.iot.us-gov-east-1.amazonaws.com",
@@ -13,7 +12,6 @@ const regionHash: RegionHash = {
     signingRegion: "us-gov-east-1",
   },
   "dataplane-us-gov-west-1": {
-    hostname: "greengrass-ats.iot.us-gov-west-1.amazonaws.com",
     variants: [
       {
         hostname: "greengrass-ats.iot.us-gov-west-1.amazonaws.com",
@@ -23,7 +21,6 @@ const regionHash: RegionHash = {
     signingRegion: "us-gov-west-1",
   },
   "us-gov-east-1": {
-    hostname: "greengrass.us-gov-east-1.amazonaws.com",
     variants: [
       {
         hostname: "greengrass.us-gov-east-1.amazonaws.com",
@@ -37,7 +34,6 @@ const regionHash: RegionHash = {
     signingRegion: "us-gov-east-1",
   },
   "us-gov-west-1": {
-    hostname: "greengrass.us-gov-west-1.amazonaws.com",
     variants: [
       {
         hostname: "greengrass.us-gov-west-1.amazonaws.com",
@@ -74,7 +70,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "greengrass.{region}.amazonaws.com",
     variants: [
       {
         hostname: "greengrass.{region}.amazonaws.com",
@@ -97,7 +92,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "greengrass.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "greengrass.{region}.amazonaws.com.cn",
@@ -120,7 +114,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "greengrass.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "greengrass.{region}.c2s.ic.gov",
@@ -131,7 +124,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "greengrass.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "greengrass.{region}.sc2s.sgov.gov",
@@ -148,7 +140,6 @@ const partitionHash: PartitionHash = {
       "us-gov-west-1",
     ],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "greengrass.{region}.amazonaws.com",
     variants: [
       {
         hostname: "greengrass.{region}.amazonaws.com",

--- a/clients/client-greengrassv2/src/endpoints.ts
+++ b/clients/client-greengrassv2/src/endpoints.ts
@@ -3,7 +3,6 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
   "dataplane-us-gov-east-1": {
-    hostname: "greengrass-ats.iot.us-gov-east-1.amazonaws.com",
     variants: [
       {
         hostname: "greengrass-ats.iot.us-gov-east-1.amazonaws.com",
@@ -13,7 +12,6 @@ const regionHash: RegionHash = {
     signingRegion: "us-gov-east-1",
   },
   "dataplane-us-gov-west-1": {
-    hostname: "greengrass-ats.iot.us-gov-west-1.amazonaws.com",
     variants: [
       {
         hostname: "greengrass-ats.iot.us-gov-west-1.amazonaws.com",
@@ -23,7 +21,6 @@ const regionHash: RegionHash = {
     signingRegion: "us-gov-west-1",
   },
   "us-gov-east-1": {
-    hostname: "greengrass.us-gov-east-1.amazonaws.com",
     variants: [
       {
         hostname: "greengrass.us-gov-east-1.amazonaws.com",
@@ -37,7 +34,6 @@ const regionHash: RegionHash = {
     signingRegion: "us-gov-east-1",
   },
   "us-gov-west-1": {
-    hostname: "greengrass.us-gov-west-1.amazonaws.com",
     variants: [
       {
         hostname: "greengrass.us-gov-west-1.amazonaws.com",
@@ -74,7 +70,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "greengrass.{region}.amazonaws.com",
     variants: [
       {
         hostname: "greengrass.{region}.amazonaws.com",
@@ -97,7 +92,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "greengrass.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "greengrass.{region}.amazonaws.com.cn",
@@ -120,7 +114,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "greengrass.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "greengrass.{region}.c2s.ic.gov",
@@ -131,7 +124,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "greengrass.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "greengrass.{region}.sc2s.sgov.gov",
@@ -148,7 +140,6 @@ const partitionHash: PartitionHash = {
       "us-gov-west-1",
     ],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "greengrass.{region}.amazonaws.com",
     variants: [
       {
         hostname: "greengrass.{region}.amazonaws.com",

--- a/clients/client-groundstation/src/endpoints.ts
+++ b/clients/client-groundstation/src/endpoints.ts
@@ -3,7 +3,6 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
   "us-east-1": {
-    hostname: "groundstation.us-east-1.amazonaws.com",
     variants: [
       {
         hostname: "groundstation.us-east-1.amazonaws.com",
@@ -16,7 +15,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-east-2": {
-    hostname: "groundstation.us-east-2.amazonaws.com",
     variants: [
       {
         hostname: "groundstation.us-east-2.amazonaws.com",
@@ -29,7 +27,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-west-2": {
-    hostname: "groundstation.us-west-2.amazonaws.com",
     variants: [
       {
         hostname: "groundstation.us-west-2.amazonaws.com",
@@ -72,7 +69,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "groundstation.{region}.amazonaws.com",
     variants: [
       {
         hostname: "groundstation.{region}.amazonaws.com",
@@ -95,7 +91,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "groundstation.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "groundstation.{region}.amazonaws.com.cn",
@@ -118,7 +113,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "groundstation.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "groundstation.{region}.c2s.ic.gov",
@@ -129,7 +123,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "groundstation.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "groundstation.{region}.sc2s.sgov.gov",
@@ -140,7 +133,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "groundstation.{region}.amazonaws.com",
     variants: [
       {
         hostname: "groundstation.{region}.amazonaws.com",

--- a/clients/client-guardduty/src/endpoints.ts
+++ b/clients/client-guardduty/src/endpoints.ts
@@ -3,7 +3,6 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
   "us-east-1": {
-    hostname: "guardduty.us-east-1.amazonaws.com",
     variants: [
       {
         hostname: "guardduty.us-east-1.amazonaws.com",
@@ -16,7 +15,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-east-2": {
-    hostname: "guardduty.us-east-2.amazonaws.com",
     variants: [
       {
         hostname: "guardduty.us-east-2.amazonaws.com",
@@ -29,7 +27,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-gov-east-1": {
-    hostname: "guardduty.us-gov-east-1.amazonaws.com",
     variants: [
       {
         hostname: "guardduty.us-gov-east-1.amazonaws.com",
@@ -42,7 +39,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-gov-west-1": {
-    hostname: "guardduty.us-gov-west-1.amazonaws.com",
     variants: [
       {
         hostname: "guardduty.us-gov-west-1.amazonaws.com",
@@ -55,7 +51,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-west-1": {
-    hostname: "guardduty.us-west-1.amazonaws.com",
     variants: [
       {
         hostname: "guardduty.us-west-1.amazonaws.com",
@@ -68,7 +63,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-west-2": {
-    hostname: "guardduty.us-west-2.amazonaws.com",
     variants: [
       {
         hostname: "guardduty.us-west-2.amazonaws.com",
@@ -112,7 +106,6 @@ const partitionHash: PartitionHash = {
       "us-west-2-fips",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "guardduty.{region}.amazonaws.com",
     variants: [
       {
         hostname: "guardduty.{region}.amazonaws.com",
@@ -135,7 +128,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "guardduty.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "guardduty.{region}.amazonaws.com.cn",
@@ -158,7 +150,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "guardduty.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "guardduty.{region}.c2s.ic.gov",
@@ -169,7 +160,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "guardduty.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "guardduty.{region}.sc2s.sgov.gov",
@@ -180,7 +170,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-east-1-fips", "us-gov-west-1", "us-gov-west-1-fips"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "guardduty.{region}.amazonaws.com",
     variants: [
       {
         hostname: "guardduty.{region}.amazonaws.com",

--- a/clients/client-health/src/endpoints.ts
+++ b/clients/client-health/src/endpoints.ts
@@ -30,7 +30,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "health.{region}.amazonaws.com",
     variants: [
       {
         hostname: "health.{region}.amazonaws.com",
@@ -53,7 +52,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "health.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "health.{region}.amazonaws.com.cn",
@@ -76,7 +74,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "health.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "health.{region}.c2s.ic.gov",
@@ -87,7 +84,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "health.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "health.{region}.sc2s.sgov.gov",
@@ -98,7 +94,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["fips-us-gov-west-1", "us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "health.{region}.amazonaws.com",
     variants: [
       {
         hostname: "health.{region}.amazonaws.com",

--- a/clients/client-healthlake/src/endpoints.ts
+++ b/clients/client-healthlake/src/endpoints.ts
@@ -29,7 +29,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "healthlake.{region}.amazonaws.com",
     variants: [
       {
         hostname: "healthlake.{region}.amazonaws.com",
@@ -52,7 +51,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "healthlake.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "healthlake.{region}.amazonaws.com.cn",
@@ -75,7 +73,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "healthlake.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "healthlake.{region}.c2s.ic.gov",
@@ -86,7 +83,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "healthlake.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "healthlake.{region}.sc2s.sgov.gov",
@@ -97,7 +93,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "healthlake.{region}.amazonaws.com",
     variants: [
       {
         hostname: "healthlake.{region}.amazonaws.com",

--- a/clients/client-honeycode/src/endpoints.ts
+++ b/clients/client-honeycode/src/endpoints.ts
@@ -29,7 +29,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "honeycode.{region}.amazonaws.com",
     variants: [
       {
         hostname: "honeycode.{region}.amazonaws.com",
@@ -52,7 +51,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "honeycode.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "honeycode.{region}.amazonaws.com.cn",
@@ -75,7 +73,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "honeycode.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "honeycode.{region}.c2s.ic.gov",
@@ -86,7 +83,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "honeycode.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "honeycode.{region}.sc2s.sgov.gov",
@@ -97,7 +93,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "honeycode.{region}.amazonaws.com",
     variants: [
       {
         hostname: "honeycode.{region}.amazonaws.com",

--- a/clients/client-iam/src/endpoints.ts
+++ b/clients/client-iam/src/endpoints.ts
@@ -3,7 +3,6 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
   "aws-cn-global": {
-    hostname: "iam.cn-north-1.amazonaws.com.cn",
     variants: [
       {
         hostname: "iam.cn-north-1.amazonaws.com.cn",
@@ -13,7 +12,6 @@ const regionHash: RegionHash = {
     signingRegion: "cn-north-1",
   },
   "aws-global": {
-    hostname: "iam.amazonaws.com",
     variants: [
       {
         hostname: "iam.amazonaws.com",
@@ -27,7 +25,6 @@ const regionHash: RegionHash = {
     signingRegion: "us-east-1",
   },
   "aws-iso-b-global": {
-    hostname: "iam.us-isob-east-1.sc2s.sgov.gov",
     variants: [
       {
         hostname: "iam.us-isob-east-1.sc2s.sgov.gov",
@@ -37,7 +34,6 @@ const regionHash: RegionHash = {
     signingRegion: "us-isob-east-1",
   },
   "aws-iso-global": {
-    hostname: "iam.us-iso-east-1.c2s.ic.gov",
     variants: [
       {
         hostname: "iam.us-iso-east-1.c2s.ic.gov",
@@ -47,7 +43,6 @@ const regionHash: RegionHash = {
     signingRegion: "us-iso-east-1",
   },
   "aws-us-gov-global": {
-    hostname: "iam.us-gov.amazonaws.com",
     variants: [
       {
         hostname: "iam.us-gov.amazonaws.com",
@@ -92,7 +87,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "iam.{region}.amazonaws.com",
     variants: [
       {
         hostname: "iam.{region}.amazonaws.com",
@@ -116,7 +110,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["aws-cn-global", "cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "iam.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "iam.{region}.amazonaws.com.cn",
@@ -140,7 +133,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["aws-iso-global", "us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "iam.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "iam.{region}.c2s.ic.gov",
@@ -152,7 +144,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["aws-iso-b-global", "us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "iam.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "iam.{region}.sc2s.sgov.gov",
@@ -171,7 +162,6 @@ const partitionHash: PartitionHash = {
       "us-gov-west-1",
     ],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "iam.{region}.amazonaws.com",
     variants: [
       {
         hostname: "iam.{region}.amazonaws.com",

--- a/clients/client-identitystore/src/endpoints.ts
+++ b/clients/client-identitystore/src/endpoints.ts
@@ -3,7 +3,6 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
   "us-gov-west-1": {
-    hostname: "identitystore.us-gov-west-1.amazonaws.com",
     variants: [
       {
         hostname: "identitystore.us-gov-west-1.amazonaws.com",
@@ -43,7 +42,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "identitystore.{region}.amazonaws.com",
     variants: [
       {
         hostname: "identitystore.{region}.amazonaws.com",
@@ -66,7 +64,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "identitystore.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "identitystore.{region}.amazonaws.com.cn",
@@ -89,7 +86,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "identitystore.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "identitystore.{region}.c2s.ic.gov",
@@ -100,7 +96,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "identitystore.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "identitystore.{region}.sc2s.sgov.gov",
@@ -111,7 +106,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["fips-us-gov-west-1", "us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "identitystore.{region}.amazonaws.com",
     variants: [
       {
         hostname: "identitystore.{region}.amazonaws.com",

--- a/clients/client-imagebuilder/src/endpoints.ts
+++ b/clients/client-imagebuilder/src/endpoints.ts
@@ -29,7 +29,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "imagebuilder.{region}.amazonaws.com",
     variants: [
       {
         hostname: "imagebuilder.{region}.amazonaws.com",
@@ -52,7 +51,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "imagebuilder.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "imagebuilder.{region}.amazonaws.com.cn",
@@ -75,7 +73,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "imagebuilder.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "imagebuilder.{region}.c2s.ic.gov",
@@ -86,7 +83,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "imagebuilder.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "imagebuilder.{region}.sc2s.sgov.gov",
@@ -97,7 +93,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "imagebuilder.{region}.amazonaws.com",
     variants: [
       {
         hostname: "imagebuilder.{region}.amazonaws.com",

--- a/clients/client-inspector/src/endpoints.ts
+++ b/clients/client-inspector/src/endpoints.ts
@@ -3,7 +3,6 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
   "us-east-1": {
-    hostname: "inspector.us-east-1.amazonaws.com",
     variants: [
       {
         hostname: "inspector.us-east-1.amazonaws.com",
@@ -16,7 +15,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-east-2": {
-    hostname: "inspector.us-east-2.amazonaws.com",
     variants: [
       {
         hostname: "inspector.us-east-2.amazonaws.com",
@@ -29,7 +27,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-gov-east-1": {
-    hostname: "inspector.us-gov-east-1.amazonaws.com",
     variants: [
       {
         hostname: "inspector.us-gov-east-1.amazonaws.com",
@@ -42,7 +39,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-gov-west-1": {
-    hostname: "inspector.us-gov-west-1.amazonaws.com",
     variants: [
       {
         hostname: "inspector.us-gov-west-1.amazonaws.com",
@@ -55,7 +51,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-west-1": {
-    hostname: "inspector.us-west-1.amazonaws.com",
     variants: [
       {
         hostname: "inspector.us-west-1.amazonaws.com",
@@ -68,7 +63,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-west-2": {
-    hostname: "inspector.us-west-2.amazonaws.com",
     variants: [
       {
         hostname: "inspector.us-west-2.amazonaws.com",
@@ -112,7 +106,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "inspector.{region}.amazonaws.com",
     variants: [
       {
         hostname: "inspector.{region}.amazonaws.com",
@@ -135,7 +128,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "inspector.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "inspector.{region}.amazonaws.com.cn",
@@ -158,7 +150,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "inspector.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "inspector.{region}.c2s.ic.gov",
@@ -169,7 +160,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "inspector.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "inspector.{region}.sc2s.sgov.gov",
@@ -180,7 +170,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["fips-us-gov-east-1", "fips-us-gov-west-1", "us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "inspector.{region}.amazonaws.com",
     variants: [
       {
         hostname: "inspector.{region}.amazonaws.com",

--- a/clients/client-iot-1click-devices-service/src/endpoints.ts
+++ b/clients/client-iot-1click-devices-service/src/endpoints.ts
@@ -29,7 +29,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "devices.iot1click.{region}.amazonaws.com",
     variants: [
       {
         hostname: "devices.iot1click.{region}.amazonaws.com",
@@ -52,7 +51,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "devices.iot1click.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "devices.iot1click.{region}.amazonaws.com.cn",
@@ -75,7 +73,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "devices.iot1click.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "devices.iot1click.{region}.c2s.ic.gov",
@@ -86,7 +83,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "devices.iot1click.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "devices.iot1click.{region}.sc2s.sgov.gov",
@@ -97,7 +93,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "devices.iot1click.{region}.amazonaws.com",
     variants: [
       {
         hostname: "devices.iot1click.{region}.amazonaws.com",

--- a/clients/client-iot-1click-projects/src/endpoints.ts
+++ b/clients/client-iot-1click-projects/src/endpoints.ts
@@ -29,7 +29,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "projects.iot1click.{region}.amazonaws.com",
     variants: [
       {
         hostname: "projects.iot1click.{region}.amazonaws.com",
@@ -52,7 +51,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "projects.iot1click.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "projects.iot1click.{region}.amazonaws.com.cn",
@@ -75,7 +73,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "projects.iot1click.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "projects.iot1click.{region}.c2s.ic.gov",
@@ -86,7 +83,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "projects.iot1click.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "projects.iot1click.{region}.sc2s.sgov.gov",
@@ -97,7 +93,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "projects.iot1click.{region}.amazonaws.com",
     variants: [
       {
         hostname: "projects.iot1click.{region}.amazonaws.com",

--- a/clients/client-iot-data-plane/src/endpoints.ts
+++ b/clients/client-iot-data-plane/src/endpoints.ts
@@ -3,7 +3,6 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
   "ca-central-1": {
-    hostname: "data.iot.ca-central-1.amazonaws.com",
     variants: [
       {
         hostname: "data.iot.ca-central-1.amazonaws.com",
@@ -16,7 +15,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-east-1": {
-    hostname: "data.iot.us-east-1.amazonaws.com",
     variants: [
       {
         hostname: "data.iot.us-east-1.amazonaws.com",
@@ -29,7 +27,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-east-2": {
-    hostname: "data.iot.us-east-2.amazonaws.com",
     variants: [
       {
         hostname: "data.iot.us-east-2.amazonaws.com",
@@ -42,7 +39,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-gov-east-1": {
-    hostname: "data.iot.us-gov-east-1.amazonaws.com",
     variants: [
       {
         hostname: "data.iot.us-gov-east-1.amazonaws.com",
@@ -55,7 +51,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-gov-west-1": {
-    hostname: "data.iot.us-gov-west-1.amazonaws.com",
     variants: [
       {
         hostname: "data.iot.us-gov-west-1.amazonaws.com",
@@ -68,7 +63,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-west-1": {
-    hostname: "data.iot.us-west-1.amazonaws.com",
     variants: [
       {
         hostname: "data.iot.us-west-1.amazonaws.com",
@@ -81,7 +75,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-west-2": {
-    hostname: "data.iot.us-west-2.amazonaws.com",
     variants: [
       {
         hostname: "data.iot.us-west-2.amazonaws.com",
@@ -126,7 +119,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "data.iot.{region}.amazonaws.com",
     variants: [
       {
         hostname: "data.iot.{region}.amazonaws.com",
@@ -149,7 +141,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "data.iot.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "data.iot.{region}.amazonaws.com.cn",
@@ -172,7 +163,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "data.iot.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "data.iot.{region}.c2s.ic.gov",
@@ -183,7 +173,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "data.iot.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "data.iot.{region}.sc2s.sgov.gov",
@@ -194,7 +183,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["fips-us-gov-east-1", "fips-us-gov-west-1", "us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "data.iot.{region}.amazonaws.com",
     variants: [
       {
         hostname: "data.iot.{region}.amazonaws.com",

--- a/clients/client-iot-events-data/src/endpoints.ts
+++ b/clients/client-iot-events-data/src/endpoints.ts
@@ -29,7 +29,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "data.iotevents.{region}.amazonaws.com",
     variants: [
       {
         hostname: "data.iotevents.{region}.amazonaws.com",
@@ -52,7 +51,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "data.iotevents.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "data.iotevents.{region}.amazonaws.com.cn",
@@ -75,7 +73,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "data.iotevents.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "data.iotevents.{region}.c2s.ic.gov",
@@ -86,7 +83,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "data.iotevents.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "data.iotevents.{region}.sc2s.sgov.gov",
@@ -97,7 +93,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "data.iotevents.{region}.amazonaws.com",
     variants: [
       {
         hostname: "data.iotevents.{region}.amazonaws.com",

--- a/clients/client-iot-events/src/endpoints.ts
+++ b/clients/client-iot-events/src/endpoints.ts
@@ -29,7 +29,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "iotevents.{region}.amazonaws.com",
     variants: [
       {
         hostname: "iotevents.{region}.amazonaws.com",
@@ -52,7 +51,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "iotevents.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "iotevents.{region}.amazonaws.com.cn",
@@ -75,7 +73,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "iotevents.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "iotevents.{region}.c2s.ic.gov",
@@ -86,7 +83,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "iotevents.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "iotevents.{region}.sc2s.sgov.gov",
@@ -97,7 +93,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "iotevents.{region}.amazonaws.com",
     variants: [
       {
         hostname: "iotevents.{region}.amazonaws.com",

--- a/clients/client-iot-jobs-data-plane/src/endpoints.ts
+++ b/clients/client-iot-jobs-data-plane/src/endpoints.ts
@@ -3,7 +3,6 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
   "ca-central-1": {
-    hostname: "data.jobs.iot.ca-central-1.amazonaws.com",
     variants: [
       {
         hostname: "data.jobs.iot.ca-central-1.amazonaws.com",
@@ -16,7 +15,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-east-1": {
-    hostname: "data.jobs.iot.us-east-1.amazonaws.com",
     variants: [
       {
         hostname: "data.jobs.iot.us-east-1.amazonaws.com",
@@ -29,7 +27,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-east-2": {
-    hostname: "data.jobs.iot.us-east-2.amazonaws.com",
     variants: [
       {
         hostname: "data.jobs.iot.us-east-2.amazonaws.com",
@@ -42,7 +39,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-gov-east-1": {
-    hostname: "data.jobs.iot.us-gov-east-1.amazonaws.com",
     variants: [
       {
         hostname: "data.jobs.iot.us-gov-east-1.amazonaws.com",
@@ -55,7 +51,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-gov-west-1": {
-    hostname: "data.jobs.iot.us-gov-west-1.amazonaws.com",
     variants: [
       {
         hostname: "data.jobs.iot.us-gov-west-1.amazonaws.com",
@@ -68,7 +63,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-west-1": {
-    hostname: "data.jobs.iot.us-west-1.amazonaws.com",
     variants: [
       {
         hostname: "data.jobs.iot.us-west-1.amazonaws.com",
@@ -81,7 +75,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-west-2": {
-    hostname: "data.jobs.iot.us-west-2.amazonaws.com",
     variants: [
       {
         hostname: "data.jobs.iot.us-west-2.amazonaws.com",
@@ -126,7 +119,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "data.jobs.iot.{region}.amazonaws.com",
     variants: [
       {
         hostname: "data.jobs.iot.{region}.amazonaws.com",
@@ -149,7 +141,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "data.jobs.iot.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "data.jobs.iot.{region}.amazonaws.com.cn",
@@ -172,7 +163,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "data.jobs.iot.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "data.jobs.iot.{region}.c2s.ic.gov",
@@ -183,7 +173,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "data.jobs.iot.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "data.jobs.iot.{region}.sc2s.sgov.gov",
@@ -194,7 +183,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["fips-us-gov-east-1", "fips-us-gov-west-1", "us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "data.jobs.iot.{region}.amazonaws.com",
     variants: [
       {
         hostname: "data.jobs.iot.{region}.amazonaws.com",

--- a/clients/client-iot-wireless/src/endpoints.ts
+++ b/clients/client-iot-wireless/src/endpoints.ts
@@ -29,7 +29,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "api.iotwireless.{region}.amazonaws.com",
     variants: [
       {
         hostname: "api.iotwireless.{region}.amazonaws.com",
@@ -52,7 +51,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "api.iotwireless.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "api.iotwireless.{region}.amazonaws.com.cn",
@@ -75,7 +73,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "api.iotwireless.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "api.iotwireless.{region}.c2s.ic.gov",
@@ -86,7 +83,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "api.iotwireless.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "api.iotwireless.{region}.sc2s.sgov.gov",
@@ -97,7 +93,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "api.iotwireless.{region}.amazonaws.com",
     variants: [
       {
         hostname: "api.iotwireless.{region}.amazonaws.com",

--- a/clients/client-iot/src/endpoints.ts
+++ b/clients/client-iot/src/endpoints.ts
@@ -3,7 +3,6 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
   "ca-central-1": {
-    hostname: "iot.ca-central-1.amazonaws.com",
     variants: [
       {
         hostname: "iot.ca-central-1.amazonaws.com",
@@ -16,7 +15,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-east-1": {
-    hostname: "iot.us-east-1.amazonaws.com",
     variants: [
       {
         hostname: "iot.us-east-1.amazonaws.com",
@@ -29,7 +27,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-east-2": {
-    hostname: "iot.us-east-2.amazonaws.com",
     variants: [
       {
         hostname: "iot.us-east-2.amazonaws.com",
@@ -42,7 +39,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-gov-east-1": {
-    hostname: "iot.us-gov-east-1.amazonaws.com",
     variants: [
       {
         hostname: "iot.us-gov-east-1.amazonaws.com",
@@ -55,7 +51,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-gov-west-1": {
-    hostname: "iot.us-gov-west-1.amazonaws.com",
     variants: [
       {
         hostname: "iot.us-gov-west-1.amazonaws.com",
@@ -68,7 +63,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-west-1": {
-    hostname: "iot.us-west-1.amazonaws.com",
     variants: [
       {
         hostname: "iot.us-west-1.amazonaws.com",
@@ -81,7 +75,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-west-2": {
-    hostname: "iot.us-west-2.amazonaws.com",
     variants: [
       {
         hostname: "iot.us-west-2.amazonaws.com",
@@ -126,7 +119,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "iot.{region}.amazonaws.com",
     variants: [
       {
         hostname: "iot.{region}.amazonaws.com",
@@ -149,7 +141,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "iot.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "iot.{region}.amazonaws.com.cn",
@@ -172,7 +163,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "iot.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "iot.{region}.c2s.ic.gov",
@@ -183,7 +173,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "iot.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "iot.{region}.sc2s.sgov.gov",
@@ -194,7 +183,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["fips-us-gov-east-1", "fips-us-gov-west-1", "us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "iot.{region}.amazonaws.com",
     variants: [
       {
         hostname: "iot.{region}.amazonaws.com",

--- a/clients/client-iotanalytics/src/endpoints.ts
+++ b/clients/client-iotanalytics/src/endpoints.ts
@@ -29,7 +29,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "iotanalytics.{region}.amazonaws.com",
     variants: [
       {
         hostname: "iotanalytics.{region}.amazonaws.com",
@@ -52,7 +51,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "iotanalytics.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "iotanalytics.{region}.amazonaws.com.cn",
@@ -75,7 +73,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "iotanalytics.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "iotanalytics.{region}.c2s.ic.gov",
@@ -86,7 +83,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "iotanalytics.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "iotanalytics.{region}.sc2s.sgov.gov",
@@ -97,7 +93,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "iotanalytics.{region}.amazonaws.com",
     variants: [
       {
         hostname: "iotanalytics.{region}.amazonaws.com",

--- a/clients/client-iotdeviceadvisor/src/endpoints.ts
+++ b/clients/client-iotdeviceadvisor/src/endpoints.ts
@@ -29,7 +29,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "api.iotdeviceadvisor.{region}.amazonaws.com",
     variants: [
       {
         hostname: "api.iotdeviceadvisor.{region}.amazonaws.com",
@@ -52,7 +51,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "api.iotdeviceadvisor.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "api.iotdeviceadvisor.{region}.amazonaws.com.cn",
@@ -75,7 +73,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "api.iotdeviceadvisor.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "api.iotdeviceadvisor.{region}.c2s.ic.gov",
@@ -86,7 +83,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "api.iotdeviceadvisor.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "api.iotdeviceadvisor.{region}.sc2s.sgov.gov",
@@ -97,7 +93,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "api.iotdeviceadvisor.{region}.amazonaws.com",
     variants: [
       {
         hostname: "api.iotdeviceadvisor.{region}.amazonaws.com",

--- a/clients/client-iotfleethub/src/endpoints.ts
+++ b/clients/client-iotfleethub/src/endpoints.ts
@@ -3,7 +3,6 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
   "ca-central-1": {
-    hostname: "api.fleethub.iot.ca-central-1.amazonaws.com",
     variants: [
       {
         hostname: "api.fleethub.iot.ca-central-1.amazonaws.com",
@@ -16,7 +15,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-east-1": {
-    hostname: "api.fleethub.iot.us-east-1.amazonaws.com",
     variants: [
       {
         hostname: "api.fleethub.iot.us-east-1.amazonaws.com",
@@ -29,7 +27,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-east-2": {
-    hostname: "api.fleethub.iot.us-east-2.amazonaws.com",
     variants: [
       {
         hostname: "api.fleethub.iot.us-east-2.amazonaws.com",
@@ -42,7 +39,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-west-2": {
-    hostname: "api.fleethub.iot.us-west-2.amazonaws.com",
     variants: [
       {
         hostname: "api.fleethub.iot.us-west-2.amazonaws.com",
@@ -86,7 +82,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "api.fleethub.iot.{region}.amazonaws.com",
     variants: [
       {
         hostname: "api.fleethub.iot.{region}.amazonaws.com",
@@ -109,7 +104,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "api.fleethub.iot.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "api.fleethub.iot.{region}.amazonaws.com.cn",
@@ -132,7 +126,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "api.fleethub.iot.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "api.fleethub.iot.{region}.c2s.ic.gov",
@@ -143,7 +136,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "api.fleethub.iot.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "api.fleethub.iot.{region}.sc2s.sgov.gov",
@@ -154,7 +146,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "api.fleethub.iot.{region}.amazonaws.com",
     variants: [
       {
         hostname: "api.fleethub.iot.{region}.amazonaws.com",

--- a/clients/client-iotsecuretunneling/src/endpoints.ts
+++ b/clients/client-iotsecuretunneling/src/endpoints.ts
@@ -29,7 +29,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "api.tunneling.iot.{region}.amazonaws.com",
     variants: [
       {
         hostname: "api.tunneling.iot.{region}.amazonaws.com",
@@ -52,7 +51,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "api.tunneling.iot.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "api.tunneling.iot.{region}.amazonaws.com.cn",
@@ -75,7 +73,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "api.tunneling.iot.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "api.tunneling.iot.{region}.c2s.ic.gov",
@@ -86,7 +83,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "api.tunneling.iot.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "api.tunneling.iot.{region}.sc2s.sgov.gov",
@@ -97,7 +93,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "api.tunneling.iot.{region}.amazonaws.com",
     variants: [
       {
         hostname: "api.tunneling.iot.{region}.amazonaws.com",

--- a/clients/client-iotsitewise/src/endpoints.ts
+++ b/clients/client-iotsitewise/src/endpoints.ts
@@ -29,7 +29,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "iotsitewise.{region}.amazonaws.com",
     variants: [
       {
         hostname: "iotsitewise.{region}.amazonaws.com",
@@ -52,7 +51,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "iotsitewise.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "iotsitewise.{region}.amazonaws.com.cn",
@@ -75,7 +73,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "iotsitewise.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "iotsitewise.{region}.c2s.ic.gov",
@@ -86,7 +83,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "iotsitewise.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "iotsitewise.{region}.sc2s.sgov.gov",
@@ -97,7 +93,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "iotsitewise.{region}.amazonaws.com",
     variants: [
       {
         hostname: "iotsitewise.{region}.amazonaws.com",

--- a/clients/client-iotthingsgraph/src/endpoints.ts
+++ b/clients/client-iotthingsgraph/src/endpoints.ts
@@ -29,7 +29,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "iotthingsgraph.{region}.amazonaws.com",
     variants: [
       {
         hostname: "iotthingsgraph.{region}.amazonaws.com",
@@ -52,7 +51,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "iotthingsgraph.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "iotthingsgraph.{region}.amazonaws.com.cn",
@@ -75,7 +73,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "iotthingsgraph.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "iotthingsgraph.{region}.c2s.ic.gov",
@@ -86,7 +83,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "iotthingsgraph.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "iotthingsgraph.{region}.sc2s.sgov.gov",
@@ -97,7 +93,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "iotthingsgraph.{region}.amazonaws.com",
     variants: [
       {
         hostname: "iotthingsgraph.{region}.amazonaws.com",

--- a/clients/client-ivs/src/endpoints.ts
+++ b/clients/client-ivs/src/endpoints.ts
@@ -29,7 +29,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "ivs.{region}.amazonaws.com",
     variants: [
       {
         hostname: "ivs.{region}.amazonaws.com",
@@ -52,7 +51,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "ivs.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "ivs.{region}.amazonaws.com.cn",
@@ -75,7 +73,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "ivs.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "ivs.{region}.c2s.ic.gov",
@@ -86,7 +83,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "ivs.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "ivs.{region}.sc2s.sgov.gov",
@@ -97,7 +93,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "ivs.{region}.amazonaws.com",
     variants: [
       {
         hostname: "ivs.{region}.amazonaws.com",

--- a/clients/client-kafka/src/endpoints.ts
+++ b/clients/client-kafka/src/endpoints.ts
@@ -29,7 +29,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "kafka.{region}.amazonaws.com",
     variants: [
       {
         hostname: "kafka.{region}.amazonaws.com",
@@ -52,7 +51,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "kafka.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "kafka.{region}.amazonaws.com.cn",
@@ -75,7 +73,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "kafka.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "kafka.{region}.c2s.ic.gov",
@@ -86,7 +83,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "kafka.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "kafka.{region}.sc2s.sgov.gov",
@@ -97,7 +93,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "kafka.{region}.amazonaws.com",
     variants: [
       {
         hostname: "kafka.{region}.amazonaws.com",

--- a/clients/client-kafkaconnect/src/endpoints.ts
+++ b/clients/client-kafkaconnect/src/endpoints.ts
@@ -29,7 +29,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "kafkaconnect.{region}.amazonaws.com",
     variants: [
       {
         hostname: "kafkaconnect.{region}.amazonaws.com",
@@ -52,7 +51,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "kafkaconnect.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "kafkaconnect.{region}.amazonaws.com.cn",
@@ -75,7 +73,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "kafkaconnect.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "kafkaconnect.{region}.c2s.ic.gov",
@@ -86,7 +83,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "kafkaconnect.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "kafkaconnect.{region}.sc2s.sgov.gov",
@@ -97,7 +93,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "kafkaconnect.{region}.amazonaws.com",
     variants: [
       {
         hostname: "kafkaconnect.{region}.amazonaws.com",

--- a/clients/client-kendra/src/endpoints.ts
+++ b/clients/client-kendra/src/endpoints.ts
@@ -3,7 +3,6 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
   "us-east-1": {
-    hostname: "kendra.us-east-1.amazonaws.com",
     variants: [
       {
         hostname: "kendra.us-east-1.amazonaws.com",
@@ -16,7 +15,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-east-2": {
-    hostname: "kendra.us-east-2.amazonaws.com",
     variants: [
       {
         hostname: "kendra.us-east-2.amazonaws.com",
@@ -29,7 +27,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-gov-west-1": {
-    hostname: "kendra.us-gov-west-1.amazonaws.com",
     variants: [
       {
         hostname: "kendra.us-gov-west-1.amazonaws.com",
@@ -42,7 +39,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-west-2": {
-    hostname: "kendra.us-west-2.amazonaws.com",
     variants: [
       {
         hostname: "kendra.us-west-2.amazonaws.com",
@@ -85,7 +81,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "kendra.{region}.amazonaws.com",
     variants: [
       {
         hostname: "kendra.{region}.amazonaws.com",
@@ -108,7 +103,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "kendra.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "kendra.{region}.amazonaws.com.cn",
@@ -131,7 +125,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "kendra.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "kendra.{region}.c2s.ic.gov",
@@ -142,7 +135,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "kendra.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "kendra.{region}.sc2s.sgov.gov",
@@ -153,7 +145,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["fips-us-gov-west-1", "us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "kendra.{region}.amazonaws.com",
     variants: [
       {
         hostname: "kendra.{region}.amazonaws.com",

--- a/clients/client-kinesis-analytics-v2/src/endpoints.ts
+++ b/clients/client-kinesis-analytics-v2/src/endpoints.ts
@@ -29,7 +29,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "kinesisanalytics.{region}.amazonaws.com",
     variants: [
       {
         hostname: "kinesisanalytics.{region}.amazonaws.com",
@@ -52,7 +51,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "kinesisanalytics.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "kinesisanalytics.{region}.amazonaws.com.cn",
@@ -75,7 +73,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "kinesisanalytics.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "kinesisanalytics.{region}.c2s.ic.gov",
@@ -86,7 +83,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "kinesisanalytics.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "kinesisanalytics.{region}.sc2s.sgov.gov",
@@ -97,7 +93,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "kinesisanalytics.{region}.amazonaws.com",
     variants: [
       {
         hostname: "kinesisanalytics.{region}.amazonaws.com",

--- a/clients/client-kinesis-analytics/src/endpoints.ts
+++ b/clients/client-kinesis-analytics/src/endpoints.ts
@@ -29,7 +29,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "kinesisanalytics.{region}.amazonaws.com",
     variants: [
       {
         hostname: "kinesisanalytics.{region}.amazonaws.com",
@@ -52,7 +51,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "kinesisanalytics.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "kinesisanalytics.{region}.amazonaws.com.cn",
@@ -75,7 +73,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "kinesisanalytics.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "kinesisanalytics.{region}.c2s.ic.gov",
@@ -86,7 +83,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "kinesisanalytics.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "kinesisanalytics.{region}.sc2s.sgov.gov",
@@ -97,7 +93,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "kinesisanalytics.{region}.amazonaws.com",
     variants: [
       {
         hostname: "kinesisanalytics.{region}.amazonaws.com",

--- a/clients/client-kinesis-video-archived-media/src/endpoints.ts
+++ b/clients/client-kinesis-video-archived-media/src/endpoints.ts
@@ -29,7 +29,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "kinesisvideo.{region}.amazonaws.com",
     variants: [
       {
         hostname: "kinesisvideo.{region}.amazonaws.com",
@@ -52,7 +51,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "kinesisvideo.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "kinesisvideo.{region}.amazonaws.com.cn",
@@ -75,7 +73,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "kinesisvideo.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "kinesisvideo.{region}.c2s.ic.gov",
@@ -86,7 +83,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "kinesisvideo.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "kinesisvideo.{region}.sc2s.sgov.gov",
@@ -97,7 +93,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "kinesisvideo.{region}.amazonaws.com",
     variants: [
       {
         hostname: "kinesisvideo.{region}.amazonaws.com",

--- a/clients/client-kinesis-video-media/src/endpoints.ts
+++ b/clients/client-kinesis-video-media/src/endpoints.ts
@@ -29,7 +29,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "kinesisvideo.{region}.amazonaws.com",
     variants: [
       {
         hostname: "kinesisvideo.{region}.amazonaws.com",
@@ -52,7 +51,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "kinesisvideo.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "kinesisvideo.{region}.amazonaws.com.cn",
@@ -75,7 +73,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "kinesisvideo.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "kinesisvideo.{region}.c2s.ic.gov",
@@ -86,7 +83,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "kinesisvideo.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "kinesisvideo.{region}.sc2s.sgov.gov",
@@ -97,7 +93,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "kinesisvideo.{region}.amazonaws.com",
     variants: [
       {
         hostname: "kinesisvideo.{region}.amazonaws.com",

--- a/clients/client-kinesis-video-signaling/src/endpoints.ts
+++ b/clients/client-kinesis-video-signaling/src/endpoints.ts
@@ -29,7 +29,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "kinesisvideo.{region}.amazonaws.com",
     variants: [
       {
         hostname: "kinesisvideo.{region}.amazonaws.com",
@@ -52,7 +51,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "kinesisvideo.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "kinesisvideo.{region}.amazonaws.com.cn",
@@ -75,7 +73,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "kinesisvideo.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "kinesisvideo.{region}.c2s.ic.gov",
@@ -86,7 +83,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "kinesisvideo.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "kinesisvideo.{region}.sc2s.sgov.gov",
@@ -97,7 +93,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "kinesisvideo.{region}.amazonaws.com",
     variants: [
       {
         hostname: "kinesisvideo.{region}.amazonaws.com",

--- a/clients/client-kinesis-video/src/endpoints.ts
+++ b/clients/client-kinesis-video/src/endpoints.ts
@@ -29,7 +29,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "kinesisvideo.{region}.amazonaws.com",
     variants: [
       {
         hostname: "kinesisvideo.{region}.amazonaws.com",
@@ -52,7 +51,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "kinesisvideo.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "kinesisvideo.{region}.amazonaws.com.cn",
@@ -75,7 +73,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "kinesisvideo.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "kinesisvideo.{region}.c2s.ic.gov",
@@ -86,7 +83,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "kinesisvideo.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "kinesisvideo.{region}.sc2s.sgov.gov",
@@ -97,7 +93,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "kinesisvideo.{region}.amazonaws.com",
     variants: [
       {
         hostname: "kinesisvideo.{region}.amazonaws.com",

--- a/clients/client-kinesis/src/endpoints.ts
+++ b/clients/client-kinesis/src/endpoints.ts
@@ -3,7 +3,6 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
   "us-east-1": {
-    hostname: "kinesis.us-east-1.amazonaws.com",
     variants: [
       {
         hostname: "kinesis.us-east-1.amazonaws.com",
@@ -16,7 +15,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-east-2": {
-    hostname: "kinesis.us-east-2.amazonaws.com",
     variants: [
       {
         hostname: "kinesis.us-east-2.amazonaws.com",
@@ -29,7 +27,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-gov-east-1": {
-    hostname: "kinesis.us-gov-east-1.amazonaws.com",
     variants: [
       {
         hostname: "kinesis.us-gov-east-1.amazonaws.com",
@@ -39,7 +36,6 @@ const regionHash: RegionHash = {
     signingRegion: "us-gov-east-1",
   },
   "us-gov-west-1": {
-    hostname: "kinesis.us-gov-west-1.amazonaws.com",
     variants: [
       {
         hostname: "kinesis.us-gov-west-1.amazonaws.com",
@@ -49,7 +45,6 @@ const regionHash: RegionHash = {
     signingRegion: "us-gov-west-1",
   },
   "us-west-1": {
-    hostname: "kinesis.us-west-1.amazonaws.com",
     variants: [
       {
         hostname: "kinesis.us-west-1.amazonaws.com",
@@ -62,7 +57,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-west-2": {
-    hostname: "kinesis.us-west-2.amazonaws.com",
     variants: [
       {
         hostname: "kinesis.us-west-2.amazonaws.com",
@@ -106,7 +100,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "kinesis.{region}.amazonaws.com",
     variants: [
       {
         hostname: "kinesis.{region}.amazonaws.com",
@@ -129,7 +122,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "kinesis.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "kinesis.{region}.amazonaws.com.cn",
@@ -152,7 +144,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "kinesis.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "kinesis.{region}.c2s.ic.gov",
@@ -163,7 +154,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "kinesis.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "kinesis.{region}.sc2s.sgov.gov",
@@ -174,7 +164,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "kinesis.{region}.amazonaws.com",
     variants: [
       {
         hostname: "kinesis.{region}.amazonaws.com",

--- a/clients/client-kms/src/endpoints.ts
+++ b/clients/client-kms/src/endpoints.ts
@@ -3,7 +3,6 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
   "af-south-1": {
-    hostname: "kms.af-south-1.amazonaws.com",
     variants: [
       {
         hostname: "kms.af-south-1.amazonaws.com",
@@ -16,7 +15,6 @@ const regionHash: RegionHash = {
     ],
   },
   "ap-east-1": {
-    hostname: "kms.ap-east-1.amazonaws.com",
     variants: [
       {
         hostname: "kms.ap-east-1.amazonaws.com",
@@ -29,7 +27,6 @@ const regionHash: RegionHash = {
     ],
   },
   "ap-northeast-1": {
-    hostname: "kms.ap-northeast-1.amazonaws.com",
     variants: [
       {
         hostname: "kms.ap-northeast-1.amazonaws.com",
@@ -42,7 +39,6 @@ const regionHash: RegionHash = {
     ],
   },
   "ap-northeast-2": {
-    hostname: "kms.ap-northeast-2.amazonaws.com",
     variants: [
       {
         hostname: "kms.ap-northeast-2.amazonaws.com",
@@ -55,7 +51,6 @@ const regionHash: RegionHash = {
     ],
   },
   "ap-northeast-3": {
-    hostname: "kms.ap-northeast-3.amazonaws.com",
     variants: [
       {
         hostname: "kms.ap-northeast-3.amazonaws.com",
@@ -68,7 +63,6 @@ const regionHash: RegionHash = {
     ],
   },
   "ap-south-1": {
-    hostname: "kms.ap-south-1.amazonaws.com",
     variants: [
       {
         hostname: "kms.ap-south-1.amazonaws.com",
@@ -81,7 +75,6 @@ const regionHash: RegionHash = {
     ],
   },
   "ap-southeast-1": {
-    hostname: "kms.ap-southeast-1.amazonaws.com",
     variants: [
       {
         hostname: "kms.ap-southeast-1.amazonaws.com",
@@ -94,7 +87,6 @@ const regionHash: RegionHash = {
     ],
   },
   "ap-southeast-2": {
-    hostname: "kms.ap-southeast-2.amazonaws.com",
     variants: [
       {
         hostname: "kms.ap-southeast-2.amazonaws.com",
@@ -107,7 +99,6 @@ const regionHash: RegionHash = {
     ],
   },
   "ca-central-1": {
-    hostname: "kms.ca-central-1.amazonaws.com",
     variants: [
       {
         hostname: "kms.ca-central-1.amazonaws.com",
@@ -120,7 +111,6 @@ const regionHash: RegionHash = {
     ],
   },
   "eu-central-1": {
-    hostname: "kms.eu-central-1.amazonaws.com",
     variants: [
       {
         hostname: "kms.eu-central-1.amazonaws.com",
@@ -133,7 +123,6 @@ const regionHash: RegionHash = {
     ],
   },
   "eu-north-1": {
-    hostname: "kms.eu-north-1.amazonaws.com",
     variants: [
       {
         hostname: "kms.eu-north-1.amazonaws.com",
@@ -146,7 +135,6 @@ const regionHash: RegionHash = {
     ],
   },
   "eu-south-1": {
-    hostname: "kms.eu-south-1.amazonaws.com",
     variants: [
       {
         hostname: "kms.eu-south-1.amazonaws.com",
@@ -159,7 +147,6 @@ const regionHash: RegionHash = {
     ],
   },
   "eu-west-1": {
-    hostname: "kms.eu-west-1.amazonaws.com",
     variants: [
       {
         hostname: "kms.eu-west-1.amazonaws.com",
@@ -172,7 +159,6 @@ const regionHash: RegionHash = {
     ],
   },
   "eu-west-2": {
-    hostname: "kms.eu-west-2.amazonaws.com",
     variants: [
       {
         hostname: "kms.eu-west-2.amazonaws.com",
@@ -185,7 +171,6 @@ const regionHash: RegionHash = {
     ],
   },
   "eu-west-3": {
-    hostname: "kms.eu-west-3.amazonaws.com",
     variants: [
       {
         hostname: "kms.eu-west-3.amazonaws.com",
@@ -198,7 +183,6 @@ const regionHash: RegionHash = {
     ],
   },
   "me-south-1": {
-    hostname: "kms.me-south-1.amazonaws.com",
     variants: [
       {
         hostname: "kms.me-south-1.amazonaws.com",
@@ -211,7 +195,6 @@ const regionHash: RegionHash = {
     ],
   },
   "sa-east-1": {
-    hostname: "kms.sa-east-1.amazonaws.com",
     variants: [
       {
         hostname: "kms.sa-east-1.amazonaws.com",
@@ -224,7 +207,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-east-1": {
-    hostname: "kms.us-east-1.amazonaws.com",
     variants: [
       {
         hostname: "kms.us-east-1.amazonaws.com",
@@ -237,7 +219,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-east-2": {
-    hostname: "kms.us-east-2.amazonaws.com",
     variants: [
       {
         hostname: "kms.us-east-2.amazonaws.com",
@@ -250,7 +231,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-gov-east-1": {
-    hostname: "kms.us-gov-east-1.amazonaws.com",
     variants: [
       {
         hostname: "kms.us-gov-east-1.amazonaws.com",
@@ -263,7 +243,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-gov-west-1": {
-    hostname: "kms.us-gov-west-1.amazonaws.com",
     variants: [
       {
         hostname: "kms.us-gov-west-1.amazonaws.com",
@@ -276,7 +255,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-iso-east-1": {
-    hostname: "kms.us-iso-east-1.c2s.ic.gov",
     variants: [
       {
         hostname: "kms.us-iso-east-1.c2s.ic.gov",
@@ -289,7 +267,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-iso-west-1": {
-    hostname: "kms.us-iso-west-1.c2s.ic.gov",
     variants: [
       {
         hostname: "kms.us-iso-west-1.c2s.ic.gov",
@@ -302,7 +279,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-isob-east-1": {
-    hostname: "kms.us-isob-east-1.sc2s.sgov.gov",
     variants: [
       {
         hostname: "kms.us-isob-east-1.sc2s.sgov.gov",
@@ -315,7 +291,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-west-1": {
-    hostname: "kms.us-west-1.amazonaws.com",
     variants: [
       {
         hostname: "kms.us-west-1.amazonaws.com",
@@ -328,7 +303,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-west-2": {
-    hostname: "kms.us-west-2.amazonaws.com",
     variants: [
       {
         hostname: "kms.us-west-2.amazonaws.com",
@@ -389,7 +363,6 @@ const partitionHash: PartitionHash = {
       "us-west-2-fips",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "kms.{region}.amazonaws.com",
     variants: [
       {
         hostname: "kms.{region}.amazonaws.com",
@@ -412,7 +385,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "kms.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "kms.{region}.amazonaws.com.cn",
@@ -435,7 +407,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["ProdFips", "us-iso-east-1", "us-iso-east-1-fips", "us-iso-west-1", "us-iso-west-1-fips"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "kms.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "kms.{region}.c2s.ic.gov",
@@ -446,7 +417,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["ProdFips", "us-isob-east-1", "us-isob-east-1-fips"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "kms.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "kms.{region}.sc2s.sgov.gov",
@@ -457,7 +427,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["ProdFips", "us-gov-east-1", "us-gov-east-1-fips", "us-gov-west-1", "us-gov-west-1-fips"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "kms.{region}.amazonaws.com",
     variants: [
       {
         hostname: "kms.{region}.amazonaws.com",

--- a/clients/client-lakeformation/src/endpoints.ts
+++ b/clients/client-lakeformation/src/endpoints.ts
@@ -3,7 +3,6 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
   "us-east-1": {
-    hostname: "lakeformation.us-east-1.amazonaws.com",
     variants: [
       {
         hostname: "lakeformation.us-east-1.amazonaws.com",
@@ -16,7 +15,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-east-2": {
-    hostname: "lakeformation.us-east-2.amazonaws.com",
     variants: [
       {
         hostname: "lakeformation.us-east-2.amazonaws.com",
@@ -29,7 +27,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-gov-west-1": {
-    hostname: "lakeformation.us-gov-west-1.amazonaws.com",
     variants: [
       {
         hostname: "lakeformation.us-gov-west-1.amazonaws.com",
@@ -42,7 +39,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-west-1": {
-    hostname: "lakeformation.us-west-1.amazonaws.com",
     variants: [
       {
         hostname: "lakeformation.us-west-1.amazonaws.com",
@@ -55,7 +51,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-west-2": {
-    hostname: "lakeformation.us-west-2.amazonaws.com",
     variants: [
       {
         hostname: "lakeformation.us-west-2.amazonaws.com",
@@ -99,7 +94,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "lakeformation.{region}.amazonaws.com",
     variants: [
       {
         hostname: "lakeformation.{region}.amazonaws.com",
@@ -122,7 +116,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "lakeformation.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "lakeformation.{region}.amazonaws.com.cn",
@@ -145,7 +138,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "lakeformation.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "lakeformation.{region}.c2s.ic.gov",
@@ -156,7 +148,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "lakeformation.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "lakeformation.{region}.sc2s.sgov.gov",
@@ -167,7 +158,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["fips-us-gov-west-1", "us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "lakeformation.{region}.amazonaws.com",
     variants: [
       {
         hostname: "lakeformation.{region}.amazonaws.com",

--- a/clients/client-lambda/src/endpoints.ts
+++ b/clients/client-lambda/src/endpoints.ts
@@ -3,7 +3,6 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
   "us-east-1": {
-    hostname: "lambda.us-east-1.amazonaws.com",
     variants: [
       {
         hostname: "lambda.us-east-1.amazonaws.com",
@@ -16,7 +15,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-east-2": {
-    hostname: "lambda.us-east-2.amazonaws.com",
     variants: [
       {
         hostname: "lambda.us-east-2.amazonaws.com",
@@ -29,7 +27,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-gov-east-1": {
-    hostname: "lambda.us-gov-east-1.amazonaws.com",
     variants: [
       {
         hostname: "lambda.us-gov-east-1.amazonaws.com",
@@ -42,7 +39,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-gov-west-1": {
-    hostname: "lambda.us-gov-west-1.amazonaws.com",
     variants: [
       {
         hostname: "lambda.us-gov-west-1.amazonaws.com",
@@ -55,7 +51,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-west-1": {
-    hostname: "lambda.us-west-1.amazonaws.com",
     variants: [
       {
         hostname: "lambda.us-west-1.amazonaws.com",
@@ -68,7 +63,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-west-2": {
-    hostname: "lambda.us-west-2.amazonaws.com",
     variants: [
       {
         hostname: "lambda.us-west-2.amazonaws.com",
@@ -112,7 +106,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "lambda.{region}.amazonaws.com",
     variants: [
       {
         hostname: "lambda.{region}.amazonaws.com",
@@ -135,7 +128,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "lambda.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "lambda.{region}.amazonaws.com.cn",
@@ -158,7 +150,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "lambda.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "lambda.{region}.c2s.ic.gov",
@@ -169,7 +160,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "lambda.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "lambda.{region}.sc2s.sgov.gov",
@@ -180,7 +170,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["fips-us-gov-east-1", "fips-us-gov-west-1", "us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "lambda.{region}.amazonaws.com",
     variants: [
       {
         hostname: "lambda.{region}.amazonaws.com",

--- a/clients/client-lex-model-building-service/src/endpoints.ts
+++ b/clients/client-lex-model-building-service/src/endpoints.ts
@@ -3,7 +3,6 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
   "us-east-1": {
-    hostname: "models.lex.us-east-1.amazonaws.com",
     variants: [
       {
         hostname: "models.lex.us-east-1.amazonaws.com",
@@ -16,7 +15,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-gov-west-1": {
-    hostname: "models.lex.us-gov-west-1.amazonaws.com",
     variants: [
       {
         hostname: "models.lex.us-gov-west-1.amazonaws.com",
@@ -29,7 +27,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-west-2": {
-    hostname: "models.lex.us-west-2.amazonaws.com",
     variants: [
       {
         hostname: "models.lex.us-west-2.amazonaws.com",
@@ -71,7 +68,6 @@ const partitionHash: PartitionHash = {
       "us-west-2-fips",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "models.lex.{region}.amazonaws.com",
     variants: [
       {
         hostname: "models.lex.{region}.amazonaws.com",
@@ -86,7 +82,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "models.lex.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "models.lex.{region}.amazonaws.com.cn",
@@ -109,7 +104,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "models.lex.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "models.lex.{region}.c2s.ic.gov",
@@ -120,7 +114,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "models.lex.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "models.lex.{region}.sc2s.sgov.gov",
@@ -131,7 +124,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1", "us-gov-west-1-fips"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "models.lex.{region}.amazonaws.com",
     variants: [
       {
         hostname: "models.lex.{region}.amazonaws.com",

--- a/clients/client-lex-models-v2/src/endpoints.ts
+++ b/clients/client-lex-models-v2/src/endpoints.ts
@@ -29,7 +29,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "models-v2-lex.{region}.amazonaws.com",
     variants: [
       {
         hostname: "models-v2-lex.{region}.amazonaws.com",
@@ -52,7 +51,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "models-v2-lex.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "models-v2-lex.{region}.amazonaws.com.cn",
@@ -75,7 +73,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "models-v2-lex.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "models-v2-lex.{region}.c2s.ic.gov",
@@ -86,7 +83,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "models-v2-lex.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "models-v2-lex.{region}.sc2s.sgov.gov",
@@ -97,7 +93,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "models-v2-lex.{region}.amazonaws.com",
     variants: [
       {
         hostname: "models-v2-lex.{region}.amazonaws.com",

--- a/clients/client-lex-runtime-service/src/endpoints.ts
+++ b/clients/client-lex-runtime-service/src/endpoints.ts
@@ -3,7 +3,6 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
   "us-east-1": {
-    hostname: "runtime.lex.us-east-1.amazonaws.com",
     variants: [
       {
         hostname: "runtime.lex.us-east-1.amazonaws.com",
@@ -16,7 +15,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-gov-west-1": {
-    hostname: "runtime.lex.us-gov-west-1.amazonaws.com",
     variants: [
       {
         hostname: "runtime.lex.us-gov-west-1.amazonaws.com",
@@ -29,7 +27,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-west-2": {
-    hostname: "runtime.lex.us-west-2.amazonaws.com",
     variants: [
       {
         hostname: "runtime.lex.us-west-2.amazonaws.com",
@@ -71,7 +68,6 @@ const partitionHash: PartitionHash = {
       "us-west-2-fips",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "runtime.lex.{region}.amazonaws.com",
     variants: [
       {
         hostname: "runtime.lex.{region}.amazonaws.com",
@@ -86,7 +82,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "runtime.lex.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "runtime.lex.{region}.amazonaws.com.cn",
@@ -109,7 +104,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "runtime.lex.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "runtime.lex.{region}.c2s.ic.gov",
@@ -120,7 +114,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "runtime.lex.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "runtime.lex.{region}.sc2s.sgov.gov",
@@ -131,7 +124,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1", "us-gov-west-1-fips"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "runtime.lex.{region}.amazonaws.com",
     variants: [
       {
         hostname: "runtime.lex.{region}.amazonaws.com",

--- a/clients/client-lex-runtime-v2/src/endpoints.ts
+++ b/clients/client-lex-runtime-v2/src/endpoints.ts
@@ -29,7 +29,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "runtime-v2-lex.{region}.amazonaws.com",
     variants: [
       {
         hostname: "runtime-v2-lex.{region}.amazonaws.com",
@@ -52,7 +51,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "runtime-v2-lex.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "runtime-v2-lex.{region}.amazonaws.com.cn",
@@ -75,7 +73,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "runtime-v2-lex.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "runtime-v2-lex.{region}.c2s.ic.gov",
@@ -86,7 +83,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "runtime-v2-lex.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "runtime-v2-lex.{region}.sc2s.sgov.gov",
@@ -97,7 +93,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "runtime-v2-lex.{region}.amazonaws.com",
     variants: [
       {
         hostname: "runtime-v2-lex.{region}.amazonaws.com",

--- a/clients/client-license-manager/src/endpoints.ts
+++ b/clients/client-license-manager/src/endpoints.ts
@@ -3,7 +3,6 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
   "us-east-1": {
-    hostname: "license-manager.us-east-1.amazonaws.com",
     variants: [
       {
         hostname: "license-manager.us-east-1.amazonaws.com",
@@ -16,7 +15,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-east-2": {
-    hostname: "license-manager.us-east-2.amazonaws.com",
     variants: [
       {
         hostname: "license-manager.us-east-2.amazonaws.com",
@@ -29,7 +27,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-gov-east-1": {
-    hostname: "license-manager.us-gov-east-1.amazonaws.com",
     variants: [
       {
         hostname: "license-manager.us-gov-east-1.amazonaws.com",
@@ -42,7 +39,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-gov-west-1": {
-    hostname: "license-manager.us-gov-west-1.amazonaws.com",
     variants: [
       {
         hostname: "license-manager.us-gov-west-1.amazonaws.com",
@@ -55,7 +51,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-west-1": {
-    hostname: "license-manager.us-west-1.amazonaws.com",
     variants: [
       {
         hostname: "license-manager.us-west-1.amazonaws.com",
@@ -68,7 +63,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-west-2": {
-    hostname: "license-manager.us-west-2.amazonaws.com",
     variants: [
       {
         hostname: "license-manager.us-west-2.amazonaws.com",
@@ -112,7 +106,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "license-manager.{region}.amazonaws.com",
     variants: [
       {
         hostname: "license-manager.{region}.amazonaws.com",
@@ -135,7 +128,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "license-manager.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "license-manager.{region}.amazonaws.com.cn",
@@ -158,7 +150,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "license-manager.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "license-manager.{region}.c2s.ic.gov",
@@ -169,7 +160,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "license-manager.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "license-manager.{region}.sc2s.sgov.gov",
@@ -180,7 +170,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["fips-us-gov-east-1", "fips-us-gov-west-1", "us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "license-manager.{region}.amazonaws.com",
     variants: [
       {
         hostname: "license-manager.{region}.amazonaws.com",

--- a/clients/client-lightsail/src/endpoints.ts
+++ b/clients/client-lightsail/src/endpoints.ts
@@ -29,7 +29,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "lightsail.{region}.amazonaws.com",
     variants: [
       {
         hostname: "lightsail.{region}.amazonaws.com",
@@ -52,7 +51,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "lightsail.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "lightsail.{region}.amazonaws.com.cn",
@@ -75,7 +73,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "lightsail.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "lightsail.{region}.c2s.ic.gov",
@@ -86,7 +83,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "lightsail.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "lightsail.{region}.sc2s.sgov.gov",
@@ -97,7 +93,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "lightsail.{region}.amazonaws.com",
     variants: [
       {
         hostname: "lightsail.{region}.amazonaws.com",

--- a/clients/client-location/src/endpoints.ts
+++ b/clients/client-location/src/endpoints.ts
@@ -29,7 +29,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "geo.{region}.amazonaws.com",
     variants: [
       {
         hostname: "geo.{region}.amazonaws.com",
@@ -52,7 +51,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "geo.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "geo.{region}.amazonaws.com.cn",
@@ -75,7 +73,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "geo.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "geo.{region}.c2s.ic.gov",
@@ -86,7 +83,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "geo.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "geo.{region}.sc2s.sgov.gov",
@@ -97,7 +93,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "geo.{region}.amazonaws.com",
     variants: [
       {
         hostname: "geo.{region}.amazonaws.com",

--- a/clients/client-lookoutequipment/src/endpoints.ts
+++ b/clients/client-lookoutequipment/src/endpoints.ts
@@ -29,7 +29,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "lookoutequipment.{region}.amazonaws.com",
     variants: [
       {
         hostname: "lookoutequipment.{region}.amazonaws.com",
@@ -52,7 +51,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "lookoutequipment.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "lookoutequipment.{region}.amazonaws.com.cn",
@@ -75,7 +73,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "lookoutequipment.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "lookoutequipment.{region}.c2s.ic.gov",
@@ -86,7 +83,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "lookoutequipment.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "lookoutequipment.{region}.sc2s.sgov.gov",
@@ -97,7 +93,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "lookoutequipment.{region}.amazonaws.com",
     variants: [
       {
         hostname: "lookoutequipment.{region}.amazonaws.com",

--- a/clients/client-lookoutmetrics/src/endpoints.ts
+++ b/clients/client-lookoutmetrics/src/endpoints.ts
@@ -29,7 +29,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "lookoutmetrics.{region}.amazonaws.com",
     variants: [
       {
         hostname: "lookoutmetrics.{region}.amazonaws.com",
@@ -52,7 +51,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "lookoutmetrics.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "lookoutmetrics.{region}.amazonaws.com.cn",
@@ -75,7 +73,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "lookoutmetrics.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "lookoutmetrics.{region}.c2s.ic.gov",
@@ -86,7 +83,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "lookoutmetrics.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "lookoutmetrics.{region}.sc2s.sgov.gov",
@@ -97,7 +93,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "lookoutmetrics.{region}.amazonaws.com",
     variants: [
       {
         hostname: "lookoutmetrics.{region}.amazonaws.com",

--- a/clients/client-lookoutvision/src/endpoints.ts
+++ b/clients/client-lookoutvision/src/endpoints.ts
@@ -29,7 +29,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "lookoutvision.{region}.amazonaws.com",
     variants: [
       {
         hostname: "lookoutvision.{region}.amazonaws.com",
@@ -52,7 +51,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "lookoutvision.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "lookoutvision.{region}.amazonaws.com.cn",
@@ -75,7 +73,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "lookoutvision.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "lookoutvision.{region}.c2s.ic.gov",
@@ -86,7 +83,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "lookoutvision.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "lookoutvision.{region}.sc2s.sgov.gov",
@@ -97,7 +93,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "lookoutvision.{region}.amazonaws.com",
     variants: [
       {
         hostname: "lookoutvision.{region}.amazonaws.com",

--- a/clients/client-machine-learning/src/endpoints.ts
+++ b/clients/client-machine-learning/src/endpoints.ts
@@ -29,7 +29,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "machinelearning.{region}.amazonaws.com",
     variants: [
       {
         hostname: "machinelearning.{region}.amazonaws.com",
@@ -52,7 +51,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "machinelearning.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "machinelearning.{region}.amazonaws.com.cn",
@@ -75,7 +73,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "machinelearning.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "machinelearning.{region}.c2s.ic.gov",
@@ -86,7 +83,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "machinelearning.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "machinelearning.{region}.sc2s.sgov.gov",
@@ -97,7 +93,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "machinelearning.{region}.amazonaws.com",
     variants: [
       {
         hostname: "machinelearning.{region}.amazonaws.com",

--- a/clients/client-macie/src/endpoints.ts
+++ b/clients/client-macie/src/endpoints.ts
@@ -3,7 +3,6 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
   "us-east-1": {
-    hostname: "macie.us-east-1.amazonaws.com",
     variants: [
       {
         hostname: "macie.us-east-1.amazonaws.com",
@@ -16,7 +15,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-west-2": {
-    hostname: "macie.us-west-2.amazonaws.com",
     variants: [
       {
         hostname: "macie.us-west-2.amazonaws.com",
@@ -58,7 +56,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "macie.{region}.amazonaws.com",
     variants: [
       {
         hostname: "macie.{region}.amazonaws.com",
@@ -81,7 +78,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "macie.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "macie.{region}.amazonaws.com.cn",
@@ -104,7 +100,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "macie.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "macie.{region}.c2s.ic.gov",
@@ -115,7 +110,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "macie.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "macie.{region}.sc2s.sgov.gov",
@@ -126,7 +120,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "macie.{region}.amazonaws.com",
     variants: [
       {
         hostname: "macie.{region}.amazonaws.com",

--- a/clients/client-macie2/src/endpoints.ts
+++ b/clients/client-macie2/src/endpoints.ts
@@ -3,7 +3,6 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
   "us-east-1": {
-    hostname: "macie2.us-east-1.amazonaws.com",
     variants: [
       {
         hostname: "macie2.us-east-1.amazonaws.com",
@@ -16,7 +15,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-east-2": {
-    hostname: "macie2.us-east-2.amazonaws.com",
     variants: [
       {
         hostname: "macie2.us-east-2.amazonaws.com",
@@ -29,7 +27,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-west-1": {
-    hostname: "macie2.us-west-1.amazonaws.com",
     variants: [
       {
         hostname: "macie2.us-west-1.amazonaws.com",
@@ -42,7 +39,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-west-2": {
-    hostname: "macie2.us-west-2.amazonaws.com",
     variants: [
       {
         hostname: "macie2.us-west-2.amazonaws.com",
@@ -86,7 +82,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "macie2.{region}.amazonaws.com",
     variants: [
       {
         hostname: "macie2.{region}.amazonaws.com",
@@ -109,7 +104,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "macie2.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "macie2.{region}.amazonaws.com.cn",
@@ -132,7 +126,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "macie2.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "macie2.{region}.c2s.ic.gov",
@@ -143,7 +136,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "macie2.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "macie2.{region}.sc2s.sgov.gov",
@@ -154,7 +146,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "macie2.{region}.amazonaws.com",
     variants: [
       {
         hostname: "macie2.{region}.amazonaws.com",

--- a/clients/client-managedblockchain/src/endpoints.ts
+++ b/clients/client-managedblockchain/src/endpoints.ts
@@ -29,7 +29,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "managedblockchain.{region}.amazonaws.com",
     variants: [
       {
         hostname: "managedblockchain.{region}.amazonaws.com",
@@ -52,7 +51,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "managedblockchain.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "managedblockchain.{region}.amazonaws.com.cn",
@@ -75,7 +73,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "managedblockchain.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "managedblockchain.{region}.c2s.ic.gov",
@@ -86,7 +83,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "managedblockchain.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "managedblockchain.{region}.sc2s.sgov.gov",
@@ -97,7 +93,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "managedblockchain.{region}.amazonaws.com",
     variants: [
       {
         hostname: "managedblockchain.{region}.amazonaws.com",

--- a/clients/client-marketplace-catalog/src/endpoints.ts
+++ b/clients/client-marketplace-catalog/src/endpoints.ts
@@ -29,7 +29,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "catalog.marketplace.{region}.amazonaws.com",
     variants: [
       {
         hostname: "catalog.marketplace.{region}.amazonaws.com",
@@ -52,7 +51,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "catalog.marketplace.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "catalog.marketplace.{region}.amazonaws.com.cn",
@@ -75,7 +73,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "catalog.marketplace.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "catalog.marketplace.{region}.c2s.ic.gov",
@@ -86,7 +83,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "catalog.marketplace.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "catalog.marketplace.{region}.sc2s.sgov.gov",
@@ -97,7 +93,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "catalog.marketplace.{region}.amazonaws.com",
     variants: [
       {
         hostname: "catalog.marketplace.{region}.amazonaws.com",

--- a/clients/client-marketplace-commerce-analytics/src/endpoints.ts
+++ b/clients/client-marketplace-commerce-analytics/src/endpoints.ts
@@ -29,7 +29,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "marketplacecommerceanalytics.{region}.amazonaws.com",
     variants: [
       {
         hostname: "marketplacecommerceanalytics.{region}.amazonaws.com",
@@ -52,7 +51,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "marketplacecommerceanalytics.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "marketplacecommerceanalytics.{region}.amazonaws.com.cn",
@@ -75,7 +73,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "marketplacecommerceanalytics.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "marketplacecommerceanalytics.{region}.c2s.ic.gov",
@@ -86,7 +83,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "marketplacecommerceanalytics.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "marketplacecommerceanalytics.{region}.sc2s.sgov.gov",
@@ -97,7 +93,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "marketplacecommerceanalytics.{region}.amazonaws.com",
     variants: [
       {
         hostname: "marketplacecommerceanalytics.{region}.amazonaws.com",

--- a/clients/client-marketplace-entitlement-service/src/endpoints.ts
+++ b/clients/client-marketplace-entitlement-service/src/endpoints.ts
@@ -29,7 +29,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "entitlement.marketplace.{region}.amazonaws.com",
     variants: [
       {
         hostname: "entitlement.marketplace.{region}.amazonaws.com",
@@ -52,7 +51,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "entitlement.marketplace.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "entitlement.marketplace.{region}.amazonaws.com.cn",
@@ -75,7 +73,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "entitlement.marketplace.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "entitlement.marketplace.{region}.c2s.ic.gov",
@@ -86,7 +83,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "entitlement.marketplace.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "entitlement.marketplace.{region}.sc2s.sgov.gov",
@@ -97,7 +93,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "entitlement.marketplace.{region}.amazonaws.com",
     variants: [
       {
         hostname: "entitlement.marketplace.{region}.amazonaws.com",

--- a/clients/client-marketplace-metering/src/endpoints.ts
+++ b/clients/client-marketplace-metering/src/endpoints.ts
@@ -29,7 +29,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "metering.marketplace.{region}.amazonaws.com",
     variants: [
       {
         hostname: "metering.marketplace.{region}.amazonaws.com",
@@ -52,7 +51,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "metering.marketplace.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "metering.marketplace.{region}.amazonaws.com.cn",
@@ -75,7 +73,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "metering.marketplace.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "metering.marketplace.{region}.c2s.ic.gov",
@@ -86,7 +83,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "metering.marketplace.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "metering.marketplace.{region}.sc2s.sgov.gov",
@@ -97,7 +93,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "metering.marketplace.{region}.amazonaws.com",
     variants: [
       {
         hostname: "metering.marketplace.{region}.amazonaws.com",

--- a/clients/client-mediaconnect/src/endpoints.ts
+++ b/clients/client-mediaconnect/src/endpoints.ts
@@ -29,7 +29,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "mediaconnect.{region}.amazonaws.com",
     variants: [
       {
         hostname: "mediaconnect.{region}.amazonaws.com",
@@ -52,7 +51,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "mediaconnect.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "mediaconnect.{region}.amazonaws.com.cn",
@@ -75,7 +73,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "mediaconnect.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "mediaconnect.{region}.c2s.ic.gov",
@@ -86,7 +83,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "mediaconnect.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "mediaconnect.{region}.sc2s.sgov.gov",
@@ -97,7 +93,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "mediaconnect.{region}.amazonaws.com",
     variants: [
       {
         hostname: "mediaconnect.{region}.amazonaws.com",

--- a/clients/client-mediaconvert/src/endpoints.ts
+++ b/clients/client-mediaconvert/src/endpoints.ts
@@ -3,7 +3,6 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
   "ca-central-1": {
-    hostname: "mediaconvert.ca-central-1.amazonaws.com",
     variants: [
       {
         hostname: "mediaconvert.ca-central-1.amazonaws.com",
@@ -16,7 +15,6 @@ const regionHash: RegionHash = {
     ],
   },
   "cn-northwest-1": {
-    hostname: "subscribe.mediaconvert.cn-northwest-1.amazonaws.com.cn",
     variants: [
       {
         hostname: "subscribe.mediaconvert.cn-northwest-1.amazonaws.com.cn",
@@ -26,7 +24,6 @@ const regionHash: RegionHash = {
     signingRegion: "cn-northwest-1",
   },
   "us-east-1": {
-    hostname: "mediaconvert.us-east-1.amazonaws.com",
     variants: [
       {
         hostname: "mediaconvert.us-east-1.amazonaws.com",
@@ -39,7 +36,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-east-2": {
-    hostname: "mediaconvert.us-east-2.amazonaws.com",
     variants: [
       {
         hostname: "mediaconvert.us-east-2.amazonaws.com",
@@ -52,7 +48,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-gov-west-1": {
-    hostname: "mediaconvert.us-gov-west-1.amazonaws.com",
     variants: [
       {
         hostname: "mediaconvert.us-gov-west-1.amazonaws.com",
@@ -62,7 +57,6 @@ const regionHash: RegionHash = {
     signingRegion: "us-gov-west-1",
   },
   "us-west-1": {
-    hostname: "mediaconvert.us-west-1.amazonaws.com",
     variants: [
       {
         hostname: "mediaconvert.us-west-1.amazonaws.com",
@@ -75,7 +69,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-west-2": {
-    hostname: "mediaconvert.us-west-2.amazonaws.com",
     variants: [
       {
         hostname: "mediaconvert.us-west-2.amazonaws.com",
@@ -120,7 +113,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "mediaconvert.{region}.amazonaws.com",
     variants: [
       {
         hostname: "mediaconvert.{region}.amazonaws.com",
@@ -143,7 +135,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "mediaconvert.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "mediaconvert.{region}.amazonaws.com.cn",
@@ -166,7 +157,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "mediaconvert.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "mediaconvert.{region}.c2s.ic.gov",
@@ -177,7 +167,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "mediaconvert.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "mediaconvert.{region}.sc2s.sgov.gov",
@@ -188,7 +177,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "mediaconvert.{region}.amazonaws.com",
     variants: [
       {
         hostname: "mediaconvert.{region}.amazonaws.com",

--- a/clients/client-medialive/src/endpoints.ts
+++ b/clients/client-medialive/src/endpoints.ts
@@ -3,7 +3,6 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
   "us-east-1": {
-    hostname: "medialive.us-east-1.amazonaws.com",
     variants: [
       {
         hostname: "medialive.us-east-1.amazonaws.com",
@@ -16,7 +15,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-east-2": {
-    hostname: "medialive.us-east-2.amazonaws.com",
     variants: [
       {
         hostname: "medialive.us-east-2.amazonaws.com",
@@ -29,7 +27,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-west-2": {
-    hostname: "medialive.us-west-2.amazonaws.com",
     variants: [
       {
         hostname: "medialive.us-west-2.amazonaws.com",
@@ -72,7 +69,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "medialive.{region}.amazonaws.com",
     variants: [
       {
         hostname: "medialive.{region}.amazonaws.com",
@@ -95,7 +91,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "medialive.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "medialive.{region}.amazonaws.com.cn",
@@ -118,7 +113,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "medialive.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "medialive.{region}.c2s.ic.gov",
@@ -129,7 +123,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "medialive.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "medialive.{region}.sc2s.sgov.gov",
@@ -140,7 +133,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "medialive.{region}.amazonaws.com",
     variants: [
       {
         hostname: "medialive.{region}.amazonaws.com",

--- a/clients/client-mediapackage-vod/src/endpoints.ts
+++ b/clients/client-mediapackage-vod/src/endpoints.ts
@@ -29,7 +29,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "mediapackage-vod.{region}.amazonaws.com",
     variants: [
       {
         hostname: "mediapackage-vod.{region}.amazonaws.com",
@@ -52,7 +51,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "mediapackage-vod.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "mediapackage-vod.{region}.amazonaws.com.cn",
@@ -75,7 +73,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "mediapackage-vod.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "mediapackage-vod.{region}.c2s.ic.gov",
@@ -86,7 +83,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "mediapackage-vod.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "mediapackage-vod.{region}.sc2s.sgov.gov",
@@ -97,7 +93,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "mediapackage-vod.{region}.amazonaws.com",
     variants: [
       {
         hostname: "mediapackage-vod.{region}.amazonaws.com",

--- a/clients/client-mediapackage/src/endpoints.ts
+++ b/clients/client-mediapackage/src/endpoints.ts
@@ -29,7 +29,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "mediapackage.{region}.amazonaws.com",
     variants: [
       {
         hostname: "mediapackage.{region}.amazonaws.com",
@@ -52,7 +51,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "mediapackage.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "mediapackage.{region}.amazonaws.com.cn",
@@ -75,7 +73,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "mediapackage.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "mediapackage.{region}.c2s.ic.gov",
@@ -86,7 +83,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "mediapackage.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "mediapackage.{region}.sc2s.sgov.gov",
@@ -97,7 +93,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "mediapackage.{region}.amazonaws.com",
     variants: [
       {
         hostname: "mediapackage.{region}.amazonaws.com",

--- a/clients/client-mediastore-data/src/endpoints.ts
+++ b/clients/client-mediastore-data/src/endpoints.ts
@@ -29,7 +29,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "data.mediastore.{region}.amazonaws.com",
     variants: [
       {
         hostname: "data.mediastore.{region}.amazonaws.com",
@@ -52,7 +51,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "data.mediastore.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "data.mediastore.{region}.amazonaws.com.cn",
@@ -75,7 +73,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "data.mediastore.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "data.mediastore.{region}.c2s.ic.gov",
@@ -86,7 +83,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "data.mediastore.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "data.mediastore.{region}.sc2s.sgov.gov",
@@ -97,7 +93,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "data.mediastore.{region}.amazonaws.com",
     variants: [
       {
         hostname: "data.mediastore.{region}.amazonaws.com",

--- a/clients/client-mediastore/src/endpoints.ts
+++ b/clients/client-mediastore/src/endpoints.ts
@@ -29,7 +29,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "mediastore.{region}.amazonaws.com",
     variants: [
       {
         hostname: "mediastore.{region}.amazonaws.com",
@@ -52,7 +51,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "mediastore.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "mediastore.{region}.amazonaws.com.cn",
@@ -75,7 +73,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "mediastore.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "mediastore.{region}.c2s.ic.gov",
@@ -86,7 +83,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "mediastore.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "mediastore.{region}.sc2s.sgov.gov",
@@ -97,7 +93,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "mediastore.{region}.amazonaws.com",
     variants: [
       {
         hostname: "mediastore.{region}.amazonaws.com",

--- a/clients/client-mediatailor/src/endpoints.ts
+++ b/clients/client-mediatailor/src/endpoints.ts
@@ -29,7 +29,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "api.mediatailor.{region}.amazonaws.com",
     variants: [
       {
         hostname: "api.mediatailor.{region}.amazonaws.com",
@@ -52,7 +51,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "api.mediatailor.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "api.mediatailor.{region}.amazonaws.com.cn",
@@ -75,7 +73,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "api.mediatailor.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "api.mediatailor.{region}.c2s.ic.gov",
@@ -86,7 +83,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "api.mediatailor.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "api.mediatailor.{region}.sc2s.sgov.gov",
@@ -97,7 +93,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "api.mediatailor.{region}.amazonaws.com",
     variants: [
       {
         hostname: "api.mediatailor.{region}.amazonaws.com",

--- a/clients/client-memorydb/src/endpoints.ts
+++ b/clients/client-memorydb/src/endpoints.ts
@@ -29,7 +29,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "memory-db.{region}.amazonaws.com",
     variants: [
       {
         hostname: "memory-db.{region}.amazonaws.com",
@@ -52,7 +51,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "memory-db.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "memory-db.{region}.amazonaws.com.cn",
@@ -75,7 +73,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "memory-db.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "memory-db.{region}.c2s.ic.gov",
@@ -86,7 +83,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "memory-db.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "memory-db.{region}.sc2s.sgov.gov",
@@ -97,7 +93,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "memory-db.{region}.amazonaws.com",
     variants: [
       {
         hostname: "memory-db.{region}.amazonaws.com",

--- a/clients/client-mgn/src/endpoints.ts
+++ b/clients/client-mgn/src/endpoints.ts
@@ -29,7 +29,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "mgn.{region}.amazonaws.com",
     variants: [
       {
         hostname: "mgn.{region}.amazonaws.com",
@@ -52,7 +51,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "mgn.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "mgn.{region}.amazonaws.com.cn",
@@ -75,7 +73,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "mgn.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "mgn.{region}.c2s.ic.gov",
@@ -86,7 +83,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "mgn.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "mgn.{region}.sc2s.sgov.gov",
@@ -97,7 +93,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "mgn.{region}.amazonaws.com",
     variants: [
       {
         hostname: "mgn.{region}.amazonaws.com",

--- a/clients/client-migration-hub/src/endpoints.ts
+++ b/clients/client-migration-hub/src/endpoints.ts
@@ -29,7 +29,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "mgh.{region}.amazonaws.com",
     variants: [
       {
         hostname: "mgh.{region}.amazonaws.com",
@@ -52,7 +51,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "mgh.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "mgh.{region}.amazonaws.com.cn",
@@ -75,7 +73,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "mgh.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "mgh.{region}.c2s.ic.gov",
@@ -86,7 +83,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "mgh.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "mgh.{region}.sc2s.sgov.gov",
@@ -97,7 +93,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "mgh.{region}.amazonaws.com",
     variants: [
       {
         hostname: "mgh.{region}.amazonaws.com",

--- a/clients/client-migrationhub-config/src/endpoints.ts
+++ b/clients/client-migrationhub-config/src/endpoints.ts
@@ -29,7 +29,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "migrationhub-config.{region}.amazonaws.com",
     variants: [
       {
         hostname: "migrationhub-config.{region}.amazonaws.com",
@@ -52,7 +51,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "migrationhub-config.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "migrationhub-config.{region}.amazonaws.com.cn",
@@ -75,7 +73,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "migrationhub-config.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "migrationhub-config.{region}.c2s.ic.gov",
@@ -86,7 +83,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "migrationhub-config.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "migrationhub-config.{region}.sc2s.sgov.gov",
@@ -97,7 +93,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "migrationhub-config.{region}.amazonaws.com",
     variants: [
       {
         hostname: "migrationhub-config.{region}.amazonaws.com",

--- a/clients/client-mobile/src/endpoints.ts
+++ b/clients/client-mobile/src/endpoints.ts
@@ -29,7 +29,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "mobile.{region}.amazonaws.com",
     variants: [
       {
         hostname: "mobile.{region}.amazonaws.com",
@@ -52,7 +51,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "mobile.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "mobile.{region}.amazonaws.com.cn",
@@ -75,7 +73,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "mobile.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "mobile.{region}.c2s.ic.gov",
@@ -86,7 +83,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "mobile.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "mobile.{region}.sc2s.sgov.gov",
@@ -97,7 +93,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "mobile.{region}.amazonaws.com",
     variants: [
       {
         hostname: "mobile.{region}.amazonaws.com",

--- a/clients/client-mq/src/endpoints.ts
+++ b/clients/client-mq/src/endpoints.ts
@@ -3,7 +3,6 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
   "us-east-1": {
-    hostname: "mq.us-east-1.amazonaws.com",
     variants: [
       {
         hostname: "mq.us-east-1.amazonaws.com",
@@ -16,7 +15,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-east-2": {
-    hostname: "mq.us-east-2.amazonaws.com",
     variants: [
       {
         hostname: "mq.us-east-2.amazonaws.com",
@@ -29,7 +27,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-gov-east-1": {
-    hostname: "mq.us-gov-east-1.amazonaws.com",
     variants: [
       {
         hostname: "mq.us-gov-east-1.amazonaws.com",
@@ -42,7 +39,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-gov-west-1": {
-    hostname: "mq.us-gov-west-1.amazonaws.com",
     variants: [
       {
         hostname: "mq.us-gov-west-1.amazonaws.com",
@@ -55,7 +51,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-west-1": {
-    hostname: "mq.us-west-1.amazonaws.com",
     variants: [
       {
         hostname: "mq.us-west-1.amazonaws.com",
@@ -68,7 +63,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-west-2": {
-    hostname: "mq.us-west-2.amazonaws.com",
     variants: [
       {
         hostname: "mq.us-west-2.amazonaws.com",
@@ -112,7 +106,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "mq.{region}.amazonaws.com",
     variants: [
       {
         hostname: "mq.{region}.amazonaws.com",
@@ -135,7 +128,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "mq.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "mq.{region}.amazonaws.com.cn",
@@ -158,7 +150,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "mq.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "mq.{region}.c2s.ic.gov",
@@ -169,7 +160,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "mq.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "mq.{region}.sc2s.sgov.gov",
@@ -180,7 +170,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["fips-us-gov-east-1", "fips-us-gov-west-1", "us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "mq.{region}.amazonaws.com",
     variants: [
       {
         hostname: "mq.{region}.amazonaws.com",

--- a/clients/client-mturk/src/endpoints.ts
+++ b/clients/client-mturk/src/endpoints.ts
@@ -3,7 +3,6 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
   sandbox: {
-    hostname: "mturk-requester-sandbox.us-east-1.amazonaws.com",
     variants: [
       {
         hostname: "mturk-requester-sandbox.us-east-1.amazonaws.com",
@@ -40,7 +39,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "mturk-requester.{region}.amazonaws.com",
     variants: [
       {
         hostname: "mturk-requester.{region}.amazonaws.com",
@@ -63,7 +61,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "mturk-requester.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "mturk-requester.{region}.amazonaws.com.cn",
@@ -86,7 +83,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "mturk-requester.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "mturk-requester.{region}.c2s.ic.gov",
@@ -97,7 +93,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "mturk-requester.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "mturk-requester.{region}.sc2s.sgov.gov",
@@ -108,7 +103,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "mturk-requester.{region}.amazonaws.com",
     variants: [
       {
         hostname: "mturk-requester.{region}.amazonaws.com",

--- a/clients/client-mwaa/src/endpoints.ts
+++ b/clients/client-mwaa/src/endpoints.ts
@@ -29,7 +29,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "airflow.{region}.amazonaws.com",
     variants: [
       {
         hostname: "airflow.{region}.amazonaws.com",
@@ -52,7 +51,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "airflow.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "airflow.{region}.amazonaws.com.cn",
@@ -75,7 +73,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "airflow.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "airflow.{region}.c2s.ic.gov",
@@ -86,7 +83,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "airflow.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "airflow.{region}.sc2s.sgov.gov",
@@ -97,7 +93,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "airflow.{region}.amazonaws.com",
     variants: [
       {
         hostname: "airflow.{region}.amazonaws.com",

--- a/clients/client-neptune/src/endpoints.ts
+++ b/clients/client-neptune/src/endpoints.ts
@@ -3,7 +3,6 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
   "ca-central-1": {
-    hostname: "rds.ca-central-1.amazonaws.com",
     variants: [
       {
         hostname: "rds.ca-central-1.amazonaws.com",
@@ -16,7 +15,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-east-1": {
-    hostname: "rds.us-east-1.amazonaws.com",
     variants: [
       {
         hostname: "rds.us-east-1.amazonaws.com",
@@ -29,7 +27,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-east-2": {
-    hostname: "rds.us-east-2.amazonaws.com",
     variants: [
       {
         hostname: "rds.us-east-2.amazonaws.com",
@@ -42,7 +39,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-gov-east-1": {
-    hostname: "rds.us-gov-east-1.amazonaws.com",
     variants: [
       {
         hostname: "rds.us-gov-east-1.amazonaws.com",
@@ -55,7 +51,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-gov-west-1": {
-    hostname: "rds.us-gov-west-1.amazonaws.com",
     variants: [
       {
         hostname: "rds.us-gov-west-1.amazonaws.com",
@@ -68,7 +63,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-west-1": {
-    hostname: "rds.us-west-1.amazonaws.com",
     variants: [
       {
         hostname: "rds.us-west-1.amazonaws.com",
@@ -81,7 +75,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-west-2": {
-    hostname: "rds.us-west-2.amazonaws.com",
     variants: [
       {
         hostname: "rds.us-west-2.amazonaws.com",
@@ -136,7 +129,6 @@ const partitionHash: PartitionHash = {
       "us-west-2-fips",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "rds.{region}.amazonaws.com",
     variants: [
       {
         hostname: "rds.{region}.amazonaws.com",
@@ -159,7 +151,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "rds.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "rds.{region}.amazonaws.com.cn",
@@ -182,7 +173,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "rds.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "rds.{region}.c2s.ic.gov",
@@ -193,7 +183,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "rds.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "rds.{region}.sc2s.sgov.gov",
@@ -211,7 +200,6 @@ const partitionHash: PartitionHash = {
       "us-gov-west-1-fips",
     ],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "rds.{region}.amazonaws.com",
     variants: [
       {
         hostname: "rds.{region}.amazonaws.com",

--- a/clients/client-network-firewall/src/endpoints.ts
+++ b/clients/client-network-firewall/src/endpoints.ts
@@ -3,7 +3,6 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
   "ca-central-1": {
-    hostname: "network-firewall.ca-central-1.amazonaws.com",
     variants: [
       {
         hostname: "network-firewall.ca-central-1.amazonaws.com",
@@ -16,7 +15,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-east-1": {
-    hostname: "network-firewall.us-east-1.amazonaws.com",
     variants: [
       {
         hostname: "network-firewall.us-east-1.amazonaws.com",
@@ -29,7 +27,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-east-2": {
-    hostname: "network-firewall.us-east-2.amazonaws.com",
     variants: [
       {
         hostname: "network-firewall.us-east-2.amazonaws.com",
@@ -42,7 +39,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-gov-east-1": {
-    hostname: "network-firewall.us-gov-east-1.amazonaws.com",
     variants: [
       {
         hostname: "network-firewall.us-gov-east-1.amazonaws.com",
@@ -55,7 +51,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-gov-west-1": {
-    hostname: "network-firewall.us-gov-west-1.amazonaws.com",
     variants: [
       {
         hostname: "network-firewall.us-gov-west-1.amazonaws.com",
@@ -68,7 +63,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-west-1": {
-    hostname: "network-firewall.us-west-1.amazonaws.com",
     variants: [
       {
         hostname: "network-firewall.us-west-1.amazonaws.com",
@@ -81,7 +75,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-west-2": {
-    hostname: "network-firewall.us-west-2.amazonaws.com",
     variants: [
       {
         hostname: "network-firewall.us-west-2.amazonaws.com",
@@ -126,7 +119,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "network-firewall.{region}.amazonaws.com",
     variants: [
       {
         hostname: "network-firewall.{region}.amazonaws.com",
@@ -149,7 +141,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "network-firewall.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "network-firewall.{region}.amazonaws.com.cn",
@@ -172,7 +163,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "network-firewall.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "network-firewall.{region}.c2s.ic.gov",
@@ -183,7 +173,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "network-firewall.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "network-firewall.{region}.sc2s.sgov.gov",
@@ -194,7 +183,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["fips-us-gov-east-1", "fips-us-gov-west-1", "us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "network-firewall.{region}.amazonaws.com",
     variants: [
       {
         hostname: "network-firewall.{region}.amazonaws.com",

--- a/clients/client-networkmanager/src/endpoints.ts
+++ b/clients/client-networkmanager/src/endpoints.ts
@@ -3,7 +3,6 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
   "aws-global": {
-    hostname: "networkmanager.us-west-2.amazonaws.com",
     variants: [
       {
         hostname: "networkmanager.us-west-2.amazonaws.com",
@@ -13,7 +12,6 @@ const regionHash: RegionHash = {
     signingRegion: "us-west-2",
   },
   "aws-us-gov-global": {
-    hostname: "networkmanager.us-gov-west-1.amazonaws.com",
     variants: [
       {
         hostname: "networkmanager.us-gov-west-1.amazonaws.com",
@@ -51,7 +49,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "networkmanager.{region}.amazonaws.com",
     variants: [
       {
         hostname: "networkmanager.{region}.amazonaws.com",
@@ -75,7 +72,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "networkmanager.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "networkmanager.{region}.amazonaws.com.cn",
@@ -98,7 +94,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "networkmanager.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "networkmanager.{region}.c2s.ic.gov",
@@ -109,7 +104,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "networkmanager.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "networkmanager.{region}.sc2s.sgov.gov",
@@ -120,7 +114,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["aws-us-gov-global", "us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "networkmanager.{region}.amazonaws.com",
     variants: [
       {
         hostname: "networkmanager.{region}.amazonaws.com",

--- a/clients/client-nimble/src/endpoints.ts
+++ b/clients/client-nimble/src/endpoints.ts
@@ -29,7 +29,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "nimble.{region}.amazonaws.com",
     variants: [
       {
         hostname: "nimble.{region}.amazonaws.com",
@@ -52,7 +51,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "nimble.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "nimble.{region}.amazonaws.com.cn",
@@ -75,7 +73,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "nimble.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "nimble.{region}.c2s.ic.gov",
@@ -86,7 +83,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "nimble.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "nimble.{region}.sc2s.sgov.gov",
@@ -97,7 +93,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "nimble.{region}.amazonaws.com",
     variants: [
       {
         hostname: "nimble.{region}.amazonaws.com",

--- a/clients/client-opensearch/src/endpoints.ts
+++ b/clients/client-opensearch/src/endpoints.ts
@@ -3,7 +3,6 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
   "us-east-1": {
-    hostname: "es.us-east-1.amazonaws.com",
     variants: [
       {
         hostname: "es.us-east-1.amazonaws.com",
@@ -16,7 +15,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-east-2": {
-    hostname: "es.us-east-2.amazonaws.com",
     variants: [
       {
         hostname: "es.us-east-2.amazonaws.com",
@@ -29,7 +27,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-gov-east-1": {
-    hostname: "es.us-gov-east-1.amazonaws.com",
     variants: [
       {
         hostname: "es.us-gov-east-1.amazonaws.com",
@@ -42,7 +39,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-gov-west-1": {
-    hostname: "es.us-gov-west-1.amazonaws.com",
     variants: [
       {
         hostname: "es.us-gov-west-1.amazonaws.com",
@@ -55,7 +51,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-west-1": {
-    hostname: "es.us-west-1.amazonaws.com",
     variants: [
       {
         hostname: "es.us-west-1.amazonaws.com",
@@ -68,7 +63,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-west-2": {
-    hostname: "es.us-west-2.amazonaws.com",
     variants: [
       {
         hostname: "es.us-west-2.amazonaws.com",
@@ -113,7 +107,6 @@ const partitionHash: PartitionHash = {
       "us-west-2-fips",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "es.{region}.amazonaws.com",
     variants: [
       {
         hostname: "es.{region}.amazonaws.com",
@@ -136,7 +129,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "es.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "es.{region}.amazonaws.com.cn",
@@ -159,7 +151,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "es.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "es.{region}.c2s.ic.gov",
@@ -170,7 +161,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "es.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "es.{region}.sc2s.sgov.gov",
@@ -181,7 +171,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["fips", "us-gov-east-1", "us-gov-east-1-fips", "us-gov-west-1", "us-gov-west-1-fips"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "es.{region}.amazonaws.com",
     variants: [
       {
         hostname: "es.{region}.amazonaws.com",

--- a/clients/client-opsworks/src/endpoints.ts
+++ b/clients/client-opsworks/src/endpoints.ts
@@ -29,7 +29,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "opsworks.{region}.amazonaws.com",
     variants: [
       {
         hostname: "opsworks.{region}.amazonaws.com",
@@ -52,7 +51,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "opsworks.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "opsworks.{region}.amazonaws.com.cn",
@@ -75,7 +73,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "opsworks.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "opsworks.{region}.c2s.ic.gov",
@@ -86,7 +83,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "opsworks.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "opsworks.{region}.sc2s.sgov.gov",
@@ -97,7 +93,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "opsworks.{region}.amazonaws.com",
     variants: [
       {
         hostname: "opsworks.{region}.amazonaws.com",

--- a/clients/client-opsworkscm/src/endpoints.ts
+++ b/clients/client-opsworkscm/src/endpoints.ts
@@ -29,7 +29,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "opsworks-cm.{region}.amazonaws.com",
     variants: [
       {
         hostname: "opsworks-cm.{region}.amazonaws.com",
@@ -52,7 +51,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "opsworks-cm.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "opsworks-cm.{region}.amazonaws.com.cn",
@@ -75,7 +73,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "opsworks-cm.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "opsworks-cm.{region}.c2s.ic.gov",
@@ -86,7 +83,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "opsworks-cm.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "opsworks-cm.{region}.sc2s.sgov.gov",
@@ -97,7 +93,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "opsworks-cm.{region}.amazonaws.com",
     variants: [
       {
         hostname: "opsworks-cm.{region}.amazonaws.com",

--- a/clients/client-organizations/src/endpoints.ts
+++ b/clients/client-organizations/src/endpoints.ts
@@ -3,7 +3,6 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
   "aws-cn-global": {
-    hostname: "organizations.cn-northwest-1.amazonaws.com.cn",
     variants: [
       {
         hostname: "organizations.cn-northwest-1.amazonaws.com.cn",
@@ -13,7 +12,6 @@ const regionHash: RegionHash = {
     signingRegion: "cn-northwest-1",
   },
   "aws-global": {
-    hostname: "organizations.us-east-1.amazonaws.com",
     variants: [
       {
         hostname: "organizations.us-east-1.amazonaws.com",
@@ -27,7 +25,6 @@ const regionHash: RegionHash = {
     signingRegion: "us-east-1",
   },
   "aws-us-gov-global": {
-    hostname: "organizations.us-gov-west-1.amazonaws.com",
     variants: [
       {
         hostname: "organizations.us-gov-west-1.amazonaws.com",
@@ -70,7 +67,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "organizations.{region}.amazonaws.com",
     variants: [
       {
         hostname: "organizations.{region}.amazonaws.com",
@@ -94,7 +90,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["aws-cn-global", "cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "organizations.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "organizations.{region}.amazonaws.com.cn",
@@ -118,7 +113,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "organizations.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "organizations.{region}.c2s.ic.gov",
@@ -129,7 +123,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "organizations.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "organizations.{region}.sc2s.sgov.gov",
@@ -140,7 +133,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["aws-us-gov-global", "fips-aws-us-gov-global", "us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "organizations.{region}.amazonaws.com",
     variants: [
       {
         hostname: "organizations.{region}.amazonaws.com",

--- a/clients/client-outposts/src/endpoints.ts
+++ b/clients/client-outposts/src/endpoints.ts
@@ -3,7 +3,6 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
   "ca-central-1": {
-    hostname: "outposts.ca-central-1.amazonaws.com",
     variants: [
       {
         hostname: "outposts.ca-central-1.amazonaws.com",
@@ -16,7 +15,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-east-1": {
-    hostname: "outposts.us-east-1.amazonaws.com",
     variants: [
       {
         hostname: "outposts.us-east-1.amazonaws.com",
@@ -29,7 +27,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-east-2": {
-    hostname: "outposts.us-east-2.amazonaws.com",
     variants: [
       {
         hostname: "outposts.us-east-2.amazonaws.com",
@@ -42,7 +39,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-gov-east-1": {
-    hostname: "outposts.us-gov-east-1.amazonaws.com",
     variants: [
       {
         hostname: "outposts.us-gov-east-1.amazonaws.com",
@@ -52,7 +48,6 @@ const regionHash: RegionHash = {
     signingRegion: "us-gov-east-1",
   },
   "us-gov-west-1": {
-    hostname: "outposts.us-gov-west-1.amazonaws.com",
     variants: [
       {
         hostname: "outposts.us-gov-west-1.amazonaws.com",
@@ -62,7 +57,6 @@ const regionHash: RegionHash = {
     signingRegion: "us-gov-west-1",
   },
   "us-west-1": {
-    hostname: "outposts.us-west-1.amazonaws.com",
     variants: [
       {
         hostname: "outposts.us-west-1.amazonaws.com",
@@ -75,7 +69,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-west-2": {
-    hostname: "outposts.us-west-2.amazonaws.com",
     variants: [
       {
         hostname: "outposts.us-west-2.amazonaws.com",
@@ -120,7 +113,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "outposts.{region}.amazonaws.com",
     variants: [
       {
         hostname: "outposts.{region}.amazonaws.com",
@@ -143,7 +135,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "outposts.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "outposts.{region}.amazonaws.com.cn",
@@ -166,7 +157,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "outposts.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "outposts.{region}.c2s.ic.gov",
@@ -177,7 +167,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "outposts.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "outposts.{region}.sc2s.sgov.gov",
@@ -188,7 +177,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "outposts.{region}.amazonaws.com",
     variants: [
       {
         hostname: "outposts.{region}.amazonaws.com",

--- a/clients/client-panorama/src/endpoints.ts
+++ b/clients/client-panorama/src/endpoints.ts
@@ -29,7 +29,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "panorama.{region}.amazonaws.com",
     variants: [
       {
         hostname: "panorama.{region}.amazonaws.com",
@@ -52,7 +51,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "panorama.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "panorama.{region}.amazonaws.com.cn",
@@ -75,7 +73,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "panorama.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "panorama.{region}.c2s.ic.gov",
@@ -86,7 +83,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "panorama.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "panorama.{region}.sc2s.sgov.gov",
@@ -97,7 +93,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "panorama.{region}.amazonaws.com",
     variants: [
       {
         hostname: "panorama.{region}.amazonaws.com",

--- a/clients/client-personalize-events/src/endpoints.ts
+++ b/clients/client-personalize-events/src/endpoints.ts
@@ -29,7 +29,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "personalize-events.{region}.amazonaws.com",
     variants: [
       {
         hostname: "personalize-events.{region}.amazonaws.com",
@@ -52,7 +51,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "personalize-events.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "personalize-events.{region}.amazonaws.com.cn",
@@ -75,7 +73,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "personalize-events.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "personalize-events.{region}.c2s.ic.gov",
@@ -86,7 +83,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "personalize-events.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "personalize-events.{region}.sc2s.sgov.gov",
@@ -97,7 +93,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "personalize-events.{region}.amazonaws.com",
     variants: [
       {
         hostname: "personalize-events.{region}.amazonaws.com",

--- a/clients/client-personalize-runtime/src/endpoints.ts
+++ b/clients/client-personalize-runtime/src/endpoints.ts
@@ -29,7 +29,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "personalize-runtime.{region}.amazonaws.com",
     variants: [
       {
         hostname: "personalize-runtime.{region}.amazonaws.com",
@@ -52,7 +51,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "personalize-runtime.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "personalize-runtime.{region}.amazonaws.com.cn",
@@ -75,7 +73,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "personalize-runtime.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "personalize-runtime.{region}.c2s.ic.gov",
@@ -86,7 +83,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "personalize-runtime.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "personalize-runtime.{region}.sc2s.sgov.gov",
@@ -97,7 +93,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "personalize-runtime.{region}.amazonaws.com",
     variants: [
       {
         hostname: "personalize-runtime.{region}.amazonaws.com",

--- a/clients/client-personalize/src/endpoints.ts
+++ b/clients/client-personalize/src/endpoints.ts
@@ -29,7 +29,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "personalize.{region}.amazonaws.com",
     variants: [
       {
         hostname: "personalize.{region}.amazonaws.com",
@@ -52,7 +51,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "personalize.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "personalize.{region}.amazonaws.com.cn",
@@ -75,7 +73,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "personalize.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "personalize.{region}.c2s.ic.gov",
@@ -86,7 +83,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "personalize.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "personalize.{region}.sc2s.sgov.gov",
@@ -97,7 +93,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "personalize.{region}.amazonaws.com",
     variants: [
       {
         hostname: "personalize.{region}.amazonaws.com",

--- a/clients/client-pi/src/endpoints.ts
+++ b/clients/client-pi/src/endpoints.ts
@@ -29,7 +29,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "pi.{region}.amazonaws.com",
     variants: [
       {
         hostname: "pi.{region}.amazonaws.com",
@@ -52,7 +51,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "pi.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "pi.{region}.amazonaws.com.cn",
@@ -75,7 +73,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "pi.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "pi.{region}.c2s.ic.gov",
@@ -86,7 +83,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "pi.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "pi.{region}.sc2s.sgov.gov",
@@ -97,7 +93,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "pi.{region}.amazonaws.com",
     variants: [
       {
         hostname: "pi.{region}.amazonaws.com",

--- a/clients/client-pinpoint-email/src/endpoints.ts
+++ b/clients/client-pinpoint-email/src/endpoints.ts
@@ -3,7 +3,6 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
   "us-gov-west-1": {
-    hostname: "email.us-gov-west-1.amazonaws.com",
     variants: [
       {
         hostname: "email.us-gov-west-1.amazonaws.com",
@@ -43,7 +42,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "email.{region}.amazonaws.com",
     variants: [
       {
         hostname: "email.{region}.amazonaws.com",
@@ -66,7 +64,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "email.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "email.{region}.amazonaws.com.cn",
@@ -89,7 +86,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "email.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "email.{region}.c2s.ic.gov",
@@ -100,7 +96,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "email.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "email.{region}.sc2s.sgov.gov",
@@ -111,7 +106,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["fips-us-gov-west-1", "us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "email.{region}.amazonaws.com",
     variants: [
       {
         hostname: "email.{region}.amazonaws.com",

--- a/clients/client-pinpoint-sms-voice/src/endpoints.ts
+++ b/clients/client-pinpoint-sms-voice/src/endpoints.ts
@@ -29,7 +29,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "sms-voice.pinpoint.{region}.amazonaws.com",
     variants: [
       {
         hostname: "sms-voice.pinpoint.{region}.amazonaws.com",
@@ -52,7 +51,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "sms-voice.pinpoint.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "sms-voice.pinpoint.{region}.amazonaws.com.cn",
@@ -75,7 +73,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "sms-voice.pinpoint.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "sms-voice.pinpoint.{region}.c2s.ic.gov",
@@ -86,7 +83,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "sms-voice.pinpoint.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "sms-voice.pinpoint.{region}.sc2s.sgov.gov",
@@ -97,7 +93,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "sms-voice.pinpoint.{region}.amazonaws.com",
     variants: [
       {
         hostname: "sms-voice.pinpoint.{region}.amazonaws.com",

--- a/clients/client-pinpoint/src/endpoints.ts
+++ b/clients/client-pinpoint/src/endpoints.ts
@@ -3,7 +3,6 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
   "us-east-1": {
-    hostname: "pinpoint.us-east-1.amazonaws.com",
     variants: [
       {
         hostname: "pinpoint.us-east-1.amazonaws.com",
@@ -17,7 +16,6 @@ const regionHash: RegionHash = {
     signingRegion: "us-east-1",
   },
   "us-gov-west-1": {
-    hostname: "pinpoint.us-gov-west-1.amazonaws.com",
     variants: [
       {
         hostname: "pinpoint.us-gov-west-1.amazonaws.com",
@@ -31,7 +29,6 @@ const regionHash: RegionHash = {
     signingRegion: "us-gov-west-1",
   },
   "us-west-2": {
-    hostname: "pinpoint.us-west-2.amazonaws.com",
     variants: [
       {
         hostname: "pinpoint.us-west-2.amazonaws.com",
@@ -74,7 +71,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "pinpoint.{region}.amazonaws.com",
     variants: [
       {
         hostname: "pinpoint.{region}.amazonaws.com",
@@ -97,7 +93,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "pinpoint.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "pinpoint.{region}.amazonaws.com.cn",
@@ -120,7 +115,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "pinpoint.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "pinpoint.{region}.c2s.ic.gov",
@@ -131,7 +125,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "pinpoint.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "pinpoint.{region}.sc2s.sgov.gov",
@@ -142,7 +135,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["fips-us-gov-west-1", "us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "pinpoint.{region}.amazonaws.com",
     variants: [
       {
         hostname: "pinpoint.{region}.amazonaws.com",

--- a/clients/client-polly/src/endpoints.ts
+++ b/clients/client-polly/src/endpoints.ts
@@ -3,7 +3,6 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
   "us-east-1": {
-    hostname: "polly.us-east-1.amazonaws.com",
     variants: [
       {
         hostname: "polly.us-east-1.amazonaws.com",
@@ -16,7 +15,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-east-2": {
-    hostname: "polly.us-east-2.amazonaws.com",
     variants: [
       {
         hostname: "polly.us-east-2.amazonaws.com",
@@ -29,7 +27,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-gov-west-1": {
-    hostname: "polly.us-gov-west-1.amazonaws.com",
     variants: [
       {
         hostname: "polly.us-gov-west-1.amazonaws.com",
@@ -42,7 +39,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-west-1": {
-    hostname: "polly.us-west-1.amazonaws.com",
     variants: [
       {
         hostname: "polly.us-west-1.amazonaws.com",
@@ -55,7 +51,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-west-2": {
-    hostname: "polly.us-west-2.amazonaws.com",
     variants: [
       {
         hostname: "polly.us-west-2.amazonaws.com",
@@ -99,7 +94,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "polly.{region}.amazonaws.com",
     variants: [
       {
         hostname: "polly.{region}.amazonaws.com",
@@ -122,7 +116,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "polly.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "polly.{region}.amazonaws.com.cn",
@@ -145,7 +138,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "polly.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "polly.{region}.c2s.ic.gov",
@@ -156,7 +148,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "polly.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "polly.{region}.sc2s.sgov.gov",
@@ -167,7 +158,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["fips-us-gov-west-1", "us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "polly.{region}.amazonaws.com",
     variants: [
       {
         hostname: "polly.{region}.amazonaws.com",

--- a/clients/client-pricing/src/endpoints.ts
+++ b/clients/client-pricing/src/endpoints.ts
@@ -29,7 +29,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "api.pricing.{region}.amazonaws.com",
     variants: [
       {
         hostname: "api.pricing.{region}.amazonaws.com",
@@ -52,7 +51,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "api.pricing.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "api.pricing.{region}.amazonaws.com.cn",
@@ -75,7 +73,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "api.pricing.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "api.pricing.{region}.c2s.ic.gov",
@@ -86,7 +83,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "api.pricing.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "api.pricing.{region}.sc2s.sgov.gov",
@@ -97,7 +93,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "api.pricing.{region}.amazonaws.com",
     variants: [
       {
         hostname: "api.pricing.{region}.amazonaws.com",

--- a/clients/client-proton/src/endpoints.ts
+++ b/clients/client-proton/src/endpoints.ts
@@ -29,7 +29,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "proton.{region}.amazonaws.com",
     variants: [
       {
         hostname: "proton.{region}.amazonaws.com",
@@ -52,7 +51,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "proton.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "proton.{region}.amazonaws.com.cn",
@@ -75,7 +73,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "proton.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "proton.{region}.c2s.ic.gov",
@@ -86,7 +83,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "proton.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "proton.{region}.sc2s.sgov.gov",
@@ -97,7 +93,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "proton.{region}.amazonaws.com",
     variants: [
       {
         hostname: "proton.{region}.amazonaws.com",

--- a/clients/client-qldb-session/src/endpoints.ts
+++ b/clients/client-qldb-session/src/endpoints.ts
@@ -3,7 +3,6 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
   "us-east-1": {
-    hostname: "session.qldb.us-east-1.amazonaws.com",
     variants: [
       {
         hostname: "session.qldb.us-east-1.amazonaws.com",
@@ -16,7 +15,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-east-2": {
-    hostname: "session.qldb.us-east-2.amazonaws.com",
     variants: [
       {
         hostname: "session.qldb.us-east-2.amazonaws.com",
@@ -29,7 +27,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-west-2": {
-    hostname: "session.qldb.us-west-2.amazonaws.com",
     variants: [
       {
         hostname: "session.qldb.us-west-2.amazonaws.com",
@@ -72,7 +69,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "session.qldb.{region}.amazonaws.com",
     variants: [
       {
         hostname: "session.qldb.{region}.amazonaws.com",
@@ -95,7 +91,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "session.qldb.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "session.qldb.{region}.amazonaws.com.cn",
@@ -118,7 +113,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "session.qldb.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "session.qldb.{region}.c2s.ic.gov",
@@ -129,7 +123,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "session.qldb.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "session.qldb.{region}.sc2s.sgov.gov",
@@ -140,7 +133,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "session.qldb.{region}.amazonaws.com",
     variants: [
       {
         hostname: "session.qldb.{region}.amazonaws.com",

--- a/clients/client-qldb/src/endpoints.ts
+++ b/clients/client-qldb/src/endpoints.ts
@@ -3,7 +3,6 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
   "us-east-1": {
-    hostname: "qldb.us-east-1.amazonaws.com",
     variants: [
       {
         hostname: "qldb.us-east-1.amazonaws.com",
@@ -16,7 +15,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-east-2": {
-    hostname: "qldb.us-east-2.amazonaws.com",
     variants: [
       {
         hostname: "qldb.us-east-2.amazonaws.com",
@@ -29,7 +27,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-west-2": {
-    hostname: "qldb.us-west-2.amazonaws.com",
     variants: [
       {
         hostname: "qldb.us-west-2.amazonaws.com",
@@ -72,7 +69,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "qldb.{region}.amazonaws.com",
     variants: [
       {
         hostname: "qldb.{region}.amazonaws.com",
@@ -95,7 +91,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "qldb.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "qldb.{region}.amazonaws.com.cn",
@@ -118,7 +113,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "qldb.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "qldb.{region}.c2s.ic.gov",
@@ -129,7 +123,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "qldb.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "qldb.{region}.sc2s.sgov.gov",
@@ -140,7 +133,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "qldb.{region}.amazonaws.com",
     variants: [
       {
         hostname: "qldb.{region}.amazonaws.com",

--- a/clients/client-quicksight/src/endpoints.ts
+++ b/clients/client-quicksight/src/endpoints.ts
@@ -30,7 +30,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "quicksight.{region}.amazonaws.com",
     variants: [
       {
         hostname: "quicksight.{region}.amazonaws.com",
@@ -53,7 +52,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "quicksight.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "quicksight.{region}.amazonaws.com.cn",
@@ -76,7 +74,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "quicksight.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "quicksight.{region}.c2s.ic.gov",
@@ -87,7 +84,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "quicksight.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "quicksight.{region}.sc2s.sgov.gov",
@@ -98,7 +94,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["api", "us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "quicksight.{region}.amazonaws.com",
     variants: [
       {
         hostname: "quicksight.{region}.amazonaws.com",

--- a/clients/client-ram/src/endpoints.ts
+++ b/clients/client-ram/src/endpoints.ts
@@ -3,7 +3,6 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
   "ca-central-1": {
-    hostname: "ram.ca-central-1.amazonaws.com",
     variants: [
       {
         hostname: "ram.ca-central-1.amazonaws.com",
@@ -16,7 +15,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-east-1": {
-    hostname: "ram.us-east-1.amazonaws.com",
     variants: [
       {
         hostname: "ram.us-east-1.amazonaws.com",
@@ -29,7 +27,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-east-2": {
-    hostname: "ram.us-east-2.amazonaws.com",
     variants: [
       {
         hostname: "ram.us-east-2.amazonaws.com",
@@ -42,7 +39,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-gov-east-1": {
-    hostname: "ram.us-gov-east-1.amazonaws.com",
     variants: [
       {
         hostname: "ram.us-gov-east-1.amazonaws.com",
@@ -52,7 +48,6 @@ const regionHash: RegionHash = {
     signingRegion: "us-gov-east-1",
   },
   "us-gov-west-1": {
-    hostname: "ram.us-gov-west-1.amazonaws.com",
     variants: [
       {
         hostname: "ram.us-gov-west-1.amazonaws.com",
@@ -62,7 +57,6 @@ const regionHash: RegionHash = {
     signingRegion: "us-gov-west-1",
   },
   "us-west-1": {
-    hostname: "ram.us-west-1.amazonaws.com",
     variants: [
       {
         hostname: "ram.us-west-1.amazonaws.com",
@@ -75,7 +69,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-west-2": {
-    hostname: "ram.us-west-2.amazonaws.com",
     variants: [
       {
         hostname: "ram.us-west-2.amazonaws.com",
@@ -120,7 +113,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "ram.{region}.amazonaws.com",
     variants: [
       {
         hostname: "ram.{region}.amazonaws.com",
@@ -143,7 +135,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "ram.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "ram.{region}.amazonaws.com.cn",
@@ -166,7 +157,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "ram.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "ram.{region}.c2s.ic.gov",
@@ -177,7 +167,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "ram.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "ram.{region}.sc2s.sgov.gov",
@@ -188,7 +177,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "ram.{region}.amazonaws.com",
     variants: [
       {
         hostname: "ram.{region}.amazonaws.com",

--- a/clients/client-rds-data/src/endpoints.ts
+++ b/clients/client-rds-data/src/endpoints.ts
@@ -29,7 +29,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "rds-data.{region}.amazonaws.com",
     variants: [
       {
         hostname: "rds-data.{region}.amazonaws.com",
@@ -52,7 +51,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "rds-data.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "rds-data.{region}.amazonaws.com.cn",
@@ -75,7 +73,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "rds-data.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "rds-data.{region}.c2s.ic.gov",
@@ -86,7 +83,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "rds-data.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "rds-data.{region}.sc2s.sgov.gov",
@@ -97,7 +93,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "rds-data.{region}.amazonaws.com",
     variants: [
       {
         hostname: "rds-data.{region}.amazonaws.com",

--- a/clients/client-rds/src/endpoints.ts
+++ b/clients/client-rds/src/endpoints.ts
@@ -3,7 +3,6 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
   "ca-central-1": {
-    hostname: "rds.ca-central-1.amazonaws.com",
     variants: [
       {
         hostname: "rds.ca-central-1.amazonaws.com",
@@ -16,7 +15,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-east-1": {
-    hostname: "rds.us-east-1.amazonaws.com",
     variants: [
       {
         hostname: "rds.us-east-1.amazonaws.com",
@@ -29,7 +27,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-east-2": {
-    hostname: "rds.us-east-2.amazonaws.com",
     variants: [
       {
         hostname: "rds.us-east-2.amazonaws.com",
@@ -42,7 +39,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-gov-east-1": {
-    hostname: "rds.us-gov-east-1.amazonaws.com",
     variants: [
       {
         hostname: "rds.us-gov-east-1.amazonaws.com",
@@ -55,7 +51,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-gov-west-1": {
-    hostname: "rds.us-gov-west-1.amazonaws.com",
     variants: [
       {
         hostname: "rds.us-gov-west-1.amazonaws.com",
@@ -68,7 +63,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-west-1": {
-    hostname: "rds.us-west-1.amazonaws.com",
     variants: [
       {
         hostname: "rds.us-west-1.amazonaws.com",
@@ -81,7 +75,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-west-2": {
-    hostname: "rds.us-west-2.amazonaws.com",
     variants: [
       {
         hostname: "rds.us-west-2.amazonaws.com",
@@ -136,7 +129,6 @@ const partitionHash: PartitionHash = {
       "us-west-2-fips",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "rds.{region}.amazonaws.com",
     variants: [
       {
         hostname: "rds.{region}.amazonaws.com",
@@ -159,7 +151,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "rds.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "rds.{region}.amazonaws.com.cn",
@@ -182,7 +173,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "rds.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "rds.{region}.c2s.ic.gov",
@@ -193,7 +183,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "rds.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "rds.{region}.sc2s.sgov.gov",
@@ -211,7 +200,6 @@ const partitionHash: PartitionHash = {
       "us-gov-west-1-fips",
     ],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "rds.{region}.amazonaws.com",
     variants: [
       {
         hostname: "rds.{region}.amazonaws.com",

--- a/clients/client-redshift-data/src/endpoints.ts
+++ b/clients/client-redshift-data/src/endpoints.ts
@@ -29,7 +29,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "redshift-data.{region}.amazonaws.com",
     variants: [
       {
         hostname: "redshift-data.{region}.amazonaws.com",
@@ -52,7 +51,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "redshift-data.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "redshift-data.{region}.amazonaws.com.cn",
@@ -75,7 +73,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "redshift-data.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "redshift-data.{region}.c2s.ic.gov",
@@ -86,7 +83,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "redshift-data.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "redshift-data.{region}.sc2s.sgov.gov",
@@ -97,7 +93,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "redshift-data.{region}.amazonaws.com",
     variants: [
       {
         hostname: "redshift-data.{region}.amazonaws.com",

--- a/clients/client-redshift/src/endpoints.ts
+++ b/clients/client-redshift/src/endpoints.ts
@@ -3,7 +3,6 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
   "ca-central-1": {
-    hostname: "redshift.ca-central-1.amazonaws.com",
     variants: [
       {
         hostname: "redshift.ca-central-1.amazonaws.com",
@@ -16,7 +15,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-east-1": {
-    hostname: "redshift.us-east-1.amazonaws.com",
     variants: [
       {
         hostname: "redshift.us-east-1.amazonaws.com",
@@ -29,7 +27,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-east-2": {
-    hostname: "redshift.us-east-2.amazonaws.com",
     variants: [
       {
         hostname: "redshift.us-east-2.amazonaws.com",
@@ -42,7 +39,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-gov-east-1": {
-    hostname: "redshift.us-gov-east-1.amazonaws.com",
     variants: [
       {
         hostname: "redshift.us-gov-east-1.amazonaws.com",
@@ -52,7 +48,6 @@ const regionHash: RegionHash = {
     signingRegion: "us-gov-east-1",
   },
   "us-gov-west-1": {
-    hostname: "redshift.us-gov-west-1.amazonaws.com",
     variants: [
       {
         hostname: "redshift.us-gov-west-1.amazonaws.com",
@@ -62,7 +57,6 @@ const regionHash: RegionHash = {
     signingRegion: "us-gov-west-1",
   },
   "us-west-1": {
-    hostname: "redshift.us-west-1.amazonaws.com",
     variants: [
       {
         hostname: "redshift.us-west-1.amazonaws.com",
@@ -75,7 +69,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-west-2": {
-    hostname: "redshift.us-west-2.amazonaws.com",
     variants: [
       {
         hostname: "redshift.us-west-2.amazonaws.com",
@@ -120,7 +113,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "redshift.{region}.amazonaws.com",
     variants: [
       {
         hostname: "redshift.{region}.amazonaws.com",
@@ -143,7 +135,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "redshift.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "redshift.{region}.amazonaws.com.cn",
@@ -166,7 +157,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "redshift.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "redshift.{region}.c2s.ic.gov",
@@ -177,7 +167,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "redshift.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "redshift.{region}.sc2s.sgov.gov",
@@ -188,7 +177,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "redshift.{region}.amazonaws.com",
     variants: [
       {
         hostname: "redshift.{region}.amazonaws.com",

--- a/clients/client-rekognition/src/endpoints.ts
+++ b/clients/client-rekognition/src/endpoints.ts
@@ -3,7 +3,6 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
   "ca-central-1": {
-    hostname: "rekognition.ca-central-1.amazonaws.com",
     variants: [
       {
         hostname: "rekognition.ca-central-1.amazonaws.com",
@@ -16,7 +15,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-east-1": {
-    hostname: "rekognition.us-east-1.amazonaws.com",
     variants: [
       {
         hostname: "rekognition.us-east-1.amazonaws.com",
@@ -29,7 +27,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-east-2": {
-    hostname: "rekognition.us-east-2.amazonaws.com",
     variants: [
       {
         hostname: "rekognition.us-east-2.amazonaws.com",
@@ -42,7 +39,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-gov-west-1": {
-    hostname: "rekognition.us-gov-west-1.amazonaws.com",
     variants: [
       {
         hostname: "rekognition.us-gov-west-1.amazonaws.com",
@@ -55,7 +51,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-west-1": {
-    hostname: "rekognition.us-west-1.amazonaws.com",
     variants: [
       {
         hostname: "rekognition.us-west-1.amazonaws.com",
@@ -68,7 +63,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-west-2": {
-    hostname: "rekognition.us-west-2.amazonaws.com",
     variants: [
       {
         hostname: "rekognition.us-west-2.amazonaws.com",
@@ -123,7 +117,6 @@ const partitionHash: PartitionHash = {
       "us-west-2-fips",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "rekognition.{region}.amazonaws.com",
     variants: [
       {
         hostname: "rekognition.{region}.amazonaws.com",
@@ -146,7 +139,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "rekognition.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "rekognition.{region}.amazonaws.com.cn",
@@ -169,7 +161,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "rekognition.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "rekognition.{region}.c2s.ic.gov",
@@ -180,7 +171,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "rekognition.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "rekognition.{region}.sc2s.sgov.gov",
@@ -197,7 +187,6 @@ const partitionHash: PartitionHash = {
       "us-gov-west-1-fips",
     ],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "rekognition.{region}.amazonaws.com",
     variants: [
       {
         hostname: "rekognition.{region}.amazonaws.com",

--- a/clients/client-resource-groups-tagging-api/src/endpoints.ts
+++ b/clients/client-resource-groups-tagging-api/src/endpoints.ts
@@ -29,7 +29,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "tagging.{region}.amazonaws.com",
     variants: [
       {
         hostname: "tagging.{region}.amazonaws.com",
@@ -52,7 +51,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "tagging.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "tagging.{region}.amazonaws.com.cn",
@@ -75,7 +73,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "tagging.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "tagging.{region}.c2s.ic.gov",
@@ -86,7 +83,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "tagging.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "tagging.{region}.sc2s.sgov.gov",
@@ -97,7 +93,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "tagging.{region}.amazonaws.com",
     variants: [
       {
         hostname: "tagging.{region}.amazonaws.com",

--- a/clients/client-resource-groups/src/endpoints.ts
+++ b/clients/client-resource-groups/src/endpoints.ts
@@ -3,7 +3,6 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
   "us-east-1": {
-    hostname: "resource-groups.us-east-1.amazonaws.com",
     variants: [
       {
         hostname: "resource-groups.us-east-1.amazonaws.com",
@@ -16,7 +15,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-east-2": {
-    hostname: "resource-groups.us-east-2.amazonaws.com",
     variants: [
       {
         hostname: "resource-groups.us-east-2.amazonaws.com",
@@ -29,7 +27,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-gov-east-1": {
-    hostname: "resource-groups.us-gov-east-1.amazonaws.com",
     variants: [
       {
         hostname: "resource-groups.us-gov-east-1.amazonaws.com",
@@ -42,7 +39,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-gov-west-1": {
-    hostname: "resource-groups.us-gov-west-1.amazonaws.com",
     variants: [
       {
         hostname: "resource-groups.us-gov-west-1.amazonaws.com",
@@ -55,7 +51,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-west-1": {
-    hostname: "resource-groups.us-west-1.amazonaws.com",
     variants: [
       {
         hostname: "resource-groups.us-west-1.amazonaws.com",
@@ -68,7 +63,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-west-2": {
-    hostname: "resource-groups.us-west-2.amazonaws.com",
     variants: [
       {
         hostname: "resource-groups.us-west-2.amazonaws.com",
@@ -112,7 +106,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "resource-groups.{region}.amazonaws.com",
     variants: [
       {
         hostname: "resource-groups.{region}.amazonaws.com",
@@ -135,7 +128,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "resource-groups.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "resource-groups.{region}.amazonaws.com.cn",
@@ -158,7 +150,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "resource-groups.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "resource-groups.{region}.c2s.ic.gov",
@@ -169,7 +160,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "resource-groups.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "resource-groups.{region}.sc2s.sgov.gov",
@@ -180,7 +170,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["fips-us-gov-east-1", "fips-us-gov-west-1", "us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "resource-groups.{region}.amazonaws.com",
     variants: [
       {
         hostname: "resource-groups.{region}.amazonaws.com",

--- a/clients/client-robomaker/src/endpoints.ts
+++ b/clients/client-robomaker/src/endpoints.ts
@@ -29,7 +29,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "robomaker.{region}.amazonaws.com",
     variants: [
       {
         hostname: "robomaker.{region}.amazonaws.com",
@@ -52,7 +51,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "robomaker.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "robomaker.{region}.amazonaws.com.cn",
@@ -75,7 +73,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "robomaker.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "robomaker.{region}.c2s.ic.gov",
@@ -86,7 +83,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "robomaker.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "robomaker.{region}.sc2s.sgov.gov",
@@ -97,7 +93,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "robomaker.{region}.amazonaws.com",
     variants: [
       {
         hostname: "robomaker.{region}.amazonaws.com",

--- a/clients/client-route-53-domains/src/endpoints.ts
+++ b/clients/client-route-53-domains/src/endpoints.ts
@@ -29,7 +29,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "route53domains.{region}.amazonaws.com",
     variants: [
       {
         hostname: "route53domains.{region}.amazonaws.com",
@@ -52,7 +51,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "route53domains.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "route53domains.{region}.amazonaws.com.cn",
@@ -75,7 +73,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "route53domains.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "route53domains.{region}.c2s.ic.gov",
@@ -86,7 +83,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "route53domains.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "route53domains.{region}.sc2s.sgov.gov",
@@ -97,7 +93,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "route53domains.{region}.amazonaws.com",
     variants: [
       {
         hostname: "route53domains.{region}.amazonaws.com",

--- a/clients/client-route-53/src/endpoints.ts
+++ b/clients/client-route-53/src/endpoints.ts
@@ -3,7 +3,6 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
   "aws-cn-global": {
-    hostname: "route53.amazonaws.com.cn",
     variants: [
       {
         hostname: "route53.amazonaws.com.cn",
@@ -13,7 +12,6 @@ const regionHash: RegionHash = {
     signingRegion: "cn-northwest-1",
   },
   "aws-global": {
-    hostname: "route53.amazonaws.com",
     variants: [
       {
         hostname: "route53.amazonaws.com",
@@ -27,7 +25,6 @@ const regionHash: RegionHash = {
     signingRegion: "us-east-1",
   },
   "aws-iso-b-global": {
-    hostname: "route53.sc2s.sgov.gov",
     variants: [
       {
         hostname: "route53.sc2s.sgov.gov",
@@ -37,7 +34,6 @@ const regionHash: RegionHash = {
     signingRegion: "us-isob-east-1",
   },
   "aws-iso-global": {
-    hostname: "route53.c2s.ic.gov",
     variants: [
       {
         hostname: "route53.c2s.ic.gov",
@@ -47,7 +43,6 @@ const regionHash: RegionHash = {
     signingRegion: "us-iso-east-1",
   },
   "aws-us-gov-global": {
-    hostname: "route53.us-gov.amazonaws.com",
     variants: [
       {
         hostname: "route53.us-gov.amazonaws.com",
@@ -90,7 +85,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "route53.{region}.amazonaws.com",
     variants: [
       {
         hostname: "route53.{region}.amazonaws.com",
@@ -114,7 +108,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["aws-cn-global", "cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "route53.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "route53.{region}.amazonaws.com.cn",
@@ -138,7 +131,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["aws-iso-global", "us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "route53.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "route53.{region}.c2s.ic.gov",
@@ -150,7 +142,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["aws-iso-b-global", "us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "route53.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "route53.{region}.sc2s.sgov.gov",
@@ -162,7 +153,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["aws-us-gov-global", "fips-aws-us-gov-global", "us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "route53.{region}.amazonaws.com",
     variants: [
       {
         hostname: "route53.{region}.amazonaws.com",

--- a/clients/client-route53-recovery-cluster/src/endpoints.ts
+++ b/clients/client-route53-recovery-cluster/src/endpoints.ts
@@ -29,7 +29,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "route53-recovery-cluster.{region}.amazonaws.com",
     variants: [
       {
         hostname: "route53-recovery-cluster.{region}.amazonaws.com",
@@ -52,7 +51,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "route53-recovery-cluster.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "route53-recovery-cluster.{region}.amazonaws.com.cn",
@@ -75,7 +73,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "route53-recovery-cluster.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "route53-recovery-cluster.{region}.c2s.ic.gov",
@@ -86,7 +83,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "route53-recovery-cluster.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "route53-recovery-cluster.{region}.sc2s.sgov.gov",
@@ -97,7 +93,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "route53-recovery-cluster.{region}.amazonaws.com",
     variants: [
       {
         hostname: "route53-recovery-cluster.{region}.amazonaws.com",

--- a/clients/client-route53-recovery-control-config/src/endpoints.ts
+++ b/clients/client-route53-recovery-control-config/src/endpoints.ts
@@ -3,7 +3,6 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
   "aws-global": {
-    hostname: "route53-recovery-control-config.us-west-2.amazonaws.com",
     variants: [
       {
         hostname: "route53-recovery-control-config.us-west-2.amazonaws.com",
@@ -41,7 +40,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "route53-recovery-control-config.{region}.amazonaws.com",
     variants: [
       {
         hostname: "route53-recovery-control-config.{region}.amazonaws.com",
@@ -64,7 +62,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "route53-recovery-control-config.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "route53-recovery-control-config.{region}.amazonaws.com.cn",
@@ -87,7 +84,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "route53-recovery-control-config.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "route53-recovery-control-config.{region}.c2s.ic.gov",
@@ -98,7 +94,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "route53-recovery-control-config.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "route53-recovery-control-config.{region}.sc2s.sgov.gov",
@@ -109,7 +104,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "route53-recovery-control-config.{region}.amazonaws.com",
     variants: [
       {
         hostname: "route53-recovery-control-config.{region}.amazonaws.com",

--- a/clients/client-route53-recovery-readiness/src/endpoints.ts
+++ b/clients/client-route53-recovery-readiness/src/endpoints.ts
@@ -29,7 +29,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "route53-recovery-readiness.{region}.amazonaws.com",
     variants: [
       {
         hostname: "route53-recovery-readiness.{region}.amazonaws.com",
@@ -52,7 +51,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "route53-recovery-readiness.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "route53-recovery-readiness.{region}.amazonaws.com.cn",
@@ -75,7 +73,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "route53-recovery-readiness.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "route53-recovery-readiness.{region}.c2s.ic.gov",
@@ -86,7 +83,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "route53-recovery-readiness.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "route53-recovery-readiness.{region}.sc2s.sgov.gov",
@@ -97,7 +93,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "route53-recovery-readiness.{region}.amazonaws.com",
     variants: [
       {
         hostname: "route53-recovery-readiness.{region}.amazonaws.com",

--- a/clients/client-route53resolver/src/endpoints.ts
+++ b/clients/client-route53resolver/src/endpoints.ts
@@ -29,7 +29,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "route53resolver.{region}.amazonaws.com",
     variants: [
       {
         hostname: "route53resolver.{region}.amazonaws.com",
@@ -52,7 +51,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "route53resolver.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "route53resolver.{region}.amazonaws.com.cn",
@@ -75,7 +73,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "route53resolver.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "route53resolver.{region}.c2s.ic.gov",
@@ -86,7 +83,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "route53resolver.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "route53resolver.{region}.sc2s.sgov.gov",
@@ -97,7 +93,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "route53resolver.{region}.amazonaws.com",
     variants: [
       {
         hostname: "route53resolver.{region}.amazonaws.com",

--- a/clients/client-s3-control/src/endpoints.ts
+++ b/clients/client-s3-control/src/endpoints.ts
@@ -3,7 +3,6 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
   "ap-northeast-1": {
-    hostname: "s3-control.ap-northeast-1.amazonaws.com",
     variants: [
       {
         hostname: "s3-control.ap-northeast-1.amazonaws.com",
@@ -17,7 +16,6 @@ const regionHash: RegionHash = {
     signingRegion: "ap-northeast-1",
   },
   "ap-northeast-2": {
-    hostname: "s3-control.ap-northeast-2.amazonaws.com",
     variants: [
       {
         hostname: "s3-control.ap-northeast-2.amazonaws.com",
@@ -31,7 +29,6 @@ const regionHash: RegionHash = {
     signingRegion: "ap-northeast-2",
   },
   "ap-northeast-3": {
-    hostname: "s3-control.ap-northeast-3.amazonaws.com",
     variants: [
       {
         hostname: "s3-control.ap-northeast-3.amazonaws.com",
@@ -45,7 +42,6 @@ const regionHash: RegionHash = {
     signingRegion: "ap-northeast-3",
   },
   "ap-south-1": {
-    hostname: "s3-control.ap-south-1.amazonaws.com",
     variants: [
       {
         hostname: "s3-control.ap-south-1.amazonaws.com",
@@ -59,7 +55,6 @@ const regionHash: RegionHash = {
     signingRegion: "ap-south-1",
   },
   "ap-southeast-1": {
-    hostname: "s3-control.ap-southeast-1.amazonaws.com",
     variants: [
       {
         hostname: "s3-control.ap-southeast-1.amazonaws.com",
@@ -73,7 +68,6 @@ const regionHash: RegionHash = {
     signingRegion: "ap-southeast-1",
   },
   "ap-southeast-2": {
-    hostname: "s3-control.ap-southeast-2.amazonaws.com",
     variants: [
       {
         hostname: "s3-control.ap-southeast-2.amazonaws.com",
@@ -87,7 +81,6 @@ const regionHash: RegionHash = {
     signingRegion: "ap-southeast-2",
   },
   "ca-central-1": {
-    hostname: "s3-control.ca-central-1.amazonaws.com",
     variants: [
       {
         hostname: "s3-control.ca-central-1.amazonaws.com",
@@ -109,7 +102,6 @@ const regionHash: RegionHash = {
     signingRegion: "ca-central-1",
   },
   "cn-north-1": {
-    hostname: "s3-control.cn-north-1.amazonaws.com.cn",
     variants: [
       {
         hostname: "s3-control.cn-north-1.amazonaws.com.cn",
@@ -123,7 +115,6 @@ const regionHash: RegionHash = {
     signingRegion: "cn-north-1",
   },
   "cn-northwest-1": {
-    hostname: "s3-control.cn-northwest-1.amazonaws.com.cn",
     variants: [
       {
         hostname: "s3-control.cn-northwest-1.amazonaws.com.cn",
@@ -137,7 +128,6 @@ const regionHash: RegionHash = {
     signingRegion: "cn-northwest-1",
   },
   "eu-central-1": {
-    hostname: "s3-control.eu-central-1.amazonaws.com",
     variants: [
       {
         hostname: "s3-control.eu-central-1.amazonaws.com",
@@ -151,7 +141,6 @@ const regionHash: RegionHash = {
     signingRegion: "eu-central-1",
   },
   "eu-north-1": {
-    hostname: "s3-control.eu-north-1.amazonaws.com",
     variants: [
       {
         hostname: "s3-control.eu-north-1.amazonaws.com",
@@ -165,7 +154,6 @@ const regionHash: RegionHash = {
     signingRegion: "eu-north-1",
   },
   "eu-west-1": {
-    hostname: "s3-control.eu-west-1.amazonaws.com",
     variants: [
       {
         hostname: "s3-control.eu-west-1.amazonaws.com",
@@ -179,7 +167,6 @@ const regionHash: RegionHash = {
     signingRegion: "eu-west-1",
   },
   "eu-west-2": {
-    hostname: "s3-control.eu-west-2.amazonaws.com",
     variants: [
       {
         hostname: "s3-control.eu-west-2.amazonaws.com",
@@ -193,7 +180,6 @@ const regionHash: RegionHash = {
     signingRegion: "eu-west-2",
   },
   "eu-west-3": {
-    hostname: "s3-control.eu-west-3.amazonaws.com",
     variants: [
       {
         hostname: "s3-control.eu-west-3.amazonaws.com",
@@ -207,7 +193,6 @@ const regionHash: RegionHash = {
     signingRegion: "eu-west-3",
   },
   "sa-east-1": {
-    hostname: "s3-control.sa-east-1.amazonaws.com",
     variants: [
       {
         hostname: "s3-control.sa-east-1.amazonaws.com",
@@ -221,7 +206,6 @@ const regionHash: RegionHash = {
     signingRegion: "sa-east-1",
   },
   "us-east-1": {
-    hostname: "s3-control.us-east-1.amazonaws.com",
     variants: [
       {
         hostname: "s3-control.us-east-1.amazonaws.com",
@@ -243,7 +227,6 @@ const regionHash: RegionHash = {
     signingRegion: "us-east-1",
   },
   "us-east-2": {
-    hostname: "s3-control.us-east-2.amazonaws.com",
     variants: [
       {
         hostname: "s3-control.us-east-2.amazonaws.com",
@@ -265,7 +248,6 @@ const regionHash: RegionHash = {
     signingRegion: "us-east-2",
   },
   "us-gov-east-1": {
-    hostname: "s3-control.us-gov-east-1.amazonaws.com",
     variants: [
       {
         hostname: "s3-control.us-gov-east-1.amazonaws.com",
@@ -287,7 +269,6 @@ const regionHash: RegionHash = {
     signingRegion: "us-gov-east-1",
   },
   "us-gov-west-1": {
-    hostname: "s3-control.us-gov-west-1.amazonaws.com",
     variants: [
       {
         hostname: "s3-control.us-gov-west-1.amazonaws.com",
@@ -309,7 +290,6 @@ const regionHash: RegionHash = {
     signingRegion: "us-gov-west-1",
   },
   "us-west-1": {
-    hostname: "s3-control.us-west-1.amazonaws.com",
     variants: [
       {
         hostname: "s3-control.us-west-1.amazonaws.com",
@@ -331,7 +311,6 @@ const regionHash: RegionHash = {
     signingRegion: "us-west-1",
   },
   "us-west-2": {
-    hostname: "s3-control.us-west-2.amazonaws.com",
     variants: [
       {
         hostname: "s3-control.us-west-2.amazonaws.com",
@@ -385,7 +364,6 @@ const partitionHash: PartitionHash = {
       "us-west-2-fips",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "s3-control.{region}.amazonaws.com",
     variants: [
       {
         hostname: "s3-control.{region}.amazonaws.com",
@@ -408,7 +386,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "s3-control.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "s3-control.{region}.amazonaws.com.cn",
@@ -431,7 +408,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "s3-control.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "s3-control.{region}.c2s.ic.gov",
@@ -442,7 +418,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "s3-control.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "s3-control.{region}.sc2s.sgov.gov",
@@ -453,7 +428,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-east-1-fips", "us-gov-west-1", "us-gov-west-1-fips"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "s3-control.{region}.amazonaws.com",
     variants: [
       {
         hostname: "s3-control.{region}.amazonaws.com",

--- a/clients/client-s3/src/endpoints.ts
+++ b/clients/client-s3/src/endpoints.ts
@@ -3,7 +3,6 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
   "af-south-1": {
-    hostname: "s3.af-south-1.amazonaws.com",
     variants: [
       {
         hostname: "s3.af-south-1.amazonaws.com",
@@ -16,7 +15,6 @@ const regionHash: RegionHash = {
     ],
   },
   "ap-east-1": {
-    hostname: "s3.ap-east-1.amazonaws.com",
     variants: [
       {
         hostname: "s3.ap-east-1.amazonaws.com",
@@ -29,7 +27,6 @@ const regionHash: RegionHash = {
     ],
   },
   "ap-northeast-1": {
-    hostname: "s3.ap-northeast-1.amazonaws.com",
     variants: [
       {
         hostname: "s3.ap-northeast-1.amazonaws.com",
@@ -42,7 +39,6 @@ const regionHash: RegionHash = {
     ],
   },
   "ap-northeast-2": {
-    hostname: "s3.ap-northeast-2.amazonaws.com",
     variants: [
       {
         hostname: "s3.ap-northeast-2.amazonaws.com",
@@ -55,7 +51,6 @@ const regionHash: RegionHash = {
     ],
   },
   "ap-northeast-3": {
-    hostname: "s3.ap-northeast-3.amazonaws.com",
     variants: [
       {
         hostname: "s3.ap-northeast-3.amazonaws.com",
@@ -68,7 +63,6 @@ const regionHash: RegionHash = {
     ],
   },
   "ap-south-1": {
-    hostname: "s3.ap-south-1.amazonaws.com",
     variants: [
       {
         hostname: "s3.ap-south-1.amazonaws.com",
@@ -81,7 +75,6 @@ const regionHash: RegionHash = {
     ],
   },
   "ap-southeast-1": {
-    hostname: "s3.ap-southeast-1.amazonaws.com",
     variants: [
       {
         hostname: "s3.ap-southeast-1.amazonaws.com",
@@ -94,7 +87,6 @@ const regionHash: RegionHash = {
     ],
   },
   "ap-southeast-2": {
-    hostname: "s3.ap-southeast-2.amazonaws.com",
     variants: [
       {
         hostname: "s3.ap-southeast-2.amazonaws.com",
@@ -107,7 +99,6 @@ const regionHash: RegionHash = {
     ],
   },
   "aws-global": {
-    hostname: "s3.amazonaws.com",
     variants: [
       {
         hostname: "s3.amazonaws.com",
@@ -117,7 +108,6 @@ const regionHash: RegionHash = {
     signingRegion: "us-east-1",
   },
   "ca-central-1": {
-    hostname: "s3.ca-central-1.amazonaws.com",
     variants: [
       {
         hostname: "s3.ca-central-1.amazonaws.com",
@@ -138,7 +128,6 @@ const regionHash: RegionHash = {
     ],
   },
   "cn-north-1": {
-    hostname: "s3.cn-north-1.amazonaws.com.cn",
     variants: [
       {
         hostname: "s3.cn-north-1.amazonaws.com.cn",
@@ -151,7 +140,6 @@ const regionHash: RegionHash = {
     ],
   },
   "cn-northwest-1": {
-    hostname: "s3.cn-northwest-1.amazonaws.com.cn",
     variants: [
       {
         hostname: "s3.cn-northwest-1.amazonaws.com.cn",
@@ -164,7 +152,6 @@ const regionHash: RegionHash = {
     ],
   },
   "eu-central-1": {
-    hostname: "s3.eu-central-1.amazonaws.com",
     variants: [
       {
         hostname: "s3.eu-central-1.amazonaws.com",
@@ -177,7 +164,6 @@ const regionHash: RegionHash = {
     ],
   },
   "eu-north-1": {
-    hostname: "s3.eu-north-1.amazonaws.com",
     variants: [
       {
         hostname: "s3.eu-north-1.amazonaws.com",
@@ -190,7 +176,6 @@ const regionHash: RegionHash = {
     ],
   },
   "eu-south-1": {
-    hostname: "s3.eu-south-1.amazonaws.com",
     variants: [
       {
         hostname: "s3.eu-south-1.amazonaws.com",
@@ -203,7 +188,6 @@ const regionHash: RegionHash = {
     ],
   },
   "eu-west-1": {
-    hostname: "s3.eu-west-1.amazonaws.com",
     variants: [
       {
         hostname: "s3.eu-west-1.amazonaws.com",
@@ -216,7 +200,6 @@ const regionHash: RegionHash = {
     ],
   },
   "eu-west-2": {
-    hostname: "s3.eu-west-2.amazonaws.com",
     variants: [
       {
         hostname: "s3.eu-west-2.amazonaws.com",
@@ -229,7 +212,6 @@ const regionHash: RegionHash = {
     ],
   },
   "eu-west-3": {
-    hostname: "s3.eu-west-3.amazonaws.com",
     variants: [
       {
         hostname: "s3.eu-west-3.amazonaws.com",
@@ -242,7 +224,6 @@ const regionHash: RegionHash = {
     ],
   },
   "me-south-1": {
-    hostname: "s3.me-south-1.amazonaws.com",
     variants: [
       {
         hostname: "s3.me-south-1.amazonaws.com",
@@ -255,7 +236,6 @@ const regionHash: RegionHash = {
     ],
   },
   "s3-external-1": {
-    hostname: "s3-external-1.amazonaws.com",
     variants: [
       {
         hostname: "s3-external-1.amazonaws.com",
@@ -265,7 +245,6 @@ const regionHash: RegionHash = {
     signingRegion: "us-east-1",
   },
   "sa-east-1": {
-    hostname: "s3.sa-east-1.amazonaws.com",
     variants: [
       {
         hostname: "s3.sa-east-1.amazonaws.com",
@@ -278,7 +257,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-east-1": {
-    hostname: "s3.us-east-1.amazonaws.com",
     variants: [
       {
         hostname: "s3.us-east-1.amazonaws.com",
@@ -299,7 +277,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-east-2": {
-    hostname: "s3.us-east-2.amazonaws.com",
     variants: [
       {
         hostname: "s3.us-east-2.amazonaws.com",
@@ -320,7 +297,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-gov-east-1": {
-    hostname: "s3.us-gov-east-1.amazonaws.com",
     variants: [
       {
         hostname: "s3.us-gov-east-1.amazonaws.com",
@@ -337,7 +313,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-gov-west-1": {
-    hostname: "s3.us-gov-west-1.amazonaws.com",
     variants: [
       {
         hostname: "s3.us-gov-west-1.amazonaws.com",
@@ -354,7 +329,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-west-1": {
-    hostname: "s3.us-west-1.amazonaws.com",
     variants: [
       {
         hostname: "s3.us-west-1.amazonaws.com",
@@ -375,7 +349,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-west-2": {
-    hostname: "s3.us-west-2.amazonaws.com",
     variants: [
       {
         hostname: "s3.us-west-2.amazonaws.com",
@@ -430,7 +403,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "s3.{region}.amazonaws.com",
     variants: [
       {
         hostname: "s3.{region}.amazonaws.com",
@@ -449,7 +421,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "s3.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "s3.{region}.amazonaws.com.cn",
@@ -464,7 +435,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "s3.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "s3.{region}.c2s.ic.gov",
@@ -475,7 +445,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "s3.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "s3.{region}.sc2s.sgov.gov",
@@ -486,7 +455,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["fips-us-gov-east-1", "fips-us-gov-west-1", "us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "s3.{region}.amazonaws.com",
     variants: [
       {
         hostname: "s3.{region}.amazonaws.com",

--- a/clients/client-s3outposts/src/endpoints.ts
+++ b/clients/client-s3outposts/src/endpoints.ts
@@ -29,7 +29,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "s3-outposts.{region}.amazonaws.com",
     variants: [
       {
         hostname: "s3-outposts.{region}.amazonaws.com",
@@ -52,7 +51,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "s3-outposts.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "s3-outposts.{region}.amazonaws.com.cn",
@@ -75,7 +73,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "s3-outposts.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "s3-outposts.{region}.c2s.ic.gov",
@@ -86,7 +83,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "s3-outposts.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "s3-outposts.{region}.sc2s.sgov.gov",
@@ -97,7 +93,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "s3-outposts.{region}.amazonaws.com",
     variants: [
       {
         hostname: "s3-outposts.{region}.amazonaws.com",

--- a/clients/client-sagemaker-a2i-runtime/src/endpoints.ts
+++ b/clients/client-sagemaker-a2i-runtime/src/endpoints.ts
@@ -29,7 +29,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "a2i-runtime.sagemaker.{region}.amazonaws.com",
     variants: [
       {
         hostname: "a2i-runtime.sagemaker.{region}.amazonaws.com",
@@ -52,7 +51,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "a2i-runtime.sagemaker.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "a2i-runtime.sagemaker.{region}.amazonaws.com.cn",
@@ -75,7 +73,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "a2i-runtime.sagemaker.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "a2i-runtime.sagemaker.{region}.c2s.ic.gov",
@@ -86,7 +83,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "a2i-runtime.sagemaker.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "a2i-runtime.sagemaker.{region}.sc2s.sgov.gov",
@@ -97,7 +93,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "a2i-runtime.sagemaker.{region}.amazonaws.com",
     variants: [
       {
         hostname: "a2i-runtime.sagemaker.{region}.amazonaws.com",

--- a/clients/client-sagemaker-edge/src/endpoints.ts
+++ b/clients/client-sagemaker-edge/src/endpoints.ts
@@ -29,7 +29,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "edge.sagemaker.{region}.amazonaws.com",
     variants: [
       {
         hostname: "edge.sagemaker.{region}.amazonaws.com",
@@ -52,7 +51,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "edge.sagemaker.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "edge.sagemaker.{region}.amazonaws.com.cn",
@@ -75,7 +73,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "edge.sagemaker.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "edge.sagemaker.{region}.c2s.ic.gov",
@@ -86,7 +83,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "edge.sagemaker.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "edge.sagemaker.{region}.sc2s.sgov.gov",
@@ -97,7 +93,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "edge.sagemaker.{region}.amazonaws.com",
     variants: [
       {
         hostname: "edge.sagemaker.{region}.amazonaws.com",

--- a/clients/client-sagemaker-featurestore-runtime/src/endpoints.ts
+++ b/clients/client-sagemaker-featurestore-runtime/src/endpoints.ts
@@ -29,7 +29,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "featurestore-runtime.sagemaker.{region}.amazonaws.com",
     variants: [
       {
         hostname: "featurestore-runtime.sagemaker.{region}.amazonaws.com",
@@ -52,7 +51,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "featurestore-runtime.sagemaker.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "featurestore-runtime.sagemaker.{region}.amazonaws.com.cn",
@@ -75,7 +73,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "featurestore-runtime.sagemaker.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "featurestore-runtime.sagemaker.{region}.c2s.ic.gov",
@@ -86,7 +83,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "featurestore-runtime.sagemaker.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "featurestore-runtime.sagemaker.{region}.sc2s.sgov.gov",
@@ -97,7 +93,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "featurestore-runtime.sagemaker.{region}.amazonaws.com",
     variants: [
       {
         hostname: "featurestore-runtime.sagemaker.{region}.amazonaws.com",

--- a/clients/client-sagemaker-runtime/src/endpoints.ts
+++ b/clients/client-sagemaker-runtime/src/endpoints.ts
@@ -3,7 +3,6 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
   "us-east-1": {
-    hostname: "runtime.sagemaker.us-east-1.amazonaws.com",
     variants: [
       {
         hostname: "runtime.sagemaker.us-east-1.amazonaws.com",
@@ -16,7 +15,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-east-2": {
-    hostname: "runtime.sagemaker.us-east-2.amazonaws.com",
     variants: [
       {
         hostname: "runtime.sagemaker.us-east-2.amazonaws.com",
@@ -29,7 +27,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-gov-west-1": {
-    hostname: "runtime.sagemaker.us-gov-west-1.amazonaws.com",
     variants: [
       {
         hostname: "runtime.sagemaker.us-gov-west-1.amazonaws.com",
@@ -42,7 +39,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-west-1": {
-    hostname: "runtime.sagemaker.us-west-1.amazonaws.com",
     variants: [
       {
         hostname: "runtime.sagemaker.us-west-1.amazonaws.com",
@@ -55,7 +51,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-west-2": {
-    hostname: "runtime.sagemaker.us-west-2.amazonaws.com",
     variants: [
       {
         hostname: "runtime.sagemaker.us-west-2.amazonaws.com",
@@ -99,7 +94,6 @@ const partitionHash: PartitionHash = {
       "us-west-2-fips",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "runtime.sagemaker.{region}.amazonaws.com",
     variants: [
       {
         hostname: "runtime.sagemaker.{region}.amazonaws.com",
@@ -114,7 +108,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "runtime.sagemaker.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "runtime.sagemaker.{region}.amazonaws.com.cn",
@@ -137,7 +130,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "runtime.sagemaker.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "runtime.sagemaker.{region}.c2s.ic.gov",
@@ -148,7 +140,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "runtime.sagemaker.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "runtime.sagemaker.{region}.sc2s.sgov.gov",
@@ -159,7 +150,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1", "us-gov-west-1-fips"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "runtime.sagemaker.{region}.amazonaws.com",
     variants: [
       {
         hostname: "runtime.sagemaker.{region}.amazonaws.com",

--- a/clients/client-sagemaker/src/endpoints.ts
+++ b/clients/client-sagemaker/src/endpoints.ts
@@ -3,7 +3,6 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
   "us-east-1": {
-    hostname: "api.sagemaker.us-east-1.amazonaws.com",
     variants: [
       {
         hostname: "api.sagemaker.us-east-1.amazonaws.com",
@@ -16,7 +15,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-east-2": {
-    hostname: "api.sagemaker.us-east-2.amazonaws.com",
     variants: [
       {
         hostname: "api.sagemaker.us-east-2.amazonaws.com",
@@ -29,7 +27,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-gov-west-1": {
-    hostname: "api.sagemaker.us-gov-west-1.amazonaws.com",
     variants: [
       {
         hostname: "api.sagemaker.us-gov-west-1.amazonaws.com",
@@ -42,7 +39,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-west-1": {
-    hostname: "api.sagemaker.us-west-1.amazonaws.com",
     variants: [
       {
         hostname: "api.sagemaker.us-west-1.amazonaws.com",
@@ -55,7 +51,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-west-2": {
-    hostname: "api.sagemaker.us-west-2.amazonaws.com",
     variants: [
       {
         hostname: "api.sagemaker.us-west-2.amazonaws.com",
@@ -99,7 +94,6 @@ const partitionHash: PartitionHash = {
       "us-west-2-fips",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "api.sagemaker.{region}.amazonaws.com",
     variants: [
       {
         hostname: "api.sagemaker.{region}.amazonaws.com",
@@ -114,7 +108,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "api.sagemaker.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "api.sagemaker.{region}.amazonaws.com.cn",
@@ -137,7 +130,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "api.sagemaker.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "api.sagemaker.{region}.c2s.ic.gov",
@@ -148,7 +140,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "api.sagemaker.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "api.sagemaker.{region}.sc2s.sgov.gov",
@@ -165,7 +156,6 @@ const partitionHash: PartitionHash = {
       "us-gov-west-1-secondary",
     ],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "api.sagemaker.{region}.amazonaws.com",
     variants: [
       {
         hostname: "api.sagemaker.{region}.amazonaws.com",

--- a/clients/client-savingsplans/src/endpoints.ts
+++ b/clients/client-savingsplans/src/endpoints.ts
@@ -3,7 +3,6 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
   "aws-global": {
-    hostname: "savingsplans.amazonaws.com",
     variants: [
       {
         hostname: "savingsplans.amazonaws.com",
@@ -41,7 +40,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "savingsplans.{region}.amazonaws.com",
     variants: [
       {
         hostname: "savingsplans.{region}.amazonaws.com",
@@ -65,7 +63,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "savingsplans.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "savingsplans.{region}.amazonaws.com.cn",
@@ -88,7 +85,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "savingsplans.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "savingsplans.{region}.c2s.ic.gov",
@@ -99,7 +95,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "savingsplans.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "savingsplans.{region}.sc2s.sgov.gov",
@@ -110,7 +105,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "savingsplans.{region}.amazonaws.com",
     variants: [
       {
         hostname: "savingsplans.{region}.amazonaws.com",

--- a/clients/client-schemas/src/endpoints.ts
+++ b/clients/client-schemas/src/endpoints.ts
@@ -29,7 +29,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "schemas.{region}.amazonaws.com",
     variants: [
       {
         hostname: "schemas.{region}.amazonaws.com",
@@ -52,7 +51,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "schemas.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "schemas.{region}.amazonaws.com.cn",
@@ -75,7 +73,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "schemas.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "schemas.{region}.c2s.ic.gov",
@@ -86,7 +83,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "schemas.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "schemas.{region}.sc2s.sgov.gov",
@@ -97,7 +93,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "schemas.{region}.amazonaws.com",
     variants: [
       {
         hostname: "schemas.{region}.amazonaws.com",

--- a/clients/client-secrets-manager/src/endpoints.ts
+++ b/clients/client-secrets-manager/src/endpoints.ts
@@ -3,7 +3,6 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
   "us-east-1": {
-    hostname: "secretsmanager.us-east-1.amazonaws.com",
     variants: [
       {
         hostname: "secretsmanager.us-east-1.amazonaws.com",
@@ -16,7 +15,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-east-2": {
-    hostname: "secretsmanager.us-east-2.amazonaws.com",
     variants: [
       {
         hostname: "secretsmanager.us-east-2.amazonaws.com",
@@ -29,7 +27,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-gov-east-1": {
-    hostname: "secretsmanager.us-gov-east-1.amazonaws.com",
     variants: [
       {
         hostname: "secretsmanager.us-gov-east-1.amazonaws.com",
@@ -42,7 +39,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-gov-west-1": {
-    hostname: "secretsmanager.us-gov-west-1.amazonaws.com",
     variants: [
       {
         hostname: "secretsmanager.us-gov-west-1.amazonaws.com",
@@ -55,7 +51,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-west-1": {
-    hostname: "secretsmanager.us-west-1.amazonaws.com",
     variants: [
       {
         hostname: "secretsmanager.us-west-1.amazonaws.com",
@@ -68,7 +63,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-west-2": {
-    hostname: "secretsmanager.us-west-2.amazonaws.com",
     variants: [
       {
         hostname: "secretsmanager.us-west-2.amazonaws.com",
@@ -112,7 +106,6 @@ const partitionHash: PartitionHash = {
       "us-west-2-fips",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "secretsmanager.{region}.amazonaws.com",
     variants: [
       {
         hostname: "secretsmanager.{region}.amazonaws.com",
@@ -135,7 +128,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "secretsmanager.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "secretsmanager.{region}.amazonaws.com.cn",
@@ -158,7 +150,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "secretsmanager.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "secretsmanager.{region}.c2s.ic.gov",
@@ -169,7 +160,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "secretsmanager.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "secretsmanager.{region}.sc2s.sgov.gov",
@@ -180,7 +170,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-east-1-fips", "us-gov-west-1", "us-gov-west-1-fips"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "secretsmanager.{region}.amazonaws.com",
     variants: [
       {
         hostname: "secretsmanager.{region}.amazonaws.com",

--- a/clients/client-securityhub/src/endpoints.ts
+++ b/clients/client-securityhub/src/endpoints.ts
@@ -3,7 +3,6 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
   "us-east-1": {
-    hostname: "securityhub.us-east-1.amazonaws.com",
     variants: [
       {
         hostname: "securityhub.us-east-1.amazonaws.com",
@@ -16,7 +15,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-east-2": {
-    hostname: "securityhub.us-east-2.amazonaws.com",
     variants: [
       {
         hostname: "securityhub.us-east-2.amazonaws.com",
@@ -29,7 +27,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-gov-east-1": {
-    hostname: "securityhub.us-gov-east-1.amazonaws.com",
     variants: [
       {
         hostname: "securityhub.us-gov-east-1.amazonaws.com",
@@ -42,7 +39,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-gov-west-1": {
-    hostname: "securityhub.us-gov-west-1.amazonaws.com",
     variants: [
       {
         hostname: "securityhub.us-gov-west-1.amazonaws.com",
@@ -55,7 +51,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-west-1": {
-    hostname: "securityhub.us-west-1.amazonaws.com",
     variants: [
       {
         hostname: "securityhub.us-west-1.amazonaws.com",
@@ -68,7 +63,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-west-2": {
-    hostname: "securityhub.us-west-2.amazonaws.com",
     variants: [
       {
         hostname: "securityhub.us-west-2.amazonaws.com",
@@ -112,7 +106,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "securityhub.{region}.amazonaws.com",
     variants: [
       {
         hostname: "securityhub.{region}.amazonaws.com",
@@ -135,7 +128,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "securityhub.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "securityhub.{region}.amazonaws.com.cn",
@@ -158,7 +150,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "securityhub.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "securityhub.{region}.c2s.ic.gov",
@@ -169,7 +160,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "securityhub.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "securityhub.{region}.sc2s.sgov.gov",
@@ -180,7 +170,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["fips-us-gov-east-1", "fips-us-gov-west-1", "us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "securityhub.{region}.amazonaws.com",
     variants: [
       {
         hostname: "securityhub.{region}.amazonaws.com",

--- a/clients/client-serverlessapplicationrepository/src/endpoints.ts
+++ b/clients/client-serverlessapplicationrepository/src/endpoints.ts
@@ -3,7 +3,6 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
   "us-gov-east-1": {
-    hostname: "serverlessrepo.us-gov-east-1.amazonaws.com",
     variants: [
       {
         hostname: "serverlessrepo.us-gov-east-1.amazonaws.com",
@@ -13,7 +12,6 @@ const regionHash: RegionHash = {
     signingRegion: "us-gov-east-1",
   },
   "us-gov-west-1": {
-    hostname: "serverlessrepo.us-gov-west-1.amazonaws.com",
     variants: [
       {
         hostname: "serverlessrepo.us-gov-west-1.amazonaws.com",
@@ -50,7 +48,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "serverlessrepo.{region}.amazonaws.com",
     variants: [
       {
         hostname: "serverlessrepo.{region}.amazonaws.com",
@@ -73,7 +70,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "serverlessrepo.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "serverlessrepo.{region}.amazonaws.com.cn",
@@ -96,7 +92,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "serverlessrepo.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "serverlessrepo.{region}.c2s.ic.gov",
@@ -107,7 +102,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "serverlessrepo.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "serverlessrepo.{region}.sc2s.sgov.gov",
@@ -118,7 +112,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "serverlessrepo.{region}.amazonaws.com",
     variants: [
       {
         hostname: "serverlessrepo.{region}.amazonaws.com",

--- a/clients/client-service-catalog-appregistry/src/endpoints.ts
+++ b/clients/client-service-catalog-appregistry/src/endpoints.ts
@@ -3,7 +3,6 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
   "ca-central-1": {
-    hostname: "servicecatalog-appregistry.ca-central-1.amazonaws.com",
     variants: [
       {
         hostname: "servicecatalog-appregistry.ca-central-1.amazonaws.com",
@@ -16,7 +15,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-east-1": {
-    hostname: "servicecatalog-appregistry.us-east-1.amazonaws.com",
     variants: [
       {
         hostname: "servicecatalog-appregistry.us-east-1.amazonaws.com",
@@ -29,7 +27,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-east-2": {
-    hostname: "servicecatalog-appregistry.us-east-2.amazonaws.com",
     variants: [
       {
         hostname: "servicecatalog-appregistry.us-east-2.amazonaws.com",
@@ -42,7 +39,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-gov-east-1": {
-    hostname: "servicecatalog-appregistry.us-gov-east-1.amazonaws.com",
     variants: [
       {
         hostname: "servicecatalog-appregistry.us-gov-east-1.amazonaws.com",
@@ -55,7 +51,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-gov-west-1": {
-    hostname: "servicecatalog-appregistry.us-gov-west-1.amazonaws.com",
     variants: [
       {
         hostname: "servicecatalog-appregistry.us-gov-west-1.amazonaws.com",
@@ -68,7 +63,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-west-1": {
-    hostname: "servicecatalog-appregistry.us-west-1.amazonaws.com",
     variants: [
       {
         hostname: "servicecatalog-appregistry.us-west-1.amazonaws.com",
@@ -81,7 +75,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-west-2": {
-    hostname: "servicecatalog-appregistry.us-west-2.amazonaws.com",
     variants: [
       {
         hostname: "servicecatalog-appregistry.us-west-2.amazonaws.com",
@@ -126,7 +119,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "servicecatalog-appregistry.{region}.amazonaws.com",
     variants: [
       {
         hostname: "servicecatalog-appregistry.{region}.amazonaws.com",
@@ -149,7 +141,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "servicecatalog-appregistry.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "servicecatalog-appregistry.{region}.amazonaws.com.cn",
@@ -172,7 +163,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "servicecatalog-appregistry.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "servicecatalog-appregistry.{region}.c2s.ic.gov",
@@ -183,7 +173,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "servicecatalog-appregistry.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "servicecatalog-appregistry.{region}.sc2s.sgov.gov",
@@ -194,7 +183,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["fips-us-gov-east-1", "fips-us-gov-west-1", "us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "servicecatalog-appregistry.{region}.amazonaws.com",
     variants: [
       {
         hostname: "servicecatalog-appregistry.{region}.amazonaws.com",

--- a/clients/client-service-catalog/src/endpoints.ts
+++ b/clients/client-service-catalog/src/endpoints.ts
@@ -3,7 +3,6 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
   "us-east-1": {
-    hostname: "servicecatalog.us-east-1.amazonaws.com",
     variants: [
       {
         hostname: "servicecatalog.us-east-1.amazonaws.com",
@@ -16,7 +15,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-east-2": {
-    hostname: "servicecatalog.us-east-2.amazonaws.com",
     variants: [
       {
         hostname: "servicecatalog.us-east-2.amazonaws.com",
@@ -29,7 +27,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-gov-east-1": {
-    hostname: "servicecatalog.us-gov-east-1.amazonaws.com",
     variants: [
       {
         hostname: "servicecatalog.us-gov-east-1.amazonaws.com",
@@ -42,7 +39,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-gov-west-1": {
-    hostname: "servicecatalog.us-gov-west-1.amazonaws.com",
     variants: [
       {
         hostname: "servicecatalog.us-gov-west-1.amazonaws.com",
@@ -55,7 +51,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-west-1": {
-    hostname: "servicecatalog.us-west-1.amazonaws.com",
     variants: [
       {
         hostname: "servicecatalog.us-west-1.amazonaws.com",
@@ -68,7 +63,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-west-2": {
-    hostname: "servicecatalog.us-west-2.amazonaws.com",
     variants: [
       {
         hostname: "servicecatalog.us-west-2.amazonaws.com",
@@ -112,7 +106,6 @@ const partitionHash: PartitionHash = {
       "us-west-2-fips",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "servicecatalog.{region}.amazonaws.com",
     variants: [
       {
         hostname: "servicecatalog.{region}.amazonaws.com",
@@ -135,7 +128,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "servicecatalog.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "servicecatalog.{region}.amazonaws.com.cn",
@@ -158,7 +150,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "servicecatalog.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "servicecatalog.{region}.c2s.ic.gov",
@@ -169,7 +160,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "servicecatalog.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "servicecatalog.{region}.sc2s.sgov.gov",
@@ -180,7 +170,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-east-1-fips", "us-gov-west-1", "us-gov-west-1-fips"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "servicecatalog.{region}.amazonaws.com",
     variants: [
       {
         hostname: "servicecatalog.{region}.amazonaws.com",

--- a/clients/client-service-quotas/src/endpoints.ts
+++ b/clients/client-service-quotas/src/endpoints.ts
@@ -3,7 +3,6 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
   "us-gov-east-1": {
-    hostname: "servicequotas.us-gov-east-1.amazonaws.com",
     variants: [
       {
         hostname: "servicequotas.us-gov-east-1.amazonaws.com",
@@ -16,7 +15,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-gov-west-1": {
-    hostname: "servicequotas.us-gov-west-1.amazonaws.com",
     variants: [
       {
         hostname: "servicequotas.us-gov-west-1.amazonaws.com",
@@ -56,7 +54,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "servicequotas.{region}.amazonaws.com",
     variants: [
       {
         hostname: "servicequotas.{region}.amazonaws.com",
@@ -79,7 +76,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "servicequotas.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "servicequotas.{region}.amazonaws.com.cn",
@@ -102,7 +98,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "servicequotas.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "servicequotas.{region}.c2s.ic.gov",
@@ -113,7 +108,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "servicequotas.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "servicequotas.{region}.sc2s.sgov.gov",
@@ -124,7 +118,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["fips-us-gov-east-1", "fips-us-gov-west-1", "us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "servicequotas.{region}.amazonaws.com",
     variants: [
       {
         hostname: "servicequotas.{region}.amazonaws.com",

--- a/clients/client-servicediscovery/src/endpoints.ts
+++ b/clients/client-servicediscovery/src/endpoints.ts
@@ -3,7 +3,6 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
   "ca-central-1": {
-    hostname: "servicediscovery.ca-central-1.amazonaws.com",
     variants: [
       {
         hostname: "servicediscovery.ca-central-1.amazonaws.com",
@@ -16,7 +15,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-east-1": {
-    hostname: "servicediscovery.us-east-1.amazonaws.com",
     variants: [
       {
         hostname: "servicediscovery.us-east-1.amazonaws.com",
@@ -29,7 +27,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-east-2": {
-    hostname: "servicediscovery.us-east-2.amazonaws.com",
     variants: [
       {
         hostname: "servicediscovery.us-east-2.amazonaws.com",
@@ -42,7 +39,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-gov-east-1": {
-    hostname: "servicediscovery.us-gov-east-1.amazonaws.com",
     variants: [
       {
         hostname: "servicediscovery.us-gov-east-1.amazonaws.com",
@@ -55,7 +51,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-gov-west-1": {
-    hostname: "servicediscovery.us-gov-west-1.amazonaws.com",
     variants: [
       {
         hostname: "servicediscovery.us-gov-west-1.amazonaws.com",
@@ -68,7 +63,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-west-1": {
-    hostname: "servicediscovery.us-west-1.amazonaws.com",
     variants: [
       {
         hostname: "servicediscovery.us-west-1.amazonaws.com",
@@ -81,7 +75,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-west-2": {
-    hostname: "servicediscovery.us-west-2.amazonaws.com",
     variants: [
       {
         hostname: "servicediscovery.us-west-2.amazonaws.com",
@@ -128,7 +121,6 @@ const partitionHash: PartitionHash = {
       "us-west-2-fips",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "servicediscovery.{region}.amazonaws.com",
     variants: [
       {
         hostname: "servicediscovery.{region}.amazonaws.com",
@@ -151,7 +143,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "servicediscovery.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "servicediscovery.{region}.amazonaws.com.cn",
@@ -174,7 +165,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "servicediscovery.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "servicediscovery.{region}.c2s.ic.gov",
@@ -185,7 +175,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "servicediscovery.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "servicediscovery.{region}.sc2s.sgov.gov",
@@ -203,7 +192,6 @@ const partitionHash: PartitionHash = {
       "us-gov-west-1-fips",
     ],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "servicediscovery.{region}.amazonaws.com",
     variants: [
       {
         hostname: "servicediscovery.{region}.amazonaws.com",

--- a/clients/client-ses/src/endpoints.ts
+++ b/clients/client-ses/src/endpoints.ts
@@ -3,7 +3,6 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
   "us-gov-west-1": {
-    hostname: "email.us-gov-west-1.amazonaws.com",
     variants: [
       {
         hostname: "email.us-gov-west-1.amazonaws.com",
@@ -43,7 +42,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "email.{region}.amazonaws.com",
     variants: [
       {
         hostname: "email.{region}.amazonaws.com",
@@ -66,7 +64,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "email.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "email.{region}.amazonaws.com.cn",
@@ -89,7 +86,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "email.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "email.{region}.c2s.ic.gov",
@@ -100,7 +96,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "email.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "email.{region}.sc2s.sgov.gov",
@@ -111,7 +106,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["fips-us-gov-west-1", "us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "email.{region}.amazonaws.com",
     variants: [
       {
         hostname: "email.{region}.amazonaws.com",

--- a/clients/client-sesv2/src/endpoints.ts
+++ b/clients/client-sesv2/src/endpoints.ts
@@ -3,7 +3,6 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
   "us-gov-west-1": {
-    hostname: "email.us-gov-west-1.amazonaws.com",
     variants: [
       {
         hostname: "email.us-gov-west-1.amazonaws.com",
@@ -43,7 +42,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "email.{region}.amazonaws.com",
     variants: [
       {
         hostname: "email.{region}.amazonaws.com",
@@ -66,7 +64,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "email.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "email.{region}.amazonaws.com.cn",
@@ -89,7 +86,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "email.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "email.{region}.c2s.ic.gov",
@@ -100,7 +96,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "email.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "email.{region}.sc2s.sgov.gov",
@@ -111,7 +106,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["fips-us-gov-west-1", "us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "email.{region}.amazonaws.com",
     variants: [
       {
         hostname: "email.{region}.amazonaws.com",

--- a/clients/client-sfn/src/endpoints.ts
+++ b/clients/client-sfn/src/endpoints.ts
@@ -3,7 +3,6 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
   "us-east-1": {
-    hostname: "states.us-east-1.amazonaws.com",
     variants: [
       {
         hostname: "states.us-east-1.amazonaws.com",
@@ -16,7 +15,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-east-2": {
-    hostname: "states.us-east-2.amazonaws.com",
     variants: [
       {
         hostname: "states.us-east-2.amazonaws.com",
@@ -29,7 +27,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-gov-east-1": {
-    hostname: "states.us-gov-east-1.amazonaws.com",
     variants: [
       {
         hostname: "states.us-gov-east-1.amazonaws.com",
@@ -42,7 +39,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-gov-west-1": {
-    hostname: "states.us-gov-west-1.amazonaws.com",
     variants: [
       {
         hostname: "states.us-gov-west-1.amazonaws.com",
@@ -55,7 +51,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-west-1": {
-    hostname: "states.us-west-1.amazonaws.com",
     variants: [
       {
         hostname: "states.us-west-1.amazonaws.com",
@@ -68,7 +63,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-west-2": {
-    hostname: "states.us-west-2.amazonaws.com",
     variants: [
       {
         hostname: "states.us-west-2.amazonaws.com",
@@ -112,7 +106,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "states.{region}.amazonaws.com",
     variants: [
       {
         hostname: "states.{region}.amazonaws.com",
@@ -135,7 +128,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "states.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "states.{region}.amazonaws.com.cn",
@@ -158,7 +150,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "states.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "states.{region}.c2s.ic.gov",
@@ -169,7 +160,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "states.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "states.{region}.sc2s.sgov.gov",
@@ -180,7 +170,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["fips-us-gov-east-1", "fips-us-gov-west-1", "us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "states.{region}.amazonaws.com",
     variants: [
       {
         hostname: "states.{region}.amazonaws.com",

--- a/clients/client-shield/src/endpoints.ts
+++ b/clients/client-shield/src/endpoints.ts
@@ -3,7 +3,6 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
   "aws-global": {
-    hostname: "shield.us-east-1.amazonaws.com",
     variants: [
       {
         hostname: "shield.us-east-1.amazonaws.com",
@@ -46,7 +45,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "shield.{region}.amazonaws.com",
     variants: [
       {
         hostname: "shield.{region}.amazonaws.com",
@@ -70,7 +68,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "shield.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "shield.{region}.amazonaws.com.cn",
@@ -93,7 +90,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "shield.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "shield.{region}.c2s.ic.gov",
@@ -104,7 +100,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "shield.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "shield.{region}.sc2s.sgov.gov",
@@ -115,7 +110,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "shield.{region}.amazonaws.com",
     variants: [
       {
         hostname: "shield.{region}.amazonaws.com",

--- a/clients/client-signer/src/endpoints.ts
+++ b/clients/client-signer/src/endpoints.ts
@@ -29,7 +29,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "signer.{region}.amazonaws.com",
     variants: [
       {
         hostname: "signer.{region}.amazonaws.com",
@@ -52,7 +51,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "signer.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "signer.{region}.amazonaws.com.cn",
@@ -75,7 +73,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "signer.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "signer.{region}.c2s.ic.gov",
@@ -86,7 +83,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "signer.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "signer.{region}.sc2s.sgov.gov",
@@ -97,7 +93,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "signer.{region}.amazonaws.com",
     variants: [
       {
         hostname: "signer.{region}.amazonaws.com",

--- a/clients/client-sms/src/endpoints.ts
+++ b/clients/client-sms/src/endpoints.ts
@@ -3,7 +3,6 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
   "us-east-1": {
-    hostname: "sms.us-east-1.amazonaws.com",
     variants: [
       {
         hostname: "sms.us-east-1.amazonaws.com",
@@ -16,7 +15,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-east-2": {
-    hostname: "sms.us-east-2.amazonaws.com",
     variants: [
       {
         hostname: "sms.us-east-2.amazonaws.com",
@@ -29,7 +27,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-gov-east-1": {
-    hostname: "sms.us-gov-east-1.amazonaws.com",
     variants: [
       {
         hostname: "sms.us-gov-east-1.amazonaws.com",
@@ -42,7 +39,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-gov-west-1": {
-    hostname: "sms.us-gov-west-1.amazonaws.com",
     variants: [
       {
         hostname: "sms.us-gov-west-1.amazonaws.com",
@@ -55,7 +51,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-west-1": {
-    hostname: "sms.us-west-1.amazonaws.com",
     variants: [
       {
         hostname: "sms.us-west-1.amazonaws.com",
@@ -68,7 +63,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-west-2": {
-    hostname: "sms.us-west-2.amazonaws.com",
     variants: [
       {
         hostname: "sms.us-west-2.amazonaws.com",
@@ -112,7 +106,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "sms.{region}.amazonaws.com",
     variants: [
       {
         hostname: "sms.{region}.amazonaws.com",
@@ -135,7 +128,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "sms.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "sms.{region}.amazonaws.com.cn",
@@ -158,7 +150,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "sms.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "sms.{region}.c2s.ic.gov",
@@ -169,7 +160,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "sms.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "sms.{region}.sc2s.sgov.gov",
@@ -180,7 +170,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["fips-us-gov-east-1", "fips-us-gov-west-1", "us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "sms.{region}.amazonaws.com",
     variants: [
       {
         hostname: "sms.{region}.amazonaws.com",

--- a/clients/client-snow-device-management/src/endpoints.ts
+++ b/clients/client-snow-device-management/src/endpoints.ts
@@ -29,7 +29,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "snow-device-management.{region}.amazonaws.com",
     variants: [
       {
         hostname: "snow-device-management.{region}.amazonaws.com",
@@ -52,7 +51,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "snow-device-management.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "snow-device-management.{region}.amazonaws.com.cn",
@@ -75,7 +73,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "snow-device-management.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "snow-device-management.{region}.c2s.ic.gov",
@@ -86,7 +83,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "snow-device-management.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "snow-device-management.{region}.sc2s.sgov.gov",
@@ -97,7 +93,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "snow-device-management.{region}.amazonaws.com",
     variants: [
       {
         hostname: "snow-device-management.{region}.amazonaws.com",

--- a/clients/client-snowball/src/endpoints.ts
+++ b/clients/client-snowball/src/endpoints.ts
@@ -3,7 +3,6 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
   "ap-northeast-1": {
-    hostname: "snowball.ap-northeast-1.amazonaws.com",
     variants: [
       {
         hostname: "snowball.ap-northeast-1.amazonaws.com",
@@ -16,7 +15,6 @@ const regionHash: RegionHash = {
     ],
   },
   "ap-northeast-2": {
-    hostname: "snowball.ap-northeast-2.amazonaws.com",
     variants: [
       {
         hostname: "snowball.ap-northeast-2.amazonaws.com",
@@ -29,7 +27,6 @@ const regionHash: RegionHash = {
     ],
   },
   "ap-northeast-3": {
-    hostname: "snowball.ap-northeast-3.amazonaws.com",
     variants: [
       {
         hostname: "snowball.ap-northeast-3.amazonaws.com",
@@ -42,7 +39,6 @@ const regionHash: RegionHash = {
     ],
   },
   "ap-south-1": {
-    hostname: "snowball.ap-south-1.amazonaws.com",
     variants: [
       {
         hostname: "snowball.ap-south-1.amazonaws.com",
@@ -55,7 +51,6 @@ const regionHash: RegionHash = {
     ],
   },
   "ap-southeast-1": {
-    hostname: "snowball.ap-southeast-1.amazonaws.com",
     variants: [
       {
         hostname: "snowball.ap-southeast-1.amazonaws.com",
@@ -68,7 +63,6 @@ const regionHash: RegionHash = {
     ],
   },
   "ap-southeast-2": {
-    hostname: "snowball.ap-southeast-2.amazonaws.com",
     variants: [
       {
         hostname: "snowball.ap-southeast-2.amazonaws.com",
@@ -81,7 +75,6 @@ const regionHash: RegionHash = {
     ],
   },
   "ca-central-1": {
-    hostname: "snowball.ca-central-1.amazonaws.com",
     variants: [
       {
         hostname: "snowball.ca-central-1.amazonaws.com",
@@ -94,7 +87,6 @@ const regionHash: RegionHash = {
     ],
   },
   "cn-north-1": {
-    hostname: "snowball.cn-north-1.amazonaws.com.cn",
     variants: [
       {
         hostname: "snowball.cn-north-1.amazonaws.com.cn",
@@ -107,7 +99,6 @@ const regionHash: RegionHash = {
     ],
   },
   "cn-northwest-1": {
-    hostname: "snowball.cn-northwest-1.amazonaws.com.cn",
     variants: [
       {
         hostname: "snowball.cn-northwest-1.amazonaws.com.cn",
@@ -120,7 +111,6 @@ const regionHash: RegionHash = {
     ],
   },
   "eu-central-1": {
-    hostname: "snowball.eu-central-1.amazonaws.com",
     variants: [
       {
         hostname: "snowball.eu-central-1.amazonaws.com",
@@ -133,7 +123,6 @@ const regionHash: RegionHash = {
     ],
   },
   "eu-west-1": {
-    hostname: "snowball.eu-west-1.amazonaws.com",
     variants: [
       {
         hostname: "snowball.eu-west-1.amazonaws.com",
@@ -146,7 +135,6 @@ const regionHash: RegionHash = {
     ],
   },
   "eu-west-2": {
-    hostname: "snowball.eu-west-2.amazonaws.com",
     variants: [
       {
         hostname: "snowball.eu-west-2.amazonaws.com",
@@ -159,7 +147,6 @@ const regionHash: RegionHash = {
     ],
   },
   "eu-west-3": {
-    hostname: "snowball.eu-west-3.amazonaws.com",
     variants: [
       {
         hostname: "snowball.eu-west-3.amazonaws.com",
@@ -172,7 +159,6 @@ const regionHash: RegionHash = {
     ],
   },
   "sa-east-1": {
-    hostname: "snowball.sa-east-1.amazonaws.com",
     variants: [
       {
         hostname: "snowball.sa-east-1.amazonaws.com",
@@ -185,7 +171,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-east-1": {
-    hostname: "snowball.us-east-1.amazonaws.com",
     variants: [
       {
         hostname: "snowball.us-east-1.amazonaws.com",
@@ -198,7 +183,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-east-2": {
-    hostname: "snowball.us-east-2.amazonaws.com",
     variants: [
       {
         hostname: "snowball.us-east-2.amazonaws.com",
@@ -211,7 +195,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-gov-east-1": {
-    hostname: "snowball.us-gov-east-1.amazonaws.com",
     variants: [
       {
         hostname: "snowball.us-gov-east-1.amazonaws.com",
@@ -224,7 +207,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-gov-west-1": {
-    hostname: "snowball.us-gov-west-1.amazonaws.com",
     variants: [
       {
         hostname: "snowball.us-gov-west-1.amazonaws.com",
@@ -237,7 +219,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-west-1": {
-    hostname: "snowball.us-west-1.amazonaws.com",
     variants: [
       {
         hostname: "snowball.us-west-1.amazonaws.com",
@@ -250,7 +231,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-west-2": {
-    hostname: "snowball.us-west-2.amazonaws.com",
     variants: [
       {
         hostname: "snowball.us-west-2.amazonaws.com",
@@ -306,7 +286,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "snowball.{region}.amazonaws.com",
     variants: [
       {
         hostname: "snowball.{region}.amazonaws.com",
@@ -329,7 +308,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1", "fips-cn-north-1", "fips-cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "snowball.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "snowball.{region}.amazonaws.com.cn",
@@ -352,7 +330,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "snowball.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "snowball.{region}.c2s.ic.gov",
@@ -363,7 +340,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "snowball.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "snowball.{region}.sc2s.sgov.gov",
@@ -374,7 +350,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["fips-us-gov-east-1", "fips-us-gov-west-1", "us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "snowball.{region}.amazonaws.com",
     variants: [
       {
         hostname: "snowball.{region}.amazonaws.com",

--- a/clients/client-sns/src/endpoints.ts
+++ b/clients/client-sns/src/endpoints.ts
@@ -3,7 +3,6 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
   "us-east-1": {
-    hostname: "sns.us-east-1.amazonaws.com",
     variants: [
       {
         hostname: "sns.us-east-1.amazonaws.com",
@@ -16,7 +15,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-east-2": {
-    hostname: "sns.us-east-2.amazonaws.com",
     variants: [
       {
         hostname: "sns.us-east-2.amazonaws.com",
@@ -29,7 +27,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-gov-east-1": {
-    hostname: "sns.us-gov-east-1.amazonaws.com",
     variants: [
       {
         hostname: "sns.us-gov-east-1.amazonaws.com",
@@ -39,7 +36,6 @@ const regionHash: RegionHash = {
     signingRegion: "us-gov-east-1",
   },
   "us-gov-west-1": {
-    hostname: "sns.us-gov-west-1.amazonaws.com",
     variants: [
       {
         hostname: "sns.us-gov-west-1.amazonaws.com",
@@ -49,7 +45,6 @@ const regionHash: RegionHash = {
     signingRegion: "us-gov-west-1",
   },
   "us-west-1": {
-    hostname: "sns.us-west-1.amazonaws.com",
     variants: [
       {
         hostname: "sns.us-west-1.amazonaws.com",
@@ -62,7 +57,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-west-2": {
-    hostname: "sns.us-west-2.amazonaws.com",
     variants: [
       {
         hostname: "sns.us-west-2.amazonaws.com",
@@ -106,7 +100,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "sns.{region}.amazonaws.com",
     variants: [
       {
         hostname: "sns.{region}.amazonaws.com",
@@ -129,7 +122,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "sns.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "sns.{region}.amazonaws.com.cn",
@@ -152,7 +144,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "sns.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "sns.{region}.c2s.ic.gov",
@@ -163,7 +154,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "sns.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "sns.{region}.sc2s.sgov.gov",
@@ -174,7 +164,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "sns.{region}.amazonaws.com",
     variants: [
       {
         hostname: "sns.{region}.amazonaws.com",

--- a/clients/client-sqs/src/endpoints.ts
+++ b/clients/client-sqs/src/endpoints.ts
@@ -3,7 +3,6 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
   "us-east-1": {
-    hostname: "sqs.us-east-1.amazonaws.com",
     variants: [
       {
         hostname: "sqs.us-east-1.amazonaws.com",
@@ -16,7 +15,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-east-2": {
-    hostname: "sqs.us-east-2.amazonaws.com",
     variants: [
       {
         hostname: "sqs.us-east-2.amazonaws.com",
@@ -29,7 +27,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-gov-east-1": {
-    hostname: "sqs.us-gov-east-1.amazonaws.com",
     variants: [
       {
         hostname: "sqs.us-gov-east-1.amazonaws.com",
@@ -39,7 +36,6 @@ const regionHash: RegionHash = {
     signingRegion: "us-gov-east-1",
   },
   "us-gov-west-1": {
-    hostname: "sqs.us-gov-west-1.amazonaws.com",
     variants: [
       {
         hostname: "sqs.us-gov-west-1.amazonaws.com",
@@ -49,7 +45,6 @@ const regionHash: RegionHash = {
     signingRegion: "us-gov-west-1",
   },
   "us-west-1": {
-    hostname: "sqs.us-west-1.amazonaws.com",
     variants: [
       {
         hostname: "sqs.us-west-1.amazonaws.com",
@@ -62,7 +57,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-west-2": {
-    hostname: "sqs.us-west-2.amazonaws.com",
     variants: [
       {
         hostname: "sqs.us-west-2.amazonaws.com",
@@ -106,7 +100,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "sqs.{region}.amazonaws.com",
     variants: [
       {
         hostname: "sqs.{region}.amazonaws.com",
@@ -129,7 +122,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "sqs.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "sqs.{region}.amazonaws.com.cn",
@@ -152,7 +144,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "sqs.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "sqs.{region}.c2s.ic.gov",
@@ -163,7 +154,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "sqs.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "sqs.{region}.sc2s.sgov.gov",
@@ -174,7 +164,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "sqs.{region}.amazonaws.com",
     variants: [
       {
         hostname: "sqs.{region}.amazonaws.com",

--- a/clients/client-ssm-contacts/src/endpoints.ts
+++ b/clients/client-ssm-contacts/src/endpoints.ts
@@ -29,7 +29,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "ssm-contacts.{region}.amazonaws.com",
     variants: [
       {
         hostname: "ssm-contacts.{region}.amazonaws.com",
@@ -52,7 +51,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "ssm-contacts.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "ssm-contacts.{region}.amazonaws.com.cn",
@@ -75,7 +73,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "ssm-contacts.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "ssm-contacts.{region}.c2s.ic.gov",
@@ -86,7 +83,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "ssm-contacts.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "ssm-contacts.{region}.sc2s.sgov.gov",
@@ -97,7 +93,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "ssm-contacts.{region}.amazonaws.com",
     variants: [
       {
         hostname: "ssm-contacts.{region}.amazonaws.com",

--- a/clients/client-ssm-incidents/src/endpoints.ts
+++ b/clients/client-ssm-incidents/src/endpoints.ts
@@ -29,7 +29,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "ssm-incidents.{region}.amazonaws.com",
     variants: [
       {
         hostname: "ssm-incidents.{region}.amazonaws.com",
@@ -52,7 +51,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "ssm-incidents.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "ssm-incidents.{region}.amazonaws.com.cn",
@@ -75,7 +73,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "ssm-incidents.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "ssm-incidents.{region}.c2s.ic.gov",
@@ -86,7 +83,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "ssm-incidents.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "ssm-incidents.{region}.sc2s.sgov.gov",
@@ -97,7 +93,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "ssm-incidents.{region}.amazonaws.com",
     variants: [
       {
         hostname: "ssm-incidents.{region}.amazonaws.com",

--- a/clients/client-ssm/src/endpoints.ts
+++ b/clients/client-ssm/src/endpoints.ts
@@ -3,7 +3,6 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
   "ca-central-1": {
-    hostname: "ssm.ca-central-1.amazonaws.com",
     variants: [
       {
         hostname: "ssm.ca-central-1.amazonaws.com",
@@ -16,7 +15,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-east-1": {
-    hostname: "ssm.us-east-1.amazonaws.com",
     variants: [
       {
         hostname: "ssm.us-east-1.amazonaws.com",
@@ -29,7 +27,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-east-2": {
-    hostname: "ssm.us-east-2.amazonaws.com",
     variants: [
       {
         hostname: "ssm.us-east-2.amazonaws.com",
@@ -42,7 +39,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-gov-east-1": {
-    hostname: "ssm.us-gov-east-1.amazonaws.com",
     variants: [
       {
         hostname: "ssm.us-gov-east-1.amazonaws.com",
@@ -55,7 +51,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-gov-west-1": {
-    hostname: "ssm.us-gov-west-1.amazonaws.com",
     variants: [
       {
         hostname: "ssm.us-gov-west-1.amazonaws.com",
@@ -68,7 +63,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-west-1": {
-    hostname: "ssm.us-west-1.amazonaws.com",
     variants: [
       {
         hostname: "ssm.us-west-1.amazonaws.com",
@@ -81,7 +75,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-west-2": {
-    hostname: "ssm.us-west-2.amazonaws.com",
     variants: [
       {
         hostname: "ssm.us-west-2.amazonaws.com",
@@ -126,7 +119,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "ssm.{region}.amazonaws.com",
     variants: [
       {
         hostname: "ssm.{region}.amazonaws.com",
@@ -149,7 +141,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "ssm.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "ssm.{region}.amazonaws.com.cn",
@@ -172,7 +163,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "ssm.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "ssm.{region}.c2s.ic.gov",
@@ -183,7 +173,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "ssm.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "ssm.{region}.sc2s.sgov.gov",
@@ -194,7 +183,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["fips-us-gov-east-1", "fips-us-gov-west-1", "us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "ssm.{region}.amazonaws.com",
     variants: [
       {
         hostname: "ssm.{region}.amazonaws.com",

--- a/clients/client-sso-admin/src/endpoints.ts
+++ b/clients/client-sso-admin/src/endpoints.ts
@@ -29,7 +29,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "sso.{region}.amazonaws.com",
     variants: [
       {
         hostname: "sso.{region}.amazonaws.com",
@@ -52,7 +51,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "sso.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "sso.{region}.amazonaws.com.cn",
@@ -75,7 +73,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "sso.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "sso.{region}.c2s.ic.gov",
@@ -86,7 +83,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "sso.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "sso.{region}.sc2s.sgov.gov",
@@ -97,7 +93,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "sso.{region}.amazonaws.com",
     variants: [
       {
         hostname: "sso.{region}.amazonaws.com",

--- a/clients/client-sso-oidc/src/endpoints.ts
+++ b/clients/client-sso-oidc/src/endpoints.ts
@@ -3,7 +3,6 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
   "ap-northeast-1": {
-    hostname: "oidc.ap-northeast-1.amazonaws.com",
     variants: [
       {
         hostname: "oidc.ap-northeast-1.amazonaws.com",
@@ -13,7 +12,6 @@ const regionHash: RegionHash = {
     signingRegion: "ap-northeast-1",
   },
   "ap-northeast-2": {
-    hostname: "oidc.ap-northeast-2.amazonaws.com",
     variants: [
       {
         hostname: "oidc.ap-northeast-2.amazonaws.com",
@@ -23,7 +21,6 @@ const regionHash: RegionHash = {
     signingRegion: "ap-northeast-2",
   },
   "ap-south-1": {
-    hostname: "oidc.ap-south-1.amazonaws.com",
     variants: [
       {
         hostname: "oidc.ap-south-1.amazonaws.com",
@@ -33,7 +30,6 @@ const regionHash: RegionHash = {
     signingRegion: "ap-south-1",
   },
   "ap-southeast-1": {
-    hostname: "oidc.ap-southeast-1.amazonaws.com",
     variants: [
       {
         hostname: "oidc.ap-southeast-1.amazonaws.com",
@@ -43,7 +39,6 @@ const regionHash: RegionHash = {
     signingRegion: "ap-southeast-1",
   },
   "ap-southeast-2": {
-    hostname: "oidc.ap-southeast-2.amazonaws.com",
     variants: [
       {
         hostname: "oidc.ap-southeast-2.amazonaws.com",
@@ -53,7 +48,6 @@ const regionHash: RegionHash = {
     signingRegion: "ap-southeast-2",
   },
   "ca-central-1": {
-    hostname: "oidc.ca-central-1.amazonaws.com",
     variants: [
       {
         hostname: "oidc.ca-central-1.amazonaws.com",
@@ -63,7 +57,6 @@ const regionHash: RegionHash = {
     signingRegion: "ca-central-1",
   },
   "eu-central-1": {
-    hostname: "oidc.eu-central-1.amazonaws.com",
     variants: [
       {
         hostname: "oidc.eu-central-1.amazonaws.com",
@@ -73,7 +66,6 @@ const regionHash: RegionHash = {
     signingRegion: "eu-central-1",
   },
   "eu-north-1": {
-    hostname: "oidc.eu-north-1.amazonaws.com",
     variants: [
       {
         hostname: "oidc.eu-north-1.amazonaws.com",
@@ -83,7 +75,6 @@ const regionHash: RegionHash = {
     signingRegion: "eu-north-1",
   },
   "eu-west-1": {
-    hostname: "oidc.eu-west-1.amazonaws.com",
     variants: [
       {
         hostname: "oidc.eu-west-1.amazonaws.com",
@@ -93,7 +84,6 @@ const regionHash: RegionHash = {
     signingRegion: "eu-west-1",
   },
   "eu-west-2": {
-    hostname: "oidc.eu-west-2.amazonaws.com",
     variants: [
       {
         hostname: "oidc.eu-west-2.amazonaws.com",
@@ -103,7 +93,6 @@ const regionHash: RegionHash = {
     signingRegion: "eu-west-2",
   },
   "eu-west-3": {
-    hostname: "oidc.eu-west-3.amazonaws.com",
     variants: [
       {
         hostname: "oidc.eu-west-3.amazonaws.com",
@@ -113,7 +102,6 @@ const regionHash: RegionHash = {
     signingRegion: "eu-west-3",
   },
   "sa-east-1": {
-    hostname: "oidc.sa-east-1.amazonaws.com",
     variants: [
       {
         hostname: "oidc.sa-east-1.amazonaws.com",
@@ -123,7 +111,6 @@ const regionHash: RegionHash = {
     signingRegion: "sa-east-1",
   },
   "us-east-1": {
-    hostname: "oidc.us-east-1.amazonaws.com",
     variants: [
       {
         hostname: "oidc.us-east-1.amazonaws.com",
@@ -133,7 +120,6 @@ const regionHash: RegionHash = {
     signingRegion: "us-east-1",
   },
   "us-east-2": {
-    hostname: "oidc.us-east-2.amazonaws.com",
     variants: [
       {
         hostname: "oidc.us-east-2.amazonaws.com",
@@ -143,7 +129,6 @@ const regionHash: RegionHash = {
     signingRegion: "us-east-2",
   },
   "us-gov-west-1": {
-    hostname: "oidc.us-gov-west-1.amazonaws.com",
     variants: [
       {
         hostname: "oidc.us-gov-west-1.amazonaws.com",
@@ -153,7 +138,6 @@ const regionHash: RegionHash = {
     signingRegion: "us-gov-west-1",
   },
   "us-west-2": {
-    hostname: "oidc.us-west-2.amazonaws.com",
     variants: [
       {
         hostname: "oidc.us-west-2.amazonaws.com",
@@ -190,7 +174,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "oidc.{region}.amazonaws.com",
     variants: [
       {
         hostname: "oidc.{region}.amazonaws.com",
@@ -213,7 +196,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "oidc.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "oidc.{region}.amazonaws.com.cn",
@@ -236,7 +218,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "oidc.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "oidc.{region}.c2s.ic.gov",
@@ -247,7 +228,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "oidc.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "oidc.{region}.sc2s.sgov.gov",
@@ -258,7 +238,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "oidc.{region}.amazonaws.com",
     variants: [
       {
         hostname: "oidc.{region}.amazonaws.com",

--- a/clients/client-sso/src/endpoints.ts
+++ b/clients/client-sso/src/endpoints.ts
@@ -3,7 +3,6 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
   "ap-northeast-1": {
-    hostname: "portal.sso.ap-northeast-1.amazonaws.com",
     variants: [
       {
         hostname: "portal.sso.ap-northeast-1.amazonaws.com",
@@ -13,7 +12,6 @@ const regionHash: RegionHash = {
     signingRegion: "ap-northeast-1",
   },
   "ap-northeast-2": {
-    hostname: "portal.sso.ap-northeast-2.amazonaws.com",
     variants: [
       {
         hostname: "portal.sso.ap-northeast-2.amazonaws.com",
@@ -23,7 +21,6 @@ const regionHash: RegionHash = {
     signingRegion: "ap-northeast-2",
   },
   "ap-south-1": {
-    hostname: "portal.sso.ap-south-1.amazonaws.com",
     variants: [
       {
         hostname: "portal.sso.ap-south-1.amazonaws.com",
@@ -33,7 +30,6 @@ const regionHash: RegionHash = {
     signingRegion: "ap-south-1",
   },
   "ap-southeast-1": {
-    hostname: "portal.sso.ap-southeast-1.amazonaws.com",
     variants: [
       {
         hostname: "portal.sso.ap-southeast-1.amazonaws.com",
@@ -43,7 +39,6 @@ const regionHash: RegionHash = {
     signingRegion: "ap-southeast-1",
   },
   "ap-southeast-2": {
-    hostname: "portal.sso.ap-southeast-2.amazonaws.com",
     variants: [
       {
         hostname: "portal.sso.ap-southeast-2.amazonaws.com",
@@ -53,7 +48,6 @@ const regionHash: RegionHash = {
     signingRegion: "ap-southeast-2",
   },
   "ca-central-1": {
-    hostname: "portal.sso.ca-central-1.amazonaws.com",
     variants: [
       {
         hostname: "portal.sso.ca-central-1.amazonaws.com",
@@ -63,7 +57,6 @@ const regionHash: RegionHash = {
     signingRegion: "ca-central-1",
   },
   "eu-central-1": {
-    hostname: "portal.sso.eu-central-1.amazonaws.com",
     variants: [
       {
         hostname: "portal.sso.eu-central-1.amazonaws.com",
@@ -73,7 +66,6 @@ const regionHash: RegionHash = {
     signingRegion: "eu-central-1",
   },
   "eu-north-1": {
-    hostname: "portal.sso.eu-north-1.amazonaws.com",
     variants: [
       {
         hostname: "portal.sso.eu-north-1.amazonaws.com",
@@ -83,7 +75,6 @@ const regionHash: RegionHash = {
     signingRegion: "eu-north-1",
   },
   "eu-west-1": {
-    hostname: "portal.sso.eu-west-1.amazonaws.com",
     variants: [
       {
         hostname: "portal.sso.eu-west-1.amazonaws.com",
@@ -93,7 +84,6 @@ const regionHash: RegionHash = {
     signingRegion: "eu-west-1",
   },
   "eu-west-2": {
-    hostname: "portal.sso.eu-west-2.amazonaws.com",
     variants: [
       {
         hostname: "portal.sso.eu-west-2.amazonaws.com",
@@ -103,7 +93,6 @@ const regionHash: RegionHash = {
     signingRegion: "eu-west-2",
   },
   "eu-west-3": {
-    hostname: "portal.sso.eu-west-3.amazonaws.com",
     variants: [
       {
         hostname: "portal.sso.eu-west-3.amazonaws.com",
@@ -113,7 +102,6 @@ const regionHash: RegionHash = {
     signingRegion: "eu-west-3",
   },
   "sa-east-1": {
-    hostname: "portal.sso.sa-east-1.amazonaws.com",
     variants: [
       {
         hostname: "portal.sso.sa-east-1.amazonaws.com",
@@ -123,7 +111,6 @@ const regionHash: RegionHash = {
     signingRegion: "sa-east-1",
   },
   "us-east-1": {
-    hostname: "portal.sso.us-east-1.amazonaws.com",
     variants: [
       {
         hostname: "portal.sso.us-east-1.amazonaws.com",
@@ -133,7 +120,6 @@ const regionHash: RegionHash = {
     signingRegion: "us-east-1",
   },
   "us-east-2": {
-    hostname: "portal.sso.us-east-2.amazonaws.com",
     variants: [
       {
         hostname: "portal.sso.us-east-2.amazonaws.com",
@@ -143,7 +129,6 @@ const regionHash: RegionHash = {
     signingRegion: "us-east-2",
   },
   "us-gov-west-1": {
-    hostname: "portal.sso.us-gov-west-1.amazonaws.com",
     variants: [
       {
         hostname: "portal.sso.us-gov-west-1.amazonaws.com",
@@ -153,7 +138,6 @@ const regionHash: RegionHash = {
     signingRegion: "us-gov-west-1",
   },
   "us-west-2": {
-    hostname: "portal.sso.us-west-2.amazonaws.com",
     variants: [
       {
         hostname: "portal.sso.us-west-2.amazonaws.com",
@@ -190,7 +174,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "portal.sso.{region}.amazonaws.com",
     variants: [
       {
         hostname: "portal.sso.{region}.amazonaws.com",
@@ -213,7 +196,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "portal.sso.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "portal.sso.{region}.amazonaws.com.cn",
@@ -236,7 +218,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "portal.sso.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "portal.sso.{region}.c2s.ic.gov",
@@ -247,7 +228,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "portal.sso.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "portal.sso.{region}.sc2s.sgov.gov",
@@ -258,7 +238,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "portal.sso.{region}.amazonaws.com",
     variants: [
       {
         hostname: "portal.sso.{region}.amazonaws.com",

--- a/clients/client-storage-gateway/src/endpoints.ts
+++ b/clients/client-storage-gateway/src/endpoints.ts
@@ -3,7 +3,6 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
   "ca-central-1": {
-    hostname: "storagegateway.ca-central-1.amazonaws.com",
     variants: [
       {
         hostname: "storagegateway.ca-central-1.amazonaws.com",
@@ -16,7 +15,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-east-1": {
-    hostname: "storagegateway.us-east-1.amazonaws.com",
     variants: [
       {
         hostname: "storagegateway.us-east-1.amazonaws.com",
@@ -29,7 +27,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-east-2": {
-    hostname: "storagegateway.us-east-2.amazonaws.com",
     variants: [
       {
         hostname: "storagegateway.us-east-2.amazonaws.com",
@@ -42,7 +39,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-gov-east-1": {
-    hostname: "storagegateway.us-gov-east-1.amazonaws.com",
     variants: [
       {
         hostname: "storagegateway.us-gov-east-1.amazonaws.com",
@@ -55,7 +51,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-gov-west-1": {
-    hostname: "storagegateway.us-gov-west-1.amazonaws.com",
     variants: [
       {
         hostname: "storagegateway.us-gov-west-1.amazonaws.com",
@@ -68,7 +63,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-west-1": {
-    hostname: "storagegateway.us-west-1.amazonaws.com",
     variants: [
       {
         hostname: "storagegateway.us-west-1.amazonaws.com",
@@ -81,7 +75,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-west-2": {
-    hostname: "storagegateway.us-west-2.amazonaws.com",
     variants: [
       {
         hostname: "storagegateway.us-west-2.amazonaws.com",
@@ -127,7 +120,6 @@ const partitionHash: PartitionHash = {
       "us-west-2-fips",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "storagegateway.{region}.amazonaws.com",
     variants: [
       {
         hostname: "storagegateway.{region}.amazonaws.com",
@@ -150,7 +142,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "storagegateway.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "storagegateway.{region}.amazonaws.com.cn",
@@ -173,7 +164,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "storagegateway.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "storagegateway.{region}.c2s.ic.gov",
@@ -184,7 +174,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "storagegateway.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "storagegateway.{region}.sc2s.sgov.gov",
@@ -195,7 +184,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["fips", "us-gov-east-1", "us-gov-east-1-fips", "us-gov-west-1", "us-gov-west-1-fips"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "storagegateway.{region}.amazonaws.com",
     variants: [
       {
         hostname: "storagegateway.{region}.amazonaws.com",

--- a/clients/client-sts/src/endpoints.ts
+++ b/clients/client-sts/src/endpoints.ts
@@ -3,7 +3,6 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
   "aws-global": {
-    hostname: "sts.amazonaws.com",
     variants: [
       {
         hostname: "sts.amazonaws.com",
@@ -13,7 +12,6 @@ const regionHash: RegionHash = {
     signingRegion: "us-east-1",
   },
   "us-east-1": {
-    hostname: "sts.us-east-1.amazonaws.com",
     variants: [
       {
         hostname: "sts.us-east-1.amazonaws.com",
@@ -26,7 +24,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-east-2": {
-    hostname: "sts.us-east-2.amazonaws.com",
     variants: [
       {
         hostname: "sts.us-east-2.amazonaws.com",
@@ -39,7 +36,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-gov-east-1": {
-    hostname: "sts.us-gov-east-1.amazonaws.com",
     variants: [
       {
         hostname: "sts.us-gov-east-1.amazonaws.com",
@@ -52,7 +48,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-gov-west-1": {
-    hostname: "sts.us-gov-west-1.amazonaws.com",
     variants: [
       {
         hostname: "sts.us-gov-west-1.amazonaws.com",
@@ -65,7 +60,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-west-1": {
-    hostname: "sts.us-west-1.amazonaws.com",
     variants: [
       {
         hostname: "sts.us-west-1.amazonaws.com",
@@ -78,7 +72,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-west-2": {
-    hostname: "sts.us-west-2.amazonaws.com",
     variants: [
       {
         hostname: "sts.us-west-2.amazonaws.com",
@@ -123,7 +116,6 @@ const partitionHash: PartitionHash = {
       "us-west-2-fips",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "sts.{region}.amazonaws.com",
     variants: [
       {
         hostname: "sts.{region}.amazonaws.com",
@@ -146,7 +138,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "sts.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "sts.{region}.amazonaws.com.cn",
@@ -169,7 +160,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "sts.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "sts.{region}.c2s.ic.gov",
@@ -180,7 +170,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "sts.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "sts.{region}.sc2s.sgov.gov",
@@ -191,7 +180,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-east-1-fips", "us-gov-west-1", "us-gov-west-1-fips"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "sts.{region}.amazonaws.com",
     variants: [
       {
         hostname: "sts.{region}.amazonaws.com",

--- a/clients/client-support/src/endpoints.ts
+++ b/clients/client-support/src/endpoints.ts
@@ -3,7 +3,6 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
   "aws-cn-global": {
-    hostname: "support.cn-north-1.amazonaws.com.cn",
     variants: [
       {
         hostname: "support.cn-north-1.amazonaws.com.cn",
@@ -13,7 +12,6 @@ const regionHash: RegionHash = {
     signingRegion: "cn-north-1",
   },
   "aws-global": {
-    hostname: "support.us-east-1.amazonaws.com",
     variants: [
       {
         hostname: "support.us-east-1.amazonaws.com",
@@ -23,7 +21,6 @@ const regionHash: RegionHash = {
     signingRegion: "us-east-1",
   },
   "aws-iso-b-global": {
-    hostname: "support.us-isob-east-1.sc2s.sgov.gov",
     variants: [
       {
         hostname: "support.us-isob-east-1.sc2s.sgov.gov",
@@ -33,7 +30,6 @@ const regionHash: RegionHash = {
     signingRegion: "us-isob-east-1",
   },
   "aws-iso-global": {
-    hostname: "support.us-iso-east-1.c2s.ic.gov",
     variants: [
       {
         hostname: "support.us-iso-east-1.c2s.ic.gov",
@@ -43,7 +39,6 @@ const regionHash: RegionHash = {
     signingRegion: "us-iso-east-1",
   },
   "aws-us-gov-global": {
-    hostname: "support.us-gov-west-1.amazonaws.com",
     variants: [
       {
         hostname: "support.us-gov-west-1.amazonaws.com",
@@ -81,7 +76,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "support.{region}.amazonaws.com",
     variants: [
       {
         hostname: "support.{region}.amazonaws.com",
@@ -104,7 +98,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["aws-cn-global", "cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "support.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "support.{region}.amazonaws.com.cn",
@@ -127,7 +120,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["aws-iso-global", "us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "support.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "support.{region}.c2s.ic.gov",
@@ -138,7 +130,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["aws-iso-b-global", "us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "support.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "support.{region}.sc2s.sgov.gov",
@@ -149,7 +140,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["aws-us-gov-global", "fips-us-gov-west-1", "us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "support.{region}.amazonaws.com",
     variants: [
       {
         hostname: "support.{region}.amazonaws.com",

--- a/clients/client-swf/src/endpoints.ts
+++ b/clients/client-swf/src/endpoints.ts
@@ -3,7 +3,6 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
   "us-east-1": {
-    hostname: "swf.us-east-1.amazonaws.com",
     variants: [
       {
         hostname: "swf.us-east-1.amazonaws.com",
@@ -16,7 +15,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-east-2": {
-    hostname: "swf.us-east-2.amazonaws.com",
     variants: [
       {
         hostname: "swf.us-east-2.amazonaws.com",
@@ -29,7 +27,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-gov-east-1": {
-    hostname: "swf.us-gov-east-1.amazonaws.com",
     variants: [
       {
         hostname: "swf.us-gov-east-1.amazonaws.com",
@@ -39,7 +36,6 @@ const regionHash: RegionHash = {
     signingRegion: "us-gov-east-1",
   },
   "us-gov-west-1": {
-    hostname: "swf.us-gov-west-1.amazonaws.com",
     variants: [
       {
         hostname: "swf.us-gov-west-1.amazonaws.com",
@@ -49,7 +45,6 @@ const regionHash: RegionHash = {
     signingRegion: "us-gov-west-1",
   },
   "us-west-1": {
-    hostname: "swf.us-west-1.amazonaws.com",
     variants: [
       {
         hostname: "swf.us-west-1.amazonaws.com",
@@ -62,7 +57,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-west-2": {
-    hostname: "swf.us-west-2.amazonaws.com",
     variants: [
       {
         hostname: "swf.us-west-2.amazonaws.com",
@@ -106,7 +100,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "swf.{region}.amazonaws.com",
     variants: [
       {
         hostname: "swf.{region}.amazonaws.com",
@@ -129,7 +122,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "swf.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "swf.{region}.amazonaws.com.cn",
@@ -152,7 +144,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "swf.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "swf.{region}.c2s.ic.gov",
@@ -163,7 +154,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "swf.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "swf.{region}.sc2s.sgov.gov",
@@ -174,7 +164,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "swf.{region}.amazonaws.com",
     variants: [
       {
         hostname: "swf.{region}.amazonaws.com",

--- a/clients/client-synthetics/src/endpoints.ts
+++ b/clients/client-synthetics/src/endpoints.ts
@@ -29,7 +29,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "synthetics.{region}.amazonaws.com",
     variants: [
       {
         hostname: "synthetics.{region}.amazonaws.com",
@@ -52,7 +51,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "synthetics.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "synthetics.{region}.amazonaws.com.cn",
@@ -75,7 +73,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "synthetics.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "synthetics.{region}.c2s.ic.gov",
@@ -86,7 +83,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "synthetics.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "synthetics.{region}.sc2s.sgov.gov",
@@ -97,7 +93,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "synthetics.{region}.amazonaws.com",
     variants: [
       {
         hostname: "synthetics.{region}.amazonaws.com",

--- a/clients/client-textract/src/endpoints.ts
+++ b/clients/client-textract/src/endpoints.ts
@@ -3,7 +3,6 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
   "ca-central-1": {
-    hostname: "textract.ca-central-1.amazonaws.com",
     variants: [
       {
         hostname: "textract.ca-central-1.amazonaws.com",
@@ -16,7 +15,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-east-1": {
-    hostname: "textract.us-east-1.amazonaws.com",
     variants: [
       {
         hostname: "textract.us-east-1.amazonaws.com",
@@ -29,7 +27,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-east-2": {
-    hostname: "textract.us-east-2.amazonaws.com",
     variants: [
       {
         hostname: "textract.us-east-2.amazonaws.com",
@@ -42,7 +39,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-gov-east-1": {
-    hostname: "textract.us-gov-east-1.amazonaws.com",
     variants: [
       {
         hostname: "textract.us-gov-east-1.amazonaws.com",
@@ -55,7 +51,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-gov-west-1": {
-    hostname: "textract.us-gov-west-1.amazonaws.com",
     variants: [
       {
         hostname: "textract.us-gov-west-1.amazonaws.com",
@@ -68,7 +63,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-west-1": {
-    hostname: "textract.us-west-1.amazonaws.com",
     variants: [
       {
         hostname: "textract.us-west-1.amazonaws.com",
@@ -81,7 +75,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-west-2": {
-    hostname: "textract.us-west-2.amazonaws.com",
     variants: [
       {
         hostname: "textract.us-west-2.amazonaws.com",
@@ -126,7 +119,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "textract.{region}.amazonaws.com",
     variants: [
       {
         hostname: "textract.{region}.amazonaws.com",
@@ -149,7 +141,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "textract.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "textract.{region}.amazonaws.com.cn",
@@ -172,7 +163,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "textract.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "textract.{region}.c2s.ic.gov",
@@ -183,7 +173,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "textract.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "textract.{region}.sc2s.sgov.gov",
@@ -194,7 +183,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["fips-us-gov-east-1", "fips-us-gov-west-1", "us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "textract.{region}.amazonaws.com",
     variants: [
       {
         hostname: "textract.{region}.amazonaws.com",

--- a/clients/client-timestream-query/src/endpoints.ts
+++ b/clients/client-timestream-query/src/endpoints.ts
@@ -29,7 +29,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "query.timestream.{region}.amazonaws.com",
     variants: [
       {
         hostname: "query.timestream.{region}.amazonaws.com",
@@ -52,7 +51,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "query.timestream.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "query.timestream.{region}.amazonaws.com.cn",
@@ -75,7 +73,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "query.timestream.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "query.timestream.{region}.c2s.ic.gov",
@@ -86,7 +83,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "query.timestream.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "query.timestream.{region}.sc2s.sgov.gov",
@@ -97,7 +93,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "query.timestream.{region}.amazonaws.com",
     variants: [
       {
         hostname: "query.timestream.{region}.amazonaws.com",

--- a/clients/client-timestream-write/src/endpoints.ts
+++ b/clients/client-timestream-write/src/endpoints.ts
@@ -29,7 +29,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "ingest.timestream.{region}.amazonaws.com",
     variants: [
       {
         hostname: "ingest.timestream.{region}.amazonaws.com",
@@ -52,7 +51,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "ingest.timestream.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "ingest.timestream.{region}.amazonaws.com.cn",
@@ -75,7 +73,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "ingest.timestream.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "ingest.timestream.{region}.c2s.ic.gov",
@@ -86,7 +83,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "ingest.timestream.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "ingest.timestream.{region}.sc2s.sgov.gov",
@@ -97,7 +93,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "ingest.timestream.{region}.amazonaws.com",
     variants: [
       {
         hostname: "ingest.timestream.{region}.amazonaws.com",

--- a/clients/client-transcribe-streaming/src/endpoints.ts
+++ b/clients/client-transcribe-streaming/src/endpoints.ts
@@ -37,7 +37,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "transcribestreaming.{region}.amazonaws.com",
     variants: [
       {
         hostname: "transcribestreaming.{region}.amazonaws.com",
@@ -60,7 +59,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "transcribestreaming.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "transcribestreaming.{region}.amazonaws.com.cn",
@@ -83,7 +81,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "transcribestreaming.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "transcribestreaming.{region}.c2s.ic.gov",
@@ -94,7 +91,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "transcribestreaming.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "transcribestreaming.{region}.sc2s.sgov.gov",
@@ -105,7 +101,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "transcribestreaming.{region}.amazonaws.com",
     variants: [
       {
         hostname: "transcribestreaming.{region}.amazonaws.com",

--- a/clients/client-transcribe/src/endpoints.ts
+++ b/clients/client-transcribe/src/endpoints.ts
@@ -3,7 +3,6 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
   "cn-north-1": {
-    hostname: "cn.transcribe.cn-north-1.amazonaws.com.cn",
     variants: [
       {
         hostname: "cn.transcribe.cn-north-1.amazonaws.com.cn",
@@ -13,7 +12,6 @@ const regionHash: RegionHash = {
     signingRegion: "cn-north-1",
   },
   "cn-northwest-1": {
-    hostname: "cn.transcribe.cn-northwest-1.amazonaws.com.cn",
     variants: [
       {
         hostname: "cn.transcribe.cn-northwest-1.amazonaws.com.cn",
@@ -23,7 +21,6 @@ const regionHash: RegionHash = {
     signingRegion: "cn-northwest-1",
   },
   "us-east-1": {
-    hostname: "transcribe.us-east-1.amazonaws.com",
     variants: [
       {
         hostname: "transcribe.us-east-1.amazonaws.com",
@@ -36,7 +33,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-east-2": {
-    hostname: "transcribe.us-east-2.amazonaws.com",
     variants: [
       {
         hostname: "transcribe.us-east-2.amazonaws.com",
@@ -49,7 +45,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-gov-east-1": {
-    hostname: "transcribe.us-gov-east-1.amazonaws.com",
     variants: [
       {
         hostname: "transcribe.us-gov-east-1.amazonaws.com",
@@ -62,7 +57,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-gov-west-1": {
-    hostname: "transcribe.us-gov-west-1.amazonaws.com",
     variants: [
       {
         hostname: "transcribe.us-gov-west-1.amazonaws.com",
@@ -75,7 +69,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-west-1": {
-    hostname: "transcribe.us-west-1.amazonaws.com",
     variants: [
       {
         hostname: "transcribe.us-west-1.amazonaws.com",
@@ -88,7 +81,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-west-2": {
-    hostname: "transcribe.us-west-2.amazonaws.com",
     variants: [
       {
         hostname: "transcribe.us-west-2.amazonaws.com",
@@ -132,7 +124,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "transcribe.{region}.amazonaws.com",
     variants: [
       {
         hostname: "transcribe.{region}.amazonaws.com",
@@ -147,7 +138,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "transcribe.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "transcribe.{region}.amazonaws.com.cn",
@@ -170,7 +160,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "transcribe.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "transcribe.{region}.c2s.ic.gov",
@@ -181,7 +170,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "transcribe.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "transcribe.{region}.sc2s.sgov.gov",
@@ -192,7 +180,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["fips-us-gov-east-1", "fips-us-gov-west-1", "us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "transcribe.{region}.amazonaws.com",
     variants: [
       {
         hostname: "transcribe.{region}.amazonaws.com",

--- a/clients/client-transfer/src/endpoints.ts
+++ b/clients/client-transfer/src/endpoints.ts
@@ -3,7 +3,6 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
   "ca-central-1": {
-    hostname: "transfer.ca-central-1.amazonaws.com",
     variants: [
       {
         hostname: "transfer.ca-central-1.amazonaws.com",
@@ -16,7 +15,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-east-1": {
-    hostname: "transfer.us-east-1.amazonaws.com",
     variants: [
       {
         hostname: "transfer.us-east-1.amazonaws.com",
@@ -29,7 +27,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-east-2": {
-    hostname: "transfer.us-east-2.amazonaws.com",
     variants: [
       {
         hostname: "transfer.us-east-2.amazonaws.com",
@@ -42,7 +39,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-gov-east-1": {
-    hostname: "transfer.us-gov-east-1.amazonaws.com",
     variants: [
       {
         hostname: "transfer.us-gov-east-1.amazonaws.com",
@@ -55,7 +51,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-gov-west-1": {
-    hostname: "transfer.us-gov-west-1.amazonaws.com",
     variants: [
       {
         hostname: "transfer.us-gov-west-1.amazonaws.com",
@@ -68,7 +63,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-west-1": {
-    hostname: "transfer.us-west-1.amazonaws.com",
     variants: [
       {
         hostname: "transfer.us-west-1.amazonaws.com",
@@ -81,7 +75,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-west-2": {
-    hostname: "transfer.us-west-2.amazonaws.com",
     variants: [
       {
         hostname: "transfer.us-west-2.amazonaws.com",
@@ -126,7 +119,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "transfer.{region}.amazonaws.com",
     variants: [
       {
         hostname: "transfer.{region}.amazonaws.com",
@@ -149,7 +141,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "transfer.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "transfer.{region}.amazonaws.com.cn",
@@ -172,7 +163,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "transfer.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "transfer.{region}.c2s.ic.gov",
@@ -183,7 +173,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "transfer.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "transfer.{region}.sc2s.sgov.gov",
@@ -194,7 +183,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["fips-us-gov-east-1", "fips-us-gov-west-1", "us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "transfer.{region}.amazonaws.com",
     variants: [
       {
         hostname: "transfer.{region}.amazonaws.com",

--- a/clients/client-translate/src/endpoints.ts
+++ b/clients/client-translate/src/endpoints.ts
@@ -3,7 +3,6 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
   "us-east-1": {
-    hostname: "translate.us-east-1.amazonaws.com",
     variants: [
       {
         hostname: "translate.us-east-1.amazonaws.com",
@@ -16,7 +15,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-east-2": {
-    hostname: "translate.us-east-2.amazonaws.com",
     variants: [
       {
         hostname: "translate.us-east-2.amazonaws.com",
@@ -29,7 +27,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-gov-west-1": {
-    hostname: "translate.us-gov-west-1.amazonaws.com",
     variants: [
       {
         hostname: "translate.us-gov-west-1.amazonaws.com",
@@ -42,7 +39,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-west-2": {
-    hostname: "translate.us-west-2.amazonaws.com",
     variants: [
       {
         hostname: "translate.us-west-2.amazonaws.com",
@@ -85,7 +81,6 @@ const partitionHash: PartitionHash = {
       "us-west-2-fips",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "translate.{region}.amazonaws.com",
     variants: [
       {
         hostname: "translate.{region}.amazonaws.com",
@@ -108,7 +103,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "translate.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "translate.{region}.amazonaws.com.cn",
@@ -131,7 +125,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "translate.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "translate.{region}.c2s.ic.gov",
@@ -142,7 +135,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "translate.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "translate.{region}.sc2s.sgov.gov",
@@ -153,7 +145,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1", "us-gov-west-1-fips"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "translate.{region}.amazonaws.com",
     variants: [
       {
         hostname: "translate.{region}.amazonaws.com",

--- a/clients/client-voice-id/src/endpoints.ts
+++ b/clients/client-voice-id/src/endpoints.ts
@@ -29,7 +29,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "voiceid.{region}.amazonaws.com",
     variants: [
       {
         hostname: "voiceid.{region}.amazonaws.com",
@@ -52,7 +51,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "voiceid.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "voiceid.{region}.amazonaws.com.cn",
@@ -75,7 +73,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "voiceid.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "voiceid.{region}.c2s.ic.gov",
@@ -86,7 +83,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "voiceid.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "voiceid.{region}.sc2s.sgov.gov",
@@ -97,7 +93,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "voiceid.{region}.amazonaws.com",
     variants: [
       {
         hostname: "voiceid.{region}.amazonaws.com",

--- a/clients/client-waf-regional/src/endpoints.ts
+++ b/clients/client-waf-regional/src/endpoints.ts
@@ -3,7 +3,6 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
   "af-south-1": {
-    hostname: "waf-regional.af-south-1.amazonaws.com",
     variants: [
       {
         hostname: "waf-regional.af-south-1.amazonaws.com",
@@ -17,7 +16,6 @@ const regionHash: RegionHash = {
     signingRegion: "af-south-1",
   },
   "ap-east-1": {
-    hostname: "waf-regional.ap-east-1.amazonaws.com",
     variants: [
       {
         hostname: "waf-regional.ap-east-1.amazonaws.com",
@@ -31,7 +29,6 @@ const regionHash: RegionHash = {
     signingRegion: "ap-east-1",
   },
   "ap-northeast-1": {
-    hostname: "waf-regional.ap-northeast-1.amazonaws.com",
     variants: [
       {
         hostname: "waf-regional.ap-northeast-1.amazonaws.com",
@@ -45,7 +42,6 @@ const regionHash: RegionHash = {
     signingRegion: "ap-northeast-1",
   },
   "ap-northeast-2": {
-    hostname: "waf-regional.ap-northeast-2.amazonaws.com",
     variants: [
       {
         hostname: "waf-regional.ap-northeast-2.amazonaws.com",
@@ -59,7 +55,6 @@ const regionHash: RegionHash = {
     signingRegion: "ap-northeast-2",
   },
   "ap-northeast-3": {
-    hostname: "waf-regional.ap-northeast-3.amazonaws.com",
     variants: [
       {
         hostname: "waf-regional.ap-northeast-3.amazonaws.com",
@@ -73,7 +68,6 @@ const regionHash: RegionHash = {
     signingRegion: "ap-northeast-3",
   },
   "ap-south-1": {
-    hostname: "waf-regional.ap-south-1.amazonaws.com",
     variants: [
       {
         hostname: "waf-regional.ap-south-1.amazonaws.com",
@@ -87,7 +81,6 @@ const regionHash: RegionHash = {
     signingRegion: "ap-south-1",
   },
   "ap-southeast-1": {
-    hostname: "waf-regional.ap-southeast-1.amazonaws.com",
     variants: [
       {
         hostname: "waf-regional.ap-southeast-1.amazonaws.com",
@@ -101,7 +94,6 @@ const regionHash: RegionHash = {
     signingRegion: "ap-southeast-1",
   },
   "ap-southeast-2": {
-    hostname: "waf-regional.ap-southeast-2.amazonaws.com",
     variants: [
       {
         hostname: "waf-regional.ap-southeast-2.amazonaws.com",
@@ -115,7 +107,6 @@ const regionHash: RegionHash = {
     signingRegion: "ap-southeast-2",
   },
   "ca-central-1": {
-    hostname: "waf-regional.ca-central-1.amazonaws.com",
     variants: [
       {
         hostname: "waf-regional.ca-central-1.amazonaws.com",
@@ -129,7 +120,6 @@ const regionHash: RegionHash = {
     signingRegion: "ca-central-1",
   },
   "cn-north-1": {
-    hostname: "waf-regional.cn-north-1.amazonaws.com.cn",
     variants: [
       {
         hostname: "waf-regional.cn-north-1.amazonaws.com.cn",
@@ -143,7 +133,6 @@ const regionHash: RegionHash = {
     signingRegion: "cn-north-1",
   },
   "cn-northwest-1": {
-    hostname: "waf-regional.cn-northwest-1.amazonaws.com.cn",
     variants: [
       {
         hostname: "waf-regional.cn-northwest-1.amazonaws.com.cn",
@@ -157,7 +146,6 @@ const regionHash: RegionHash = {
     signingRegion: "cn-northwest-1",
   },
   "eu-central-1": {
-    hostname: "waf-regional.eu-central-1.amazonaws.com",
     variants: [
       {
         hostname: "waf-regional.eu-central-1.amazonaws.com",
@@ -171,7 +159,6 @@ const regionHash: RegionHash = {
     signingRegion: "eu-central-1",
   },
   "eu-north-1": {
-    hostname: "waf-regional.eu-north-1.amazonaws.com",
     variants: [
       {
         hostname: "waf-regional.eu-north-1.amazonaws.com",
@@ -185,7 +172,6 @@ const regionHash: RegionHash = {
     signingRegion: "eu-north-1",
   },
   "eu-south-1": {
-    hostname: "waf-regional.eu-south-1.amazonaws.com",
     variants: [
       {
         hostname: "waf-regional.eu-south-1.amazonaws.com",
@@ -199,7 +185,6 @@ const regionHash: RegionHash = {
     signingRegion: "eu-south-1",
   },
   "eu-west-1": {
-    hostname: "waf-regional.eu-west-1.amazonaws.com",
     variants: [
       {
         hostname: "waf-regional.eu-west-1.amazonaws.com",
@@ -213,7 +198,6 @@ const regionHash: RegionHash = {
     signingRegion: "eu-west-1",
   },
   "eu-west-2": {
-    hostname: "waf-regional.eu-west-2.amazonaws.com",
     variants: [
       {
         hostname: "waf-regional.eu-west-2.amazonaws.com",
@@ -227,7 +211,6 @@ const regionHash: RegionHash = {
     signingRegion: "eu-west-2",
   },
   "eu-west-3": {
-    hostname: "waf-regional.eu-west-3.amazonaws.com",
     variants: [
       {
         hostname: "waf-regional.eu-west-3.amazonaws.com",
@@ -241,7 +224,6 @@ const regionHash: RegionHash = {
     signingRegion: "eu-west-3",
   },
   "me-south-1": {
-    hostname: "waf-regional.me-south-1.amazonaws.com",
     variants: [
       {
         hostname: "waf-regional.me-south-1.amazonaws.com",
@@ -255,7 +237,6 @@ const regionHash: RegionHash = {
     signingRegion: "me-south-1",
   },
   "sa-east-1": {
-    hostname: "waf-regional.sa-east-1.amazonaws.com",
     variants: [
       {
         hostname: "waf-regional.sa-east-1.amazonaws.com",
@@ -269,7 +250,6 @@ const regionHash: RegionHash = {
     signingRegion: "sa-east-1",
   },
   "us-east-1": {
-    hostname: "waf-regional.us-east-1.amazonaws.com",
     variants: [
       {
         hostname: "waf-regional.us-east-1.amazonaws.com",
@@ -283,7 +263,6 @@ const regionHash: RegionHash = {
     signingRegion: "us-east-1",
   },
   "us-east-2": {
-    hostname: "waf-regional.us-east-2.amazonaws.com",
     variants: [
       {
         hostname: "waf-regional.us-east-2.amazonaws.com",
@@ -297,7 +276,6 @@ const regionHash: RegionHash = {
     signingRegion: "us-east-2",
   },
   "us-gov-east-1": {
-    hostname: "waf-regional.us-gov-east-1.amazonaws.com",
     variants: [
       {
         hostname: "waf-regional.us-gov-east-1.amazonaws.com",
@@ -311,7 +289,6 @@ const regionHash: RegionHash = {
     signingRegion: "us-gov-east-1",
   },
   "us-gov-west-1": {
-    hostname: "waf-regional.us-gov-west-1.amazonaws.com",
     variants: [
       {
         hostname: "waf-regional.us-gov-west-1.amazonaws.com",
@@ -325,7 +302,6 @@ const regionHash: RegionHash = {
     signingRegion: "us-gov-west-1",
   },
   "us-west-1": {
-    hostname: "waf-regional.us-west-1.amazonaws.com",
     variants: [
       {
         hostname: "waf-regional.us-west-1.amazonaws.com",
@@ -339,7 +315,6 @@ const regionHash: RegionHash = {
     signingRegion: "us-west-1",
   },
   "us-west-2": {
-    hostname: "waf-regional.us-west-2.amazonaws.com",
     variants: [
       {
         hostname: "waf-regional.us-west-2.amazonaws.com",
@@ -401,7 +376,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "waf-regional.{region}.amazonaws.com",
     variants: [
       {
         hostname: "waf-regional.{region}.amazonaws.com",
@@ -424,7 +398,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1", "fips-cn-north-1", "fips-cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "waf-regional.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "waf-regional.{region}.amazonaws.com.cn",
@@ -447,7 +420,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "waf-regional.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "waf-regional.{region}.c2s.ic.gov",
@@ -458,7 +430,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "waf-regional.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "waf-regional.{region}.sc2s.sgov.gov",
@@ -469,7 +440,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["fips-us-gov-east-1", "fips-us-gov-west-1", "us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "waf-regional.{region}.amazonaws.com",
     variants: [
       {
         hostname: "waf-regional.{region}.amazonaws.com",

--- a/clients/client-waf/src/endpoints.ts
+++ b/clients/client-waf/src/endpoints.ts
@@ -3,7 +3,6 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
   "aws-global": {
-    hostname: "waf.amazonaws.com",
     variants: [
       {
         hostname: "waf.amazonaws.com",
@@ -48,7 +47,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "waf.{region}.amazonaws.com",
     variants: [
       {
         hostname: "waf.{region}.amazonaws.com",
@@ -72,7 +70,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "waf.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "waf.{region}.amazonaws.com.cn",
@@ -95,7 +92,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "waf.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "waf.{region}.c2s.ic.gov",
@@ -106,7 +102,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "waf.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "waf.{region}.sc2s.sgov.gov",
@@ -117,7 +112,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "waf.{region}.amazonaws.com",
     variants: [
       {
         hostname: "waf.{region}.amazonaws.com",

--- a/clients/client-wafv2/src/endpoints.ts
+++ b/clients/client-wafv2/src/endpoints.ts
@@ -29,7 +29,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "wafv2.{region}.amazonaws.com",
     variants: [
       {
         hostname: "wafv2.{region}.amazonaws.com",
@@ -52,7 +51,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "wafv2.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "wafv2.{region}.amazonaws.com.cn",
@@ -75,7 +73,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "wafv2.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "wafv2.{region}.c2s.ic.gov",
@@ -86,7 +83,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "wafv2.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "wafv2.{region}.sc2s.sgov.gov",
@@ -97,7 +93,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "wafv2.{region}.amazonaws.com",
     variants: [
       {
         hostname: "wafv2.{region}.amazonaws.com",

--- a/clients/client-wellarchitected/src/endpoints.ts
+++ b/clients/client-wellarchitected/src/endpoints.ts
@@ -29,7 +29,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "wellarchitected.{region}.amazonaws.com",
     variants: [
       {
         hostname: "wellarchitected.{region}.amazonaws.com",
@@ -52,7 +51,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "wellarchitected.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "wellarchitected.{region}.amazonaws.com.cn",
@@ -75,7 +73,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "wellarchitected.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "wellarchitected.{region}.c2s.ic.gov",
@@ -86,7 +83,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "wellarchitected.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "wellarchitected.{region}.sc2s.sgov.gov",
@@ -97,7 +93,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "wellarchitected.{region}.amazonaws.com",
     variants: [
       {
         hostname: "wellarchitected.{region}.amazonaws.com",

--- a/clients/client-wisdom/src/endpoints.ts
+++ b/clients/client-wisdom/src/endpoints.ts
@@ -29,7 +29,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "wisdom.{region}.amazonaws.com",
     variants: [
       {
         hostname: "wisdom.{region}.amazonaws.com",
@@ -52,7 +51,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "wisdom.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "wisdom.{region}.amazonaws.com.cn",
@@ -75,7 +73,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "wisdom.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "wisdom.{region}.c2s.ic.gov",
@@ -86,7 +83,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "wisdom.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "wisdom.{region}.sc2s.sgov.gov",
@@ -97,7 +93,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "wisdom.{region}.amazonaws.com",
     variants: [
       {
         hostname: "wisdom.{region}.amazonaws.com",

--- a/clients/client-workdocs/src/endpoints.ts
+++ b/clients/client-workdocs/src/endpoints.ts
@@ -3,7 +3,6 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
   "us-east-1": {
-    hostname: "workdocs.us-east-1.amazonaws.com",
     variants: [
       {
         hostname: "workdocs.us-east-1.amazonaws.com",
@@ -16,7 +15,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-west-2": {
-    hostname: "workdocs.us-west-2.amazonaws.com",
     variants: [
       {
         hostname: "workdocs.us-west-2.amazonaws.com",
@@ -58,7 +56,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "workdocs.{region}.amazonaws.com",
     variants: [
       {
         hostname: "workdocs.{region}.amazonaws.com",
@@ -81,7 +78,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "workdocs.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "workdocs.{region}.amazonaws.com.cn",
@@ -104,7 +100,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "workdocs.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "workdocs.{region}.c2s.ic.gov",
@@ -115,7 +110,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "workdocs.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "workdocs.{region}.sc2s.sgov.gov",
@@ -126,7 +120,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "workdocs.{region}.amazonaws.com",
     variants: [
       {
         hostname: "workdocs.{region}.amazonaws.com",

--- a/clients/client-worklink/src/endpoints.ts
+++ b/clients/client-worklink/src/endpoints.ts
@@ -29,7 +29,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "worklink.{region}.amazonaws.com",
     variants: [
       {
         hostname: "worklink.{region}.amazonaws.com",
@@ -52,7 +51,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "worklink.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "worklink.{region}.amazonaws.com.cn",
@@ -75,7 +73,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "worklink.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "worklink.{region}.c2s.ic.gov",
@@ -86,7 +83,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "worklink.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "worklink.{region}.sc2s.sgov.gov",
@@ -97,7 +93,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "worklink.{region}.amazonaws.com",
     variants: [
       {
         hostname: "worklink.{region}.amazonaws.com",

--- a/clients/client-workmail/src/endpoints.ts
+++ b/clients/client-workmail/src/endpoints.ts
@@ -29,7 +29,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "workmail.{region}.amazonaws.com",
     variants: [
       {
         hostname: "workmail.{region}.amazonaws.com",
@@ -52,7 +51,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "workmail.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "workmail.{region}.amazonaws.com.cn",
@@ -75,7 +73,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "workmail.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "workmail.{region}.c2s.ic.gov",
@@ -86,7 +83,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "workmail.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "workmail.{region}.sc2s.sgov.gov",
@@ -97,7 +93,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "workmail.{region}.amazonaws.com",
     variants: [
       {
         hostname: "workmail.{region}.amazonaws.com",

--- a/clients/client-workmailmessageflow/src/endpoints.ts
+++ b/clients/client-workmailmessageflow/src/endpoints.ts
@@ -29,7 +29,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "workmailmessageflow.{region}.amazonaws.com",
     variants: [
       {
         hostname: "workmailmessageflow.{region}.amazonaws.com",
@@ -52,7 +51,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "workmailmessageflow.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "workmailmessageflow.{region}.amazonaws.com.cn",
@@ -75,7 +73,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "workmailmessageflow.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "workmailmessageflow.{region}.c2s.ic.gov",
@@ -86,7 +83,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "workmailmessageflow.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "workmailmessageflow.{region}.sc2s.sgov.gov",
@@ -97,7 +93,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "workmailmessageflow.{region}.amazonaws.com",
     variants: [
       {
         hostname: "workmailmessageflow.{region}.amazonaws.com",

--- a/clients/client-workspaces/src/endpoints.ts
+++ b/clients/client-workspaces/src/endpoints.ts
@@ -3,7 +3,6 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
   "us-east-1": {
-    hostname: "workspaces.us-east-1.amazonaws.com",
     variants: [
       {
         hostname: "workspaces.us-east-1.amazonaws.com",
@@ -16,7 +15,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-gov-west-1": {
-    hostname: "workspaces.us-gov-west-1.amazonaws.com",
     variants: [
       {
         hostname: "workspaces.us-gov-west-1.amazonaws.com",
@@ -29,7 +27,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-west-2": {
-    hostname: "workspaces.us-west-2.amazonaws.com",
     variants: [
       {
         hostname: "workspaces.us-west-2.amazonaws.com",
@@ -71,7 +68,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "workspaces.{region}.amazonaws.com",
     variants: [
       {
         hostname: "workspaces.{region}.amazonaws.com",
@@ -94,7 +90,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "workspaces.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "workspaces.{region}.amazonaws.com.cn",
@@ -117,7 +112,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "workspaces.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "workspaces.{region}.c2s.ic.gov",
@@ -128,7 +122,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "workspaces.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "workspaces.{region}.sc2s.sgov.gov",
@@ -139,7 +132,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["fips-us-gov-west-1", "us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "workspaces.{region}.amazonaws.com",
     variants: [
       {
         hostname: "workspaces.{region}.amazonaws.com",

--- a/clients/client-xray/src/endpoints.ts
+++ b/clients/client-xray/src/endpoints.ts
@@ -3,7 +3,6 @@ import { RegionInfoProvider, RegionInfoProviderOptions } from "@aws-sdk/types";
 
 const regionHash: RegionHash = {
   "us-east-1": {
-    hostname: "xray.us-east-1.amazonaws.com",
     variants: [
       {
         hostname: "xray.us-east-1.amazonaws.com",
@@ -16,7 +15,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-east-2": {
-    hostname: "xray.us-east-2.amazonaws.com",
     variants: [
       {
         hostname: "xray.us-east-2.amazonaws.com",
@@ -29,7 +27,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-gov-east-1": {
-    hostname: "xray.us-gov-east-1.amazonaws.com",
     variants: [
       {
         hostname: "xray.us-gov-east-1.amazonaws.com",
@@ -42,7 +39,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-gov-west-1": {
-    hostname: "xray.us-gov-west-1.amazonaws.com",
     variants: [
       {
         hostname: "xray.us-gov-west-1.amazonaws.com",
@@ -55,7 +51,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-west-1": {
-    hostname: "xray.us-west-1.amazonaws.com",
     variants: [
       {
         hostname: "xray.us-west-1.amazonaws.com",
@@ -68,7 +63,6 @@ const regionHash: RegionHash = {
     ],
   },
   "us-west-2": {
-    hostname: "xray.us-west-2.amazonaws.com",
     variants: [
       {
         hostname: "xray.us-west-2.amazonaws.com",
@@ -112,7 +106,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "xray.{region}.amazonaws.com",
     variants: [
       {
         hostname: "xray.{region}.amazonaws.com",
@@ -135,7 +128,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "xray.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "xray.{region}.amazonaws.com.cn",
@@ -158,7 +150,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "xray.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "xray.{region}.c2s.ic.gov",
@@ -169,7 +160,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "xray.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "xray.{region}.sc2s.sgov.gov",
@@ -180,7 +170,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["fips-us-gov-east-1", "fips-us-gov-west-1", "us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "xray.{region}.amazonaws.com",
     variants: [
       {
         hostname: "xray.{region}.amazonaws.com",

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/EndpointGenerator.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/EndpointGenerator.java
@@ -138,11 +138,7 @@ final class EndpointGenerator implements Runnable {
                         }
                     });
                     writer.write("regionRegex: $S,", partition.regionRegex);
-
-                    // TODO: Remove hostname after fully switching to variants.
-                    writer.write("hostname: $S,", partition.hostnameTemplate);
                     writer.write("variants: $L,", ArrayNode.prettyPrintJson(partition.getVariants()));
-
                     partition.getPartitionEndpoint().ifPresent(
                         endpoint -> writer.write("endpoint: $S,", endpoint));
                 });
@@ -171,10 +167,6 @@ final class EndpointGenerator implements Runnable {
 
     private void writeEndpointSpecificResolver(String region, ObjectNode resolved) {
         writer.openBlock("$S: {", "},", region, () -> {
-            // TODO: Remove hostname after fully switching to variants.
-            String hostname = resolved.expectStringMember("hostname").getValue();
-            writer.write("hostname: $S,", hostname);
-
             ArrayNode variants = resolved.expectArrayMember("variants");
             writer.write("variants: $L,", ArrayNode.prettyPrintJson(variants));
 

--- a/packages/config-resolver/src/regionInfo/PartitionHash.ts
+++ b/packages/config-resolver/src/regionInfo/PartitionHash.ts
@@ -9,8 +9,6 @@ export type PartitionHash = {
   [key: string]: {
     regions: string[];
     regionRegex: string;
-    // TODO: Remove hostname after fully switching to variants.
-    hostname: string;
     variants: EndpointVariant[];
     endpoint?: string;
   };

--- a/packages/config-resolver/src/regionInfo/RegionHash.ts
+++ b/packages/config-resolver/src/regionInfo/RegionHash.ts
@@ -6,8 +6,6 @@ import { EndpointVariant } from "./EndpointVariant";
  */
 export type RegionHash = {
   [key: string]: {
-    // TODO: Remove hostname after fully switching to variants.
-    hostname: string;
     variants: EndpointVariant[];
     signingService?: string;
     signingRegion?: string;

--- a/packages/config-resolver/src/regionInfo/getRegionInfo.spec.ts
+++ b/packages/config-resolver/src/regionInfo/getRegionInfo.spec.ts
@@ -30,13 +30,11 @@ describe(getRegionInfo.name, () => {
   const getMockRegionHash = (regionCase: RegionCase): RegionHash => ({
     ...((regionCase === RegionCase.REGION || regionCase === RegionCase.REGION_AND_ENDPOINT) && {
       [mockRegion]: {
-        hostname: mockHostname,
         variants: [{ hostname: mockHostname, tags: [] }],
       },
     }),
     ...((regionCase === RegionCase.ENDPOINT || regionCase === RegionCase.REGION_AND_ENDPOINT) && {
       [mockEndpointRegion]: {
-        hostname: mockEndpointHostname,
         variants: [{ hostname: mockEndpointHostname, tags: [] }],
       },
     }),
@@ -46,7 +44,6 @@ describe(getRegionInfo.name, () => {
     [mockPartition]: {
       regions: [mockRegion, `${mockRegion}2`, `${mockRegion}3`],
       regionRegex: mockRegionRegex,
-      hostname: mockHostname,
       variants: [{ hostname: mockHostname, tags: [] }],
       ...((regionCase === RegionCase.ENDPOINT || regionCase === RegionCase.REGION_AND_ENDPOINT) && {
         endpoint: mockEndpointRegion,

--- a/packages/config-resolver/src/regionInfo/getResolvedPartition.spec.ts
+++ b/packages/config-resolver/src/regionInfo/getResolvedPartition.spec.ts
@@ -12,7 +12,6 @@ describe(getResolvedPartition.name, () => {
       [mockPartition]: {
         regions: [mockRegion, `${mockRegion}2`, `${mockRegion}3`],
         regionRegex: mockRegionRegex,
-        hostname: mockHostname,
         variants: [{ hostname: mockHostname, tags: [] }],
       },
     };
@@ -24,7 +23,6 @@ describe(getResolvedPartition.name, () => {
       [`${mockPartition}2`]: {
         regions: [`${mockRegion}2`, `${mockRegion}3`],
         regionRegex: mockRegionRegex,
-        hostname: mockHostname,
         variants: [{ hostname: mockHostname, tags: [] }],
       },
     };

--- a/private/aws-protocoltests-ec2/src/endpoints.ts
+++ b/private/aws-protocoltests-ec2/src/endpoints.ts
@@ -29,7 +29,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "awsec2.{region}.amazonaws.com",
     variants: [
       {
         hostname: "awsec2.{region}.amazonaws.com",
@@ -52,7 +51,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "awsec2.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "awsec2.{region}.amazonaws.com.cn",
@@ -75,7 +73,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "awsec2.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "awsec2.{region}.c2s.ic.gov",
@@ -86,7 +83,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "awsec2.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "awsec2.{region}.sc2s.sgov.gov",
@@ -97,7 +93,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "awsec2.{region}.amazonaws.com",
     variants: [
       {
         hostname: "awsec2.{region}.amazonaws.com",

--- a/private/aws-protocoltests-json-10/src/endpoints.ts
+++ b/private/aws-protocoltests-json-10/src/endpoints.ts
@@ -29,7 +29,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "jsonrpc10.{region}.amazonaws.com",
     variants: [
       {
         hostname: "jsonrpc10.{region}.amazonaws.com",
@@ -52,7 +51,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "jsonrpc10.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "jsonrpc10.{region}.amazonaws.com.cn",
@@ -75,7 +73,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "jsonrpc10.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "jsonrpc10.{region}.c2s.ic.gov",
@@ -86,7 +83,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "jsonrpc10.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "jsonrpc10.{region}.sc2s.sgov.gov",
@@ -97,7 +93,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "jsonrpc10.{region}.amazonaws.com",
     variants: [
       {
         hostname: "jsonrpc10.{region}.amazonaws.com",

--- a/private/aws-protocoltests-json/src/endpoints.ts
+++ b/private/aws-protocoltests-json/src/endpoints.ts
@@ -29,7 +29,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "jsonprotocol.{region}.amazonaws.com",
     variants: [
       {
         hostname: "jsonprotocol.{region}.amazonaws.com",
@@ -52,7 +51,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "jsonprotocol.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "jsonprotocol.{region}.amazonaws.com.cn",
@@ -75,7 +73,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "jsonprotocol.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "jsonprotocol.{region}.c2s.ic.gov",
@@ -86,7 +83,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "jsonprotocol.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "jsonprotocol.{region}.sc2s.sgov.gov",
@@ -97,7 +93,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "jsonprotocol.{region}.amazonaws.com",
     variants: [
       {
         hostname: "jsonprotocol.{region}.amazonaws.com",

--- a/private/aws-protocoltests-query/src/endpoints.ts
+++ b/private/aws-protocoltests-query/src/endpoints.ts
@@ -29,7 +29,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "awsquery.{region}.amazonaws.com",
     variants: [
       {
         hostname: "awsquery.{region}.amazonaws.com",
@@ -52,7 +51,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "awsquery.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "awsquery.{region}.amazonaws.com.cn",
@@ -75,7 +73,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "awsquery.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "awsquery.{region}.c2s.ic.gov",
@@ -86,7 +83,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "awsquery.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "awsquery.{region}.sc2s.sgov.gov",
@@ -97,7 +93,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "awsquery.{region}.amazonaws.com",
     variants: [
       {
         hostname: "awsquery.{region}.amazonaws.com",

--- a/private/aws-protocoltests-restjson/src/endpoints.ts
+++ b/private/aws-protocoltests-restjson/src/endpoints.ts
@@ -29,7 +29,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "restjson.{region}.amazonaws.com",
     variants: [
       {
         hostname: "restjson.{region}.amazonaws.com",
@@ -52,7 +51,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "restjson.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "restjson.{region}.amazonaws.com.cn",
@@ -75,7 +73,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "restjson.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "restjson.{region}.c2s.ic.gov",
@@ -86,7 +83,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "restjson.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "restjson.{region}.sc2s.sgov.gov",
@@ -97,7 +93,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "restjson.{region}.amazonaws.com",
     variants: [
       {
         hostname: "restjson.{region}.amazonaws.com",

--- a/private/aws-protocoltests-restxml/src/endpoints.ts
+++ b/private/aws-protocoltests-restxml/src/endpoints.ts
@@ -29,7 +29,6 @@ const partitionHash: PartitionHash = {
       "us-west-2",
     ],
     regionRegex: "^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$",
-    hostname: "restxml.{region}.amazonaws.com",
     variants: [
       {
         hostname: "restxml.{region}.amazonaws.com",
@@ -52,7 +51,6 @@ const partitionHash: PartitionHash = {
   "aws-cn": {
     regions: ["cn-north-1", "cn-northwest-1"],
     regionRegex: "^cn\\-\\w+\\-\\d+$",
-    hostname: "restxml.{region}.amazonaws.com.cn",
     variants: [
       {
         hostname: "restxml.{region}.amazonaws.com.cn",
@@ -75,7 +73,6 @@ const partitionHash: PartitionHash = {
   "aws-iso": {
     regions: ["us-iso-east-1", "us-iso-west-1"],
     regionRegex: "^us\\-iso\\-\\w+\\-\\d+$",
-    hostname: "restxml.{region}.c2s.ic.gov",
     variants: [
       {
         hostname: "restxml.{region}.c2s.ic.gov",
@@ -86,7 +83,6 @@ const partitionHash: PartitionHash = {
   "aws-iso-b": {
     regions: ["us-isob-east-1"],
     regionRegex: "^us\\-isob\\-\\w+\\-\\d+$",
-    hostname: "restxml.{region}.sc2s.sgov.gov",
     variants: [
       {
         hostname: "restxml.{region}.sc2s.sgov.gov",
@@ -97,7 +93,6 @@ const partitionHash: PartitionHash = {
   "aws-us-gov": {
     regions: ["us-gov-east-1", "us-gov-west-1"],
     regionRegex: "^us\\-gov\\-\\w+\\-\\d+$",
-    hostname: "restxml.{region}.amazonaws.com",
     variants: [
       {
         hostname: "restxml.{region}.amazonaws.com",


### PR DESCRIPTION
### Issue
Follow-up to https://github.com/aws/aws-sdk-js-v3/pull/2989

### Description
Removes hostname key from hashes as the value is populated as a default variant:
* Variants were populated in https://github.com/aws/aws-sdk-js-v3/pull/2974
* Hostname was resolved from variants in https://github.com/aws/aws-sdk-js-v3/pull/2980

### Testing
Functional testing

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
