### PR TITLE
fix(middleware-bucket-endpoint): remove dualstack from hostname before processing

### DIFF
--- a/packages/middleware-bucket-endpoint/src/bucketHostname.spec.ts
+++ b/packages/middleware-bucket-endpoint/src/bucketHostname.spec.ts
@@ -6,6 +6,7 @@ describe("bucketHostname", () => {
   const region = "us-west-2";
   describe("from bucket name", () => {
     [
+      { baseHostname: "s3.dualstack.us-west-2.amazonaws.com", isCustomEndpoint: false, dualstackEndpoint: true },
       { baseHostname: "s3.us-west-2.amazonaws.com", isCustomEndpoint: false },
       { baseHostname: "beta.example.com", isCustomEndpoint: true },
     ].forEach(({ baseHostname, isCustomEndpoint }) => {

--- a/packages/middleware-bucket-endpoint/src/bucketHostname.spec.ts
+++ b/packages/middleware-bucket-endpoint/src/bucketHostname.spec.ts
@@ -188,20 +188,24 @@ describe("bucketHostname", () => {
 
   describe("from Access Point ARN", () => {
     describe("populates access point endpoint from ARN", () => {
-      const s3Hostname = "s3.us-west-2.amazonaws.com";
       const customHostname = "example.com";
 
-      describe(`baseHostname: ${s3Hostname}`, () => {
-        const baseHostname = s3Hostname;
+      describe.each([
+        ["s3.us-west-2.amazonaws.com", false],
+        ["s3.dualstack.us-west-2.amazonaws.com", true],
+      ])(`baseHostname: %s, dualstackEndpoint: %s`, (baseHostname, dualstackEndpoint) => {
         it("should use client region", () => {
           const { bucketEndpoint, hostname } = bucketHostname({
             bucketName: parseArn("arn:aws:s3:us-west-2:123456789012:accesspoint:myendpoint"),
             baseHostname,
             isCustomEndpoint: false,
             clientRegion: region,
+            dualstackEndpoint,
           });
           expect(bucketEndpoint).toBe(true);
-          expect(hostname).toBe("myendpoint-123456789012.s3-accesspoint.us-west-2.amazonaws.com");
+          expect(hostname).toBe(
+            `myendpoint-123456789012.s3-accesspoint${dualstackEndpoint ? ".dualstack" : ""}.us-west-2.amazonaws.com`
+          );
         });
 
         it("should use ARN region", () => {
@@ -211,9 +215,12 @@ describe("bucketHostname", () => {
             isCustomEndpoint: false,
             clientRegion: region,
             useArnRegion: true,
+            dualstackEndpoint,
           });
           expect(bucketEndpoint).toBe(true);
-          expect(hostname).toBe("myendpoint-123456789012.s3-accesspoint.us-east-1.amazonaws.com");
+          expect(hostname).toBe(
+            `myendpoint-123456789012.s3-accesspoint${dualstackEndpoint ? ".dualstack" : ""}.us-east-1.amazonaws.com`
+          );
         });
       });
 

--- a/packages/middleware-bucket-endpoint/src/bucketHostname.ts
+++ b/packages/middleware-bucket-endpoint/src/bucketHostname.ts
@@ -51,6 +51,7 @@ const getEndpointFromBucketName = ({
   tlsCompatible = true,
   isCustomEndpoint = false,
 }: BucketHostnameParams): BucketHostname => {
+  // TODO: Remove checks for ".dualstack" from entire middleware.
   const suffixHostname = dualstackEndpoint ? baseHostname.replace(".dualstack", "") : baseHostname;
   const [clientRegion, hostnameSuffix] = isCustomEndpoint ? [region, baseHostname] : getSuffix(suffixHostname);
   if (pathStyleEndpoint || !isDnsCompatibleBucketName(bucketName) || (tlsCompatible && DOT_PATTERN.test(bucketName))) {

--- a/packages/middleware-bucket-endpoint/src/bucketHostname.ts
+++ b/packages/middleware-bucket-endpoint/src/bucketHostname.ts
@@ -51,7 +51,8 @@ const getEndpointFromBucketName = ({
   tlsCompatible = true,
   isCustomEndpoint = false,
 }: BucketHostnameParams): BucketHostname => {
-  const [clientRegion, hostnameSuffix] = isCustomEndpoint ? [region, baseHostname] : getSuffix(baseHostname);
+  const suffixHostname = dualstackEndpoint ? baseHostname.replace(".dualstack", "") : baseHostname;
+  const [clientRegion, hostnameSuffix] = isCustomEndpoint ? [region, baseHostname] : getSuffix(suffixHostname);
   if (pathStyleEndpoint || !isDnsCompatibleBucketName(bucketName) || (tlsCompatible && DOT_PATTERN.test(bucketName))) {
     return {
       bucketEndpoint: false,

--- a/packages/middleware-bucket-endpoint/src/bucketHostname.ts
+++ b/packages/middleware-bucket-endpoint/src/bucketHostname.ts
@@ -33,11 +33,16 @@ export interface BucketHostname {
 
 export const bucketHostname = (options: BucketHostnameParams | ArnHostnameParams): BucketHostname => {
   validateCustomEndpoint(options);
+
+  // TODO: Remove checks for ".dualstack" from entire middleware.
+  const { dualstackEndpoint, baseHostname } = options;
+  const updatedBaseHostname = dualstackEndpoint ? baseHostname.replace(".dualstack", "") : baseHostname;
+
   return isBucketNameOptions(options)
     ? // Construct endpoint when bucketName is a string referring to a bucket name
-      getEndpointFromBucketName(options)
+      getEndpointFromBucketName({ ...options, baseHostname: updatedBaseHostname })
     : // Construct endpoint when bucketName is an ARN referring to an S3 resource like Access Point
-      getEndpointFromArn(options);
+      getEndpointFromArn({ ...options, baseHostname: updatedBaseHostname });
 };
 
 const getEndpointFromBucketName = ({
@@ -51,9 +56,7 @@ const getEndpointFromBucketName = ({
   tlsCompatible = true,
   isCustomEndpoint = false,
 }: BucketHostnameParams): BucketHostname => {
-  // TODO: Remove checks for ".dualstack" from entire middleware.
-  const suffixHostname = dualstackEndpoint ? baseHostname.replace(".dualstack", "") : baseHostname;
-  const [clientRegion, hostnameSuffix] = isCustomEndpoint ? [region, baseHostname] : getSuffix(suffixHostname);
+  const [clientRegion, hostnameSuffix] = isCustomEndpoint ? [region, baseHostname] : getSuffix(baseHostname);
   if (pathStyleEndpoint || !isDnsCompatibleBucketName(bucketName) || (tlsCompatible && DOT_PATTERN.test(bucketName))) {
     return {
       bucketEndpoint: false,


### PR DESCRIPTION
### Issue
Fixes https://github.com/aws/aws-sdk-js-v3/issues/3001
Fixes https://github.com/aws/aws-sdk-js-v3/issues/3002

### Description
Removes dualstack from hostname before processing

### Testing
* Unit testing
* Manual testing with repro code given in:
  * #3001 
  * #3002

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
