### PR TITLE
chore(middleware-bucket-endpoint): include fips/dualstack checks in s3 hostname pattern

### DIFF
--- a/packages/middleware-bucket-endpoint/src/bucketHostname.ts
+++ b/packages/middleware-bucket-endpoint/src/bucketHostname.ts
@@ -33,16 +33,11 @@ export interface BucketHostname {
 
 export const bucketHostname = (options: BucketHostnameParams | ArnHostnameParams): BucketHostname => {
   validateCustomEndpoint(options);
-
-  // TODO: Remove checks for ".dualstack" from entire middleware.
-  const { dualstackEndpoint, baseHostname } = options;
-  const updatedBaseHostname = dualstackEndpoint ? baseHostname.replace(".dualstack", "") : baseHostname;
-
   return isBucketNameOptions(options)
     ? // Construct endpoint when bucketName is a string referring to a bucket name
-      getEndpointFromBucketName({ ...options, baseHostname: updatedBaseHostname })
+      getEndpointFromBucketName(options)
     : // Construct endpoint when bucketName is an ARN referring to an S3 resource like Access Point
-      getEndpointFromArn({ ...options, baseHostname: updatedBaseHostname });
+      getEndpointFromArn(options);
 };
 
 const getEndpointFromBucketName = ({

--- a/packages/middleware-bucket-endpoint/src/bucketHostnameUtils.ts
+++ b/packages/middleware-bucket-endpoint/src/bucketHostnameUtils.ts
@@ -4,7 +4,7 @@ const DOMAIN_PATTERN = /^[a-z0-9][a-z0-9\.\-]{1,61}[a-z0-9]$/;
 const IP_ADDRESS_PATTERN = /(\d+\.){3}\d+/;
 const DOTS_PATTERN = /\.\./;
 export const DOT_PATTERN = /\./;
-export const S3_HOSTNAME_PATTERN = /^(.+\.)?s3[.-]([a-z0-9-]+)\./;
+export const S3_HOSTNAME_PATTERN = /^(.+\.)?s3(-fips)?(\.dualstack)?[.-]([a-z0-9-]+)\./;
 const S3_US_EAST_1_ALTNAME_PATTERN = /^s3(-external-1)?\.amazonaws\.com$/;
 const AWS_PARTITION_SUFFIX = "amazonaws.com";
 
@@ -49,7 +49,7 @@ export const isDnsCompatibleBucketName = (bucketName: string): boolean =>
 
 const getRegionalSuffix = (hostname: string): [string, string] => {
   const parts = hostname.match(S3_HOSTNAME_PATTERN)!;
-  return [parts[2], hostname.replace(new RegExp(`^${parts[0]}`), "")];
+  return [parts[4], hostname.replace(new RegExp(`^${parts[0]}`), "")];
 };
 
 export const getSuffix = (hostname: string): [string, string] =>


### PR DESCRIPTION
### Issue
Follow-up to https://github.com/aws/aws-sdk-js-v3/pull/3003

### Description
Adds check for fips/dualstack in s3 hostname pattern, so that additional modification is not required elsewhere.

### Testing
* Unit testing
* Manual testing with repro code given in:
  * #3001 
  * #3002

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
