### PR TITLE
fix(credential-provider-web-identity): exclude node.js files for web

### DIFF
--- a/packages/credential-provider-web-identity/package.json
+++ b/packages/credential-provider-web-identity/package.json
@@ -12,6 +12,14 @@
     "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
     "test": "jest"
   },
+  "browser": {
+    "./dist-es/fromTokenFile": false,
+    "./dist-cjs/fromTokenFile": false
+  },
+  "react-native": {
+    "./dist-es/fromTokenFile": false,
+    "./dist-cjs/fromTokenFile": false
+  },
   "keywords": [
     "aws",
     "credentials"


### PR DESCRIPTION
### Description
Found as part of bundler test: https://github.com/AllanZhengYP/aws-sdk-js-v3/pull/195
The Web Identity Credential Provider contains both Node.js-specific module and browser-specific module. It causes the bundlers like Webpack to fail with `cannot resolve 'fs' module`. This change exclude the files that requires node.js specific module. 

### Testing
Tested with bundler test.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
