### PR TITLE
fix(credential-providers): exclude node.js files for web

### DIFF
--- a/packages/credential-providers/package.json
+++ b/packages/credential-providers/package.json
@@ -4,22 +4,8 @@
   "description": "A collection of credential providers, without requiring service clients like STS, Cognito",
   "main": "./dist-cjs/index.js",
   "module": "./dist-es/index.js",
-  "browser": {
-    "./fromContainerMetadata": false,
-    "./fromEnv": false,
-    "./fromInstanceMetadata": false,
-    "./fromProcess": false,
-    "./fromSSO": false,
-    "./fromIni": false
-  },
-  "react-native": {
-    "./fromContainerMetadata": false,
-    "./fromEnv": false,
-    "./fromInstanceMetadata": false,
-    "./fromProcess": false,
-    "./fromSSO": false,
-    "./fromIni": false
-  },
+  "browser": "./dist-es/index.web.js",
+  "react-native": "./dist-es/index.web.js",
   "sideEffects": false,
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",

--- a/packages/credential-providers/package.json
+++ b/packages/credential-providers/package.json
@@ -7,16 +7,16 @@
   "browser": {
     "@aws-sdk/credential-provider-env": false,
     "@aws-sdk/credential-provider-imds": false,
-    "./fromIni": false,
     "@aws-sdk/credential-provider-process": false,
-    "./fromTokenFile": false
+    "@aws-sdk/credential-provider-sso": false,
+    "@aws-sdk/credential-provider-ini": false
   },
   "react-native": {
     "@aws-sdk/credential-provider-env": false,
     "@aws-sdk/credential-provider-imds": false,
-    "./fromIni": false,
     "@aws-sdk/credential-provider-process": false,
-    "./fromTokenFile": false
+    "@aws-sdk/credential-provider-sso": false,
+    "@aws-sdk/credential-provider-ini": false
   },
   "sideEffects": false,
   "scripts": {

--- a/packages/credential-providers/package.json
+++ b/packages/credential-providers/package.json
@@ -5,18 +5,20 @@
   "main": "./dist-cjs/index.js",
   "module": "./dist-es/index.js",
   "browser": {
-    "@aws-sdk/credential-provider-env": false,
-    "@aws-sdk/credential-provider-imds": false,
-    "@aws-sdk/credential-provider-process": false,
-    "@aws-sdk/credential-provider-sso": false,
-    "@aws-sdk/credential-provider-ini": false
+    "./fromContainerMetadata": false,
+    "./fromEnv": false,
+    "./fromInstanceMetadata": false,
+    "./fromProcess": false,
+    "./fromSSO": false,
+    "./fromIni": false
   },
   "react-native": {
-    "@aws-sdk/credential-provider-env": false,
-    "@aws-sdk/credential-provider-imds": false,
-    "@aws-sdk/credential-provider-process": false,
-    "@aws-sdk/credential-provider-sso": false,
-    "@aws-sdk/credential-provider-ini": false
+    "./fromContainerMetadata": false,
+    "./fromEnv": false,
+    "./fromInstanceMetadata": false,
+    "./fromProcess": false,
+    "./fromSSO": false,
+    "./fromIni": false
   },
   "sideEffects": false,
   "scripts": {

--- a/packages/credential-providers/src/index.web.ts
+++ b/packages/credential-providers/src/index.web.ts
@@ -1,0 +1,4 @@
+export * from "./fromCognitoIdentity";
+export * from "./fromCognitoIdentityPool";
+export * from "./fromTemporaryCredentials";
+export * from "./fromWebToken";


### PR DESCRIPTION
### Description
Follow up to https://github.com/aws/aws-sdk-js-v3/pull/3005. Correctly exclude node.js specific modules.


Related: https://github.com/AllanZhengYP/aws-sdk-js-v3/pull/195

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
