### PR TITLE
chore: add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @aws/aws-sdk-js-team


### PR DESCRIPTION
### Issue
Refs: https://github.com/aws/aws-sdk-js/pull/3946

### Description
Add CODEOWNERS with @aws/aws-sdk-js-team as the owner.

### Testing
N/A

### Additional context
GitHub docs for code owners: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
