### PR TITLE
fix(polly-request-presigner): add missing polly dependency

### DIFF
--- a/packages/polly-request-presigner/package.json
+++ b/packages/polly-request-presigner/package.json
@@ -19,6 +19,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@aws-sdk/protocol-http": "3.40.0",
+    "@aws-sdk/client-polly": "3.40.0",
     "@aws-sdk/signature-v4": "3.40.0",
     "@aws-sdk/types": "3.40.0",
     "@aws-sdk/util-create-request": "3.40.0",
@@ -26,7 +27,6 @@
     "tslib": "^2.3.0"
   },
   "devDependencies": {
-    "@aws-sdk/client-polly": "3.40.0",
     "@aws-sdk/hash-node": "3.40.0",
     "@types/jest": "^26.0.4",
     "@types/node": "^12.0.2",

--- a/packages/polly-request-presigner/src/getSynthesizeSpeechUrl.ts
+++ b/packages/polly-request-presigner/src/getSynthesizeSpeechUrl.ts
@@ -1,4 +1,4 @@
-import { Polly, PollyClient, SynthesizeSpeechCommand, SynthesizeSpeechInput } from "@aws-sdk/client-polly";
+import { PollyClient, SynthesizeSpeechCommand, SynthesizeSpeechInput } from "@aws-sdk/client-polly";
 
 import { getSignedUrl } from "./getSignedUrls";
 


### PR DESCRIPTION
### Issue
Related: AllanZhengYP#195
`@aws-sdk/client-polly` was not included in in the production dependency. This will cause the failure with bundlers.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
