### PR TITLE
fix(codegen): use specific Smithy version

### DIFF
--- a/codegen/build.gradle.kts
+++ b/codegen/build.gradle.kts
@@ -31,6 +31,8 @@ allprojects {
     version = "0.7.0"
 }
 
+extra["smithyVersion"] = "[1.12.0,1.13.0["
+
 // The root project doesn't produce a JAR.
 tasks["jar"].enabled = false
 

--- a/codegen/generic-client-test-codegen/build.gradle.kts
+++ b/codegen/generic-client-test-codegen/build.gradle.kts
@@ -15,12 +15,21 @@
 
 import software.amazon.smithy.gradle.tasks.SmithyBuild
 
+buildscript {
+    repositories {
+        mavenCentral()
+    }
+    dependencies {
+        "classpath"("software.amazon.smithy:smithy-cli:${rootProject.extra["smithyVersion"]}")
+    }
+}
+
 plugins {
     id("software.amazon.smithy") version "0.5.3"
 }
 
 dependencies {
-    implementation("software.amazon.smithy:smithy-aws-protocol-tests:[1.12.0, 1.13.0[")
+    implementation("software.amazon.smithy:smithy-aws-protocol-tests:${rootProject.extra["smithyVersion"]}")
     implementation(project(":smithy-aws-typescript-codegen"))
 }
 

--- a/codegen/protocol-test-codegen/build.gradle.kts
+++ b/codegen/protocol-test-codegen/build.gradle.kts
@@ -15,12 +15,21 @@
 
 import software.amazon.smithy.gradle.tasks.SmithyBuild
 
+buildscript {
+    repositories {
+        mavenCentral()
+    }
+    dependencies {
+        "classpath"("software.amazon.smithy:smithy-cli:1.12.+")
+    }
+}
+
 plugins {
     id("software.amazon.smithy") version "0.5.3"
 }
 
 dependencies {
-    implementation("software.amazon.smithy:smithy-aws-protocol-tests:[1.12.0, 1.13.0[")
+    implementation("software.amazon.smithy:smithy-aws-protocol-tests:${rootProject.extra["smithyVersion"]}")
     implementation(project(":smithy-aws-typescript-codegen"))
 }
 

--- a/codegen/sdk-codegen/build.gradle.kts
+++ b/codegen/sdk-codegen/build.gradle.kts
@@ -25,7 +25,8 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        "classpath"("software.amazon.smithy:smithy-aws-traits:[1.12.0,1.13.0[")
+        "classpath"("software.amazon.smithy:smithy-cli:${rootProject.extra["smithyVersion"]}")
+        "classpath"("software.amazon.smithy:smithy-aws-traits:${rootProject.extra["smithyVersion"]}")
     }
 }
 

--- a/codegen/smithy-aws-typescript-codegen/build.gradle.kts
+++ b/codegen/smithy-aws-typescript-codegen/build.gradle.kts
@@ -25,16 +25,17 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath("software.amazon.smithy:smithy-model:[1.12.0, 1.13.0[")
+        classpath("software.amazon.smithy:smithy-model:${rootProject.extra["smithyVersion"]}")
     }
 }
 
 dependencies {
-    api("software.amazon.smithy:smithy-aws-cloudformation-traits:[1.12.0, 1.13.0[")
-    api("software.amazon.smithy:smithy-aws-traits:[1.12.0, 1.13.0[")
-    api("software.amazon.smithy:smithy-waiters:[1.12.0, 1.13.0[")
-    api("software.amazon.smithy:smithy-aws-iam-traits:[1.12.0, 1.13.0[")
-    api("software.amazon.smithy:smithy-protocol-test-traits:[1.12.0, 1.13.0[")
+    api("software.amazon.smithy:smithy-aws-cloudformation-traits:${rootProject.extra["smithyVersion"]}")
+    api("software.amazon.smithy:smithy-aws-traits:${rootProject.extra["smithyVersion"]}")
+    api("software.amazon.smithy:smithy-waiters:${rootProject.extra["smithyVersion"]}")
+    api("software.amazon.smithy:smithy-aws-iam-traits:${rootProject.extra["smithyVersion"]}")
+    api("software.amazon.smithy:smithy-protocol-test-traits:${rootProject.extra["smithyVersion"]}")
+    api("software.amazon.smithy:smithy-model:${rootProject.extra["smithyVersion"]}")
     api("software.amazon.smithy.typescript:smithy-typescript-codegen:0.7.0")
 }
 


### PR DESCRIPTION
### Description
This centralizes the Smithy version in the root Gradle file for ease of use,
and locks the CLI to the same Smithy version as the Smithy dependencies.

### Testing
Built locally in combination with https://github.com/awslabs/smithy-typescript/pull/465

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
