### PR TITLE
test(integration): disable Rescue SES InvalidParameterValue test

### DIFF
--- a/features/ses/ses.feature
+++ b/features/ses/ses.feature
@@ -13,8 +13,9 @@ Feature: SES
     When I ask to verify the email address "foo@example.com"
     Then the status code should be 200
 
-  Scenario: Rescue SES InvalidParameterValue
-    When I ask to verify the email address "abc123"
-    Then I should get the error:
-    | name                  | message                        |
-    | InvalidParameterValue | Invalid email address<abc123>. |
+  # Uncomment when P55107118 is resolved
+  # Scenario: Rescue SES InvalidParameterValue
+  #   When I ask to verify the email address "abc123"
+  #   Then I should get the error:
+  #   | name                  | message                        |
+  #   | InvalidParameterValue | Invalid email address<abc123>. |


### PR DESCRIPTION
### Issue
Refs: https://github.com/aws/aws-sdk-js/pull/3956

### Description
Disables Rescue SES InvalidParameterValue test

### Testing
Integration tests are successful.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
