### PR TITLE
test(integration): enable Rescue SES InvalidParameterValue test

### DIFF
--- a/features/ses/ses.feature
+++ b/features/ses/ses.feature
@@ -13,9 +13,8 @@ Feature: SES
     When I ask to verify the email address "foo@example.com"
     Then the status code should be 200
 
-  # Uncomment when P55107118 is resolved
-  # Scenario: Rescue SES InvalidParameterValue
-  #   When I ask to verify the email address "abc123"
-  #   Then I should get the error:
-  #   | name                  | message                        |
-  #   | InvalidParameterValue | Invalid email address<abc123>. |
+  Scenario: Rescue SES InvalidParameterValue
+    When I ask to verify the email address "abc123"
+    Then I should get the error:
+    | name                  | message                        |
+    | InvalidParameterValue | Invalid email address<abc123>. |


### PR DESCRIPTION
### Issue
Reverts https://github.com/aws/aws-sdk-js-v3/pull/3013

### Description
Enable Rescue SES InvalidParameterValue test, as the error message is corrected by the service.

### Testing

<details>
<summary>Integration test run</summary>

```console
$ yarn test:integration:legacy -t @ses
yarn run v1.22.17
$ cucumber-js --fail-fast -t @ses
.............

3 scenarios (3 passed)
7 steps (7 passed)
```

</details>

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
