### PR TITLE
fix(middleware-sdk-ec2): remove double encoding of presigned url

### DIFF
--- a/packages/middleware-sdk-ec2/package.json
+++ b/packages/middleware-sdk-ec2/package.json
@@ -22,7 +22,6 @@
     "@aws-sdk/signature-v4": "3.40.0",
     "@aws-sdk/types": "3.40.0",
     "@aws-sdk/util-format-url": "3.40.0",
-    "@aws-sdk/util-uri-escape": "3.37.0",
     "tslib": "^2.3.0"
   },
   "devDependencies": {

--- a/packages/middleware-sdk-ec2/src/index.spec.ts
+++ b/packages/middleware-sdk-ec2/src/index.spec.ts
@@ -27,19 +27,19 @@ describe("middleware-sdk-ec2", () => {
     expect(middlewareOutput.input.SourceSnapshotId).toEqual(params.SourceSnapshotId);
     expect(middlewareOutput.input.DestinationRegion).toEqual(await region());
     const presignedUrl = middlewareOutput.input.PresignedUrl;
-    expect(presignedUrl).toMatch(/https%3A%2F%2Fec2.src-region.amazonaws.com%2F%3F/);
-    expect(presignedUrl).toMatch(/Action%3DCopySnapshot/);
-    expect(presignedUrl).toMatch(/Version%3D2016\-11\-15/);
+    expect(presignedUrl).toMatch(/https\:\/\/ec2.src-region.amazonaws.com\/\?/);
+    expect(presignedUrl).toMatch(/Action\=CopySnapshot/);
+    expect(presignedUrl).toMatch(/Version\=2016\-11\-15/);
     expect(presignedUrl).toMatch(
-      /DestinationRegion%3Dmock\-region%26SourceRegion%3Dsrc\-region%26SourceSnapshotId%3Dsnap\-123456789/
+      /DestinationRegion\=mock\-region\&SourceRegion\=src\-region\&SourceSnapshotId\=snap\-123456789/
     );
-    expect(presignedUrl).toMatch(/X\-Amz\-Security\-Token%3Dsession/);
-    expect(presignedUrl).toMatch(/X\-Amz\-Algorithm%3DAWS4\-HMAC\-SHA256/);
-    expect(presignedUrl).toMatch(/X\-Amz\-SignedHeaders%3Dhost/);
-    expect(presignedUrl).toMatch(/X\-Amz\-Credential%3D/);
-    expect(presignedUrl).toMatch(/X\-Amz\-Date%3D/);
-    expect(presignedUrl).toMatch(/X-Amz-Expires%3D([\d]+)/);
-    expect(presignedUrl).toMatch(/X-Amz-Signature%3D000000/);
+    expect(presignedUrl).toMatch(/X\-Amz\-Security\-Token\=session/);
+    expect(presignedUrl).toMatch(/X\-Amz\-Algorithm\=AWS4\-HMAC\-SHA256/);
+    expect(presignedUrl).toMatch(/X\-Amz\-SignedHeaders\=host/);
+    expect(presignedUrl).toMatch(/X\-Amz\-Credential\=/);
+    expect(presignedUrl).toMatch(/X\-Amz\-Date\=/);
+    expect(presignedUrl).toMatch(/X-Amz-Expires\=([\d]+)/);
+    expect(presignedUrl).toMatch(/X-Amz-Signature\=000000/);
   });
 
   it("does not modify input if PresignedUrl has already  been set", async () => {

--- a/packages/middleware-sdk-ec2/src/index.ts
+++ b/packages/middleware-sdk-ec2/src/index.ts
@@ -14,7 +14,6 @@ import {
   Provider,
 } from "@aws-sdk/types";
 import { formatUrl } from "@aws-sdk/util-format-url";
-import { escapeUri } from "@aws-sdk/util-uri-escape";
 
 interface PreviouslyResolved {
   credentials: Provider<Credentials>;
@@ -65,7 +64,7 @@ export function copySnapshotPresignedUrlMiddleware(options: PreviouslyResolved):
           input: {
             ...args.input,
             DestinationRegion: region,
-            PresignedUrl: escapeUri(formatUrl(presignedRequest)),
+            PresignedUrl: formatUrl(presignedRequest),
           },
         };
       }


### PR DESCRIPTION
### Issue
Fixes: https://github.com/aws/aws-sdk-js-v3/issues/3021
Similar to https://github.com/aws/aws-sdk-js-v3/pull/2711

### Description
Remove double encoding of presigned url

### Testing
* CI
* Verified while debugging https://github.com/aws/aws-sdk-js-v3/issues/3021#issuecomment-967561714

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
