### PR TITLE
fix(middleware-sdk-s3-control): do not validate for FIPS in S3 Outposts

### DIFF
--- a/packages/middleware-sdk-s3-control/src/process-arnables-plugin/getOutpostEndpoint.spec.ts
+++ b/packages/middleware-sdk-s3-control/src/process-arnables-plugin/getOutpostEndpoint.spec.ts
@@ -1,31 +1,38 @@
 import { getOutpostEndpoint } from "./getOutpostEndpoint";
 
 describe(getOutpostEndpoint.name, () => {
-  const mockRegion = "region";
-  const mockDnsSuffix = "mockDnsSuffix";
-  const mockHostname = `s3-control.${mockRegion}.${mockDnsSuffix}`;
   const mockInput = { isCustomEndpoint: false, useFipsEndpoint: false };
-
   it("returns hostname if custom endpoint is set", () => {
+    const mockHostname = "mock.hostname.com";
     expect(getOutpostEndpoint(mockHostname, { ...mockInput, isCustomEndpoint: true })).toStrictEqual(mockHostname);
   });
 
   describe("returns outpost endpoint", () => {
-    it("uses region from hostname if regionOverride if provided", () => {
-      expect(getOutpostEndpoint(mockHostname, mockInput)).toStrictEqual(`s3-outposts.${mockRegion}.${mockDnsSuffix}`);
+    const mockRegion = "region";
+    const mockDnsSuffix = "mockDnsSuffix";
+
+    const testOutpostEndpoint = (useFipsEndpoint: boolean) => {
+      const mockHostname = `s3-control${useFipsEndpoint ? "-fips" : ""}.${mockRegion}.${mockDnsSuffix}`;
+      it("uses region from hostname if regionOverride if provided", () => {
+        expect(getOutpostEndpoint(mockHostname, { ...mockInput, useFipsEndpoint })).toStrictEqual(
+          `s3-outposts${useFipsEndpoint ? "-fips" : ""}.${mockRegion}.${mockDnsSuffix}`
+        );
+      });
+
+      it("uses region from regionOverride if provided", () => {
+        const mockRegionOverride = "mockRegionOverride";
+        expect(
+          getOutpostEndpoint(mockHostname, { ...mockInput, useFipsEndpoint, regionOverride: mockRegionOverride })
+        ).toStrictEqual(`s3-outposts${useFipsEndpoint ? "-fips" : ""}.${mockRegionOverride}.${mockDnsSuffix}`);
+      });
+    };
+
+    describe("with FIPS", () => {
+      testOutpostEndpoint(true);
     });
 
-    it("uses region from regionOverride if provided", () => {
-      const mockRegionOverride = "mockRegionOverride";
-      expect(getOutpostEndpoint(mockHostname, { ...mockInput, regionOverride: mockRegionOverride })).toStrictEqual(
-        `s3-outposts.${mockRegionOverride}.${mockDnsSuffix}`
-      );
-    });
-
-    it(`adds suffix "-fips" if useFipsEndpoint is set`, () => {
-      expect(getOutpostEndpoint(mockHostname, { ...mockInput, useFipsEndpoint: true })).toStrictEqual(
-        `s3-outposts-fips.${mockRegion}.${mockDnsSuffix}`
-      );
+    describe("without FIPS", () => {
+      testOutpostEndpoint(false);
     });
   });
 });

--- a/packages/middleware-sdk-s3-control/src/process-arnables-plugin/getOutpostEndpoint.ts
+++ b/packages/middleware-sdk-s3-control/src/process-arnables-plugin/getOutpostEndpoint.ts
@@ -1,4 +1,4 @@
-const REGEX_S3CONTROL_HOSTNAME = /^(.+\.)?s3-control[.-]([a-z0-9-]+)\./;
+const REGEX_S3CONTROL_HOSTNAME = /^(.+\.)?s3-control(-fips)?[.-]([a-z0-9-]+)\./;
 
 export interface GetOutpostEndpointOptions {
   isCustomEndpoint?: boolean;
@@ -10,15 +10,17 @@ export const getOutpostEndpoint = (
   hostname: string,
   { isCustomEndpoint, regionOverride, useFipsEndpoint }: GetOutpostEndpointOptions
 ): string => {
-  const [matched, prefix, region] = hostname.match(REGEX_S3CONTROL_HOSTNAME)!;
-  // hostname prefix will be ignored even if presents
-  return isCustomEndpoint
-    ? hostname
-    : [
-        `s3-outposts${useFipsEndpoint ? "-fips" : ""}`,
-        regionOverride || region,
-        hostname.replace(new RegExp(`^${matched}`), ""),
-      ]
-        .filter((part) => part !== undefined)
-        .join(".");
+  if (isCustomEndpoint) {
+    return hostname;
+  }
+
+  const [matched, prefix, fips, region] = hostname.match(REGEX_S3CONTROL_HOSTNAME)!;
+  // hostname prefix will be ignored even if it is present
+  return [
+    `s3-outposts${useFipsEndpoint ? "-fips" : ""}`,
+    regionOverride || region,
+    hostname.replace(new RegExp(`^${matched}`), ""),
+  ]
+    .filter((part) => part !== undefined)
+    .join(".");
 };

--- a/packages/middleware-sdk-s3-control/src/process-arnables-plugin/parse-outpost-arnables.ts
+++ b/packages/middleware-sdk-s3-control/src/process-arnables-plugin/parse-outpost-arnables.ts
@@ -120,6 +120,7 @@ const validateOutpostsArn = (
     clientRegion,
     clientSigningRegion: signingRegion,
     useFipsEndpoint,
+    allowFipsRegion: true,
   });
   validateNoDualstack(useDualstackEndpoint);
 };


### PR DESCRIPTION
### Issue
Fixes: https://github.com/aws/aws-sdk-js-v3/issues/3026
This was missed in https://github.com/aws/aws-sdk-js-v3/pull/2985

### Description
Remove validation for FIPS in S3 Outposts Control Plane

### Testing
* Unit testing
* Verified with the code from bug report

<details>
<summary>Code</summary>

```js
import { S3Control } from "../aws-sdk-js-v3/clients/client-s3-control/dist-cjs/index.js";

const logHostnameMiddleware = (next) => async (args) => {
  console.log({ hostname: args.request.hostname });
  return next(args);
};
const logHostnameMiddlewareOptions = { step: "deserialize" };

const region = "us-gov-west-1";
const useFipsEndpoint = true;
const AccountId = "123456789012";
const Bucket = `arn:aws-us-gov:s3-outposts:${region}:${AccountId}:outpost:outpostName:bucket:bucketName`;

const client = new S3Control({ region, useFipsEndpoint });
client.middlewareStack.add(logHostnameMiddleware, logHostnameMiddlewareOptions);

await client.getBucket({ AccountId, Bucket });

```

</details>

<details>
<summary>Output</summary>

```console
{ hostname: 's3-outposts-fips.us-gov-west-1.amazonaws.com' }
```

</details>

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
