### PR TITLE
test(e2e-legacy): support running subset of tags without build all clients

### DIFF
--- a/features/acm/step_definitions/acm.js
+++ b/features/acm/step_definitions/acm.js
@@ -1,7 +1,7 @@
-const { ACM } = require("../../../clients/client-acm");
 const { Before } = require("cucumber");
 
 Before({ tags: "@acm" }, function (scenario, callback) {
+  const { ACM } = require("../../../clients/client-acm");
   this.service = new ACM({});
   callback();
 });

--- a/features/apigateway/step_definitions/apigateway.js
+++ b/features/apigateway/step_definitions/apigateway.js
@@ -1,7 +1,7 @@
-const { APIGateway } = require("../../../clients/client-api-gateway");
 const { Before } = require("cucumber");
 
 Before({ tags: "@apigateway" }, function (scenario, callback) {
+  const { APIGateway } = require("../../../clients/client-api-gateway");
   this.service = new APIGateway({});
   callback();
 });

--- a/features/autoscaling/step_definitions/autoscaling.js
+++ b/features/autoscaling/step_definitions/autoscaling.js
@@ -1,7 +1,7 @@
-const { AutoScaling } = require("../../../clients/client-auto-scaling");
 const { Before, Given, Then } = require("cucumber");
 
 Before({ tags: "@autoscaling" }, function (scenario, callback) {
+  const { AutoScaling } = require("../../../clients/client-auto-scaling");
   this.service = new AutoScaling({ region: "us-east-1" });
   callback();
 });

--- a/features/cloudformation/step_definitions/cloudformation.js
+++ b/features/cloudformation/step_definitions/cloudformation.js
@@ -1,7 +1,7 @@
-const { CloudFormation } = require("../../../clients/client-cloudformation");
 const { Before, Given } = require("cucumber");
 
 Before({ tags: "@cloudformation" }, function (scenario, callback) {
+  const { CloudFormation } = require("../../../clients/client-cloudformation");
   this.service = new CloudFormation({});
   callback();
 });

--- a/features/cloudfront/step_definitions/cloudfront.js
+++ b/features/cloudfront/step_definitions/cloudfront.js
@@ -1,4 +1,3 @@
-const { CloudFront } = require("../../../clients/client-cloudfront");
 const { Before, Given } = require("cucumber");
 
 const createParams = {
@@ -53,7 +52,9 @@ const createParams = {
 };
 
 Before({ tags: "@cloudfront" }, function (scenario, callback) {
+  const { CloudFront } = require("../../../clients/client-cloudfront");
   this.service = new CloudFront({});
+
   this.cfCreateParams = createParams;
   callback();
 });

--- a/features/cloudsearch/step_definitions/cloudsearch.js
+++ b/features/cloudsearch/step_definitions/cloudsearch.js
@@ -1,7 +1,7 @@
-const { CloudSearch } = require("../../../clients/client-cloudsearch");
 const { Before, Given } = require("cucumber");
 
 Before({ tags: "@cloudsearch" }, function (scenario, callback) {
+  const { CloudSearch } = require("../../../clients/client-cloudsearch");
   this.service = new CloudSearch({});
   callback();
 });

--- a/features/cloudtrail/step_definitions/cloudtrail.js
+++ b/features/cloudtrail/step_definitions/cloudtrail.js
@@ -1,7 +1,7 @@
-const { CloudTrail } = require("../../../clients/client-cloudtrail");
 const { Before, Given } = require("cucumber");
 
 Before({ tags: "@cloudtrail" }, function (scenario, callback) {
+  const { CloudTrail } = require("../../../clients/client-cloudtrail");
   this.service = new CloudTrail({});
   callback();
 });

--- a/features/cloudwatch/step_definitions/cloudwatch.js
+++ b/features/cloudwatch/step_definitions/cloudwatch.js
@@ -1,7 +1,7 @@
-const { CloudWatch } = require("../../../clients/client-cloudwatch");
 const { Before, Given, Then } = require("cucumber");
 
 Before({ tags: "@cloudwatch" }, function (scenario, callback) {
+  const { CloudWatch } = require("../../../clients/client-cloudwatch");
   this.service = new CloudWatch({});
   callback();
 });

--- a/features/cloudwatchevents/step_definitions/cloudwatchevents.js
+++ b/features/cloudwatchevents/step_definitions/cloudwatchevents.js
@@ -1,7 +1,7 @@
-const { CloudWatchEvents } = require("../../../clients/client-cloudwatch-events");
 const { Before } = require("cucumber");
 
 Before({ tags: "@cloudwatchevents" }, function (scenario, callback) {
+  const { CloudWatchEvents } = require("../../../clients/client-cloudwatchevents");
   this.service = new CloudWatchEvents({});
   callback();
 });

--- a/features/cloudwatchlogs/step_definitions/cloudwatchlogs.js
+++ b/features/cloudwatchlogs/step_definitions/cloudwatchlogs.js
@@ -1,7 +1,7 @@
-const { CloudWatchLogs } = require("../../../clients/client-cloudwatch-logs");
 const { Before, Given, Then } = require("cucumber");
 
 Before({ tags: "@cloudwatchlogs" }, function (scenario, callback) {
+  const { CloudWatchLogs } = require("../../../clients/client-cloudwatchlogs");
   this.service = new CloudWatchLogs({});
   callback();
 });

--- a/features/codecommit/step_definitions/codecommit.js
+++ b/features/codecommit/step_definitions/codecommit.js
@@ -1,7 +1,7 @@
-const { CodeCommit } = require("../../../clients/client-codecommit");
 const { Before } = require("cucumber");
 
 Before({ tags: "@codecommit" }, function (scenario, callback) {
+  const { CodeCommit } = require("../../../clients/client-codecommit");
   this.service = new CodeCommit({ region: "us-east-1" });
   callback();
 });

--- a/features/codedeploy/step_definitions/codedeploy.js
+++ b/features/codedeploy/step_definitions/codedeploy.js
@@ -1,7 +1,7 @@
-const { CodeDeploy } = require("../../../clients/client-codedeploy");
 const { Before } = require("cucumber");
 
 Before({ tags: "@codedeploy" }, function (scenario, callback) {
+  const { CodeDeploy } = require("../../../clients/client-codedeploy");
   this.service = new CodeDeploy({});
   callback();
 });

--- a/features/codepipeline/step_definitions/codepipeline.js
+++ b/features/codepipeline/step_definitions/codepipeline.js
@@ -1,7 +1,7 @@
-const { CodePipeline } = require("../../../clients/client-codepipeline");
 const { Before } = require("cucumber");
 
 Before({ tags: "@codepipeline" }, function (scenario, callback) {
+  const { CodePipeline } = require("../../../clients/client-codepipeline");
   this.service = new CodePipeline({ region: "us-east-1" });
   callback();
 });

--- a/features/cognitoidentity/step_definitions/cognitoidentity.js
+++ b/features/cognitoidentity/step_definitions/cognitoidentity.js
@@ -1,7 +1,7 @@
-const { CognitoIdentity } = require("../../../clients/client-cognito-identity");
 const { Before, Given, Then } = require("cucumber");
 
 Before({ tags: "@cognitoidentity" }, function (scenario, callback) {
+  const { CognitoIdentity } = require("../../../clients/client-cognitoidentity");
   this.service = new CognitoIdentity({});
   callback();
 });

--- a/features/cognitosync/step_definitions/cognitosync.js
+++ b/features/cognitosync/step_definitions/cognitosync.js
@@ -1,7 +1,7 @@
-const { CognitoSync } = require("../../../clients/client-cognito-sync");
 const { Before, Given } = require("cucumber");
 
 Before({ tags: "@cognitosync" }, function (scenario, callback) {
+  const { CognitoSync } = require("../../../clients/client-cognitosync");
   this.service = new CognitoSync({});
   callback();
 });

--- a/features/configservice/step_definitions/configservice.js
+++ b/features/configservice/step_definitions/configservice.js
@@ -1,7 +1,7 @@
-const { ConfigService } = require("../../../clients/client-config-service");
 const { Before } = require("cucumber");
 
 Before({ tags: "@configservice" }, function (scenario, callback) {
+  const { ConfigService } = require("../../../clients/client-configservice");
   this.service = new ConfigService({});
   callback();
 });

--- a/features/datapipeline/step_definitions/datapipeline.js
+++ b/features/datapipeline/step_definitions/datapipeline.js
@@ -1,7 +1,7 @@
-const { DataPipeline } = require("../../../clients/client-data-pipeline");
 const { Before, Given } = require("cucumber");
 
 Before({ tags: "@datapipeline" }, function (scenario, callback) {
+  const { DataPipeline } = require("../../../clients/client-datapipeline");
   this.service = new DataPipeline({});
   callback();
 });

--- a/features/devicefarm/step_definitions/devicefarm.js
+++ b/features/devicefarm/step_definitions/devicefarm.js
@@ -1,7 +1,7 @@
-const { DeviceFarm } = require("../../../clients/client-device-farm");
 const { Before } = require("cucumber");
 
 Before({ tags: "@devicefarm" }, function (scenario, callback) {
+  const { DeviceFarm } = require("../../../clients/client-devicefarm");
   this.service = new DeviceFarm({ region: "us-west-2" });
   callback();
 });

--- a/features/directconnect/step_definitions/directconnect.js
+++ b/features/directconnect/step_definitions/directconnect.js
@@ -1,7 +1,7 @@
-const { DirectConnect } = require("../../../clients/client-direct-connect");
 const { Before, Given } = require("cucumber");
 
 Before({ tags: "@directconnect" }, function (scenario, callback) {
+  const { DirectConnect } = require("../../../clients/client-directconnect");
   this.service = new DirectConnect({});
   callback();
 });

--- a/features/directoryservice/step_definitions/directoryservice.js
+++ b/features/directoryservice/step_definitions/directoryservice.js
@@ -1,7 +1,7 @@
-const { DirectoryService } = require("../../../clients/client-directory-service");
 const { Before } = require("cucumber");
 
 Before({ tags: "@directoryservice" }, function (scenario, callback) {
+  const { DirectoryService } = require("../../../clients/client-directoryservice");
   this.service = new DirectoryService({});
   callback();
 });

--- a/features/dms/step_definitions/dms.js
+++ b/features/dms/step_definitions/dms.js
@@ -1,7 +1,7 @@
-const { DatabaseMigrationService } = require("../../../clients/client-database-migration-service");
 const { Before } = require("cucumber");
 
 Before({ tags: "@databasemigrationservice" }, function (scenario, callback) {
+  const { DatabaseMigrationService } = require("../../../clients/client-databasemigrationservice");
   this.service = new DatabaseMigrationService({});
   callback();
 });

--- a/features/dynamodb/step_definitions/dynamodb.js
+++ b/features/dynamodb/step_definitions/dynamodb.js
@@ -1,7 +1,7 @@
 const jmespath = require("jmespath");
-const { DynamoDB, waitForTableExists, waitForTableNotExists } = require("../../../clients/client-dynamodb");
 
 function waitForTableExistsCallback(world, callback) {
+  const { waitForTableExists } = require("../../../clients/client-dynamodb");
   waitForTableExists({ client: world.service }, { TableName: world.tableName }).then(
     function (data) {
       callback();
@@ -13,6 +13,7 @@ function waitForTableExistsCallback(world, callback) {
 }
 
 function waitForTableNotExistsWithCallback(world, callback) {
+  const { waitForTableNotExists } = require("../../../clients/client-dynamodb");
   waitForTableNotExists({ client: world.service }, { TableName: world.tableName }).then(
     function (data) {
       callback();
@@ -26,6 +27,7 @@ function waitForTableNotExistsWithCallback(world, callback) {
 const { Before, Given, Then, When } = require("cucumber");
 
 Before({ tags: "@dynamodb" }, function (scenario, next) {
+  const { DynamoDB } = require("../../../clients/client-dynamodb");
   this.service = new DynamoDB({
     maxRetries: 2,
   });

--- a/features/dynamodbstreams/step_definitions/dynamodbstreams.js
+++ b/features/dynamodbstreams/step_definitions/dynamodbstreams.js
@@ -1,7 +1,7 @@
-const { DynamoDBStreams } = require("../../../clients/client-dynamodb-streams");
 const { Before } = require("cucumber");
 
 Before({ tags: "@dynamodbstreams" }, function (scenario, callback) {
+  const { DynamoDBStreams } = require("../../../clients/client-dynamodbstreams");
   this.service = new DynamoDBStreams({});
   callback();
 });

--- a/features/ec2/step_definitions/ec2.js
+++ b/features/ec2/step_definitions/ec2.js
@@ -1,7 +1,7 @@
-const { EC2, waitForVolumeAvailable } = require("../../../clients/client-ec2");
 const { Before, Given, Then } = require("cucumber");
 
 const waitForVolumeAvailableCallback = (ec2, volumeId, callback) => {
+  const { waitForVolumeAvailable } = require("../../../clients/client-ec2");
   waitForVolumeAvailable({ client: ec2 }, { VolumeIds: [volumeId] }).then(
     function (data) {
       callback();
@@ -13,6 +13,7 @@ const waitForVolumeAvailableCallback = (ec2, volumeId, callback) => {
 };
 
 Before({ tags: "@ec2" }, function (scenario, callback) {
+  const { EC2 } = require("../../../clients/client-ec2");
   this.service = new EC2({});
   callback();
 });
@@ -34,6 +35,7 @@ Given("I describe the EC2 instance {string}", function (instanceId, callback) {
 });
 
 Given("I attempt to copy an encrypted snapshot across regions", function (callback) {
+  const { EC2 } = require("../../../clients/client-ec2");
   const self = this;
   let volId, srcSnapId, dstSnapId, params;
   const sourceRegion = "us-west-2";

--- a/features/ecr/step_definitions/ecr.js
+++ b/features/ecr/step_definitions/ecr.js
@@ -1,7 +1,7 @@
-const { ECR } = require("../../../clients/client-ecr");
 const { Before } = require("cucumber");
 
 Before({ tags: "@ecr" }, function (scenario, callback) {
+  const { ECR } = require("../../../clients/client-ecr");
   this.service = new ECR({});
   callback();
 });

--- a/features/ecs/step_definitions/ecs.js
+++ b/features/ecs/step_definitions/ecs.js
@@ -1,7 +1,7 @@
-const { ECS } = require("../../../clients/client-ecs");
 const { Before } = require("cucumber");
 
 Before({ tags: "@ecs" }, function (scenario, callback) {
+  const { ECS } = require("../../../clients/client-ecs");
   this.service = new ECS({});
   callback();
 });

--- a/features/efs/step_definitions/efs.js
+++ b/features/efs/step_definitions/efs.js
@@ -1,7 +1,7 @@
-const { EFS } = require("../../../clients/client-efs");
 const { Before } = require("cucumber");
 
 Before({ tags: "@efs" }, function (scenario, callback) {
+  const { EFS } = require("../../../clients/client-efs");
   this.service = new EFS({ region: "us-west-2" });
   callback();
 });

--- a/features/elasticache/step_definitions/elasticache.js
+++ b/features/elasticache/step_definitions/elasticache.js
@@ -1,7 +1,7 @@
-const { ElastiCache } = require("../../../clients/client-elasticache");
 const { Before, Given, Then } = require("cucumber");
 
 Before({ tags: "@elasticache" }, function (scenario, callback) {
+  const { ElastiCache } = require("../../../clients/client-elasticache");
   this.service = new ElastiCache({});
   callback();
 });

--- a/features/elasticbeanstalk/step_definitions/elasticbeanstalk.js
+++ b/features/elasticbeanstalk/step_definitions/elasticbeanstalk.js
@@ -1,7 +1,7 @@
-const { ElasticBeanstalk } = require("../../../clients/client-elastic-beanstalk");
 const { Before, Given, Then } = require("cucumber");
 
 Before({ tags: "@elasticbeanstalk" }, function (scenario, callback) {
+  const { ElasticBeanstalk } = require("../../../clients/client-elasticbeanstalk");
   this.service = new ElasticBeanstalk({});
   callback();
 });

--- a/features/elastictranscoder/step_definitions/elastictranscoder.js
+++ b/features/elastictranscoder/step_definitions/elastictranscoder.js
@@ -1,9 +1,9 @@
-const { ElasticTranscoder } = require("../../../clients/client-elastic-transcoder");
-const { S3 } = require("../../../clients/client-s3");
-const { IAM } = require("../../../clients/client-iam");
 const { Before, Given, Then } = require("cucumber");
 
 Before({ tags: "@elastictranscoder" }, function (scenario, callback) {
+  const { S3 } = require("../../../clients/client-s3");
+  const { IAM } = require("../../../clients/client-iam");
+  const { ElasticTranscoder } = require("../../../clients/client-elastictranscoder");
   this.iam = new IAM({});
   this.s3 = new S3({});
   this.service = new ElasticTranscoder({});

--- a/features/elb/step_definitions/elb.js
+++ b/features/elb/step_definitions/elb.js
@@ -1,7 +1,7 @@
-const { ElasticLoadBalancing } = require("../../../clients/client-elastic-load-balancing");
 const { Before, Given, Then } = require("cucumber");
 
 Before({ tags: "@elasticloadbalancing" }, function (scenario, callback) {
+  const { ElasticLoadBalancing } = require("../../../clients/client-elasticloadbalancing");
   this.service = new ElasticLoadBalancing({});
   callback();
 });

--- a/features/elbv2/step_definitions/elbv2.js
+++ b/features/elbv2/step_definitions/elbv2.js
@@ -1,7 +1,7 @@
-const { ElasticLoadBalancingV2 } = require("../../../clients/client-elastic-load-balancing-v2");
 const { Before } = require("cucumber");
 
 Before({ tags: "@elasticloadbalancingv2" }, function (scenario, callback) {
+  const { ElasticLoadBalancingV2 } = require("../../../clients/client-elasticloadbalancingv2");
   this.service = new ElasticLoadBalancingV2({});
   callback();
 });

--- a/features/emr/step_definitions/emr.js
+++ b/features/emr/step_definitions/emr.js
@@ -1,13 +1,14 @@
-const { EMR } = require("../../../clients/client-emr");
 const { Before, Given } = require("cucumber");
 
 Before({ tags: "@emr" }, function (scenario, callback) {
+  const { EMR } = require("../../../clients/client-emr");
+  this.EMR = EMR;
   this.service = new EMR({});
   callback();
 });
 
 Given("I run an EMR job flow with invalid parameters", function (callback) {
-  this.service = new EMR({});
+  this.service = new this.EMR({});
   const params = { Name: "", Instances: { MasterInstanceType: "invalid" } };
   this.request(null, "runJobFlow", params, callback, false);
 });

--- a/features/es/step_definitions/es.js
+++ b/features/es/step_definitions/es.js
@@ -1,7 +1,7 @@
-const { ElasticsearchService } = require("../../../clients/client-elasticsearch-service");
 const { Before } = require("cucumber");
 
 Before({ tags: "@elasticsearchservice" }, function (scenario, callback) {
+  const { ElasticsearchService } = require("../../../clients/client-elasticsearchservice");
   this.service = new ElasticsearchService({});
   callback();
 });

--- a/features/gamelift/step_definitions/gamelift.js
+++ b/features/gamelift/step_definitions/gamelift.js
@@ -1,7 +1,7 @@
-const { GameLift } = require("../../../clients/client-gamelift");
 const { Before } = require("cucumber");
 
 Before({ tags: "@gamelift" }, function (scenario, callback) {
+  const { GameLift } = require("../../../clients/client-gamelift");
   this.service = new GameLift({});
   callback();
 });

--- a/features/glacier/step_definitions/glacier.js
+++ b/features/glacier/step_definitions/glacier.js
@@ -1,7 +1,7 @@
-const { Glacier } = require("../../../clients/client-glacier");
 const { Before, Given, Then, When } = require("cucumber");
 
 Before({ tags: "@glacier" }, function (scenario, callback) {
+  const { Glacier } = require("../../../clients/client-glacier");
   this.service = new Glacier({});
   callback();
 });

--- a/features/iam/step_definitions/iam.js
+++ b/features/iam/step_definitions/iam.js
@@ -1,7 +1,7 @@
-const { IAM } = require("../../../clients/client-iam");
 const { Before, Given, Then } = require("cucumber");
 
 Before({ tags: "@iam" }, function (scenario, callback) {
+  const { IAM } = require("../../../clients/client-iam");
   this.iam = new IAM({});
   callback();
 });

--- a/features/inspector/step_definitions/inspector.js
+++ b/features/inspector/step_definitions/inspector.js
@@ -1,7 +1,7 @@
-const { Inspector } = require("../../../clients/client-inspector");
 const { Before } = require("cucumber");
 
 Before({ tags: "@inspector" }, function (scenario, callback) {
+  const { Inspector } = require("../../../clients/client-inspector");
   this.service = new Inspector({ region: "us-west-2" });
   callback();
 });

--- a/features/iot/step_definitions/iot.js
+++ b/features/iot/step_definitions/iot.js
@@ -1,7 +1,7 @@
-const { IoT } = require("../../../clients/client-iot");
 const { Before } = require("cucumber");
 
 Before({ tags: "@iot" }, function (scenario, callback) {
+  const { IoT } = require("../../../clients/client-iot");
   this.service = new IoT({});
   callback();
 });

--- a/features/kinesis/step_definitions/kinesis.js
+++ b/features/kinesis/step_definitions/kinesis.js
@@ -1,7 +1,7 @@
-const { Kinesis } = require("../../../clients/client-kinesis");
 const { Before, Given } = require("cucumber");
 
 Before({ tags: "@kinesis" }, function (scenario, callback) {
+  const { Kinesis } = require("../../../clients/client-kinesis");
   this.service = new Kinesis({});
   callback();
 });

--- a/features/kms/step_definitions/kms.js
+++ b/features/kms/step_definitions/kms.js
@@ -1,7 +1,7 @@
-const { KMS } = require("../../../clients/client-kms");
 const { Before } = require("cucumber");
 
 Before({ tags: "@kms" }, function (scenario, callback) {
+  const { KMS } = require("../../../clients/client-kms");
   this.service = new KMS({});
   callback();
 });

--- a/features/lambda/step_definitions/lambda.js
+++ b/features/lambda/step_definitions/lambda.js
@@ -1,7 +1,7 @@
-const { Lambda } = require("../../../clients/client-lambda");
 const { Before } = require("cucumber");
 
 Before({ tags: "@lambda" }, function (scenario, callback) {
+  const { Lambda } = require("../../../clients/client-lambda");
   this.service = new Lambda({});
   callback();
 });

--- a/features/opsworks/step_definitions/opsworks.js
+++ b/features/opsworks/step_definitions/opsworks.js
@@ -1,9 +1,9 @@
-const { IAM } = require("../../../clients/client-iam");
-const { OpsWorks } = require("../../../clients/client-opsworks");
 const { Before, Given, Then } = require("cucumber");
 
 Before({ tags: "@opsworks" }, function (scenario, callback) {
+  const { IAM } = require("../../../clients/client-iam");
   this.iam = new IAM({ region: "us-west-2" });
+  const { OpsWorks } = require("../../../clients/client-opsworks");
   this.service = new OpsWorks({ region: "us-west-2" });
   callback();
 });

--- a/features/pinpoint/step_definitions/pinpoint.js
+++ b/features/pinpoint/step_definitions/pinpoint.js
@@ -1,7 +1,7 @@
-const { Pinpoint } = require("../../../clients/client-pinpoint");
 const { Before, Given } = require("cucumber");
 
 Before({ tags: "@pinpoint" }, function (scenario, callback) {
+  const { Pinpoint } = require("../../../clients/client-pinpoint");
   this.service = new Pinpoint({});
   callback();
 });

--- a/features/rds/step_definitions/rds.js
+++ b/features/rds/step_definitions/rds.js
@@ -1,8 +1,8 @@
 const jmespath = require("jmespath");
-const { RDS } = require("../../../clients/client-rds");
 const { Before, Given, Then } = require("cucumber");
 
 Before({ tags: "@rds" }, function (scenario, callback) {
+  const { RDS } = require("../../../clients/client-rds");
   this.service = new RDS({});
   callback();
 });

--- a/features/redshift/step_definitions/redshift.js
+++ b/features/redshift/step_definitions/redshift.js
@@ -1,7 +1,7 @@
-const { Redshift } = require("../../../clients/client-redshift");
 const { Before, Given } = require("cucumber");
 
 Before({ tags: "@redshift" }, function (scenario, callback) {
+  const { Redshift } = require("../../../clients/client-redshift");
   this.service = new Redshift({});
   callback();
 });

--- a/features/route53/step_definitions/route53.js
+++ b/features/route53/step_definitions/route53.js
@@ -1,7 +1,7 @@
-const { Route53 } = require("../../../clients/client-route-53");
 const { Before, Then, When } = require("cucumber");
 
 Before({ tags: "@route53" }, function (scenario, callback) {
+  const { Route53 } = require("../../../clients/client-route53");
   this.service = new Route53({});
   callback();
 });

--- a/features/route53domains/step_definitions/route53domains.js
+++ b/features/route53domains/step_definitions/route53domains.js
@@ -1,7 +1,7 @@
-const { Route53Domains } = require("../../../clients/client-route-53-domains");
 const { Before, Given } = require("cucumber");
 
 Before({ tags: "@route53domains" }, function (scenario, callback) {
+  const { Route53Domains } = require("../../../clients/client-route53domains");
   this.service = new Route53Domains({ region: "us-east-1" });
   callback();
 });

--- a/features/s3/step_definitions/buckets.js
+++ b/features/s3/step_definitions/buckets.js
@@ -1,8 +1,13 @@
-const { S3 } = require("../../../clients/client-s3");
-const { Given, Then, When } = require("cucumber");
+const { Before, Given, Then, When } = require("cucumber");
+
+Before({ tags: "@buckets" }, function (scenario, callback) {
+  const { S3 } = require("../../../clients/client-s3");
+  this.S3 = S3;
+  callback();
+});
 
 Given("I am using the S3 {string} region", function (region, callback) {
-  this.s3 = new S3({
+  this.s3 = new this.S3({
     region: region,
   });
   callback();
@@ -11,7 +16,7 @@ Given("I am using the S3 {string} region", function (region, callback) {
 Given(
   "I am using the S3 {string} region with signatureVersion {string}",
   function (region, signatureVersion, callback) {
-    this.s3 = new S3({
+    this.s3 = new this.S3({
       region: region,
       signatureVersion: signatureVersion,
     });
@@ -37,7 +42,7 @@ When("I create a bucket with the location constraint {string}", function (locati
 
 Then("the bucket should exist in region {string}", function (location, next) {
   // Bug: https://github.com/aws/aws-sdk-js-v3/issues/1799
-  this.waitForBucketExists(new S3({ region: location }), { Bucket: this.bucket }, next);
+  this.waitForBucketExists(new this.S3({ region: location }), { Bucket: this.bucket }, next);
 });
 
 Then("the bucket should have a location constraint of {string}", function (loc, callback) {
@@ -56,7 +61,7 @@ Then("the bucket should have a location constraint of {string}", function (loc, 
 
 When("I delete the bucket in region {string}", function (location, callback) {
   // Bug: https://github.com/aws/aws-sdk-js-v3/issues/1799
-  this.request(new S3({ region: location }), "deleteBucket", { Bucket: this.bucket }, callback);
+  this.request(new this.S3({ region: location }), "deleteBucket", { Bucket: this.bucket }, callback);
 });
 
 When("I put a transition lifecycle configuration on the bucket with prefix {string}", function (prefix, callback) {
@@ -216,7 +221,7 @@ When("I create a bucket with a DNS compatible name that contains a dot", functio
 });
 
 Given("I force path style requests", function (callback) {
-  this.s3 = new S3({
+  this.s3 = new this.S3({
     forcePathStyle: true,
   });
   callback();

--- a/features/s3/step_definitions/hooks.js
+++ b/features/s3/step_definitions/hooks.js
@@ -1,7 +1,7 @@
-const { S3 } = require("../../../clients/client-s3");
 const { Before } = require("cucumber");
 
 Before({ tags: "@s3" }, function (scenario, callback) {
+  const { S3 } = require("../../../clients/client-s3");
   this.service = this.s3 = new S3({
     maxRetries: 100,
   });

--- a/features/s3/step_definitions/proxy.js
+++ b/features/s3/step_definitions/proxy.js
@@ -1,9 +1,9 @@
 const url = require("url");
 const http = require("http");
-const { S3 } = require("../../../clients/client-s3");
 const { Before, Then } = require("cucumber");
 
 Before({ tags: "@s3 or @proxy" }, function (scenario, callback) {
+  const { S3 } = require("../../../clients/client-s3");
   setupProxyServer.call(this);
 
   this.service = this.s3 = new S3({
@@ -11,12 +11,12 @@ Before({ tags: "@s3 or @proxy" }, function (scenario, callback) {
       proxy: "http://localhost:" + this.proxyPort,
     },
   });
-
+  this.S3 = S3;
   callback();
 });
 
 Then("I teardown the local proxy server", function (callback) {
-  this.service = this.s3 = new S3();
+  this.service = this.s3 = new this.S3();
   this.proxyServer.close(callback);
 });
 

--- a/features/sagemaker/step_definitions/sagemaker.js
+++ b/features/sagemaker/step_definitions/sagemaker.js
@@ -1,7 +1,7 @@
-const { SageMaker } = require("../../../clients/client-sagemaker");
 const { Before } = require("cucumber");
 
 Before({ tags: "@sagemaker" }, function (scenario, callback) {
+  const { SageMaker } = require("../../../clients/client-sagemaker");
   this.service = new SageMaker({});
   callback();
 });

--- a/features/ses/step_definitions/ses.js
+++ b/features/ses/step_definitions/ses.js
@@ -1,7 +1,7 @@
-const { SES } = require("../../../clients/client-ses");
 const { Before, Then, When } = require("cucumber");
 
 Before({ tags: "@ses" }, function (scenario, callback) {
+  const { SES } = require("../../../clients/client-ses");
   this.service = new SES({});
   callback();
 });

--- a/features/sns/step_definitions/sns.js
+++ b/features/sns/step_definitions/sns.js
@@ -1,7 +1,7 @@
-const { SNS } = require("../../../clients/client-sns");
 const { Before, Given, Then } = require("cucumber");
 
 Before({ tags: "@sns" }, function (scenario, callback) {
+  const { SNS } = require("../../../clients/client-sns");
   this.service = new SNS({});
   callback();
 });

--- a/features/sqs/step_definitions/sqs.js
+++ b/features/sqs/step_definitions/sqs.js
@@ -1,7 +1,7 @@
-const { SQS } = require("../../../clients/client-sqs");
 const { Before } = require("cucumber");
 
 Before({ tags: "@sqs" }, function (scenario, callback) {
+  const { SQS } = require("../../../clients/client-sqs");
   this.service = new SQS({
     region: "us-east-1",
   });

--- a/features/ssm/step_definitions/ssm.js
+++ b/features/ssm/step_definitions/ssm.js
@@ -1,7 +1,7 @@
-const { SSM } = require("../../../clients/client-ssm");
 const { Before } = require("cucumber");
 
 Before({ tags: "@ssm" }, function (scenario, callback) {
+  const { SSM } = require("../../../clients/client-ssm");
   this.service = new SSM({});
   callback();
 });

--- a/features/storagegateway/step_definitions/storagegateway.js
+++ b/features/storagegateway/step_definitions/storagegateway.js
@@ -1,7 +1,7 @@
-const { StorageGateway } = require("../../../clients/client-storage-gateway");
 const { Before, When } = require("cucumber");
 
 Before({ tags: "@storagegateway" }, function (scenario, callback) {
+  const { StorageGateway } = require("../../../clients/client-storagegateway");
   this.service = new StorageGateway({ region: "us-east-1" });
   callback();
 });

--- a/features/sts/step_definitions/sts.js
+++ b/features/sts/step_definitions/sts.js
@@ -1,7 +1,7 @@
-const { STS } = require("../../../clients/client-sts");
 const { Before, Given } = require("cucumber");
 
 Before({ tags: "@sts" }, function (scenario, callback) {
+  const { STS } = require("../../../clients/client-sts");
   this.service = new STS({});
   callback();
 });

--- a/features/swf/step_definitions/swf.js
+++ b/features/swf/step_definitions/swf.js
@@ -1,7 +1,7 @@
-const { SWF } = require("../../../clients/client-swf");
 const { Before, Given, Then, When } = require("cucumber");
 
 Before({ tags: "@swf" }, function (scenario, callback) {
+  const { SWF } = require("../../../clients/client-swf");
   this.service = new SWF({});
   callback();
 });

--- a/features/waf/step_definitions/waf.js
+++ b/features/waf/step_definitions/waf.js
@@ -1,7 +1,7 @@
-const { WAF } = require("../../../clients/client-waf");
 const { Before } = require("cucumber");
 
 Before({ tags: "@waf" }, function (scenario, callback) {
+  const { WAF } = require("../../../clients/client-waf");
   this.service = new WAF({});
   callback();
 });

--- a/features/workspaces/step_definitions/workspaces.js
+++ b/features/workspaces/step_definitions/workspaces.js
@@ -1,7 +1,7 @@
-const { WorkSpaces } = require("../../../clients/client-workspaces");
 const { Before } = require("cucumber");
 
 Before({ tags: "@workspaces" }, function (scenario, callback) {
+  const { WorkSpaces } = require("../../../clients/client-workspaces");
   this.service = new WorkSpaces({});
   callback();
 });


### PR DESCRIPTION
### Description
The current cucumber test imports every tested client before test execution. When only a subset of clients are built and only run cucumber test against these clients will cause the test failed. Because other client packages are imported without being built. 

This PR changes the V3 packages to be imported lazily when test is executed. So if the client packages not in the test scope were not built, the test won't fail.

### Testing
```console
yarn test:integration:legacy:since:release
yarn run v1.22.10
$ ./tests/integ-legacy/index.js
Looking for changed clients that has the legacy integration test tag: @acm,@apigateway,@autoscaling,@cloudformation,@cloudfront,@cloudsearch,@cloudtrail,@cloudwatch,@cloudwatchevents,@cloudwatchlogs,@codecommit,@codedeploy,@codepipeline,@cognitoidentity,@cognitosync,@configservice,@datapipeline,@devicefarm,@directconnect,@directoryservice,@databasemigrationservice,@dynamodbstreams,@dynamodb,@tables,@ec2,@ecr,@ecs,@efs,@elasticache,@elasticbeanstalk,@elastictranscoder,@elasticloadbalancing,@elasticloadbalancingv2,@emr,@elasticsearchservice,@gamelift,@glacier,@iam,@inspector,@iot,@kinesis,@kms,@lambda,@opsworks,@pinpoint,@rds,@redshift,@route53domains,@route53,@s3,@buckets,@s3,@objects,@sagemaker,@ses,@sns,@sqs,@messages,@sqs,@queues,@ssm,@storagegateway,@sts,@swf,@waf,@workspaces,
lerna notice cli v3.22.1
lerna info Looking for changed packages since v3.40.1
lerna success found 305 packages ready to publish
Running cucumber test: 
node_modules/.bin/cucumber-js --fail-fast -t "@acm or @cloudformation or @cloudfront or @cloudsearch or @cloudtrail or @cloudwatch or @codecommit or @codedeploy or @codepipeline or @dynamodb or @ec2 or @ecr or @ecs or @efs or @elasticache or @emr or @gamelift or @glacier or @iam or @inspector or @iot or @kinesis or @kms or @lambda or @opsworks or @pinpoint or @rds or @redshift or @s3 or @sagemaker or @ses or @sns or @sqs or @ssm or @sts or @swf or @waf or @workspaces"
.........................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................

108 scenarios (108 passed)
401 steps (401 passed)
1m32.284s
Done in 100.36s.
```

Partial test:
```console
yarn test:integration:legacy:since:release         
yarn run v1.22.10
$ ./tests/integ-legacy/index.js
Looking for changed clients that has the legacy integration test tag: @acm,@apigateway,@autoscaling,@cloudformation,@cloudfront,@cloudsearch,@cloudtrail,@cloudwatch,@cloudwatchevents,@cloudwatchlogs,@codecommit,@codedeploy,@codepipeline,@cognitoidentity,@cognitosync,@configservice,@datapipeline,@devicefarm,@directconnect,@directoryservice,@databasemigrationservice,@dynamodbstreams,@dynamodb,@tables,@ec2,@ecr,@ecs,@efs,@elasticache,@elasticbeanstalk,@elastictranscoder,@elasticloadbalancing,@elasticloadbalancingv2,@emr,@elasticsearchservice,@gamelift,@glacier,@iam,@inspector,@iot,@kinesis,@kms,@lambda,@opsworks,@pinpoint,@rds,@redshift,@route53domains,@route53,@s3,@buckets,@s3,@objects,@sagemaker,@ses,@sns,@sqs,@messages,@sqs,@queues,@ssm,@storagegateway,@sts,@swf,@waf,@workspaces,
lerna notice cli v3.22.1
lerna info Looking for changed packages since v3.41.0
lerna success found 3 packages ready to publish
Running cucumber test: 
node_modules/.bin/cucumber-js --fail-fast -t "@ec2"
...............

3 scenarios (3 passed)
9 steps (9 passed)
0m22.237s
Done in 29.14s.
### Additional context
Add any other context about the PR here.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
