### PR TITLE
fix(client-kendra): change incorrectly modeled DocumentAttributeValue to structure

### DIFF
--- a/clients/client-kendra/src/models/models_0.ts
+++ b/clients/client-kendra/src/models/models_0.ts
@@ -191,46 +191,21 @@ export namespace AdditionalResultAttribute {
  * <p>The value of a custom document attribute. You can only provide one
  *             value for a custom attribute.</p>
  */
-export type DocumentAttributeValue =
-  | DocumentAttributeValue.DateValueMember
-  | DocumentAttributeValue.LongValueMember
-  | DocumentAttributeValue.StringListValueMember
-  | DocumentAttributeValue.StringValueMember
-  | DocumentAttributeValue.$UnknownMember;
-
-export namespace DocumentAttributeValue {
+export interface DocumentAttributeValue {
   /**
    * <p>A string, such as "department".</p>
    */
-  export interface StringValueMember {
-    StringValue: string;
-    StringListValue?: never;
-    LongValue?: never;
-    DateValue?: never;
-    $unknown?: never;
-  }
+  StringValue?: string;
 
   /**
    * <p>A list of strings. </p>
    */
-  export interface StringListValueMember {
-    StringValue?: never;
-    StringListValue: string[];
-    LongValue?: never;
-    DateValue?: never;
-    $unknown?: never;
-  }
+  StringListValue?: string[];
 
   /**
    * <p>A long integer value.</p>
    */
-  export interface LongValueMember {
-    StringValue?: never;
-    StringListValue?: never;
-    LongValue: number;
-    DateValue?: never;
-    $unknown?: never;
-  }
+  LongValue?: number;
 
   /**
    * <p>A date expressed as an ISO 8601 string.</p>
@@ -240,48 +215,16 @@ export namespace DocumentAttributeValue {
    *             for March 25th 2012 at 12:30PM (plus 10 seconds) in
    *             Central European Time.</p>
    */
-  export interface DateValueMember {
-    StringValue?: never;
-    StringListValue?: never;
-    LongValue?: never;
-    DateValue: Date;
-    $unknown?: never;
-  }
+  DateValue?: Date;
+}
 
-  export interface $UnknownMember {
-    StringValue?: never;
-    StringListValue?: never;
-    LongValue?: never;
-    DateValue?: never;
-    $unknown: [string, any];
-  }
-
-  export interface Visitor<T> {
-    StringValue: (value: string) => T;
-    StringListValue: (value: string[]) => T;
-    LongValue: (value: number) => T;
-    DateValue: (value: Date) => T;
-    _: (name: string, value: any) => T;
-  }
-
-  export const visit = <T>(value: DocumentAttributeValue, visitor: Visitor<T>): T => {
-    if (value.StringValue !== undefined) return visitor.StringValue(value.StringValue);
-    if (value.StringListValue !== undefined) return visitor.StringListValue(value.StringListValue);
-    if (value.LongValue !== undefined) return visitor.LongValue(value.LongValue);
-    if (value.DateValue !== undefined) return visitor.DateValue(value.DateValue);
-    return visitor._(value.$unknown[0], value.$unknown[1]);
-  };
-
+export namespace DocumentAttributeValue {
   /**
    * @internal
    */
-  export const filterSensitiveLog = (obj: DocumentAttributeValue): any => {
-    if (obj.StringValue !== undefined) return { StringValue: obj.StringValue };
-    if (obj.StringListValue !== undefined) return { StringListValue: obj.StringListValue };
-    if (obj.LongValue !== undefined) return { LongValue: obj.LongValue };
-    if (obj.DateValue !== undefined) return { DateValue: obj.DateValue };
-    if (obj.$unknown !== undefined) return { [obj.$unknown[0]]: "UNKNOWN" };
-  };
+  export const filterSensitiveLog = (obj: DocumentAttributeValue): any => ({
+    ...obj,
+  });
 }
 
 /**
@@ -305,7 +248,6 @@ export namespace DocumentAttribute {
    */
   export const filterSensitiveLog = (obj: DocumentAttribute): any => ({
     ...obj,
-    ...(obj.Value && { Value: DocumentAttributeValue.filterSensitiveLog(obj.Value) }),
   });
 }
 
@@ -631,7 +573,6 @@ export namespace DocumentInfo {
    */
   export const filterSensitiveLog = (obj: DocumentInfo): any => ({
     ...obj,
-    ...(obj.Attributes && { Attributes: obj.Attributes.map((item) => DocumentAttribute.filterSensitiveLog(item)) }),
   });
 }
 
@@ -929,7 +870,6 @@ export namespace Document {
    */
   export const filterSensitiveLog = (obj: Document): any => ({
     ...obj,
-    ...(obj.Attributes && { Attributes: obj.Attributes.map((item) => DocumentAttribute.filterSensitiveLog(item)) }),
   });
 }
 
@@ -6567,9 +6507,6 @@ export namespace DocumentAttributeValueCountPair {
    */
   export const filterSensitiveLog = (obj: DocumentAttributeValueCountPair): any => ({
     ...obj,
-    ...(obj.DocumentAttributeValue && {
-      DocumentAttributeValue: DocumentAttributeValue.filterSensitiveLog(obj.DocumentAttributeValue),
-    }),
   });
 }
 
@@ -6603,11 +6540,6 @@ export namespace FacetResult {
    */
   export const filterSensitiveLog = (obj: FacetResult): any => ({
     ...obj,
-    ...(obj.DocumentAttributeValueCountPairs && {
-      DocumentAttributeValueCountPairs: obj.DocumentAttributeValueCountPairs.map((item) =>
-        DocumentAttributeValueCountPair.filterSensitiveLog(item)
-      ),
-    }),
   });
 }
 
@@ -6721,9 +6653,6 @@ export namespace QueryResultItem {
    */
   export const filterSensitiveLog = (obj: QueryResultItem): any => ({
     ...obj,
-    ...(obj.DocumentAttributes && {
-      DocumentAttributes: obj.DocumentAttributes.map((item) => DocumentAttribute.filterSensitiveLog(item)),
-    }),
   });
 }
 
@@ -7391,20 +7320,6 @@ export namespace AttributeFilter {
    */
   export const filterSensitiveLog = (obj: AttributeFilter): any => ({
     ...obj,
-    ...(obj.AndAllFilters && {
-      AndAllFilters: obj.AndAllFilters.map((item) => AttributeFilter.filterSensitiveLog(item)),
-    }),
-    ...(obj.OrAllFilters && { OrAllFilters: obj.OrAllFilters.map((item) => AttributeFilter.filterSensitiveLog(item)) }),
-    ...(obj.NotFilter && { NotFilter: AttributeFilter.filterSensitiveLog(obj.NotFilter) }),
-    ...(obj.EqualsTo && { EqualsTo: DocumentAttribute.filterSensitiveLog(obj.EqualsTo) }),
-    ...(obj.ContainsAll && { ContainsAll: DocumentAttribute.filterSensitiveLog(obj.ContainsAll) }),
-    ...(obj.ContainsAny && { ContainsAny: DocumentAttribute.filterSensitiveLog(obj.ContainsAny) }),
-    ...(obj.GreaterThan && { GreaterThan: DocumentAttribute.filterSensitiveLog(obj.GreaterThan) }),
-    ...(obj.GreaterThanOrEquals && {
-      GreaterThanOrEquals: DocumentAttribute.filterSensitiveLog(obj.GreaterThanOrEquals),
-    }),
-    ...(obj.LessThan && { LessThan: DocumentAttribute.filterSensitiveLog(obj.LessThan) }),
-    ...(obj.LessThanOrEquals && { LessThanOrEquals: DocumentAttribute.filterSensitiveLog(obj.LessThanOrEquals) }),
   });
 }
 
@@ -7511,6 +7426,5 @@ export namespace QueryRequest {
    */
   export const filterSensitiveLog = (obj: QueryRequest): any => ({
     ...obj,
-    ...(obj.AttributeFilter && { AttributeFilter: AttributeFilter.filterSensitiveLog(obj.AttributeFilter) }),
   });
 }

--- a/clients/client-kendra/src/protocols/Aws_json1_1.ts
+++ b/clients/client-kendra/src/protocols/Aws_json1_1.ts
@@ -6,7 +6,6 @@ import {
   expectNonNull as __expectNonNull,
   expectNumber as __expectNumber,
   expectString as __expectString,
-  expectUnion as __expectUnion,
   limitedParseFloat32 as __limitedParseFloat32,
   parseEpochTimestamp as __parseEpochTimestamp,
   serializeFloat as __serializeFloat,
@@ -5849,15 +5848,16 @@ const serializeAws_json1_1DocumentAttributeStringListValue = (input: string[], c
 };
 
 const serializeAws_json1_1DocumentAttributeValue = (input: DocumentAttributeValue, context: __SerdeContext): any => {
-  return DocumentAttributeValue.visit(input, {
-    DateValue: (value) => ({ DateValue: Math.round(value.getTime() / 1000) }),
-    LongValue: (value) => ({ LongValue: value }),
-    StringListValue: (value) => ({
-      StringListValue: serializeAws_json1_1DocumentAttributeStringListValue(value, context),
-    }),
-    StringValue: (value) => ({ StringValue: value }),
-    _: (name, value) => ({ name: value } as any),
-  });
+  return {
+    ...(input.DateValue !== undefined &&
+      input.DateValue !== null && { DateValue: Math.round(input.DateValue.getTime() / 1000) }),
+    ...(input.LongValue !== undefined && input.LongValue !== null && { LongValue: input.LongValue }),
+    ...(input.StringListValue !== undefined &&
+      input.StringListValue !== null && {
+        StringListValue: serializeAws_json1_1DocumentAttributeStringListValue(input.StringListValue, context),
+      }),
+    ...(input.StringValue !== undefined && input.StringValue !== null && { StringValue: input.StringValue }),
+  };
 };
 
 const serializeAws_json1_1DocumentIdList = (input: string[], context: __SerdeContext): any => {
@@ -8170,7 +8170,7 @@ const deserializeAws_json1_1DocumentAttribute = (output: any, context: __SerdeCo
     Key: __expectString(output.Key),
     Value:
       output.Value !== undefined && output.Value !== null
-        ? deserializeAws_json1_1DocumentAttributeValue(__expectUnion(output.Value), context)
+        ? deserializeAws_json1_1DocumentAttributeValue(output.Value, context)
         : undefined,
   } as any;
 };
@@ -8198,23 +8198,18 @@ const deserializeAws_json1_1DocumentAttributeStringListValue = (output: any, con
 };
 
 const deserializeAws_json1_1DocumentAttributeValue = (output: any, context: __SerdeContext): DocumentAttributeValue => {
-  if (output.DateValue !== undefined && output.DateValue !== null) {
-    return {
-      DateValue: __expectNonNull(__parseEpochTimestamp(__expectNumber(output.DateValue))),
-    };
-  }
-  if (__expectLong(output.LongValue) !== undefined) {
-    return { LongValue: __expectLong(output.LongValue) as any };
-  }
-  if (output.StringListValue !== undefined && output.StringListValue !== null) {
-    return {
-      StringListValue: deserializeAws_json1_1DocumentAttributeStringListValue(output.StringListValue, context),
-    };
-  }
-  if (__expectString(output.StringValue) !== undefined) {
-    return { StringValue: __expectString(output.StringValue) as any };
-  }
-  return { $unknown: Object.entries(output)[0] };
+  return {
+    DateValue:
+      output.DateValue !== undefined && output.DateValue !== null
+        ? __expectNonNull(__parseEpochTimestamp(__expectNumber(output.DateValue)))
+        : undefined,
+    LongValue: __expectLong(output.LongValue),
+    StringListValue:
+      output.StringListValue !== undefined && output.StringListValue !== null
+        ? deserializeAws_json1_1DocumentAttributeStringListValue(output.StringListValue, context)
+        : undefined,
+    StringValue: __expectString(output.StringValue),
+  } as any;
 };
 
 const deserializeAws_json1_1DocumentAttributeValueCountPair = (
@@ -8225,7 +8220,7 @@ const deserializeAws_json1_1DocumentAttributeValueCountPair = (
     Count: __expectInt32(output.Count),
     DocumentAttributeValue:
       output.DocumentAttributeValue !== undefined && output.DocumentAttributeValue !== null
-        ? deserializeAws_json1_1DocumentAttributeValue(__expectUnion(output.DocumentAttributeValue), context)
+        ? deserializeAws_json1_1DocumentAttributeValue(output.DocumentAttributeValue, context)
         : undefined,
   } as any;
 };


### PR DESCRIPTION
### Description
`DocumentAttributeValue` was incorrectly modeled as an enum instead of a structure.
This update changes `DocumentAttributeValue` to a structure shape. It means the associated
JavaScript object can contain more than 1 entry.

### Additional context
This PR is separate from #3039 to generate a standalone changelog entry

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
