### PR TITLE
fix(clients): merge default variants by comparing tags

### DIFF
--- a/clients/client-acm-pca/src/endpoints.ts
+++ b/clients/client-acm-pca/src/endpoints.ts
@@ -200,6 +200,14 @@ const partitionHash: PartitionHash = {
         hostname: "acm-pca.{region}.amazonaws.com",
         tags: ["fips"],
       },
+      {
+        hostname: "acm-pca-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "acm-pca.{region}.api.aws",
+        tags: ["dualstack"],
+      },
     ],
   },
 };

--- a/clients/client-batch/src/endpoints.ts
+++ b/clients/client-batch/src/endpoints.ts
@@ -115,6 +115,14 @@ const partitionHash: PartitionHash = {
         hostname: "fips.batch.{region}.amazonaws.com",
         tags: ["fips"],
       },
+      {
+        hostname: "batch-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "batch.{region}.api.aws",
+        tags: ["dualstack"],
+      },
     ],
   },
   "aws-cn": {
@@ -178,6 +186,14 @@ const partitionHash: PartitionHash = {
       {
         hostname: "batch.{region}.amazonaws.com",
         tags: ["fips"],
+      },
+      {
+        hostname: "batch-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "batch.{region}.api.aws",
+        tags: ["dualstack"],
       },
     ],
   },

--- a/clients/client-cloudwatch/src/endpoints.ts
+++ b/clients/client-cloudwatch/src/endpoints.ts
@@ -187,6 +187,14 @@ const partitionHash: PartitionHash = {
         hostname: "monitoring.{region}.amazonaws.com",
         tags: ["fips"],
       },
+      {
+        hostname: "monitoring-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "monitoring.{region}.api.aws",
+        tags: ["dualstack"],
+      },
     ],
   },
 };

--- a/clients/client-config-service/src/endpoints.ts
+++ b/clients/client-config-service/src/endpoints.ts
@@ -187,6 +187,14 @@ const partitionHash: PartitionHash = {
         hostname: "config.{region}.amazonaws.com",
         tags: ["fips"],
       },
+      {
+        hostname: "config-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "config.{region}.api.aws",
+        tags: ["dualstack"],
+      },
     ],
   },
 };

--- a/clients/client-database-migration-service/src/endpoints.ts
+++ b/clients/client-database-migration-service/src/endpoints.ts
@@ -213,6 +213,14 @@ const partitionHash: PartitionHash = {
         hostname: "dms.{region}.amazonaws.com",
         tags: ["fips"],
       },
+      {
+        hostname: "dms-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "dms.{region}.api.aws",
+        tags: ["dualstack"],
+      },
     ],
   },
 };

--- a/clients/client-docdb/src/endpoints.ts
+++ b/clients/client-docdb/src/endpoints.ts
@@ -217,6 +217,14 @@ const partitionHash: PartitionHash = {
         hostname: "rds.{region}.amazonaws.com",
         tags: ["fips"],
       },
+      {
+        hostname: "rds-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "rds.{region}.api.aws",
+        tags: ["dualstack"],
+      },
     ],
   },
 };

--- a/clients/client-dynamodb/src/endpoints.ts
+++ b/clients/client-dynamodb/src/endpoints.ts
@@ -210,6 +210,14 @@ const partitionHash: PartitionHash = {
         hostname: "dynamodb.{region}.amazonaws.com",
         tags: ["fips"],
       },
+      {
+        hostname: "dynamodb-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "dynamodb.{region}.api.aws",
+        tags: ["dualstack"],
+      },
     ],
   },
 };

--- a/clients/client-ecr/src/endpoints.ts
+++ b/clients/client-ecr/src/endpoints.ts
@@ -327,6 +327,14 @@ const partitionHash: PartitionHash = {
         hostname: "ecr-fips.{region}.amazonaws.com",
         tags: ["fips"],
       },
+      {
+        hostname: "api.ecr-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "api.ecr.{region}.api.aws",
+        tags: ["dualstack"],
+      },
     ],
   },
   "aws-cn": {
@@ -399,6 +407,14 @@ const partitionHash: PartitionHash = {
       {
         hostname: "ecr-fips.{region}.amazonaws.com",
         tags: ["fips"],
+      },
+      {
+        hostname: "api.ecr-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "api.ecr.{region}.api.aws",
+        tags: ["dualstack"],
       },
     ],
   },

--- a/clients/client-eks/src/endpoints.ts
+++ b/clients/client-eks/src/endpoints.ts
@@ -115,6 +115,14 @@ const partitionHash: PartitionHash = {
         hostname: "fips.eks.{region}.amazonaws.com",
         tags: ["fips"],
       },
+      {
+        hostname: "eks-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "eks.{region}.api.aws",
+        tags: ["dualstack"],
+      },
     ],
   },
   "aws-cn": {
@@ -178,6 +186,14 @@ const partitionHash: PartitionHash = {
       {
         hostname: "eks.{region}.amazonaws.com",
         tags: ["fips"],
+      },
+      {
+        hostname: "eks-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "eks.{region}.api.aws",
+        tags: ["dualstack"],
       },
     ],
   },

--- a/clients/client-elastic-load-balancing-v2/src/endpoints.ts
+++ b/clients/client-elastic-load-balancing-v2/src/endpoints.ts
@@ -187,6 +187,14 @@ const partitionHash: PartitionHash = {
         hostname: "elasticloadbalancing.{region}.amazonaws.com",
         tags: ["fips"],
       },
+      {
+        hostname: "elasticloadbalancing-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "elasticloadbalancing.{region}.api.aws",
+        tags: ["dualstack"],
+      },
     ],
   },
 };

--- a/clients/client-elastic-load-balancing/src/endpoints.ts
+++ b/clients/client-elastic-load-balancing/src/endpoints.ts
@@ -187,6 +187,14 @@ const partitionHash: PartitionHash = {
         hostname: "elasticloadbalancing.{region}.amazonaws.com",
         tags: ["fips"],
       },
+      {
+        hostname: "elasticloadbalancing-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "elasticloadbalancing.{region}.api.aws",
+        tags: ["dualstack"],
+      },
     ],
   },
 };

--- a/clients/client-elasticache/src/endpoints.ts
+++ b/clients/client-elasticache/src/endpoints.ts
@@ -176,6 +176,14 @@ const partitionHash: PartitionHash = {
         hostname: "elasticache.{region}.amazonaws.com",
         tags: ["fips"],
       },
+      {
+        hostname: "elasticache-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "elasticache.{region}.api.aws",
+        tags: ["dualstack"],
+      },
     ],
   },
 };

--- a/clients/client-emr/src/endpoints.ts
+++ b/clients/client-emr/src/endpoints.ts
@@ -200,6 +200,14 @@ const partitionHash: PartitionHash = {
         hostname: "elasticmapreduce.{region}.amazonaws.com",
         tags: ["fips"],
       },
+      {
+        hostname: "elasticmapreduce-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "elasticmapreduce.{region}.api.aws",
+        tags: ["dualstack"],
+      },
     ],
   },
 };

--- a/clients/client-guardduty/src/endpoints.ts
+++ b/clients/client-guardduty/src/endpoints.ts
@@ -187,6 +187,14 @@ const partitionHash: PartitionHash = {
         hostname: "guardduty.{region}.amazonaws.com",
         tags: ["fips"],
       },
+      {
+        hostname: "guardduty-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "guardduty.{region}.api.aws",
+        tags: ["dualstack"],
+      },
     ],
   },
 };

--- a/clients/client-identitystore/src/endpoints.ts
+++ b/clients/client-identitystore/src/endpoints.ts
@@ -123,6 +123,14 @@ const partitionHash: PartitionHash = {
         hostname: "identitystore.{region}.amazonaws.com",
         tags: ["fips"],
       },
+      {
+        hostname: "identitystore-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "identitystore.{region}.api.aws",
+        tags: ["dualstack"],
+      },
     ],
   },
 };

--- a/clients/client-lex-model-building-service/src/endpoints.ts
+++ b/clients/client-lex-model-building-service/src/endpoints.ts
@@ -77,6 +77,14 @@ const partitionHash: PartitionHash = {
         hostname: "models-fips.lex.{region}.amazonaws.com",
         tags: ["fips"],
       },
+      {
+        hostname: "models.lex-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "models.lex.{region}.api.aws",
+        tags: ["dualstack"],
+      },
     ],
   },
   "aws-cn": {
@@ -140,6 +148,14 @@ const partitionHash: PartitionHash = {
       {
         hostname: "models-fips.lex.{region}.amazonaws.com",
         tags: ["fips"],
+      },
+      {
+        hostname: "models.lex-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "models.lex.{region}.api.aws",
+        tags: ["dualstack"],
       },
     ],
   },

--- a/clients/client-lex-runtime-service/src/endpoints.ts
+++ b/clients/client-lex-runtime-service/src/endpoints.ts
@@ -77,6 +77,14 @@ const partitionHash: PartitionHash = {
         hostname: "runtime-fips.lex.{region}.amazonaws.com",
         tags: ["fips"],
       },
+      {
+        hostname: "runtime.lex-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "runtime.lex.{region}.api.aws",
+        tags: ["dualstack"],
+      },
     ],
   },
   "aws-cn": {
@@ -140,6 +148,14 @@ const partitionHash: PartitionHash = {
       {
         hostname: "runtime-fips.lex.{region}.amazonaws.com",
         tags: ["fips"],
+      },
+      {
+        hostname: "runtime.lex-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "runtime.lex.{region}.api.aws",
+        tags: ["dualstack"],
       },
     ],
   },

--- a/clients/client-neptune/src/endpoints.ts
+++ b/clients/client-neptune/src/endpoints.ts
@@ -217,6 +217,14 @@ const partitionHash: PartitionHash = {
         hostname: "rds.{region}.amazonaws.com",
         tags: ["fips"],
       },
+      {
+        hostname: "rds-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "rds.{region}.api.aws",
+        tags: ["dualstack"],
+      },
     ],
   },
 };

--- a/clients/client-rds/src/endpoints.ts
+++ b/clients/client-rds/src/endpoints.ts
@@ -217,6 +217,14 @@ const partitionHash: PartitionHash = {
         hostname: "rds.{region}.amazonaws.com",
         tags: ["fips"],
       },
+      {
+        hostname: "rds-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "rds.{region}.api.aws",
+        tags: ["dualstack"],
+      },
     ],
   },
 };

--- a/clients/client-resource-groups/src/endpoints.ts
+++ b/clients/client-resource-groups/src/endpoints.ts
@@ -187,6 +187,14 @@ const partitionHash: PartitionHash = {
         hostname: "resource-groups.{region}.amazonaws.com",
         tags: ["fips"],
       },
+      {
+        hostname: "resource-groups-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "resource-groups.{region}.api.aws",
+        tags: ["dualstack"],
+      },
     ],
   },
 };

--- a/clients/client-s3-control/src/endpoints.ts
+++ b/clients/client-s3-control/src/endpoints.ts
@@ -370,6 +370,10 @@ const partitionHash: PartitionHash = {
         tags: [],
       },
       {
+        hostname: "s3-control-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
         hostname: "s3-control-fips.dualstack.{region}.amazonaws.com",
         tags: ["dualstack", "fips"],
       },
@@ -386,6 +390,14 @@ const partitionHash: PartitionHash = {
       {
         hostname: "s3-control.{region}.amazonaws.com.cn",
         tags: [],
+      },
+      {
+        hostname: "s3-control-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "s3-control-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
       },
       {
         hostname: "s3-control.dualstack.{region}.amazonaws.com.cn",
@@ -428,6 +440,10 @@ const partitionHash: PartitionHash = {
       {
         hostname: "s3-control.{region}.amazonaws.com",
         tags: [],
+      },
+      {
+        hostname: "s3-control-fips.{region}.amazonaws.com",
+        tags: ["fips"],
       },
       {
         hostname: "s3-control-fips.dualstack.{region}.amazonaws.com",

--- a/clients/client-s3/src/endpoints.ts
+++ b/clients/client-s3/src/endpoints.ts
@@ -409,6 +409,10 @@ const partitionHash: PartitionHash = {
         tags: [],
       },
       {
+        hostname: "s3-fips.{region}.amazonaws.com",
+        tags: ["fips"],
+      },
+      {
         hostname: "s3-fips.dualstack.{region}.amazonaws.com",
         tags: ["dualstack", "fips"],
       },
@@ -425,6 +429,14 @@ const partitionHash: PartitionHash = {
       {
         hostname: "s3.{region}.amazonaws.com.cn",
         tags: [],
+      },
+      {
+        hostname: "s3-fips.{region}.amazonaws.com.cn",
+        tags: ["fips"],
+      },
+      {
+        hostname: "s3-fips.{region}.api.amazonwebservices.com.cn",
+        tags: ["dualstack", "fips"],
       },
       {
         hostname: "s3.dualstack.{region}.amazonaws.com.cn",
@@ -467,6 +479,10 @@ const partitionHash: PartitionHash = {
       {
         hostname: "s3.{region}.amazonaws.com",
         tags: [],
+      },
+      {
+        hostname: "s3-fips.{region}.amazonaws.com",
+        tags: ["fips"],
       },
       {
         hostname: "s3-fips.dualstack.{region}.amazonaws.com",

--- a/clients/client-sagemaker-runtime/src/endpoints.ts
+++ b/clients/client-sagemaker-runtime/src/endpoints.ts
@@ -103,6 +103,14 @@ const partitionHash: PartitionHash = {
         hostname: "runtime-fips.sagemaker.{region}.amazonaws.com",
         tags: ["fips"],
       },
+      {
+        hostname: "runtime.sagemaker-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "runtime.sagemaker.{region}.api.aws",
+        tags: ["dualstack"],
+      },
     ],
   },
   "aws-cn": {
@@ -166,6 +174,14 @@ const partitionHash: PartitionHash = {
       {
         hostname: "runtime.sagemaker.{region}.amazonaws.com",
         tags: ["fips"],
+      },
+      {
+        hostname: "runtime.sagemaker-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "runtime.sagemaker.{region}.api.aws",
+        tags: ["dualstack"],
       },
     ],
   },

--- a/clients/client-sagemaker/src/endpoints.ts
+++ b/clients/client-sagemaker/src/endpoints.ts
@@ -103,6 +103,14 @@ const partitionHash: PartitionHash = {
         hostname: "api-fips.sagemaker.{region}.amazonaws.com",
         tags: ["fips"],
       },
+      {
+        hostname: "api.sagemaker-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "api.sagemaker.{region}.api.aws",
+        tags: ["dualstack"],
+      },
     ],
   },
   "aws-cn": {
@@ -172,6 +180,14 @@ const partitionHash: PartitionHash = {
       {
         hostname: "api-fips.sagemaker.{region}.amazonaws.com",
         tags: ["fips"],
+      },
+      {
+        hostname: "api.sagemaker-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "api.sagemaker.{region}.api.aws",
+        tags: ["dualstack"],
       },
     ],
   },

--- a/clients/client-service-catalog-appregistry/src/endpoints.ts
+++ b/clients/client-service-catalog-appregistry/src/endpoints.ts
@@ -200,6 +200,14 @@ const partitionHash: PartitionHash = {
         hostname: "servicecatalog-appregistry.{region}.amazonaws.com",
         tags: ["fips"],
       },
+      {
+        hostname: "servicecatalog-appregistry-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "servicecatalog-appregistry.{region}.api.aws",
+        tags: ["dualstack"],
+      },
     ],
   },
 };

--- a/clients/client-service-quotas/src/endpoints.ts
+++ b/clients/client-service-quotas/src/endpoints.ts
@@ -135,6 +135,14 @@ const partitionHash: PartitionHash = {
         hostname: "servicequotas.{region}.amazonaws.com",
         tags: ["fips"],
       },
+      {
+        hostname: "servicequotas-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "servicequotas.{region}.api.aws",
+        tags: ["dualstack"],
+      },
     ],
   },
 };

--- a/clients/client-ssm/src/endpoints.ts
+++ b/clients/client-ssm/src/endpoints.ts
@@ -200,6 +200,14 @@ const partitionHash: PartitionHash = {
         hostname: "ssm.{region}.amazonaws.com",
         tags: ["fips"],
       },
+      {
+        hostname: "ssm-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "ssm.{region}.api.aws",
+        tags: ["dualstack"],
+      },
     ],
   },
 };

--- a/clients/client-sts/src/endpoints.ts
+++ b/clients/client-sts/src/endpoints.ts
@@ -197,6 +197,14 @@ const partitionHash: PartitionHash = {
         hostname: "sts.{region}.amazonaws.com",
         tags: ["fips"],
       },
+      {
+        hostname: "sts-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "sts.{region}.api.aws",
+        tags: ["dualstack"],
+      },
     ],
   },
 };

--- a/clients/client-transcribe/src/endpoints.ts
+++ b/clients/client-transcribe/src/endpoints.ts
@@ -146,6 +146,14 @@ const partitionHash: PartitionHash = {
         hostname: "fips.transcribe.{region}.amazonaws.com",
         tags: ["fips"],
       },
+      {
+        hostname: "transcribe-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "transcribe.{region}.api.aws",
+        tags: ["dualstack"],
+      },
     ],
   },
   "aws-cn": {
@@ -209,6 +217,14 @@ const partitionHash: PartitionHash = {
       {
         hostname: "fips.transcribe.{region}.amazonaws.com",
         tags: ["fips"],
+      },
+      {
+        hostname: "transcribe-fips.{region}.api.aws",
+        tags: ["dualstack", "fips"],
+      },
+      {
+        hostname: "transcribe.{region}.api.aws",
+        tags: ["dualstack"],
       },
     ],
   },


### PR DESCRIPTION
### Issue
Fixes https://github.com/aws/aws-sdk-js-v3/issues/3043

### Description
Merges variants from partition defaults and service defaults using tags as unique key

### Testing
Verified that endpoint resolution returns `dynamodb.us-gov-east-1.api.aws` for DynamoDB with region=us-gov-east-1 and useDualstackEndpoint=true

<details>
<summary>Code</summary>

```js
import { DynamoDB } from "../aws-sdk-js-v3/clients/client-dynamodb/dist-cjs/index.js";

const client = new DynamoDB({
  region: "us-gov-east-1",
  useDualstackEndpoint: true,
});
await client.listTables({});
```

</details>

<details>
<summary>Output</summary>

```console
node:internal/process/esm_loader:94
    internalBinding('errors').triggerUncaughtException(
                              ^

Error: getaddrinfo ENOTFOUND dynamodb.us-gov-east-1.api.aws
    at GetAddrInfoReqWrap.onlookup [as oncomplete] (node:dns:71:26) {
  errno: -3008,
  code: 'ENOTFOUND',
  syscall: 'getaddrinfo',
  hostname: 'dynamodb.us-gov-east-1.api.aws',
  '$metadata': { attempts: 1, totalRetryDelay: 0 }
}
```

</details>

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
