### PR TITLE
chore(codegen): set JVM memory size to 4gb

### DIFF
--- a/codegen/build.gradle.kts
+++ b/codegen/build.gradle.kts
@@ -90,6 +90,10 @@ subprojects {
             useJUnitPlatform()
         }
 
+        tasks.withType<JavaExec> {
+            jvmArgs = ['-Xms4g', '-Xmx4g']
+        }
+
         // Apply junit 5 and hamcrest test dependencies to all java projects.
         dependencies {
             testImplementation("org.junit.jupiter:junit-jupiter-api:5.4.0")

--- a/codegen/build.gradle.kts
+++ b/codegen/build.gradle.kts
@@ -91,7 +91,7 @@ subprojects {
         }
 
         tasks.withType<JavaExec> {
-            jvmArgs = ['-Xms4g', '-Xmx4g']
+            jvmArgs = listOf<String>("-Xms4g", "-Xmx4g")
         }
 
         // Apply junit 5 and hamcrest test dependencies to all java projects.


### PR DESCRIPTION
### Description
Codegen throws transient out-of-memory error when generating the biggest model-EC2. Bump up the JVM memory as an workaround. 

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
