### PR TITLE
test(e2e-legacy): fix incorrect client imports

### DIFF
--- a/features/cloudwatchevents/step_definitions/cloudwatchevents.js
+++ b/features/cloudwatchevents/step_definitions/cloudwatchevents.js
@@ -1,7 +1,7 @@
 const { Before } = require("cucumber");
 
 Before({ tags: "@cloudwatchevents" }, function (scenario, callback) {
-  const { CloudWatchEvents } = require("../../../clients/client-cloudwatchevents");
+  const { CloudWatchEvents } = require("../../../clients/client-cloudwatch-events");
   this.service = new CloudWatchEvents({});
   callback();
 });

--- a/features/cloudwatchlogs/step_definitions/cloudwatchlogs.js
+++ b/features/cloudwatchlogs/step_definitions/cloudwatchlogs.js
@@ -1,7 +1,7 @@
 const { Before, Given, Then } = require("cucumber");
 
 Before({ tags: "@cloudwatchlogs" }, function (scenario, callback) {
-  const { CloudWatchLogs } = require("../../../clients/client-cloudwatchlogs");
+  const { CloudWatchLogs } = require("../../../clients/client-cloudwatch-logs");
   this.service = new CloudWatchLogs({});
   callback();
 });

--- a/features/cognitoidentity/step_definitions/cognitoidentity.js
+++ b/features/cognitoidentity/step_definitions/cognitoidentity.js
@@ -1,7 +1,7 @@
 const { Before, Given, Then } = require("cucumber");
 
 Before({ tags: "@cognitoidentity" }, function (scenario, callback) {
-  const { CognitoIdentity } = require("../../../clients/client-cognitoidentity");
+  const { CognitoIdentity } = require("../../../clients/client-cognito-identity");
   this.service = new CognitoIdentity({});
   callback();
 });

--- a/features/cognitosync/step_definitions/cognitosync.js
+++ b/features/cognitosync/step_definitions/cognitosync.js
@@ -1,7 +1,7 @@
 const { Before, Given } = require("cucumber");
 
 Before({ tags: "@cognitosync" }, function (scenario, callback) {
-  const { CognitoSync } = require("../../../clients/client-cognitosync");
+  const { CognitoSync } = require("../../../clients/client-cognito-sync");
   this.service = new CognitoSync({});
   callback();
 });

--- a/features/configservice/step_definitions/configservice.js
+++ b/features/configservice/step_definitions/configservice.js
@@ -1,7 +1,7 @@
 const { Before } = require("cucumber");
 
 Before({ tags: "@configservice" }, function (scenario, callback) {
-  const { ConfigService } = require("../../../clients/client-configservice");
+  const { ConfigService } = require("../../../clients/client-config-service");
   this.service = new ConfigService({});
   callback();
 });

--- a/features/datapipeline/step_definitions/datapipeline.js
+++ b/features/datapipeline/step_definitions/datapipeline.js
@@ -1,7 +1,7 @@
 const { Before, Given } = require("cucumber");
 
 Before({ tags: "@datapipeline" }, function (scenario, callback) {
-  const { DataPipeline } = require("../../../clients/client-datapipeline");
+  const { DataPipeline } = require("../../../clients/client-data-pipeline");
   this.service = new DataPipeline({});
   callback();
 });

--- a/features/devicefarm/step_definitions/devicefarm.js
+++ b/features/devicefarm/step_definitions/devicefarm.js
@@ -1,7 +1,7 @@
 const { Before } = require("cucumber");
 
 Before({ tags: "@devicefarm" }, function (scenario, callback) {
-  const { DeviceFarm } = require("../../../clients/client-devicefarm");
+  const { DeviceFarm } = require("../../../clients/client-device-farm");
   this.service = new DeviceFarm({ region: "us-west-2" });
   callback();
 });

--- a/features/directconnect/step_definitions/directconnect.js
+++ b/features/directconnect/step_definitions/directconnect.js
@@ -1,7 +1,7 @@
 const { Before, Given } = require("cucumber");
 
 Before({ tags: "@directconnect" }, function (scenario, callback) {
-  const { DirectConnect } = require("../../../clients/client-directconnect");
+  const { DirectConnect } = require("../../../clients/client-direct-connect");
   this.service = new DirectConnect({});
   callback();
 });

--- a/features/directoryservice/step_definitions/directoryservice.js
+++ b/features/directoryservice/step_definitions/directoryservice.js
@@ -1,7 +1,7 @@
 const { Before } = require("cucumber");
 
 Before({ tags: "@directoryservice" }, function (scenario, callback) {
-  const { DirectoryService } = require("../../../clients/client-directoryservice");
+  const { DirectoryService } = require("../../../clients/client-directory-service");
   this.service = new DirectoryService({});
   callback();
 });

--- a/features/dms/step_definitions/dms.js
+++ b/features/dms/step_definitions/dms.js
@@ -1,7 +1,7 @@
 const { Before } = require("cucumber");
 
 Before({ tags: "@databasemigrationservice" }, function (scenario, callback) {
-  const { DatabaseMigrationService } = require("../../../clients/client-databasemigrationservice");
+  const { DatabaseMigrationService } = require("../../../clients/client-database-migration-service");
   this.service = new DatabaseMigrationService({});
   callback();
 });

--- a/features/dynamodbstreams/step_definitions/dynamodbstreams.js
+++ b/features/dynamodbstreams/step_definitions/dynamodbstreams.js
@@ -1,7 +1,7 @@
 const { Before } = require("cucumber");
 
 Before({ tags: "@dynamodbstreams" }, function (scenario, callback) {
-  const { DynamoDBStreams } = require("../../../clients/client-dynamodbstreams");
+  const { DynamoDBStreams } = require("../../../clients/client-dynamodb-streams");
   this.service = new DynamoDBStreams({});
   callback();
 });

--- a/features/elasticbeanstalk/step_definitions/elasticbeanstalk.js
+++ b/features/elasticbeanstalk/step_definitions/elasticbeanstalk.js
@@ -1,7 +1,7 @@
 const { Before, Given, Then } = require("cucumber");
 
 Before({ tags: "@elasticbeanstalk" }, function (scenario, callback) {
-  const { ElasticBeanstalk } = require("../../../clients/client-elasticbeanstalk");
+  const { ElasticBeanstalk } = require("../../../clients/client-elastic-beanstalk");
   this.service = new ElasticBeanstalk({});
   callback();
 });

--- a/features/elastictranscoder/step_definitions/elastictranscoder.js
+++ b/features/elastictranscoder/step_definitions/elastictranscoder.js
@@ -3,7 +3,7 @@ const { Before, Given, Then } = require("cucumber");
 Before({ tags: "@elastictranscoder" }, function (scenario, callback) {
   const { S3 } = require("../../../clients/client-s3");
   const { IAM } = require("../../../clients/client-iam");
-  const { ElasticTranscoder } = require("../../../clients/client-elastictranscoder");
+  const { ElasticTranscoder } = require("../../../clients/client-elastic-transcoder");
   this.iam = new IAM({});
   this.s3 = new S3({});
   this.service = new ElasticTranscoder({});

--- a/features/elb/step_definitions/elb.js
+++ b/features/elb/step_definitions/elb.js
@@ -1,7 +1,7 @@
 const { Before, Given, Then } = require("cucumber");
 
 Before({ tags: "@elasticloadbalancing" }, function (scenario, callback) {
-  const { ElasticLoadBalancing } = require("../../../clients/client-elasticloadbalancing");
+  const { ElasticLoadBalancing } = require("../../../clients/client-elastic-load-balancing");
   this.service = new ElasticLoadBalancing({});
   callback();
 });

--- a/features/elbv2/step_definitions/elbv2.js
+++ b/features/elbv2/step_definitions/elbv2.js
@@ -1,7 +1,7 @@
 const { Before } = require("cucumber");
 
 Before({ tags: "@elasticloadbalancingv2" }, function (scenario, callback) {
-  const { ElasticLoadBalancingV2 } = require("../../../clients/client-elasticloadbalancingv2");
+  const { ElasticLoadBalancingV2 } = require("../../../clients/client-elastic-load-balancing-v2");
   this.service = new ElasticLoadBalancingV2({});
   callback();
 });

--- a/features/es/step_definitions/es.js
+++ b/features/es/step_definitions/es.js
@@ -1,7 +1,7 @@
 const { Before } = require("cucumber");
 
 Before({ tags: "@elasticsearchservice" }, function (scenario, callback) {
-  const { ElasticsearchService } = require("../../../clients/client-elasticsearchservice");
+  const { ElasticsearchService } = require("../../../clients/client-elasticsearch-service");
   this.service = new ElasticsearchService({});
   callback();
 });

--- a/features/route53/step_definitions/route53.js
+++ b/features/route53/step_definitions/route53.js
@@ -1,7 +1,7 @@
 const { Before, Then, When } = require("cucumber");
 
 Before({ tags: "@route53" }, function (scenario, callback) {
-  const { Route53 } = require("../../../clients/client-route53");
+  const { Route53 } = require("../../../clients/client-route-53");
   this.service = new Route53({});
   callback();
 });

--- a/features/route53domains/step_definitions/route53domains.js
+++ b/features/route53domains/step_definitions/route53domains.js
@@ -1,7 +1,7 @@
 const { Before, Given } = require("cucumber");
 
 Before({ tags: "@route53domains" }, function (scenario, callback) {
-  const { Route53Domains } = require("../../../clients/client-route53domains");
+  const { Route53Domains } = require("../../../clients/client-route-53-domains");
   this.service = new Route53Domains({ region: "us-east-1" });
   callback();
 });

--- a/features/storagegateway/step_definitions/storagegateway.js
+++ b/features/storagegateway/step_definitions/storagegateway.js
@@ -1,7 +1,7 @@
 const { Before, When } = require("cucumber");
 
 Before({ tags: "@storagegateway" }, function (scenario, callback) {
-  const { StorageGateway } = require("../../../clients/client-storagegateway");
+  const { StorageGateway } = require("../../../clients/client-storage-gateway");
   this.service = new StorageGateway({ region: "us-east-1" });
   callback();
 });


### PR DESCRIPTION
### Issue
followup: https://github.com/aws/aws-sdk-js-v3/pull/3033

### Description
Some import statement was missed in last PR. this change fixes it

### Testing
```console
node node_modules/.bin/cucumber-js
..............................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................

150 scenarios (150 passed)
523 steps (523 passed)
1m41.643s
```

### Additional context
Previous PR did not test in current cucumber test script(`test:integration:legacy` script), it only tested on `test:integration:legacy:since:release` script

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
