### PR TITLE
fix(codegen): use specific smithy-cli version in protocol-test-codegen

### DIFF
--- a/codegen/protocol-test-codegen/build.gradle.kts
+++ b/codegen/protocol-test-codegen/build.gradle.kts
@@ -20,7 +20,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        "classpath"("software.amazon.smithy:smithy-cli:1.12.+")
+        "classpath"("software.amazon.smithy:smithy-cli:${rootProject.extra["smithyVersion"]}")
     }
 }
 


### PR DESCRIPTION
Looks like a miss in earlier [PR](https://github.com/aws/aws-sdk-js-v3/pull/3011/files#diff-ecac4c366ecda2edce8ba9ad12c048529a09b34f458ade1ec42fd8f613d9e564) which locked the versions centrally.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
