### PR TITLE
chore(codegen): bump code generators to 0.8.0

### DIFF
--- a/codegen/CHANGELOG.md
+++ b/codegen/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Smithy AWS Typescript Codegen Changelog
 
+## 0.7.1 (2021-11-04)
+
+### Bug Fixes
+
+* Fixed generator to not rely on unreleased features.
+
 ## 0.7.0 (2021-11-03)
 
 ### Features

--- a/codegen/CHANGELOG.md
+++ b/codegen/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Smithy AWS Typescript Codegen Changelog
 
+## 0.8.0 (2021-11-23)
+
+### Features
+
+* Updated EndpointGenerator to merge variants from partition defaults and service defaults using tags as unique key. ([#2989](https://github.com/aws/aws-sdk-js-v3/pull/2989), [#2990](https://github.com/aws/aws-sdk-js-v3/pull/2990), [#3044](https://github.com/aws/aws-sdk-js-v3/pull/3044))
+* Centralized Smithy version for Smithy dependencies including Smithy CLI. ([#3011](https://github.com/aws/aws-sdk-js-v3/pull/3011), [#3054](https://github.com/aws/aws-sdk-js-v3/pull/3054))
+* Updated Smithy version to `1.14.x`. ([#3053](https://github.com/aws/aws-sdk-js-v3/pull/3053))
+
 ## 0.7.1 (2021-11-04)
 
 ### Bug Fixes

--- a/codegen/build.gradle.kts
+++ b/codegen/build.gradle.kts
@@ -28,7 +28,7 @@ allprojects {
         mavenCentral()
     }
     group = "software.amazon.smithy.typescript"
-    version = "0.7.0"
+    version = "0.8.0"
 }
 
 extra["smithyVersion"] = "[1.14.0,1.15.0["

--- a/codegen/smithy-aws-typescript-codegen/build.gradle.kts
+++ b/codegen/smithy-aws-typescript-codegen/build.gradle.kts
@@ -36,7 +36,7 @@ dependencies {
     api("software.amazon.smithy:smithy-aws-iam-traits:${rootProject.extra["smithyVersion"]}")
     api("software.amazon.smithy:smithy-protocol-test-traits:${rootProject.extra["smithyVersion"]}")
     api("software.amazon.smithy:smithy-model:${rootProject.extra["smithyVersion"]}")
-    api("software.amazon.smithy.typescript:smithy-typescript-codegen:0.7.0")
+    api("software.amazon.smithy.typescript:smithy-typescript-codegen:0.8.0")
 }
 
 tasks.register("set-aws-sdk-versions") {


### PR DESCRIPTION
### Description
Bumps the smithy-typescript-aws-codegen version to 0.8.0 and picks up the 0.8.0 update of smithy-typescript-codegen - https://github.com/awslabs/smithy-typescript/pull/469

### Testing
```
cd codegen
gradle build publishToMavenLocal
cd ../
yarn install
yarn generate-clients
```

### Additional context
smithy-aws-typescript-codegen 0.7.1 was created in a branch https://github.com/aws/aws-sdk-js-v3/pull/2987. Manually copied the changelog entry for 0.7.1 into main here in one commit, and then updated to 0.8.0 in 2nd commit.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
