### PR TITLE
chore(aws-protocoltests-restjson): enable RestJsonNoInputAndOutput

### DIFF
--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsProtocolUtils.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsProtocolUtils.java
@@ -298,9 +298,6 @@ final class AwsProtocolUtils {
         if (testCase.getId().equals("QueryCustomizedError")) {
             return true;
         }
-        if (testCase.getId().equals("RestJsonNoInputAndOutput")) {
-            return true;
-        }
         // TODO: Remove when server protocol tests are fixed in
         // https://github.com/aws/aws-sdk-js-v3/issues/3058
         // TODO: Move to filter specific to server protocol tests if added in

--- a/private/aws-protocoltests-restjson/test/functional/restjson1.spec.ts
+++ b/private/aws-protocoltests-restjson/test/functional/restjson1.spec.ts
@@ -6161,7 +6161,7 @@ it("RestJsonNoInputAndNoOutput:Response", async () => {
  * serialize any data in the payload, they should omit a payload
  * altogether.
  */
-it.skip("RestJsonNoInputAndOutput:Request", async () => {
+it("RestJsonNoInputAndOutput:Request", async () => {
   const client = new RestJsonProtocolClient({
     ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),

--- a/private/aws-protocoltests-restjson/test/functional/restjson1.spec.ts
+++ b/private/aws-protocoltests-restjson/test/functional/restjson1.spec.ts
@@ -7715,7 +7715,7 @@ it("RestJsonHttpWithEmptyStructurePayload:Request", async () => {
 /**
  * Serializes a payload targeting a structure
  */
-it.skip("RestJsonTestPayloadStructure:Request", async () => {
+it("RestJsonTestPayloadStructure:Request", async () => {
   const client = new RestJsonProtocolClient({
     ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
@@ -7757,7 +7757,11 @@ it.skip("RestJsonTestPayloadStructure:Request", async () => {
 /**
  * Serializes an request with header members but no payload
  */
+<<<<<<< HEAD
 it.skip("RestJsonHttpWithHeadersButNoPayload:Request", async () => {
+=======
+it("RestJsonHttpWithHeadersButNoPayload:Request", async () => {
+>>>>>>> e2c63c12e4 (chore(protocol_tests): bump smithy to 1.14.x)
   const client = new RestJsonProtocolClient({
     ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),

--- a/private/aws-protocoltests-restjson/test/functional/restjson1.spec.ts
+++ b/private/aws-protocoltests-restjson/test/functional/restjson1.spec.ts
@@ -7715,7 +7715,7 @@ it("RestJsonHttpWithEmptyStructurePayload:Request", async () => {
 /**
  * Serializes a payload targeting a structure
  */
-it("RestJsonTestPayloadStructure:Request", async () => {
+it.skip("RestJsonTestPayloadStructure:Request", async () => {
   const client = new RestJsonProtocolClient({
     ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
@@ -7757,11 +7757,7 @@ it("RestJsonTestPayloadStructure:Request", async () => {
 /**
  * Serializes an request with header members but no payload
  */
-<<<<<<< HEAD
 it.skip("RestJsonHttpWithHeadersButNoPayload:Request", async () => {
-=======
-it("RestJsonHttpWithHeadersButNoPayload:Request", async () => {
->>>>>>> e2c63c12e4 (chore(protocol_tests): bump smithy to 1.14.x)
   const client = new RestJsonProtocolClient({
     ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),


### PR DESCRIPTION
### Issue
This test was disabled when updating clients in [`d1746ce` (#2674)](https://github.com/aws/aws-sdk-js-v3/pull/2674/commits/d1746ce61ef19377f83bded44a6f89a99c5f7fe8)

The test was disabled as it was incorrect in smithy.
It was fixed by writing server only test `RestJsonNoInputAndOutputAllowsAccept` in https://github.com/awslabs/smithy/pull/935

### Description
Enables RestJsonNoInputAndOutput test in aws-protocoltests-restjson

### Testing
Protocol tests are successful.

### Additional context
This PR will be rebased from main and made ready after smithy is bumped to 1.14.x in https://github.com/aws/aws-sdk-js-v3/pull/3053

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
