### PR TITLE
feat(lib-dynamodb): add pagination

### DIFF
--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddDocumentClientPlugin.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddDocumentClientPlugin.java
@@ -22,7 +22,6 @@ import java.util.TreeSet;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import software.amazon.smithy.aws.traits.ServiceTrait;
-import software.amazon.smithy.codegen.core.Symbol;
 import software.amazon.smithy.codegen.core.SymbolProvider;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.knowledge.TopDownIndex;
@@ -68,12 +67,10 @@ public class AddDocumentClientPlugin implements TypeScriptIntegration {
                     );
 
                     if (operation.hasTrait(PaginatedTrait.ID)) {
-                        Symbol serviceSymbol = symbolProvider.toSymbol(service);
-                        String aggregatedClientName = serviceSymbol.getName().replace("Client", "");
                         String paginationFileName = DocumentClientPaginationGenerator.getOutputFilelocation(operation);
                         writerFactory.accept(paginationFileName, paginationWriter ->
                             new DocumentClientPaginationGenerator(model, service, operation, symbolProvider,
-                                    paginationWriter, aggregatedClientName).run());
+                                    paginationWriter).run());
                     }
                 }
             }

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddDocumentClientPlugin.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddDocumentClientPlugin.java
@@ -92,6 +92,11 @@ public class AddDocumentClientPlugin implements TypeScriptIntegration {
                         writer.write("export * from './$L';", operationFileName);
                     }
             });
+
+            String paginationInterfaceFileName = DocumentClientPaginationGenerator.getInterfaceFilelocation();
+            writerFactory.accept(paginationInterfaceFileName, paginationWriter ->
+                    DocumentClientPaginationGenerator.generateServicePaginationInterfaces(paginationWriter));
+
             writerFactory.accept(String.format("%sindex.ts", DocumentClientUtils.DOC_CLIENT_PREFIX), writer -> {
                 writer.write("export * from './commands';");
                 writer.write("export * from './$L';", DocumentClientUtils.CLIENT_NAME);

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddDocumentClientPlugin.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddDocumentClientPlugin.java
@@ -93,6 +93,18 @@ public class AddDocumentClientPlugin implements TypeScriptIntegration {
                     }
             });
 
+            writerFactory.accept(String.format("%s%s/index.ts", DocumentClientUtils.DOC_CLIENT_PREFIX,
+                DocumentClientPaginationGenerator.PAGINATION_FOLDER), writer -> {
+                    writer.write("export * from './Interfaces';");
+                    for (OperationShape operation : overridenOperationsList) {
+                        if (operation.hasTrait(PaginatedTrait.ID)) {
+                            String paginationFileName =
+                                DocumentClientUtils.getModifiedName(operation.getId().getName()) + "Paginator";
+                            writer.write("export * from './$L';", paginationFileName);
+                        }
+                    }
+            });
+
             String paginationInterfaceFileName = DocumentClientPaginationGenerator.getInterfaceFilelocation();
             writerFactory.accept(paginationInterfaceFileName, paginationWriter ->
                     DocumentClientPaginationGenerator.generateServicePaginationInterfaces(paginationWriter));

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddDocumentClientPlugin.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddDocumentClientPlugin.java
@@ -111,6 +111,7 @@ public class AddDocumentClientPlugin implements TypeScriptIntegration {
 
             writerFactory.accept(String.format("%sindex.ts", DocumentClientUtils.DOC_CLIENT_PREFIX), writer -> {
                 writer.write("export * from './commands';");
+                writer.write("export * from './pagination';");
                 writer.write("export * from './$L';", DocumentClientUtils.CLIENT_NAME);
                 writer.write("export * from './$L';", DocumentClientUtils.CLIENT_FULL_NAME);
             });

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/DocumentClientPaginationGenerator.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/DocumentClientPaginationGenerator.java
@@ -36,10 +36,11 @@ final class DocumentClientPaginationGenerator implements Runnable {
     private final TypeScriptWriter writer;
     private final PaginationInfo paginatedInfo;
 
-    private final String operationName;
+    private final String operationTypeName;
     private final String inputTypeName;
     private final String outputTypeName;
 
+    private final String operationName;
     private final String methodName;
     private final String paginationType;
 
@@ -56,11 +57,12 @@ final class DocumentClientPaginationGenerator implements Runnable {
         Symbol inputSymbol = symbolProvider.toSymbol(operation).expectProperty("inputType", Symbol.class);
         Symbol outputSymbol = symbolProvider.toSymbol(operation).expectProperty("outputType", Symbol.class);
 
-        this.operationName = DocumentClientUtils.getModifiedName(operationSymbol.getName());
+        this.operationTypeName = DocumentClientUtils.getModifiedName(operationSymbol.getName());
         this.inputTypeName = DocumentClientUtils.getModifiedName(inputSymbol.getName());
         this.outputTypeName = DocumentClientUtils.getModifiedName(outputSymbol.getName());
 
         // e.g. listObjects
+        this.operationName = operationTypeName.replace("Command", "");
         this.methodName = Character.toLowerCase(operationName.charAt(0)) + operationName.substring(1);
         this.paginationType = DocumentClientUtils.CLIENT_FULL_NAME + "PaginationConfiguration";
 
@@ -75,8 +77,8 @@ final class DocumentClientPaginationGenerator implements Runnable {
     public void run() {
         // Import Service Types
         String commandFileLocation = Paths.get(".", DocumentClientUtils.CLIENT_COMMANDS_FOLDER,
-            DocumentClientUtils.getModifiedName(operationName)).toString();
-        writer.addImport(operationName, operationName, commandFileLocation);
+            DocumentClientUtils.getModifiedName(operationTypeName)).toString();
+        writer.addImport(operationTypeName, operationTypeName, commandFileLocation);
         writer.addImport(inputTypeName, inputTypeName, commandFileLocation);
         writer.addImport(outputTypeName, outputTypeName, commandFileLocation);
         writer.addImport(
@@ -207,7 +209,7 @@ final class DocumentClientPaginationGenerator implements Runnable {
                 "}", DocumentClientUtils.CLIENT_NAME, inputTypeName,
                 outputTypeName, () -> {
             writer.write("// @ts-ignore");
-            writer.write("return await client.send(new $L(input), ...args);", operationName);
+            writer.write("return await client.send(new $L(input), ...args);", operationTypeName);
         });
     }
 }

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/DocumentClientPaginationGenerator.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/DocumentClientPaginationGenerator.java
@@ -133,35 +133,6 @@ final class DocumentClientPaginationGenerator implements Runnable {
         });
     }
 
-    private static String getModulePath(String fileLocation) {
-        return fileLocation.substring(
-            fileLocation.lastIndexOf("/") + 1,
-            fileLocation.length()
-        ).replace(".ts", "");
-    }
-
-    static void writeIndex(
-            Model model,
-            ServiceShape service,
-            FileManifest fileManifest
-    ) {
-        TypeScriptWriter writer = new TypeScriptWriter("");
-        // writer.write("export * from \"./$L\"", getModulePath(PAGINATION_INTERFACE_FILE));
-
-        TopDownIndex topDownIndex = TopDownIndex.of(model);
-        Set<OperationShape> containedOperations = new TreeSet<>(topDownIndex.getContainedOperations(service));
-        for (OperationShape operation : containedOperations) {
-            if (operation.hasTrait(PaginatedTrait.ID)) {
-                String outputFilepath = DocumentClientPaginationGenerator.getOutputFilelocation(operation);
-                writer.write("export * from \"./$L\"", getModulePath(outputFilepath));
-            }
-        }
-
-        fileManifest.writeFile(
-            Paths.get(CodegenUtils.SOURCE_FOLDER, PAGINATION_FOLDER, "index.ts").toString(),
-            writer.toString());
-    }
-
     private String destructurePath(String path) {
         return "."  + path.replace(".", "!.");
     }

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/DocumentClientPaginationGenerator.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/DocumentClientPaginationGenerator.java
@@ -17,20 +17,14 @@ package software.amazon.smithy.aws.typescript.codegen;
 
 import java.nio.file.Paths;
 import java.util.Optional;
-import java.util.Set;
-import java.util.TreeSet;
-import software.amazon.smithy.build.FileManifest;
 import software.amazon.smithy.codegen.core.CodegenException;
 import software.amazon.smithy.codegen.core.Symbol;
 import software.amazon.smithy.codegen.core.SymbolProvider;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.knowledge.PaginatedIndex;
 import software.amazon.smithy.model.knowledge.PaginationInfo;
-import software.amazon.smithy.model.knowledge.TopDownIndex;
 import software.amazon.smithy.model.shapes.OperationShape;
 import software.amazon.smithy.model.shapes.ServiceShape;
-import software.amazon.smithy.model.traits.PaginatedTrait;
-import software.amazon.smithy.typescript.codegen.CodegenUtils;
 import software.amazon.smithy.typescript.codegen.TypeScriptWriter;
 import software.amazon.smithy.utils.SmithyInternalApi;
 

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/DocumentClientPaginationGenerator.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/DocumentClientPaginationGenerator.java
@@ -38,8 +38,6 @@ import software.amazon.smithy.utils.SmithyInternalApi;
 final class DocumentClientPaginationGenerator implements Runnable {
 
     static final String PAGINATION_FOLDER = "pagination";
-    static final String PAGINATION_INTERFACE_FILE =
-        Paths.get(CodegenUtils.SOURCE_FOLDER, PAGINATION_FOLDER, "Interfaces.ts").toString();
 
     private final TypeScriptWriter writer;
     private final PaginationInfo paginatedInfo;
@@ -112,20 +110,26 @@ final class DocumentClientPaginationGenerator implements Runnable {
             DocumentClientUtils.getModifiedName(operation.getId().getName()) + "Paginator");
     }
 
-    static void generateServicePaginationInterfaces(
-            Symbol service,
-            TypeScriptWriter writer
-    ) {
+    static String getInterfaceFilelocation() {
+        return String.format("%s%s/%s.ts", DocumentClientUtils.DOC_CLIENT_PREFIX,
+            DocumentClientPaginationGenerator.PAGINATION_FOLDER, "Interfaces");
+    }
+
+    static void generateServicePaginationInterfaces(TypeScriptWriter writer) {
         writer.addImport("PaginationConfiguration", "PaginationConfiguration", "@aws-sdk/types");
-        String aggregatedClientLocation = service.getNamespace().replace(
-            service.getName(), DocumentClientUtils.CLIENT_FULL_NAME);
-        writer.addImport(DocumentClientUtils.CLIENT_FULL_NAME,
-            DocumentClientUtils.CLIENT_FULL_NAME, aggregatedClientLocation);
-        writer.addImport(service.getName(), service.getName(), service.getNamespace());
+
+        writer.addImport(
+            DocumentClientUtils.CLIENT_NAME,
+            DocumentClientUtils.CLIENT_NAME,
+            Paths.get(".", DocumentClientUtils.CLIENT_NAME).toString());
+        writer.addImport(
+            DocumentClientUtils.CLIENT_FULL_NAME,
+            DocumentClientUtils.CLIENT_FULL_NAME,
+            Paths.get(".", DocumentClientUtils.CLIENT_FULL_NAME).toString());
 
         writer.openBlock("export interface $LPaginationConfiguration extends PaginationConfiguration {",
                 "}", DocumentClientUtils.CLIENT_FULL_NAME, () -> {
-            writer.write("client: $L | $L;", DocumentClientUtils.CLIENT_FULL_NAME, service.getName());
+            writer.write("client: $L | $L;", DocumentClientUtils.CLIENT_FULL_NAME, DocumentClientUtils.CLIENT_NAME);
         });
     }
 
@@ -142,7 +146,7 @@ final class DocumentClientPaginationGenerator implements Runnable {
             FileManifest fileManifest
     ) {
         TypeScriptWriter writer = new TypeScriptWriter("");
-        writer.write("export * from \"./$L\"", getModulePath(PAGINATION_INTERFACE_FILE));
+        // writer.write("export * from \"./$L\"", getModulePath(PAGINATION_INTERFACE_FILE));
 
         TopDownIndex topDownIndex = TopDownIndex.of(model);
         Set<OperationShape> containedOperations = new TreeSet<>(topDownIndex.getContainedOperations(service));

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/DocumentClientPaginationGenerator.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/DocumentClientPaginationGenerator.java
@@ -95,9 +95,9 @@ final class DocumentClientPaginationGenerator implements Runnable {
             Paths.get(".", DocumentClientUtils.CLIENT_FULL_NAME).toString());
 
         // Import Pagination types
-        // writer.addImport("Paginator", "Paginator", "@aws-sdk/types");
-        // writer.addImport(paginationType, paginationType,
-        //     Paths.get(".", PAGINATION_INTERFACE_FILE.replace(".ts", "")).toString());
+        writer.addImport("Paginator", "Paginator", "@aws-sdk/types");
+        writer.addImport(paginationType, paginationType,
+            Paths.get(".", getInterfaceFilelocation().replace(".ts", "")).toString());
 
         writeCommandRequest();
         writeMethodRequest();

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/DocumentClientPaginationGenerator.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/DocumentClientPaginationGenerator.java
@@ -1,0 +1,247 @@
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.aws.typescript.codegen;
+
+import java.nio.file.Paths;
+import java.util.Optional;
+import java.util.Set;
+import java.util.TreeSet;
+import software.amazon.smithy.build.FileManifest;
+import software.amazon.smithy.codegen.core.CodegenException;
+import software.amazon.smithy.codegen.core.Symbol;
+import software.amazon.smithy.codegen.core.SymbolProvider;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.knowledge.PaginatedIndex;
+import software.amazon.smithy.model.knowledge.PaginationInfo;
+import software.amazon.smithy.model.knowledge.TopDownIndex;
+import software.amazon.smithy.model.shapes.OperationShape;
+import software.amazon.smithy.model.shapes.ServiceShape;
+import software.amazon.smithy.model.traits.PaginatedTrait;
+import software.amazon.smithy.typescript.codegen.CodegenUtils;
+import software.amazon.smithy.typescript.codegen.TypeScriptWriter;
+import software.amazon.smithy.utils.SmithyInternalApi;
+
+@SmithyInternalApi
+final class DocumentClientPaginationGenerator implements Runnable {
+
+    static final String PAGINATION_FOLDER = "pagination";
+    static final String PAGINATION_INTERFACE_FILE =
+        Paths.get(CodegenUtils.SOURCE_FOLDER, PAGINATION_FOLDER, "Interfaces.ts").toString();
+
+    private final TypeScriptWriter writer;
+    private final PaginationInfo paginatedInfo;
+
+    private final Symbol serviceSymbol;
+    private final Symbol operationSymbol;
+    private final Symbol inputSymbol;
+    private final Symbol outputSymbol;
+
+    private final String operationName;
+    private final String methodName;
+    private final String aggregatedClientName;
+    private final String paginationType;
+
+    DocumentClientPaginationGenerator(
+            Model model,
+            ServiceShape service,
+            OperationShape operation,
+            SymbolProvider symbolProvider,
+            TypeScriptWriter writer,
+            String aggregatedClientName
+    ) {
+
+        this.writer = writer;
+
+        this.serviceSymbol = symbolProvider.toSymbol(service);
+        this.operationSymbol = symbolProvider.toSymbol(operation);
+        this.inputSymbol = symbolProvider.toSymbol(operation).expectProperty("inputType", Symbol.class);
+        this.outputSymbol = symbolProvider.toSymbol(operation).expectProperty("outputType", Symbol.class);
+
+        this.operationName = operation.getId().getName();
+        this.aggregatedClientName = aggregatedClientName;
+
+        // e.g. listObjects
+        this.methodName = Character.toLowerCase(operationName.charAt(0)) + operationName.substring(1);
+        this.paginationType = this.aggregatedClientName + "PaginationConfiguration";
+
+        PaginatedIndex paginatedIndex = PaginatedIndex.of(model);
+        Optional<PaginationInfo> paginationInfo = paginatedIndex.getPaginationInfo(service, operation);
+        this.paginatedInfo = paginationInfo.orElseThrow(() -> {
+            return new CodegenException("Expected Paginator to have pagination information.");
+        });
+    }
+
+    @Override
+    public void run() {
+        // Import Service Types
+        writer.addImport(operationSymbol.getName(),
+                operationSymbol.getName(),
+                operationSymbol.getNamespace());
+        writer.addImport(inputSymbol.getName(),
+                inputSymbol.getName(),
+                inputSymbol.getNamespace());
+        writer.addImport(outputSymbol.getName(),
+                outputSymbol.getName(),
+                outputSymbol.getNamespace());
+        String aggregatedClientLocation = serviceSymbol.getNamespace()
+                .replace(serviceSymbol.getName(), aggregatedClientName);
+        writer.addImport(aggregatedClientName, aggregatedClientName, aggregatedClientLocation);
+        writer.addImport(serviceSymbol.getName(), serviceSymbol.getName(), serviceSymbol.getNamespace());
+
+        // Import Pagination types
+        writer.addImport("Paginator", "Paginator", "@aws-sdk/types");
+        writer.addImport(paginationType, paginationType,
+            Paths.get(".", PAGINATION_INTERFACE_FILE.replace(".ts", "")).toString());
+
+        writeCommandRequest();
+        writeMethodRequest();
+        writePager();
+    }
+
+    static String getOutputFilelocation(OperationShape operation) {
+        return String.format("%s%s/%s.ts", DocumentClientUtils.DOC_CLIENT_PREFIX,
+            DocumentClientPaginationGenerator.PAGINATION_FOLDER,
+            DocumentClientUtils.getModifiedName(operation.getId().getName()) + "Paginator");
+    }
+
+    static void generateServicePaginationInterfaces(
+            String aggregatedClientName,
+            Symbol service,
+            TypeScriptWriter writer
+    ) {
+        writer.addImport("PaginationConfiguration", "PaginationConfiguration", "@aws-sdk/types");
+        String aggregatedClientLocation = service.getNamespace().replace(service.getName(), aggregatedClientName);
+        writer.addImport(aggregatedClientName, aggregatedClientName, aggregatedClientLocation);
+        writer.addImport(service.getName(), service.getName(), service.getNamespace());
+
+        writer.openBlock("export interface $LPaginationConfiguration extends PaginationConfiguration {",
+                "}", aggregatedClientName, () -> {
+            writer.write("client: $L | $L;", aggregatedClientName, service.getName());
+        });
+    }
+
+    private static String getModulePath(String fileLocation) {
+        return fileLocation.substring(
+            fileLocation.lastIndexOf("/") + 1,
+            fileLocation.length()
+        ).replace(".ts", "");
+    }
+
+    static void writeIndex(
+            Model model,
+            ServiceShape service,
+            FileManifest fileManifest
+    ) {
+        TypeScriptWriter writer = new TypeScriptWriter("");
+        writer.write("export * from \"./$L\"", getModulePath(PAGINATION_INTERFACE_FILE));
+
+        TopDownIndex topDownIndex = TopDownIndex.of(model);
+        Set<OperationShape> containedOperations = new TreeSet<>(topDownIndex.getContainedOperations(service));
+        for (OperationShape operation : containedOperations) {
+            if (operation.hasTrait(PaginatedTrait.ID)) {
+                String outputFilepath = DocumentClientPaginationGenerator.getOutputFilelocation(operation);
+                writer.write("export * from \"./$L\"", getModulePath(outputFilepath));
+            }
+        }
+
+        fileManifest.writeFile(
+            Paths.get(CodegenUtils.SOURCE_FOLDER, PAGINATION_FOLDER, "index.ts").toString(),
+            writer.toString());
+    }
+
+    private String destructurePath(String path) {
+        return "."  + path.replace(".", "!.");
+    }
+
+    private void writePager() {
+        String serviceTypeName = serviceSymbol.getName();
+        String inputTypeName = inputSymbol.getName();
+        String outputTypeName = outputSymbol.getName();
+
+        String inputTokenName = paginatedInfo.getPaginatedTrait().getInputToken().get();
+        String outputTokenName = paginatedInfo.getPaginatedTrait().getOutputToken().get();
+
+        writer.openBlock(
+                "export async function* paginate$L(config: $L, input: $L, ...additionalArguments: any): Paginator<$L>{",
+                "}",  operationName, paginationType, inputTypeName, outputTypeName, () -> {
+            String destructuredInputTokenName = destructurePath(inputTokenName);
+            writer.write("// ToDo: replace with actual type instead of typeof input$L", destructuredInputTokenName);
+            writer.write("let token: typeof input$L | undefined = config.startingToken || undefined;",
+                    destructuredInputTokenName);
+
+            writer.write("let hasNext = true;");
+            writer.write("let page: $L;", outputTypeName);
+            writer.openBlock("while (hasNext) {", "}", () -> {
+                writer.write("input$L = token;", destructuredInputTokenName);
+
+                if (paginatedInfo.getPageSizeMember().isPresent()) {
+                    String pageSize = paginatedInfo.getPageSizeMember().get().getMemberName();
+                    writer.write("input[$S] = config.pageSize;", pageSize);
+                }
+
+                writer.openBlock("if (config.client instanceof $L) {", "}", aggregatedClientName, () -> {
+                    writer.write("page = await makePagedRequest(config.client, input, ...additionalArguments);");
+                });
+                writer.openBlock("else if (config.client instanceof $L) {", "}", serviceTypeName, () -> {
+                    writer.write("page = await makePagedClientRequest(config.client, input, ...additionalArguments);");
+                });
+                writer.openBlock("else {", "}", () -> {
+                    writer.write("throw new Error(\"Invalid client, expected $L | $L\");",
+                            aggregatedClientName, serviceTypeName);
+                });
+
+                writer.write("yield page;");
+                writer.write("token = page$L;", destructurePath(outputTokenName));
+
+                writer.write("hasNext = !!(token);");
+            });
+
+            writer.write("// @ts-ignore");
+            writer.write("return undefined;");
+        });
+    }
+
+
+    /**
+     * Paginated command that calls client.method({...}) under the hood. This is meant for server side environments and
+     * exposes the entire service.
+     */
+    private void writeMethodRequest() {
+        writer.writeDocs("@private");
+        writer.openBlock(
+                "const makePagedRequest = async (client: $L, input: $L, ...args: any): Promise<$L> => {",
+                "}", aggregatedClientName, inputSymbol.getName(),
+                outputSymbol.getName(), () -> {
+            writer.write("// @ts-ignore");
+            writer.write("return await client.$L(input, ...args);", methodName);
+        });
+    }
+
+    /**
+     * Paginated command that calls CommandClient().send({...}) under the hood. This is meant for client side (browser)
+     * environments and does not generally expose the entire service.
+     */
+    private void writeCommandRequest() {
+        writer.writeDocs("@private");
+        writer.openBlock(
+                "const makePagedClientRequest = async (client: $L, input: $L, ...args: any): Promise<$L> => {",
+                "}", serviceSymbol.getName(), inputSymbol.getName(),
+                outputSymbol.getName(), () -> {
+            writer.write("// @ts-ignore");
+            writer.write("return await client.send(new $L(input), ...args);", operationSymbol.getName());
+        });
+    }
+}

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/DocumentClientUtils.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/DocumentClientUtils.java
@@ -38,6 +38,7 @@ final class DocumentClientUtils {
     static final String CLIENT_CONFIG_NAME = getResolvedConfigTypeName(CLIENT_NAME);
     static final String CLIENT_COMMANDS_FOLDER = "commands";
     static final String CLIENT_UTILS_FILE = "utils";
+    static final String DOC_CLIENT_PREFIX = "doc-client-";
 
     static final String CLIENT_TRANSLATE_CONFIG_KEY = "translateConfig";
     static final String CLIENT_TRANSLATE_CONFIG_TYPE = "TranslateConfig";

--- a/lib/lib-dynamodb/src/index.ts
+++ b/lib/lib-dynamodb/src/index.ts
@@ -1,3 +1,4 @@
 export * from "./DynamoDBDocument";
 export * from "./DynamoDBDocumentClient";
 export * from "./commands";
+export * from "./pagination";

--- a/lib/lib-dynamodb/src/pagination/Interfaces.ts
+++ b/lib/lib-dynamodb/src/pagination/Interfaces.ts
@@ -1,0 +1,8 @@
+import { PaginationConfiguration } from "@aws-sdk/types";
+
+import { DynamoDBDocument } from "../DynamoDBDocument";
+import { DynamoDBDocumentClient } from "../DynamoDBDocumentClient";
+
+export interface DynamoDBDocumentPaginationConfiguration extends PaginationConfiguration {
+  client: DynamoDBDocument | DynamoDBDocumentClient;
+}

--- a/lib/lib-dynamodb/src/pagination/QueryPaginator.ts
+++ b/lib/lib-dynamodb/src/pagination/QueryPaginator.ts
@@ -1,0 +1,55 @@
+import { Paginator } from "@aws-sdk/types";
+
+import { QueryCommand, QueryCommandInput, QueryCommandOutput } from "../commands/QueryCommand";
+import { DynamoDBDocument } from "../DynamoDBDocument";
+import { DynamoDBDocumentClient } from "../DynamoDBDocumentClient";
+import { DynamoDBDocumentPaginationConfiguration } from "./Interfaces";
+
+/**
+ * @private
+ */
+const makePagedClientRequest = async (
+  client: DynamoDBDocumentClient,
+  input: QueryCommandInput,
+  ...args: any
+): Promise<QueryCommandOutput> => {
+  // @ts-ignore
+  return await client.send(new QueryCommand(input), ...args);
+};
+/**
+ * @private
+ */
+const makePagedRequest = async (
+  client: DynamoDBDocument,
+  input: QueryCommandInput,
+  ...args: any
+): Promise<QueryCommandOutput> => {
+  // @ts-ignore
+  return await client.query(input, ...args);
+};
+export async function* paginateQuery(
+  config: DynamoDBDocumentPaginationConfiguration,
+  input: QueryCommandInput,
+  ...additionalArguments: any
+): Paginator<QueryCommandOutput> {
+  // ToDo: replace with actual type instead of typeof input.ExclusiveStartKey
+  let token: typeof input.ExclusiveStartKey | undefined = config.startingToken || undefined;
+  let hasNext = true;
+  let page: QueryCommandOutput;
+  while (hasNext) {
+    input.ExclusiveStartKey = token;
+    input["Limit"] = config.pageSize;
+    if (config.client instanceof DynamoDBDocument) {
+      page = await makePagedRequest(config.client, input, ...additionalArguments);
+    } else if (config.client instanceof DynamoDBDocumentClient) {
+      page = await makePagedClientRequest(config.client, input, ...additionalArguments);
+    } else {
+      throw new Error("Invalid client, expected DynamoDBDocument | DynamoDBDocumentClient");
+    }
+    yield page;
+    token = page.LastEvaluatedKey;
+    hasNext = !!token;
+  }
+  // @ts-ignore
+  return undefined;
+}

--- a/lib/lib-dynamodb/src/pagination/ScanPaginator.ts
+++ b/lib/lib-dynamodb/src/pagination/ScanPaginator.ts
@@ -1,0 +1,55 @@
+import { Paginator } from "@aws-sdk/types";
+
+import { ScanCommand, ScanCommandInput, ScanCommandOutput } from "../commands/ScanCommand";
+import { DynamoDBDocument } from "../DynamoDBDocument";
+import { DynamoDBDocumentClient } from "../DynamoDBDocumentClient";
+import { DynamoDBDocumentPaginationConfiguration } from "./Interfaces";
+
+/**
+ * @private
+ */
+const makePagedClientRequest = async (
+  client: DynamoDBDocumentClient,
+  input: ScanCommandInput,
+  ...args: any
+): Promise<ScanCommandOutput> => {
+  // @ts-ignore
+  return await client.send(new ScanCommand(input), ...args);
+};
+/**
+ * @private
+ */
+const makePagedRequest = async (
+  client: DynamoDBDocument,
+  input: ScanCommandInput,
+  ...args: any
+): Promise<ScanCommandOutput> => {
+  // @ts-ignore
+  return await client.scan(input, ...args);
+};
+export async function* paginateScan(
+  config: DynamoDBDocumentPaginationConfiguration,
+  input: ScanCommandInput,
+  ...additionalArguments: any
+): Paginator<ScanCommandOutput> {
+  // ToDo: replace with actual type instead of typeof input.ExclusiveStartKey
+  let token: typeof input.ExclusiveStartKey | undefined = config.startingToken || undefined;
+  let hasNext = true;
+  let page: ScanCommandOutput;
+  while (hasNext) {
+    input.ExclusiveStartKey = token;
+    input["Limit"] = config.pageSize;
+    if (config.client instanceof DynamoDBDocument) {
+      page = await makePagedRequest(config.client, input, ...additionalArguments);
+    } else if (config.client instanceof DynamoDBDocumentClient) {
+      page = await makePagedClientRequest(config.client, input, ...additionalArguments);
+    } else {
+      throw new Error("Invalid client, expected DynamoDBDocument | DynamoDBDocumentClient");
+    }
+    yield page;
+    token = page.LastEvaluatedKey;
+    hasNext = !!token;
+  }
+  // @ts-ignore
+  return undefined;
+}

--- a/lib/lib-dynamodb/src/pagination/index.ts
+++ b/lib/lib-dynamodb/src/pagination/index.ts
@@ -1,0 +1,3 @@
+export * from "./Interfaces";
+export * from "./QueryPaginator";
+export * from "./ScanPaginator";


### PR DESCRIPTION
### Issue
Fixes: https://github.com/aws/aws-sdk-js-v3/issues/2159

### Description
Adds pagination to DynamoDBDocumentClient

### Testing
Verified with test code from [code examples from Developer Guide](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/GettingStarted.NodeJs.04.html)

<details>
<summary>Code</summary>

```js
import { DynamoDBClient } from "@aws-sdk/client-dynamodb"; // v3.42.0
import {
  DynamoDBDocumentClient,
  paginateQuery,
} from "../aws-sdk-js-v3/lib/lib-dynamodb/dist-cjs/index.js";

const region = "us-west-2";
const client = new DynamoDBClient({ region });
const docClient = DynamoDBDocumentClient.from(client);

const paginatorConfig = { client: docClient, pageSize: 5 };
const commandParams = {
  TableName: "Movies",
  KeyConditionExpression: "#yr = :yyyy",
  ExpressionAttributeNames: {
    "#yr": "year",
  },
  ExpressionAttributeValues: {
    ":yyyy": 1985,
  },
};
const paginator = paginateQuery(paginatorConfig, commandParams);

for await (const page of paginator) {
  const { Items } = page;
  console.log({ size: Items.length });
}

```

</details>

<details>
<summary>Output</summary>

```console
{ size: 5 }
{ size: 5 }
{ size: 5 }
{ size: 5 }
{ size: 5 }
{ size: 5 }
{ size: 5 }
{ size: 5 }
{ size: 5 }
```

</details>


---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
