### PR TITLE
fix(client-databrew): omit retry headers

### DIFF
--- a/clients/client-databrew/src/DataBrewClient.ts
+++ b/clients/client-databrew/src/DataBrewClient.ts
@@ -14,7 +14,13 @@ import {
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
 import { getLoggerPlugin } from "@aws-sdk/middleware-logger";
-import { getRetryPlugin, resolveRetryConfig, RetryInputConfig, RetryResolvedConfig } from "@aws-sdk/middleware-retry";
+import {
+  getOmitRetryHeadersPlugin,
+  getRetryPlugin,
+  resolveRetryConfig,
+  RetryInputConfig,
+  RetryResolvedConfig,
+} from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
   AwsAuthResolvedConfig,
@@ -383,6 +389,7 @@ export class DataBrewClient extends __Client<
     this.middlewareStack.use(getLoggerPlugin(this.config));
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
+    this.middlewareStack.use(getOmitRetryHeadersPlugin(this.config));
   }
 
   /**

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddOmitRetryHeadersDependency.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddOmitRetryHeadersDependency.java
@@ -32,6 +32,7 @@ import software.amazon.smithy.utils.SmithyInternalApi;
 public class AddOmitRetryHeadersDependency implements TypeScriptIntegration {
     private static final Set<String> SERVICE_IDS = SetUtils.of(
         "ConnectParticipant", // P43593766
+        "DataBrew", // P55897945
         "IoT", // P39759657
         "Kinesis Video Signaling"
     );


### PR DESCRIPTION
### Issue
Fixes: https://github.com/aws/aws-sdk-js-v3/issues/2038

### Description
Omits retry headers in client-databrew

### Testing
N/A

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
