### PR TITLE
docs(client-s3): change url-layout to ensure visibility

### DIFF
--- a/packages/middleware-bucket-endpoint/src/configurations.ts
+++ b/packages/middleware-bucket-endpoint/src/configurations.ts
@@ -6,7 +6,7 @@ export interface BucketEndpointInputConfig {
    */
   bucketEndpoint?: boolean;
   /**
-   * Whether to force path style URLs for S3 objects (e.g., https://s3.amazonaws.com/<bucketName>/<key> instead of https://<bucketName>.s3.amazonaws.com/<key>
+   * Whether to force path style URLs for S3 objects (e.g., https://s3.amazonaws.com/{bucketName}/{key} instead of https://{bucketName}.s3.amazonaws.com/{key}
    */
   forcePathStyle?: boolean;
   /**


### PR DESCRIPTION
Because the docs are part of the HTML page, a variable like `<bucketname>` does not show up in the HTML.

See the current docs: https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/clients/client-s3/interfaces/s3clientconfig.html#forcepathstyle
The parameters currently are not visible, making the example slightly confusing:

`Whether to force path style URLs for S3 objects (e.g., https://s3.amazonaws.com// instead of https://.s3.amazonaws.com/`

This PR would make this example more readable:

`Whether to force path style URLs for S3 objects (e.g., https://s3.amazonaws.com/{bucket}/{key} instead of https://{bucket}.s3.amazonaws.com/{key}`


---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
