### PR TITLE
fix: Check error body before dereference when producing error codes

### DIFF
--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsEc2.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsEc2.java
@@ -97,9 +97,13 @@ final class AwsEc2 extends HttpRpcProtocolGenerator {
                        + "  output: $T,\n"
                        + "  data: any\n"
                        + "): string => {", "};", responseType, () -> {
+            // Default a 503 status code to the Unavailable code.
+            writer.openBlock("if (output.statusCode == 503) {", "}", () -> writer.write("return 'Unavailable';"));
+
             // Attempt to fetch the error code from the specific location.
-            String errorCodeLocation = getErrorBodyLocation(context, "data") + ".Code";
-            writer.openBlock("if ($L !== undefined) {", "}", errorCodeLocation, () -> {
+            String errorBodyLocation = getErrorBodyLocation(context, "data");
+            String errorCodeLocation = errorBodyLocation + ".Code";
+            writer.openBlock("if ($L !== undefined && $L !== undefined) {", "}", errorBodyLocation, errorCodeLocation, () -> {
                 writer.write("return $L;", errorCodeLocation);
             });
 

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsQuery.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsQuery.java
@@ -97,9 +97,13 @@ final class AwsQuery extends HttpRpcProtocolGenerator {
                        + "  output: $T,\n"
                        + "  data: any\n"
                        + "): string => {", "};", responseType, () -> {
+            // Default a 503 status code to the Unavailable code.
+            writer.openBlock("if (output.statusCode == 503) {", "}", () -> writer.write("return 'Unavailable';"));
+
             // Attempt to fetch the error code from the specific location.
-            String errorCodeLocation = getErrorBodyLocation(context, "data") + ".Code";
-            writer.openBlock("if ($L !== undefined) {", "}", errorCodeLocation, () -> {
+            String errorBodyLocation = getErrorBodyLocation(context, "data");
+            String errorCodeLocation = errorBodyLocation + ".Code";
+            writer.openBlock("if ($L !== undefined && $L !== undefined) {", "}", errorBodyLocation, errorCodeLocation, () -> {
                 writer.write("return $L;", errorCodeLocation);
             });
 

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsRestXml.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsRestXml.java
@@ -110,9 +110,13 @@ final class AwsRestXml extends HttpBindingProtocolGenerator {
                        + "  output: $T,\n"
                        + "  data: any\n"
                        + "): string => {", "};", responseType, () -> {
+            // Default a 503 status code to the Unavailable code.
+            writer.openBlock("if (output.statusCode == 503) {", "}", () -> writer.write("return 'Unavailable';"));
+
             // Attempt to fetch the error code from the specific location.
-            String errorCodeLocation = getErrorBodyLocation(context, "data") + ".Code";
-            writer.openBlock("if ($L !== undefined) {", "}", errorCodeLocation, () -> {
+            String errorBodyLocation = getErrorBodyLocation(context, "data");
+            String errorCodeLocation = errorBodyLocation + ".Code";
+            writer.openBlock("if ($L !== undefined && $L !== undefined) {", "}", errorBodyLocation, errorCodeLocation, () -> {
                 writer.write("return $L;", errorCodeLocation);
             });
 


### PR DESCRIPTION
Not a perfect solution, and I certainly have no business editing this code.
But I do want to get AWS's attention to get this fixed.

### Issue
Issue number #2861

### Description
This fixes the TypeError that occurs when AWS sends back a blank response to a query.

### Testing
I didn't test it, but the original issue's been open for two months without a fix, and I figure it's bad for AWS to push us to use its shiny new V3 API when it's a little broken.

### Additional context
Add any other context about the PR here.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
