### PR TITLE
test(e2e): fix lerna filter when only 1 package to test

### DIFF
--- a/tests/e2e/run-e2e-tests.js
+++ b/tests/e2e/run-e2e-tests.js
@@ -43,7 +43,7 @@ ${packagesToTest.map((package) => package[0]).join("\n")}`);
       "run",
       "test:e2e",
       "--scope",
-      `'{${packagesToTest.map((package) => package[1]).join(",")}}'`, // https://github.com/lerna/lerna/issues/1846#issuecomment-451172783
+      `'{${packagesToTest.map((package) => `${package[1]},`).join()}}'`, // https://github.com/lerna/lerna/issues/1846#issuecomment-451172783
       "--concurrency",
       "1",
     ],


### PR DESCRIPTION
### Description
The e2e test fails when only 1 package is supplied. This is caused by a bug with the lerna command construction. Fix it according to https://github.com/lerna/lerna/issues/1846#issuecomment-855290857

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
