### PR TITLE
chore(deps-dev): bump prettier to v2.5.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "lerna": "3.22.1",
     "lint-staged": "^10.0.1",
     "mocha": "^8.0.1",
-    "prettier": "2.3.0",
+    "prettier": "2.5.1",
     "puppeteer": "^5.1.0",
     "strip-comments": "2.0.1",
     "ts-jest": "^26.4.1",

--- a/packages/s3-request-presigner/src/getSignedUrl.spec.ts
+++ b/packages/s3-request-presigner/src/getSignedUrl.spec.ts
@@ -134,7 +134,7 @@ describe("getSignedUrl", () => {
       expect(mockPresign.mock.calls[0][0].headers[header]).toBeUndefined();
     }
   );
-  
+
   it("should presign request with MRAP ARN", async () => {
     const mockPresigned = "a presigned url";
     mockPresign.mockReturnValue(mockPresigned);

--- a/yarn.lock
+++ b/yarn.lock
@@ -9967,10 +9967,10 @@ prettier-linter-helpers@^1.0.0:
   dependencies:
     fast-diff "^1.1.2"
 
-prettier@2.3.0, prettier@^2.0.4:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.3.0.tgz#b6a5bf1284026ae640f17f7ff5658a7567fc0d18"
-  integrity sha512-kXtO4s0Lz/DW/IJ9QdWhAf7/NmPWQXkFr/r/WkR3vyI+0v8amTDxiaQSLzs8NBlytfLWX/7uQUMIW677yLKl4w==
+prettier@2.5.1, prettier@^2.0.4:
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.5.1.tgz#fff75fa9d519c54cf0fce328c1017d94546bc56a"
+  integrity sha512-vBZcPRUR5MZJwoyi3ZoyQlc1rXeEck8KgeC9AwwOn+exuxLxq5toTRDTSaVrXHxelDMHy9zlicw8u66yxoSUFg==
 
 pretty-format@^26.0.0, pretty-format@^26.6.2:
   version "26.6.2"


### PR DESCRIPTION
### Issue
Previous bump was done in https://github.com/aws/aws-sdk-js-v3/pull/2444

### Description
Bumps prettier to v2.5.1

### Additional Context
* Prettier 2.4 release post https://prettier.io/blog/2021/09/09/2.4.0.html
* Prettier 2.5 release post https://prettier.io/blog/2021/11/25/2.5.0.html

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
