### PR TITLE
feat: end support for Node.js 10.x

### DIFF
--- a/clients/client-accessanalyzer/package.json
+++ b/clients/client-accessanalyzer/package.json
@@ -64,7 +64,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-account/package.json
+++ b/clients/client-account/package.json
@@ -62,7 +62,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-acm-pca/package.json
+++ b/clients/client-acm-pca/package.json
@@ -63,7 +63,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-acm/package.json
+++ b/clients/client-acm/package.json
@@ -63,7 +63,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-alexa-for-business/package.json
+++ b/clients/client-alexa-for-business/package.json
@@ -64,7 +64,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-amp/package.json
+++ b/clients/client-amp/package.json
@@ -65,7 +65,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-amplify/package.json
+++ b/clients/client-amplify/package.json
@@ -62,7 +62,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-amplifybackend/package.json
+++ b/clients/client-amplifybackend/package.json
@@ -62,7 +62,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-amplifyuibuilder/package.json
+++ b/clients/client-amplifyuibuilder/package.json
@@ -64,7 +64,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-api-gateway/package.json
+++ b/clients/client-api-gateway/package.json
@@ -63,7 +63,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-apigatewaymanagementapi/package.json
+++ b/clients/client-apigatewaymanagementapi/package.json
@@ -62,7 +62,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-apigatewayv2/package.json
+++ b/clients/client-apigatewayv2/package.json
@@ -62,7 +62,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-app-mesh/package.json
+++ b/clients/client-app-mesh/package.json
@@ -64,7 +64,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-appconfig/package.json
+++ b/clients/client-appconfig/package.json
@@ -62,7 +62,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-appconfigdata/package.json
+++ b/clients/client-appconfigdata/package.json
@@ -62,7 +62,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-appflow/package.json
+++ b/clients/client-appflow/package.json
@@ -62,7 +62,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-appintegrations/package.json
+++ b/clients/client-appintegrations/package.json
@@ -64,7 +64,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-application-auto-scaling/package.json
+++ b/clients/client-application-auto-scaling/package.json
@@ -62,7 +62,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-application-discovery-service/package.json
+++ b/clients/client-application-discovery-service/package.json
@@ -64,7 +64,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-application-insights/package.json
+++ b/clients/client-application-insights/package.json
@@ -62,7 +62,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-applicationcostprofiler/package.json
+++ b/clients/client-applicationcostprofiler/package.json
@@ -62,7 +62,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-apprunner/package.json
+++ b/clients/client-apprunner/package.json
@@ -62,7 +62,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-appstream/package.json
+++ b/clients/client-appstream/package.json
@@ -63,7 +63,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-appsync/package.json
+++ b/clients/client-appsync/package.json
@@ -62,7 +62,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-athena/package.json
+++ b/clients/client-athena/package.json
@@ -64,7 +64,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-auditmanager/package.json
+++ b/clients/client-auditmanager/package.json
@@ -62,7 +62,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-auto-scaling-plans/package.json
+++ b/clients/client-auto-scaling-plans/package.json
@@ -62,7 +62,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-auto-scaling/package.json
+++ b/clients/client-auto-scaling/package.json
@@ -65,7 +65,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-backup-gateway/package.json
+++ b/clients/client-backup-gateway/package.json
@@ -62,7 +62,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-backup/package.json
+++ b/clients/client-backup/package.json
@@ -64,7 +64,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-batch/package.json
+++ b/clients/client-batch/package.json
@@ -62,7 +62,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-braket/package.json
+++ b/clients/client-braket/package.json
@@ -64,7 +64,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-budgets/package.json
+++ b/clients/client-budgets/package.json
@@ -62,7 +62,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-chime-sdk-identity/package.json
+++ b/clients/client-chime-sdk-identity/package.json
@@ -64,7 +64,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-chime-sdk-meetings/package.json
+++ b/clients/client-chime-sdk-meetings/package.json
@@ -64,7 +64,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-chime-sdk-messaging/package.json
+++ b/clients/client-chime-sdk-messaging/package.json
@@ -64,7 +64,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-chime/package.json
+++ b/clients/client-chime/package.json
@@ -64,7 +64,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-cloud9/package.json
+++ b/clients/client-cloud9/package.json
@@ -62,7 +62,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-cloudcontrol/package.json
+++ b/clients/client-cloudcontrol/package.json
@@ -65,7 +65,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-clouddirectory/package.json
+++ b/clients/client-clouddirectory/package.json
@@ -62,7 +62,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-cloudformation/package.json
+++ b/clients/client-cloudformation/package.json
@@ -67,7 +67,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-cloudfront/package.json
+++ b/clients/client-cloudfront/package.json
@@ -66,7 +66,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-cloudhsm-v2/package.json
+++ b/clients/client-cloudhsm-v2/package.json
@@ -62,7 +62,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-cloudhsm/package.json
+++ b/clients/client-cloudhsm/package.json
@@ -62,7 +62,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-cloudsearch-domain/package.json
+++ b/clients/client-cloudsearch-domain/package.json
@@ -62,7 +62,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-cloudsearch/package.json
+++ b/clients/client-cloudsearch/package.json
@@ -64,7 +64,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-cloudtrail/package.json
+++ b/clients/client-cloudtrail/package.json
@@ -62,7 +62,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-cloudwatch-events/package.json
+++ b/clients/client-cloudwatch-events/package.json
@@ -62,7 +62,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-cloudwatch-logs/package.json
+++ b/clients/client-cloudwatch-logs/package.json
@@ -62,7 +62,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-cloudwatch/package.json
+++ b/clients/client-cloudwatch/package.json
@@ -65,7 +65,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-codeartifact/package.json
+++ b/clients/client-codeartifact/package.json
@@ -62,7 +62,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-codebuild/package.json
+++ b/clients/client-codebuild/package.json
@@ -62,7 +62,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-codecommit/package.json
+++ b/clients/client-codecommit/package.json
@@ -64,7 +64,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-codedeploy/package.json
+++ b/clients/client-codedeploy/package.json
@@ -63,7 +63,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-codeguru-reviewer/package.json
+++ b/clients/client-codeguru-reviewer/package.json
@@ -65,7 +65,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-codeguruprofiler/package.json
+++ b/clients/client-codeguruprofiler/package.json
@@ -64,7 +64,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-codepipeline/package.json
+++ b/clients/client-codepipeline/package.json
@@ -64,7 +64,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-codestar-connections/package.json
+++ b/clients/client-codestar-connections/package.json
@@ -62,7 +62,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-codestar-notifications/package.json
+++ b/clients/client-codestar-notifications/package.json
@@ -64,7 +64,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-codestar/package.json
+++ b/clients/client-codestar/package.json
@@ -62,7 +62,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-cognito-identity-provider/package.json
+++ b/clients/client-cognito-identity-provider/package.json
@@ -62,7 +62,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-cognito-identity/package.json
+++ b/clients/client-cognito-identity/package.json
@@ -66,7 +66,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-cognito-sync/package.json
+++ b/clients/client-cognito-sync/package.json
@@ -62,7 +62,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-comprehend/package.json
+++ b/clients/client-comprehend/package.json
@@ -64,7 +64,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-comprehendmedical/package.json
+++ b/clients/client-comprehendmedical/package.json
@@ -64,7 +64,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-compute-optimizer/package.json
+++ b/clients/client-compute-optimizer/package.json
@@ -62,7 +62,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-config-service/package.json
+++ b/clients/client-config-service/package.json
@@ -62,7 +62,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-connect-contact-lens/package.json
+++ b/clients/client-connect-contact-lens/package.json
@@ -62,7 +62,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-connect/package.json
+++ b/clients/client-connect/package.json
@@ -64,7 +64,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-connectparticipant/package.json
+++ b/clients/client-connectparticipant/package.json
@@ -64,7 +64,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-cost-and-usage-report-service/package.json
+++ b/clients/client-cost-and-usage-report-service/package.json
@@ -62,7 +62,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-cost-explorer/package.json
+++ b/clients/client-cost-explorer/package.json
@@ -62,7 +62,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-customer-profiles/package.json
+++ b/clients/client-customer-profiles/package.json
@@ -62,7 +62,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-data-pipeline/package.json
+++ b/clients/client-data-pipeline/package.json
@@ -62,7 +62,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-database-migration-service/package.json
+++ b/clients/client-database-migration-service/package.json
@@ -63,7 +63,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-databrew/package.json
+++ b/clients/client-databrew/package.json
@@ -62,7 +62,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-dataexchange/package.json
+++ b/clients/client-dataexchange/package.json
@@ -62,7 +62,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-datasync/package.json
+++ b/clients/client-datasync/package.json
@@ -62,7 +62,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-dax/package.json
+++ b/clients/client-dax/package.json
@@ -62,7 +62,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-detective/package.json
+++ b/clients/client-detective/package.json
@@ -62,7 +62,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-device-farm/package.json
+++ b/clients/client-device-farm/package.json
@@ -62,7 +62,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-devops-guru/package.json
+++ b/clients/client-devops-guru/package.json
@@ -64,7 +64,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-direct-connect/package.json
+++ b/clients/client-direct-connect/package.json
@@ -62,7 +62,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-directory-service/package.json
+++ b/clients/client-directory-service/package.json
@@ -62,7 +62,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-dlm/package.json
+++ b/clients/client-dlm/package.json
@@ -62,7 +62,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-docdb/package.json
+++ b/clients/client-docdb/package.json
@@ -66,7 +66,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-drs/package.json
+++ b/clients/client-drs/package.json
@@ -62,7 +62,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-dynamodb-streams/package.json
+++ b/clients/client-dynamodb-streams/package.json
@@ -62,7 +62,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-dynamodb/package.json
+++ b/clients/client-dynamodb/package.json
@@ -66,7 +66,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-ebs/package.json
+++ b/clients/client-ebs/package.json
@@ -64,7 +64,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-ec2-instance-connect/package.json
+++ b/clients/client-ec2-instance-connect/package.json
@@ -62,7 +62,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-ec2/package.json
+++ b/clients/client-ec2/package.json
@@ -68,7 +68,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-ecr-public/package.json
+++ b/clients/client-ecr-public/package.json
@@ -62,7 +62,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-ecr/package.json
+++ b/clients/client-ecr/package.json
@@ -63,7 +63,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-ecs/package.json
+++ b/clients/client-ecs/package.json
@@ -63,7 +63,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-efs/package.json
+++ b/clients/client-efs/package.json
@@ -64,7 +64,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-eks/package.json
+++ b/clients/client-eks/package.json
@@ -65,7 +65,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-elastic-beanstalk/package.json
+++ b/clients/client-elastic-beanstalk/package.json
@@ -65,7 +65,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-elastic-inference/package.json
+++ b/clients/client-elastic-inference/package.json
@@ -62,7 +62,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-elastic-load-balancing-v2/package.json
+++ b/clients/client-elastic-load-balancing-v2/package.json
@@ -65,7 +65,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-elastic-load-balancing/package.json
+++ b/clients/client-elastic-load-balancing/package.json
@@ -65,7 +65,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-elastic-transcoder/package.json
+++ b/clients/client-elastic-transcoder/package.json
@@ -63,7 +63,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-elasticache/package.json
+++ b/clients/client-elasticache/package.json
@@ -65,7 +65,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-elasticsearch-service/package.json
+++ b/clients/client-elasticsearch-service/package.json
@@ -62,7 +62,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-emr-containers/package.json
+++ b/clients/client-emr-containers/package.json
@@ -64,7 +64,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-emr/package.json
+++ b/clients/client-emr/package.json
@@ -63,7 +63,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-eventbridge/package.json
+++ b/clients/client-eventbridge/package.json
@@ -62,7 +62,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-evidently/package.json
+++ b/clients/client-evidently/package.json
@@ -62,7 +62,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-finspace-data/package.json
+++ b/clients/client-finspace-data/package.json
@@ -64,7 +64,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-finspace/package.json
+++ b/clients/client-finspace/package.json
@@ -62,7 +62,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-firehose/package.json
+++ b/clients/client-firehose/package.json
@@ -62,7 +62,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-fis/package.json
+++ b/clients/client-fis/package.json
@@ -64,7 +64,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-fms/package.json
+++ b/clients/client-fms/package.json
@@ -62,7 +62,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-forecast/package.json
+++ b/clients/client-forecast/package.json
@@ -62,7 +62,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-forecastquery/package.json
+++ b/clients/client-forecastquery/package.json
@@ -62,7 +62,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-frauddetector/package.json
+++ b/clients/client-frauddetector/package.json
@@ -62,7 +62,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-fsx/package.json
+++ b/clients/client-fsx/package.json
@@ -64,7 +64,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-gamelift/package.json
+++ b/clients/client-gamelift/package.json
@@ -62,7 +62,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-glacier/package.json
+++ b/clients/client-glacier/package.json
@@ -66,7 +66,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-global-accelerator/package.json
+++ b/clients/client-global-accelerator/package.json
@@ -64,7 +64,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-glue/package.json
+++ b/clients/client-glue/package.json
@@ -62,7 +62,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-grafana/package.json
+++ b/clients/client-grafana/package.json
@@ -64,7 +64,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-greengrass/package.json
+++ b/clients/client-greengrass/package.json
@@ -62,7 +62,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-greengrassv2/package.json
+++ b/clients/client-greengrassv2/package.json
@@ -64,7 +64,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-groundstation/package.json
+++ b/clients/client-groundstation/package.json
@@ -62,7 +62,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-guardduty/package.json
+++ b/clients/client-guardduty/package.json
@@ -64,7 +64,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-health/package.json
+++ b/clients/client-health/package.json
@@ -62,7 +62,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-healthlake/package.json
+++ b/clients/client-healthlake/package.json
@@ -64,7 +64,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-honeycode/package.json
+++ b/clients/client-honeycode/package.json
@@ -62,7 +62,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-iam/package.json
+++ b/clients/client-iam/package.json
@@ -65,7 +65,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-identitystore/package.json
+++ b/clients/client-identitystore/package.json
@@ -62,7 +62,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-imagebuilder/package.json
+++ b/clients/client-imagebuilder/package.json
@@ -64,7 +64,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-inspector/package.json
+++ b/clients/client-inspector/package.json
@@ -62,7 +62,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-inspector2/package.json
+++ b/clients/client-inspector2/package.json
@@ -64,7 +64,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-iot-1click-devices-service/package.json
+++ b/clients/client-iot-1click-devices-service/package.json
@@ -62,7 +62,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-iot-1click-projects/package.json
+++ b/clients/client-iot-1click-projects/package.json
@@ -62,7 +62,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-iot-data-plane/package.json
+++ b/clients/client-iot-data-plane/package.json
@@ -62,7 +62,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-iot-events-data/package.json
+++ b/clients/client-iot-events-data/package.json
@@ -62,7 +62,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-iot-events/package.json
+++ b/clients/client-iot-events/package.json
@@ -62,7 +62,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-iot-jobs-data-plane/package.json
+++ b/clients/client-iot-jobs-data-plane/package.json
@@ -62,7 +62,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-iot-wireless/package.json
+++ b/clients/client-iot-wireless/package.json
@@ -64,7 +64,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-iot/package.json
+++ b/clients/client-iot/package.json
@@ -64,7 +64,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-iotanalytics/package.json
+++ b/clients/client-iotanalytics/package.json
@@ -62,7 +62,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-iotdeviceadvisor/package.json
+++ b/clients/client-iotdeviceadvisor/package.json
@@ -62,7 +62,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-iotfleethub/package.json
+++ b/clients/client-iotfleethub/package.json
@@ -64,7 +64,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-iotsecuretunneling/package.json
+++ b/clients/client-iotsecuretunneling/package.json
@@ -62,7 +62,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-iotsitewise/package.json
+++ b/clients/client-iotsitewise/package.json
@@ -65,7 +65,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-iotthingsgraph/package.json
+++ b/clients/client-iotthingsgraph/package.json
@@ -62,7 +62,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-iottwinmaker/package.json
+++ b/clients/client-iottwinmaker/package.json
@@ -62,7 +62,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-ivs/package.json
+++ b/clients/client-ivs/package.json
@@ -62,7 +62,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-kafka/package.json
+++ b/clients/client-kafka/package.json
@@ -62,7 +62,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-kafkaconnect/package.json
+++ b/clients/client-kafkaconnect/package.json
@@ -62,7 +62,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-kendra/package.json
+++ b/clients/client-kendra/package.json
@@ -64,7 +64,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-kinesis-analytics-v2/package.json
+++ b/clients/client-kinesis-analytics-v2/package.json
@@ -62,7 +62,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-kinesis-analytics/package.json
+++ b/clients/client-kinesis-analytics/package.json
@@ -62,7 +62,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-kinesis-video-archived-media/package.json
+++ b/clients/client-kinesis-video-archived-media/package.json
@@ -62,7 +62,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-kinesis-video-media/package.json
+++ b/clients/client-kinesis-video-media/package.json
@@ -62,7 +62,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-kinesis-video-signaling/package.json
+++ b/clients/client-kinesis-video-signaling/package.json
@@ -62,7 +62,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-kinesis-video/package.json
+++ b/clients/client-kinesis-video/package.json
@@ -62,7 +62,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-kinesis/package.json
+++ b/clients/client-kinesis/package.json
@@ -66,7 +66,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-kms/package.json
+++ b/clients/client-kms/package.json
@@ -62,7 +62,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-lakeformation/package.json
+++ b/clients/client-lakeformation/package.json
@@ -62,7 +62,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-lambda/package.json
+++ b/clients/client-lambda/package.json
@@ -63,7 +63,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-lex-model-building-service/package.json
+++ b/clients/client-lex-model-building-service/package.json
@@ -62,7 +62,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-lex-models-v2/package.json
+++ b/clients/client-lex-models-v2/package.json
@@ -63,7 +63,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-lex-runtime-service/package.json
+++ b/clients/client-lex-runtime-service/package.json
@@ -65,7 +65,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-lex-runtime-v2/package.json
+++ b/clients/client-lex-runtime-v2/package.json
@@ -67,7 +67,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-license-manager/package.json
+++ b/clients/client-license-manager/package.json
@@ -62,7 +62,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-lightsail/package.json
+++ b/clients/client-lightsail/package.json
@@ -62,7 +62,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-location/package.json
+++ b/clients/client-location/package.json
@@ -62,7 +62,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-lookoutequipment/package.json
+++ b/clients/client-lookoutequipment/package.json
@@ -64,7 +64,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-lookoutmetrics/package.json
+++ b/clients/client-lookoutmetrics/package.json
@@ -62,7 +62,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-lookoutvision/package.json
+++ b/clients/client-lookoutvision/package.json
@@ -64,7 +64,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-machine-learning/package.json
+++ b/clients/client-machine-learning/package.json
@@ -64,7 +64,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-macie/package.json
+++ b/clients/client-macie/package.json
@@ -62,7 +62,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-macie2/package.json
+++ b/clients/client-macie2/package.json
@@ -64,7 +64,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-managedblockchain/package.json
+++ b/clients/client-managedblockchain/package.json
@@ -64,7 +64,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-marketplace-catalog/package.json
+++ b/clients/client-marketplace-catalog/package.json
@@ -62,7 +62,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-marketplace-commerce-analytics/package.json
+++ b/clients/client-marketplace-commerce-analytics/package.json
@@ -62,7 +62,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-marketplace-entitlement-service/package.json
+++ b/clients/client-marketplace-entitlement-service/package.json
@@ -62,7 +62,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-marketplace-metering/package.json
+++ b/clients/client-marketplace-metering/package.json
@@ -62,7 +62,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-mediaconnect/package.json
+++ b/clients/client-mediaconnect/package.json
@@ -63,7 +63,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-mediaconvert/package.json
+++ b/clients/client-mediaconvert/package.json
@@ -64,7 +64,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-medialive/package.json
+++ b/clients/client-medialive/package.json
@@ -65,7 +65,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-mediapackage-vod/package.json
+++ b/clients/client-mediapackage-vod/package.json
@@ -62,7 +62,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-mediapackage/package.json
+++ b/clients/client-mediapackage/package.json
@@ -62,7 +62,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-mediastore-data/package.json
+++ b/clients/client-mediastore-data/package.json
@@ -65,7 +65,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-mediastore/package.json
+++ b/clients/client-mediastore/package.json
@@ -62,7 +62,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-mediatailor/package.json
+++ b/clients/client-mediatailor/package.json
@@ -62,7 +62,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-memorydb/package.json
+++ b/clients/client-memorydb/package.json
@@ -62,7 +62,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-mgn/package.json
+++ b/clients/client-mgn/package.json
@@ -62,7 +62,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-migration-hub-refactor-spaces/package.json
+++ b/clients/client-migration-hub-refactor-spaces/package.json
@@ -64,7 +64,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-migration-hub/package.json
+++ b/clients/client-migration-hub/package.json
@@ -62,7 +62,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-migrationhub-config/package.json
+++ b/clients/client-migrationhub-config/package.json
@@ -62,7 +62,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-migrationhubstrategy/package.json
+++ b/clients/client-migrationhubstrategy/package.json
@@ -62,7 +62,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-mobile/package.json
+++ b/clients/client-mobile/package.json
@@ -62,7 +62,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-mq/package.json
+++ b/clients/client-mq/package.json
@@ -64,7 +64,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-mturk/package.json
+++ b/clients/client-mturk/package.json
@@ -62,7 +62,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-mwaa/package.json
+++ b/clients/client-mwaa/package.json
@@ -62,7 +62,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-neptune/package.json
+++ b/clients/client-neptune/package.json
@@ -66,7 +66,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-network-firewall/package.json
+++ b/clients/client-network-firewall/package.json
@@ -62,7 +62,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-networkmanager/package.json
+++ b/clients/client-networkmanager/package.json
@@ -64,7 +64,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-nimble/package.json
+++ b/clients/client-nimble/package.json
@@ -65,7 +65,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-opensearch/package.json
+++ b/clients/client-opensearch/package.json
@@ -62,7 +62,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-opsworks/package.json
+++ b/clients/client-opsworks/package.json
@@ -63,7 +63,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-opsworkscm/package.json
+++ b/clients/client-opsworkscm/package.json
@@ -63,7 +63,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-organizations/package.json
+++ b/clients/client-organizations/package.json
@@ -62,7 +62,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-outposts/package.json
+++ b/clients/client-outposts/package.json
@@ -62,7 +62,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-panorama/package.json
+++ b/clients/client-panorama/package.json
@@ -62,7 +62,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-personalize-events/package.json
+++ b/clients/client-personalize-events/package.json
@@ -62,7 +62,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-personalize-runtime/package.json
+++ b/clients/client-personalize-runtime/package.json
@@ -62,7 +62,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-personalize/package.json
+++ b/clients/client-personalize/package.json
@@ -62,7 +62,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-pi/package.json
+++ b/clients/client-pi/package.json
@@ -62,7 +62,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-pinpoint-email/package.json
+++ b/clients/client-pinpoint-email/package.json
@@ -62,7 +62,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-pinpoint-sms-voice/package.json
+++ b/clients/client-pinpoint-sms-voice/package.json
@@ -62,7 +62,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-pinpoint/package.json
+++ b/clients/client-pinpoint/package.json
@@ -62,7 +62,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-polly/package.json
+++ b/clients/client-polly/package.json
@@ -62,7 +62,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-pricing/package.json
+++ b/clients/client-pricing/package.json
@@ -62,7 +62,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-proton/package.json
+++ b/clients/client-proton/package.json
@@ -65,7 +65,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-qldb-session/package.json
+++ b/clients/client-qldb-session/package.json
@@ -62,7 +62,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-qldb/package.json
+++ b/clients/client-qldb/package.json
@@ -62,7 +62,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-quicksight/package.json
+++ b/clients/client-quicksight/package.json
@@ -62,7 +62,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-ram/package.json
+++ b/clients/client-ram/package.json
@@ -62,7 +62,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-rbin/package.json
+++ b/clients/client-rbin/package.json
@@ -62,7 +62,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-rds-data/package.json
+++ b/clients/client-rds-data/package.json
@@ -62,7 +62,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-rds/package.json
+++ b/clients/client-rds/package.json
@@ -66,7 +66,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-redshift-data/package.json
+++ b/clients/client-redshift-data/package.json
@@ -62,7 +62,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-redshift/package.json
+++ b/clients/client-redshift/package.json
@@ -65,7 +65,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-rekognition/package.json
+++ b/clients/client-rekognition/package.json
@@ -63,7 +63,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-resiliencehub/package.json
+++ b/clients/client-resiliencehub/package.json
@@ -64,7 +64,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-resource-groups-tagging-api/package.json
+++ b/clients/client-resource-groups-tagging-api/package.json
@@ -62,7 +62,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-resource-groups/package.json
+++ b/clients/client-resource-groups/package.json
@@ -62,7 +62,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-robomaker/package.json
+++ b/clients/client-robomaker/package.json
@@ -64,7 +64,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-route-53-domains/package.json
+++ b/clients/client-route-53-domains/package.json
@@ -62,7 +62,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-route-53/package.json
+++ b/clients/client-route-53/package.json
@@ -67,7 +67,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-route53-recovery-cluster/package.json
+++ b/clients/client-route53-recovery-cluster/package.json
@@ -62,7 +62,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-route53-recovery-control-config/package.json
+++ b/clients/client-route53-recovery-control-config/package.json
@@ -65,7 +65,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-route53-recovery-readiness/package.json
+++ b/clients/client-route53-recovery-readiness/package.json
@@ -62,7 +62,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-route53resolver/package.json
+++ b/clients/client-route53resolver/package.json
@@ -64,7 +64,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-rum/package.json
+++ b/clients/client-rum/package.json
@@ -62,7 +62,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-s3-control/package.json
+++ b/clients/client-s3-control/package.json
@@ -74,7 +74,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-s3/package.json
+++ b/clients/client-s3/package.json
@@ -82,7 +82,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-s3outposts/package.json
+++ b/clients/client-s3outposts/package.json
@@ -62,7 +62,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-sagemaker-a2i-runtime/package.json
+++ b/clients/client-sagemaker-a2i-runtime/package.json
@@ -62,7 +62,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-sagemaker-edge/package.json
+++ b/clients/client-sagemaker-edge/package.json
@@ -62,7 +62,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-sagemaker-featurestore-runtime/package.json
+++ b/clients/client-sagemaker-featurestore-runtime/package.json
@@ -62,7 +62,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-sagemaker-runtime/package.json
+++ b/clients/client-sagemaker-runtime/package.json
@@ -62,7 +62,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-sagemaker/package.json
+++ b/clients/client-sagemaker/package.json
@@ -65,7 +65,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-savingsplans/package.json
+++ b/clients/client-savingsplans/package.json
@@ -64,7 +64,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-schemas/package.json
+++ b/clients/client-schemas/package.json
@@ -65,7 +65,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-secrets-manager/package.json
+++ b/clients/client-secrets-manager/package.json
@@ -64,7 +64,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-securityhub/package.json
+++ b/clients/client-securityhub/package.json
@@ -62,7 +62,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-serverlessapplicationrepository/package.json
+++ b/clients/client-serverlessapplicationrepository/package.json
@@ -62,7 +62,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-service-catalog-appregistry/package.json
+++ b/clients/client-service-catalog-appregistry/package.json
@@ -64,7 +64,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-service-catalog/package.json
+++ b/clients/client-service-catalog/package.json
@@ -64,7 +64,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-service-quotas/package.json
+++ b/clients/client-service-quotas/package.json
@@ -62,7 +62,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-servicediscovery/package.json
+++ b/clients/client-servicediscovery/package.json
@@ -64,7 +64,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-ses/package.json
+++ b/clients/client-ses/package.json
@@ -65,7 +65,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-sesv2/package.json
+++ b/clients/client-sesv2/package.json
@@ -62,7 +62,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-sfn/package.json
+++ b/clients/client-sfn/package.json
@@ -62,7 +62,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-shield/package.json
+++ b/clients/client-shield/package.json
@@ -62,7 +62,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-signer/package.json
+++ b/clients/client-signer/package.json
@@ -65,7 +65,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-sms/package.json
+++ b/clients/client-sms/package.json
@@ -62,7 +62,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-snow-device-management/package.json
+++ b/clients/client-snow-device-management/package.json
@@ -64,7 +64,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-snowball/package.json
+++ b/clients/client-snowball/package.json
@@ -62,7 +62,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-sns/package.json
+++ b/clients/client-sns/package.json
@@ -64,7 +64,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-sqs/package.json
+++ b/clients/client-sqs/package.json
@@ -66,7 +66,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-ssm-contacts/package.json
+++ b/clients/client-ssm-contacts/package.json
@@ -64,7 +64,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-ssm-incidents/package.json
+++ b/clients/client-ssm-incidents/package.json
@@ -65,7 +65,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-ssm/package.json
+++ b/clients/client-ssm/package.json
@@ -65,7 +65,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-sso-admin/package.json
+++ b/clients/client-sso-admin/package.json
@@ -62,7 +62,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-sso-oidc/package.json
+++ b/clients/client-sso-oidc/package.json
@@ -59,7 +59,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-sso/package.json
+++ b/clients/client-sso/package.json
@@ -59,7 +59,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-storage-gateway/package.json
+++ b/clients/client-storage-gateway/package.json
@@ -62,7 +62,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-sts/package.json
+++ b/clients/client-sts/package.json
@@ -64,7 +64,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-support/package.json
+++ b/clients/client-support/package.json
@@ -62,7 +62,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-swf/package.json
+++ b/clients/client-swf/package.json
@@ -62,7 +62,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-synthetics/package.json
+++ b/clients/client-synthetics/package.json
@@ -62,7 +62,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-textract/package.json
+++ b/clients/client-textract/package.json
@@ -62,7 +62,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-timestream-query/package.json
+++ b/clients/client-timestream-query/package.json
@@ -65,7 +65,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-timestream-write/package.json
+++ b/clients/client-timestream-write/package.json
@@ -63,7 +63,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-transcribe-streaming/package.json
+++ b/clients/client-transcribe-streaming/package.json
@@ -70,7 +70,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-transcribe/package.json
+++ b/clients/client-transcribe/package.json
@@ -62,7 +62,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-transfer/package.json
+++ b/clients/client-transfer/package.json
@@ -62,7 +62,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-translate/package.json
+++ b/clients/client-translate/package.json
@@ -64,7 +64,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-voice-id/package.json
+++ b/clients/client-voice-id/package.json
@@ -64,7 +64,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-waf-regional/package.json
+++ b/clients/client-waf-regional/package.json
@@ -62,7 +62,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-waf/package.json
+++ b/clients/client-waf/package.json
@@ -62,7 +62,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-wafv2/package.json
+++ b/clients/client-wafv2/package.json
@@ -62,7 +62,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-wellarchitected/package.json
+++ b/clients/client-wellarchitected/package.json
@@ -64,7 +64,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-wisdom/package.json
+++ b/clients/client-wisdom/package.json
@@ -64,7 +64,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-workdocs/package.json
+++ b/clients/client-workdocs/package.json
@@ -62,7 +62,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-worklink/package.json
+++ b/clients/client-worklink/package.json
@@ -62,7 +62,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-workmail/package.json
+++ b/clients/client-workmail/package.json
@@ -64,7 +64,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-workmailmessageflow/package.json
+++ b/clients/client-workmailmessageflow/package.json
@@ -62,7 +62,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-workspaces-web/package.json
+++ b/clients/client-workspaces-web/package.json
@@ -64,7 +64,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-workspaces/package.json
+++ b/clients/client-workspaces/package.json
@@ -62,7 +62,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-xray/package.json
+++ b/clients/client-xray/package.json
@@ -62,7 +62,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/credential-provider-node/package.json
+++ b/packages/credential-provider-node/package.json
@@ -3,7 +3,7 @@
   "version": "3.45.0",
   "description": "AWS credential provider that sources credentials from a Node.JS environment. ",
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "main": "./dist-cjs/index.js",
   "module": "./dist-es/index.js",

--- a/private/aws-echo-service/package.json
+++ b/private/aws-echo-service/package.json
@@ -61,7 +61,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/private/aws-protocoltests-ec2/package.json
+++ b/private/aws-protocoltests-ec2/package.json
@@ -63,7 +63,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/private/aws-protocoltests-json-10/package.json
+++ b/private/aws-protocoltests-json-10/package.json
@@ -61,7 +61,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/private/aws-protocoltests-json/package.json
+++ b/private/aws-protocoltests-json/package.json
@@ -64,7 +64,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/private/aws-protocoltests-query/package.json
+++ b/private/aws-protocoltests-query/package.json
@@ -63,7 +63,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/private/aws-protocoltests-restjson/package.json
+++ b/private/aws-protocoltests-restjson/package.json
@@ -66,7 +66,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/private/aws-protocoltests-restxml/package.json
+++ b/private/aws-protocoltests-restxml/package.json
@@ -65,7 +65,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "typesVersions": {
     "<4.0": {


### PR DESCRIPTION
### Issue
We announced [the end of support for Node.js 10.x in the AWS SDK for JavaScript (v3)](https://aws.amazon.com/blogs/developer/announcing-the-end-of-support-for-node-js-10-x-in-the-aws-sdk-for-javascript-v3/) starting January 1, 2022 back in July.

### Description
Bump engines to node >=12.0.0 in package.json

### Testing
CI

### Additional context
Code change to update engines field for new clients https://github.com/awslabs/smithy-typescript/pull/481

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
