### PR TITLE
chore(clients): remove unused jest deps and config

### DIFF
--- a/clients/client-accessanalyzer/jest.config.js
+++ b/clients/client-accessanalyzer/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-accessanalyzer/package.json
+++ b/clients/client-accessanalyzer/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-accessanalyzer/package.json
+++ b/clients/client-accessanalyzer/package.json
@@ -56,9 +56,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-account/jest.config.js
+++ b/clients/client-account/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-account/package.json
+++ b/clients/client-account/package.json
@@ -54,9 +54,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-account/package.json
+++ b/clients/client-account/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist-*",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "jest --coverage --passWithNoTests"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-acm-pca/jest.config.js
+++ b/clients/client-acm-pca/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-acm-pca/package.json
+++ b/clients/client-acm-pca/package.json
@@ -55,9 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-acm-pca/package.json
+++ b/clients/client-acm-pca/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-acm/jest.config.js
+++ b/clients/client-acm/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-acm/package.json
+++ b/clients/client-acm/package.json
@@ -55,9 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-acm/package.json
+++ b/clients/client-acm/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-alexa-for-business/jest.config.js
+++ b/clients/client-alexa-for-business/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-alexa-for-business/package.json
+++ b/clients/client-alexa-for-business/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-alexa-for-business/package.json
+++ b/clients/client-alexa-for-business/package.json
@@ -56,9 +56,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-amp/jest.config.js
+++ b/clients/client-amp/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-amp/package.json
+++ b/clients/client-amp/package.json
@@ -57,9 +57,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-amp/package.json
+++ b/clients/client-amp/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "jest --coverage --passWithNoTests"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-amplify/jest.config.js
+++ b/clients/client-amplify/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-amplify/package.json
+++ b/clients/client-amplify/package.json
@@ -54,9 +54,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-amplify/package.json
+++ b/clients/client-amplify/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-amplifybackend/jest.config.js
+++ b/clients/client-amplifybackend/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-amplifybackend/package.json
+++ b/clients/client-amplifybackend/package.json
@@ -54,9 +54,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-amplifybackend/package.json
+++ b/clients/client-amplifybackend/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "jest --coverage --passWithNoTests"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-amplifyuibuilder/jest.config.js
+++ b/clients/client-amplifyuibuilder/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-amplifyuibuilder/package.json
+++ b/clients/client-amplifyuibuilder/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist-*",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "jest --coverage --passWithNoTests"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-amplifyuibuilder/package.json
+++ b/clients/client-amplifyuibuilder/package.json
@@ -56,9 +56,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-api-gateway/jest.config.js
+++ b/clients/client-api-gateway/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-api-gateway/package.json
+++ b/clients/client-api-gateway/package.json
@@ -55,9 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-api-gateway/package.json
+++ b/clients/client-api-gateway/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-apigatewaymanagementapi/jest.config.js
+++ b/clients/client-apigatewaymanagementapi/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-apigatewaymanagementapi/package.json
+++ b/clients/client-apigatewaymanagementapi/package.json
@@ -54,9 +54,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-apigatewaymanagementapi/package.json
+++ b/clients/client-apigatewaymanagementapi/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-apigatewayv2/jest.config.js
+++ b/clients/client-apigatewayv2/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-apigatewayv2/package.json
+++ b/clients/client-apigatewayv2/package.json
@@ -54,9 +54,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-apigatewayv2/package.json
+++ b/clients/client-apigatewayv2/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-app-mesh/jest.config.js
+++ b/clients/client-app-mesh/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-app-mesh/package.json
+++ b/clients/client-app-mesh/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-app-mesh/package.json
+++ b/clients/client-app-mesh/package.json
@@ -56,9 +56,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-appconfig/jest.config.js
+++ b/clients/client-appconfig/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-appconfig/package.json
+++ b/clients/client-appconfig/package.json
@@ -54,9 +54,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-appconfig/package.json
+++ b/clients/client-appconfig/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-appconfigdata/jest.config.js
+++ b/clients/client-appconfigdata/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-appconfigdata/package.json
+++ b/clients/client-appconfigdata/package.json
@@ -54,9 +54,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-appconfigdata/package.json
+++ b/clients/client-appconfigdata/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist-*",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "jest --coverage --passWithNoTests"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-appflow/jest.config.js
+++ b/clients/client-appflow/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-appflow/package.json
+++ b/clients/client-appflow/package.json
@@ -54,9 +54,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-appflow/package.json
+++ b/clients/client-appflow/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "jest --coverage --passWithNoTests"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-appintegrations/jest.config.js
+++ b/clients/client-appintegrations/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-appintegrations/package.json
+++ b/clients/client-appintegrations/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "jest --coverage --passWithNoTests"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-appintegrations/package.json
+++ b/clients/client-appintegrations/package.json
@@ -56,9 +56,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-application-auto-scaling/jest.config.js
+++ b/clients/client-application-auto-scaling/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-application-auto-scaling/package.json
+++ b/clients/client-application-auto-scaling/package.json
@@ -54,9 +54,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-application-auto-scaling/package.json
+++ b/clients/client-application-auto-scaling/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-application-discovery-service/jest.config.js
+++ b/clients/client-application-discovery-service/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-application-discovery-service/package.json
+++ b/clients/client-application-discovery-service/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-application-discovery-service/package.json
+++ b/clients/client-application-discovery-service/package.json
@@ -56,9 +56,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-application-insights/jest.config.js
+++ b/clients/client-application-insights/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-application-insights/package.json
+++ b/clients/client-application-insights/package.json
@@ -54,9 +54,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-application-insights/package.json
+++ b/clients/client-application-insights/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-applicationcostprofiler/jest.config.js
+++ b/clients/client-applicationcostprofiler/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-applicationcostprofiler/package.json
+++ b/clients/client-applicationcostprofiler/package.json
@@ -54,9 +54,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-applicationcostprofiler/package.json
+++ b/clients/client-applicationcostprofiler/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "jest --coverage --passWithNoTests"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-apprunner/jest.config.js
+++ b/clients/client-apprunner/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-apprunner/package.json
+++ b/clients/client-apprunner/package.json
@@ -54,9 +54,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-apprunner/package.json
+++ b/clients/client-apprunner/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "jest --coverage --passWithNoTests"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-appstream/jest.config.js
+++ b/clients/client-appstream/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-appstream/package.json
+++ b/clients/client-appstream/package.json
@@ -55,9 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-appstream/package.json
+++ b/clients/client-appstream/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-appsync/jest.config.js
+++ b/clients/client-appsync/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-appsync/package.json
+++ b/clients/client-appsync/package.json
@@ -54,9 +54,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-appsync/package.json
+++ b/clients/client-appsync/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-athena/jest.config.js
+++ b/clients/client-athena/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-athena/package.json
+++ b/clients/client-athena/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-athena/package.json
+++ b/clients/client-athena/package.json
@@ -56,9 +56,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-auditmanager/jest.config.js
+++ b/clients/client-auditmanager/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-auditmanager/package.json
+++ b/clients/client-auditmanager/package.json
@@ -54,9 +54,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-auditmanager/package.json
+++ b/clients/client-auditmanager/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "jest --coverage --passWithNoTests"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-auto-scaling-plans/jest.config.js
+++ b/clients/client-auto-scaling-plans/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-auto-scaling-plans/package.json
+++ b/clients/client-auto-scaling-plans/package.json
@@ -54,9 +54,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-auto-scaling-plans/package.json
+++ b/clients/client-auto-scaling-plans/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-auto-scaling/jest.config.js
+++ b/clients/client-auto-scaling/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-auto-scaling/package.json
+++ b/clients/client-auto-scaling/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-auto-scaling/package.json
+++ b/clients/client-auto-scaling/package.json
@@ -57,9 +57,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-backup-gateway/jest.config.js
+++ b/clients/client-backup-gateway/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-backup-gateway/package.json
+++ b/clients/client-backup-gateway/package.json
@@ -54,9 +54,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-backup-gateway/package.json
+++ b/clients/client-backup-gateway/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist-*",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "jest --coverage --passWithNoTests"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-backup/jest.config.js
+++ b/clients/client-backup/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-backup/package.json
+++ b/clients/client-backup/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-backup/package.json
+++ b/clients/client-backup/package.json
@@ -56,9 +56,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-batch/jest.config.js
+++ b/clients/client-batch/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-batch/package.json
+++ b/clients/client-batch/package.json
@@ -54,9 +54,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-batch/package.json
+++ b/clients/client-batch/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-braket/jest.config.js
+++ b/clients/client-braket/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-braket/package.json
+++ b/clients/client-braket/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "jest --coverage --passWithNoTests"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-braket/package.json
+++ b/clients/client-braket/package.json
@@ -56,9 +56,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-budgets/jest.config.js
+++ b/clients/client-budgets/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-budgets/package.json
+++ b/clients/client-budgets/package.json
@@ -54,9 +54,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-budgets/package.json
+++ b/clients/client-budgets/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-chime-sdk-identity/jest.config.js
+++ b/clients/client-chime-sdk-identity/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-chime-sdk-identity/package.json
+++ b/clients/client-chime-sdk-identity/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "jest --coverage --passWithNoTests"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-chime-sdk-identity/package.json
+++ b/clients/client-chime-sdk-identity/package.json
@@ -56,9 +56,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-chime-sdk-meetings/jest.config.js
+++ b/clients/client-chime-sdk-meetings/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-chime-sdk-meetings/package.json
+++ b/clients/client-chime-sdk-meetings/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist-*",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "jest --coverage --passWithNoTests"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-chime-sdk-meetings/package.json
+++ b/clients/client-chime-sdk-meetings/package.json
@@ -56,9 +56,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-chime-sdk-messaging/jest.config.js
+++ b/clients/client-chime-sdk-messaging/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-chime-sdk-messaging/package.json
+++ b/clients/client-chime-sdk-messaging/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "jest --coverage --passWithNoTests"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-chime-sdk-messaging/package.json
+++ b/clients/client-chime-sdk-messaging/package.json
@@ -56,9 +56,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-chime/jest.config.js
+++ b/clients/client-chime/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-chime/package.json
+++ b/clients/client-chime/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-chime/package.json
+++ b/clients/client-chime/package.json
@@ -56,9 +56,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-cloud9/jest.config.js
+++ b/clients/client-cloud9/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-cloud9/package.json
+++ b/clients/client-cloud9/package.json
@@ -54,9 +54,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-cloud9/package.json
+++ b/clients/client-cloud9/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-cloudcontrol/jest.config.js
+++ b/clients/client-cloudcontrol/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-cloudcontrol/package.json
+++ b/clients/client-cloudcontrol/package.json
@@ -57,9 +57,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-cloudcontrol/package.json
+++ b/clients/client-cloudcontrol/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist-*",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "jest --coverage --passWithNoTests"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-clouddirectory/jest.config.js
+++ b/clients/client-clouddirectory/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-clouddirectory/package.json
+++ b/clients/client-clouddirectory/package.json
@@ -54,9 +54,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-clouddirectory/package.json
+++ b/clients/client-clouddirectory/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-cloudformation/jest.config.js
+++ b/clients/client-cloudformation/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-cloudformation/package.json
+++ b/clients/client-cloudformation/package.json
@@ -59,9 +59,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-cloudformation/package.json
+++ b/clients/client-cloudformation/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-cloudfront/jest.config.js
+++ b/clients/client-cloudfront/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-cloudfront/package.json
+++ b/clients/client-cloudfront/package.json
@@ -58,9 +58,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-cloudfront/package.json
+++ b/clients/client-cloudfront/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-cloudhsm-v2/jest.config.js
+++ b/clients/client-cloudhsm-v2/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-cloudhsm-v2/package.json
+++ b/clients/client-cloudhsm-v2/package.json
@@ -54,9 +54,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-cloudhsm-v2/package.json
+++ b/clients/client-cloudhsm-v2/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-cloudhsm/jest.config.js
+++ b/clients/client-cloudhsm/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-cloudhsm/package.json
+++ b/clients/client-cloudhsm/package.json
@@ -54,9 +54,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-cloudhsm/package.json
+++ b/clients/client-cloudhsm/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-cloudsearch-domain/jest.config.js
+++ b/clients/client-cloudsearch-domain/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-cloudsearch-domain/package.json
+++ b/clients/client-cloudsearch-domain/package.json
@@ -54,9 +54,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-cloudsearch-domain/package.json
+++ b/clients/client-cloudsearch-domain/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-cloudsearch/jest.config.js
+++ b/clients/client-cloudsearch/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-cloudsearch/package.json
+++ b/clients/client-cloudsearch/package.json
@@ -56,9 +56,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-cloudsearch/package.json
+++ b/clients/client-cloudsearch/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-cloudtrail/jest.config.js
+++ b/clients/client-cloudtrail/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-cloudtrail/package.json
+++ b/clients/client-cloudtrail/package.json
@@ -54,9 +54,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-cloudtrail/package.json
+++ b/clients/client-cloudtrail/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-cloudwatch-events/jest.config.js
+++ b/clients/client-cloudwatch-events/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-cloudwatch-events/package.json
+++ b/clients/client-cloudwatch-events/package.json
@@ -54,9 +54,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-cloudwatch-events/package.json
+++ b/clients/client-cloudwatch-events/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-cloudwatch-logs/jest.config.js
+++ b/clients/client-cloudwatch-logs/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-cloudwatch-logs/package.json
+++ b/clients/client-cloudwatch-logs/package.json
@@ -54,9 +54,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-cloudwatch-logs/package.json
+++ b/clients/client-cloudwatch-logs/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-cloudwatch/jest.config.js
+++ b/clients/client-cloudwatch/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-cloudwatch/package.json
+++ b/clients/client-cloudwatch/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-cloudwatch/package.json
+++ b/clients/client-cloudwatch/package.json
@@ -57,9 +57,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-codeartifact/jest.config.js
+++ b/clients/client-codeartifact/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-codeartifact/package.json
+++ b/clients/client-codeartifact/package.json
@@ -54,9 +54,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-codeartifact/package.json
+++ b/clients/client-codeartifact/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "jest --coverage --passWithNoTests"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-codebuild/jest.config.js
+++ b/clients/client-codebuild/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-codebuild/package.json
+++ b/clients/client-codebuild/package.json
@@ -54,9 +54,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-codebuild/package.json
+++ b/clients/client-codebuild/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-codecommit/jest.config.js
+++ b/clients/client-codecommit/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-codecommit/package.json
+++ b/clients/client-codecommit/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-codecommit/package.json
+++ b/clients/client-codecommit/package.json
@@ -56,9 +56,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-codedeploy/jest.config.js
+++ b/clients/client-codedeploy/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-codedeploy/package.json
+++ b/clients/client-codedeploy/package.json
@@ -55,9 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-codedeploy/package.json
+++ b/clients/client-codedeploy/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-codeguru-reviewer/jest.config.js
+++ b/clients/client-codeguru-reviewer/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-codeguru-reviewer/package.json
+++ b/clients/client-codeguru-reviewer/package.json
@@ -57,9 +57,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-codeguru-reviewer/package.json
+++ b/clients/client-codeguru-reviewer/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-codeguruprofiler/jest.config.js
+++ b/clients/client-codeguruprofiler/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-codeguruprofiler/package.json
+++ b/clients/client-codeguruprofiler/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-codeguruprofiler/package.json
+++ b/clients/client-codeguruprofiler/package.json
@@ -56,9 +56,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-codepipeline/jest.config.js
+++ b/clients/client-codepipeline/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-codepipeline/package.json
+++ b/clients/client-codepipeline/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-codepipeline/package.json
+++ b/clients/client-codepipeline/package.json
@@ -56,9 +56,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-codestar-connections/jest.config.js
+++ b/clients/client-codestar-connections/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-codestar-connections/package.json
+++ b/clients/client-codestar-connections/package.json
@@ -54,9 +54,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-codestar-connections/package.json
+++ b/clients/client-codestar-connections/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-codestar-notifications/jest.config.js
+++ b/clients/client-codestar-notifications/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-codestar-notifications/package.json
+++ b/clients/client-codestar-notifications/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-codestar-notifications/package.json
+++ b/clients/client-codestar-notifications/package.json
@@ -56,9 +56,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-codestar/jest.config.js
+++ b/clients/client-codestar/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-codestar/package.json
+++ b/clients/client-codestar/package.json
@@ -54,9 +54,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-codestar/package.json
+++ b/clients/client-codestar/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-cognito-identity-provider/jest.config.js
+++ b/clients/client-cognito-identity-provider/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-cognito-identity-provider/package.json
+++ b/clients/client-cognito-identity-provider/package.json
@@ -54,9 +54,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-cognito-identity-provider/package.json
+++ b/clients/client-cognito-identity-provider/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-cognito-identity/jest.config.js
+++ b/clients/client-cognito-identity/jest.config.js
@@ -1,6 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  // filedoesnotexist.spec.ts is added to avoid jest error "Your test suite must contain at least one test."
-  // replace it with **/*.spec.ts once we have a decision on test infrastructure for clients.
-  testMatch: ["filedoesnotexist.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-cognito-identity/package.json
+++ b/clients/client-cognito-identity/package.json
@@ -12,7 +12,6 @@
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
     "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0",
     "test:e2e": "ts-mocha test/**/*.ispec.ts && karma start karma.conf.js"
   },
   "main": "./dist-cjs/index.js",

--- a/clients/client-cognito-identity/package.json
+++ b/clients/client-cognito-identity/package.json
@@ -58,9 +58,7 @@
     "@types/mocha": "^8.0.4",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-cognito-sync/jest.config.js
+++ b/clients/client-cognito-sync/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-cognito-sync/package.json
+++ b/clients/client-cognito-sync/package.json
@@ -54,9 +54,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-cognito-sync/package.json
+++ b/clients/client-cognito-sync/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-comprehend/jest.config.js
+++ b/clients/client-comprehend/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-comprehend/package.json
+++ b/clients/client-comprehend/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-comprehend/package.json
+++ b/clients/client-comprehend/package.json
@@ -56,9 +56,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-comprehendmedical/jest.config.js
+++ b/clients/client-comprehendmedical/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-comprehendmedical/package.json
+++ b/clients/client-comprehendmedical/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-comprehendmedical/package.json
+++ b/clients/client-comprehendmedical/package.json
@@ -56,9 +56,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-compute-optimizer/jest.config.js
+++ b/clients/client-compute-optimizer/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-compute-optimizer/package.json
+++ b/clients/client-compute-optimizer/package.json
@@ -54,9 +54,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-compute-optimizer/package.json
+++ b/clients/client-compute-optimizer/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-config-service/jest.config.js
+++ b/clients/client-config-service/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-config-service/package.json
+++ b/clients/client-config-service/package.json
@@ -54,9 +54,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-config-service/package.json
+++ b/clients/client-config-service/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-connect-contact-lens/jest.config.js
+++ b/clients/client-connect-contact-lens/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-connect-contact-lens/package.json
+++ b/clients/client-connect-contact-lens/package.json
@@ -54,9 +54,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-connect-contact-lens/package.json
+++ b/clients/client-connect-contact-lens/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "jest --coverage --passWithNoTests"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-connect/jest.config.js
+++ b/clients/client-connect/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-connect/package.json
+++ b/clients/client-connect/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-connect/package.json
+++ b/clients/client-connect/package.json
@@ -56,9 +56,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-connectparticipant/jest.config.js
+++ b/clients/client-connectparticipant/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-connectparticipant/package.json
+++ b/clients/client-connectparticipant/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-connectparticipant/package.json
+++ b/clients/client-connectparticipant/package.json
@@ -56,9 +56,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-cost-and-usage-report-service/jest.config.js
+++ b/clients/client-cost-and-usage-report-service/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-cost-and-usage-report-service/package.json
+++ b/clients/client-cost-and-usage-report-service/package.json
@@ -54,9 +54,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-cost-and-usage-report-service/package.json
+++ b/clients/client-cost-and-usage-report-service/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-cost-explorer/jest.config.js
+++ b/clients/client-cost-explorer/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-cost-explorer/package.json
+++ b/clients/client-cost-explorer/package.json
@@ -54,9 +54,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-cost-explorer/package.json
+++ b/clients/client-cost-explorer/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-customer-profiles/jest.config.js
+++ b/clients/client-customer-profiles/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-customer-profiles/package.json
+++ b/clients/client-customer-profiles/package.json
@@ -54,9 +54,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-customer-profiles/package.json
+++ b/clients/client-customer-profiles/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "jest --coverage --passWithNoTests"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-data-pipeline/jest.config.js
+++ b/clients/client-data-pipeline/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-data-pipeline/package.json
+++ b/clients/client-data-pipeline/package.json
@@ -54,9 +54,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-data-pipeline/package.json
+++ b/clients/client-data-pipeline/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-database-migration-service/jest.config.js
+++ b/clients/client-database-migration-service/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-database-migration-service/package.json
+++ b/clients/client-database-migration-service/package.json
@@ -55,9 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-database-migration-service/package.json
+++ b/clients/client-database-migration-service/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-databrew/jest.config.js
+++ b/clients/client-databrew/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-databrew/package.json
+++ b/clients/client-databrew/package.json
@@ -54,9 +54,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-databrew/package.json
+++ b/clients/client-databrew/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "jest --coverage --passWithNoTests"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-dataexchange/jest.config.js
+++ b/clients/client-dataexchange/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-dataexchange/package.json
+++ b/clients/client-dataexchange/package.json
@@ -54,9 +54,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-dataexchange/package.json
+++ b/clients/client-dataexchange/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-datasync/jest.config.js
+++ b/clients/client-datasync/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-datasync/package.json
+++ b/clients/client-datasync/package.json
@@ -54,9 +54,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-datasync/package.json
+++ b/clients/client-datasync/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-dax/jest.config.js
+++ b/clients/client-dax/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-dax/package.json
+++ b/clients/client-dax/package.json
@@ -54,9 +54,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-dax/package.json
+++ b/clients/client-dax/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-detective/jest.config.js
+++ b/clients/client-detective/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-detective/package.json
+++ b/clients/client-detective/package.json
@@ -54,9 +54,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-detective/package.json
+++ b/clients/client-detective/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-device-farm/jest.config.js
+++ b/clients/client-device-farm/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-device-farm/package.json
+++ b/clients/client-device-farm/package.json
@@ -54,9 +54,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-device-farm/package.json
+++ b/clients/client-device-farm/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-devops-guru/jest.config.js
+++ b/clients/client-devops-guru/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-devops-guru/package.json
+++ b/clients/client-devops-guru/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "jest --coverage --passWithNoTests"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-devops-guru/package.json
+++ b/clients/client-devops-guru/package.json
@@ -56,9 +56,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-direct-connect/jest.config.js
+++ b/clients/client-direct-connect/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-direct-connect/package.json
+++ b/clients/client-direct-connect/package.json
@@ -54,9 +54,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-direct-connect/package.json
+++ b/clients/client-direct-connect/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-directory-service/jest.config.js
+++ b/clients/client-directory-service/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-directory-service/package.json
+++ b/clients/client-directory-service/package.json
@@ -54,9 +54,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-directory-service/package.json
+++ b/clients/client-directory-service/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-dlm/jest.config.js
+++ b/clients/client-dlm/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-dlm/package.json
+++ b/clients/client-dlm/package.json
@@ -54,9 +54,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-dlm/package.json
+++ b/clients/client-dlm/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-docdb/jest.config.js
+++ b/clients/client-docdb/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-docdb/package.json
+++ b/clients/client-docdb/package.json
@@ -58,9 +58,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-docdb/package.json
+++ b/clients/client-docdb/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-drs/jest.config.js
+++ b/clients/client-drs/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-drs/package.json
+++ b/clients/client-drs/package.json
@@ -54,9 +54,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-drs/package.json
+++ b/clients/client-drs/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist-*",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "jest --coverage --passWithNoTests"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-dynamodb-streams/jest.config.js
+++ b/clients/client-dynamodb-streams/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-dynamodb-streams/package.json
+++ b/clients/client-dynamodb-streams/package.json
@@ -54,9 +54,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-dynamodb-streams/package.json
+++ b/clients/client-dynamodb-streams/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-dynamodb/jest.config.js
+++ b/clients/client-dynamodb/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-dynamodb/package.json
+++ b/clients/client-dynamodb/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-dynamodb/package.json
+++ b/clients/client-dynamodb/package.json
@@ -58,9 +58,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-ebs/jest.config.js
+++ b/clients/client-ebs/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-ebs/package.json
+++ b/clients/client-ebs/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-ebs/package.json
+++ b/clients/client-ebs/package.json
@@ -56,9 +56,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-ec2-instance-connect/jest.config.js
+++ b/clients/client-ec2-instance-connect/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-ec2-instance-connect/package.json
+++ b/clients/client-ec2-instance-connect/package.json
@@ -54,9 +54,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-ec2-instance-connect/package.json
+++ b/clients/client-ec2-instance-connect/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-ec2/jest.config.js
+++ b/clients/client-ec2/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-ec2/package.json
+++ b/clients/client-ec2/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-ec2/package.json
+++ b/clients/client-ec2/package.json
@@ -60,9 +60,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-ecr-public/jest.config.js
+++ b/clients/client-ecr-public/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-ecr-public/package.json
+++ b/clients/client-ecr-public/package.json
@@ -54,9 +54,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-ecr-public/package.json
+++ b/clients/client-ecr-public/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "jest --coverage --passWithNoTests"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-ecr/jest.config.js
+++ b/clients/client-ecr/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-ecr/package.json
+++ b/clients/client-ecr/package.json
@@ -55,9 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-ecr/package.json
+++ b/clients/client-ecr/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-ecs/jest.config.js
+++ b/clients/client-ecs/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-ecs/package.json
+++ b/clients/client-ecs/package.json
@@ -55,9 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-ecs/package.json
+++ b/clients/client-ecs/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-efs/jest.config.js
+++ b/clients/client-efs/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-efs/package.json
+++ b/clients/client-efs/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-efs/package.json
+++ b/clients/client-efs/package.json
@@ -56,9 +56,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-eks/jest.config.js
+++ b/clients/client-eks/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-eks/package.json
+++ b/clients/client-eks/package.json
@@ -57,9 +57,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-eks/package.json
+++ b/clients/client-eks/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-elastic-beanstalk/jest.config.js
+++ b/clients/client-elastic-beanstalk/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-elastic-beanstalk/package.json
+++ b/clients/client-elastic-beanstalk/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-elastic-beanstalk/package.json
+++ b/clients/client-elastic-beanstalk/package.json
@@ -57,9 +57,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-elastic-inference/jest.config.js
+++ b/clients/client-elastic-inference/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-elastic-inference/package.json
+++ b/clients/client-elastic-inference/package.json
@@ -54,9 +54,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-elastic-inference/package.json
+++ b/clients/client-elastic-inference/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-elastic-load-balancing-v2/jest.config.js
+++ b/clients/client-elastic-load-balancing-v2/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-elastic-load-balancing-v2/package.json
+++ b/clients/client-elastic-load-balancing-v2/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-elastic-load-balancing-v2/package.json
+++ b/clients/client-elastic-load-balancing-v2/package.json
@@ -57,9 +57,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-elastic-load-balancing/jest.config.js
+++ b/clients/client-elastic-load-balancing/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-elastic-load-balancing/package.json
+++ b/clients/client-elastic-load-balancing/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-elastic-load-balancing/package.json
+++ b/clients/client-elastic-load-balancing/package.json
@@ -57,9 +57,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-elastic-transcoder/jest.config.js
+++ b/clients/client-elastic-transcoder/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-elastic-transcoder/package.json
+++ b/clients/client-elastic-transcoder/package.json
@@ -55,9 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-elastic-transcoder/package.json
+++ b/clients/client-elastic-transcoder/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-elasticache/jest.config.js
+++ b/clients/client-elasticache/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-elasticache/package.json
+++ b/clients/client-elasticache/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-elasticache/package.json
+++ b/clients/client-elasticache/package.json
@@ -57,9 +57,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-elasticsearch-service/jest.config.js
+++ b/clients/client-elasticsearch-service/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-elasticsearch-service/package.json
+++ b/clients/client-elasticsearch-service/package.json
@@ -54,9 +54,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-elasticsearch-service/package.json
+++ b/clients/client-elasticsearch-service/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-emr-containers/jest.config.js
+++ b/clients/client-emr-containers/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-emr-containers/package.json
+++ b/clients/client-emr-containers/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "jest --coverage --passWithNoTests"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-emr-containers/package.json
+++ b/clients/client-emr-containers/package.json
@@ -56,9 +56,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-emr/jest.config.js
+++ b/clients/client-emr/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-emr/package.json
+++ b/clients/client-emr/package.json
@@ -55,9 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-emr/package.json
+++ b/clients/client-emr/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-eventbridge/jest.config.js
+++ b/clients/client-eventbridge/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-eventbridge/package.json
+++ b/clients/client-eventbridge/package.json
@@ -54,9 +54,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-eventbridge/package.json
+++ b/clients/client-eventbridge/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-evidently/jest.config.js
+++ b/clients/client-evidently/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-evidently/package.json
+++ b/clients/client-evidently/package.json
@@ -54,9 +54,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-evidently/package.json
+++ b/clients/client-evidently/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist-*",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "jest --coverage --passWithNoTests"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-finspace-data/jest.config.js
+++ b/clients/client-finspace-data/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-finspace-data/package.json
+++ b/clients/client-finspace-data/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "jest --coverage --passWithNoTests"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-finspace-data/package.json
+++ b/clients/client-finspace-data/package.json
@@ -56,9 +56,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-finspace/jest.config.js
+++ b/clients/client-finspace/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-finspace/package.json
+++ b/clients/client-finspace/package.json
@@ -54,9 +54,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-finspace/package.json
+++ b/clients/client-finspace/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "jest --coverage --passWithNoTests"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-firehose/jest.config.js
+++ b/clients/client-firehose/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-firehose/package.json
+++ b/clients/client-firehose/package.json
@@ -54,9 +54,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-firehose/package.json
+++ b/clients/client-firehose/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-fis/jest.config.js
+++ b/clients/client-fis/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-fis/package.json
+++ b/clients/client-fis/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "jest --coverage --passWithNoTests"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-fis/package.json
+++ b/clients/client-fis/package.json
@@ -56,9 +56,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-fms/jest.config.js
+++ b/clients/client-fms/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-fms/package.json
+++ b/clients/client-fms/package.json
@@ -54,9 +54,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-fms/package.json
+++ b/clients/client-fms/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-forecast/jest.config.js
+++ b/clients/client-forecast/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-forecast/package.json
+++ b/clients/client-forecast/package.json
@@ -54,9 +54,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-forecast/package.json
+++ b/clients/client-forecast/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-forecastquery/jest.config.js
+++ b/clients/client-forecastquery/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-forecastquery/package.json
+++ b/clients/client-forecastquery/package.json
@@ -54,9 +54,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-forecastquery/package.json
+++ b/clients/client-forecastquery/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-frauddetector/jest.config.js
+++ b/clients/client-frauddetector/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-frauddetector/package.json
+++ b/clients/client-frauddetector/package.json
@@ -54,9 +54,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-frauddetector/package.json
+++ b/clients/client-frauddetector/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-fsx/jest.config.js
+++ b/clients/client-fsx/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-fsx/package.json
+++ b/clients/client-fsx/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-fsx/package.json
+++ b/clients/client-fsx/package.json
@@ -56,9 +56,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-gamelift/jest.config.js
+++ b/clients/client-gamelift/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-gamelift/package.json
+++ b/clients/client-gamelift/package.json
@@ -54,9 +54,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-gamelift/package.json
+++ b/clients/client-gamelift/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-glacier/jest.config.js
+++ b/clients/client-glacier/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-glacier/package.json
+++ b/clients/client-glacier/package.json
@@ -58,9 +58,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-glacier/package.json
+++ b/clients/client-glacier/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-global-accelerator/jest.config.js
+++ b/clients/client-global-accelerator/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-global-accelerator/package.json
+++ b/clients/client-global-accelerator/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-global-accelerator/package.json
+++ b/clients/client-global-accelerator/package.json
@@ -56,9 +56,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-glue/jest.config.js
+++ b/clients/client-glue/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-glue/package.json
+++ b/clients/client-glue/package.json
@@ -54,9 +54,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-glue/package.json
+++ b/clients/client-glue/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-grafana/jest.config.js
+++ b/clients/client-grafana/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-grafana/package.json
+++ b/clients/client-grafana/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist-*",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "jest --coverage --passWithNoTests"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-grafana/package.json
+++ b/clients/client-grafana/package.json
@@ -56,9 +56,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-greengrass/jest.config.js
+++ b/clients/client-greengrass/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-greengrass/package.json
+++ b/clients/client-greengrass/package.json
@@ -54,9 +54,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-greengrass/package.json
+++ b/clients/client-greengrass/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-greengrassv2/jest.config.js
+++ b/clients/client-greengrassv2/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-greengrassv2/package.json
+++ b/clients/client-greengrassv2/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "jest --coverage --passWithNoTests"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-greengrassv2/package.json
+++ b/clients/client-greengrassv2/package.json
@@ -56,9 +56,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-groundstation/jest.config.js
+++ b/clients/client-groundstation/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-groundstation/package.json
+++ b/clients/client-groundstation/package.json
@@ -54,9 +54,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-groundstation/package.json
+++ b/clients/client-groundstation/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-guardduty/jest.config.js
+++ b/clients/client-guardduty/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-guardduty/package.json
+++ b/clients/client-guardduty/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-guardduty/package.json
+++ b/clients/client-guardduty/package.json
@@ -56,9 +56,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-health/jest.config.js
+++ b/clients/client-health/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-health/package.json
+++ b/clients/client-health/package.json
@@ -54,9 +54,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-health/package.json
+++ b/clients/client-health/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-healthlake/jest.config.js
+++ b/clients/client-healthlake/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-healthlake/package.json
+++ b/clients/client-healthlake/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "jest --coverage --passWithNoTests"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-healthlake/package.json
+++ b/clients/client-healthlake/package.json
@@ -56,9 +56,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-honeycode/jest.config.js
+++ b/clients/client-honeycode/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-honeycode/package.json
+++ b/clients/client-honeycode/package.json
@@ -54,9 +54,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-honeycode/package.json
+++ b/clients/client-honeycode/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "jest --coverage --passWithNoTests"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-iam/jest.config.js
+++ b/clients/client-iam/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-iam/package.json
+++ b/clients/client-iam/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-iam/package.json
+++ b/clients/client-iam/package.json
@@ -57,9 +57,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-identitystore/jest.config.js
+++ b/clients/client-identitystore/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-identitystore/package.json
+++ b/clients/client-identitystore/package.json
@@ -54,9 +54,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-identitystore/package.json
+++ b/clients/client-identitystore/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "jest --coverage --passWithNoTests"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-imagebuilder/jest.config.js
+++ b/clients/client-imagebuilder/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-imagebuilder/package.json
+++ b/clients/client-imagebuilder/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-imagebuilder/package.json
+++ b/clients/client-imagebuilder/package.json
@@ -56,9 +56,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-inspector/jest.config.js
+++ b/clients/client-inspector/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-inspector/package.json
+++ b/clients/client-inspector/package.json
@@ -54,9 +54,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-inspector/package.json
+++ b/clients/client-inspector/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-inspector2/jest.config.js
+++ b/clients/client-inspector2/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-inspector2/package.json
+++ b/clients/client-inspector2/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist-*",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "jest --coverage --passWithNoTests"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-inspector2/package.json
+++ b/clients/client-inspector2/package.json
@@ -56,9 +56,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-iot-1click-devices-service/jest.config.js
+++ b/clients/client-iot-1click-devices-service/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-iot-1click-devices-service/package.json
+++ b/clients/client-iot-1click-devices-service/package.json
@@ -54,9 +54,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-iot-1click-devices-service/package.json
+++ b/clients/client-iot-1click-devices-service/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-iot-1click-projects/jest.config.js
+++ b/clients/client-iot-1click-projects/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-iot-1click-projects/package.json
+++ b/clients/client-iot-1click-projects/package.json
@@ -54,9 +54,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-iot-1click-projects/package.json
+++ b/clients/client-iot-1click-projects/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-iot-data-plane/jest.config.js
+++ b/clients/client-iot-data-plane/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-iot-data-plane/package.json
+++ b/clients/client-iot-data-plane/package.json
@@ -54,9 +54,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-iot-data-plane/package.json
+++ b/clients/client-iot-data-plane/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-iot-events-data/jest.config.js
+++ b/clients/client-iot-events-data/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-iot-events-data/package.json
+++ b/clients/client-iot-events-data/package.json
@@ -54,9 +54,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-iot-events-data/package.json
+++ b/clients/client-iot-events-data/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-iot-events/jest.config.js
+++ b/clients/client-iot-events/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-iot-events/package.json
+++ b/clients/client-iot-events/package.json
@@ -54,9 +54,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-iot-events/package.json
+++ b/clients/client-iot-events/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-iot-jobs-data-plane/jest.config.js
+++ b/clients/client-iot-jobs-data-plane/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-iot-jobs-data-plane/package.json
+++ b/clients/client-iot-jobs-data-plane/package.json
@@ -54,9 +54,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-iot-jobs-data-plane/package.json
+++ b/clients/client-iot-jobs-data-plane/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-iot-wireless/jest.config.js
+++ b/clients/client-iot-wireless/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-iot-wireless/package.json
+++ b/clients/client-iot-wireless/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "jest --coverage --passWithNoTests"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-iot-wireless/package.json
+++ b/clients/client-iot-wireless/package.json
@@ -56,9 +56,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-iot/jest.config.js
+++ b/clients/client-iot/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-iot/package.json
+++ b/clients/client-iot/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-iot/package.json
+++ b/clients/client-iot/package.json
@@ -56,9 +56,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-iotanalytics/jest.config.js
+++ b/clients/client-iotanalytics/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-iotanalytics/package.json
+++ b/clients/client-iotanalytics/package.json
@@ -54,9 +54,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-iotanalytics/package.json
+++ b/clients/client-iotanalytics/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-iotdeviceadvisor/jest.config.js
+++ b/clients/client-iotdeviceadvisor/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-iotdeviceadvisor/package.json
+++ b/clients/client-iotdeviceadvisor/package.json
@@ -54,9 +54,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-iotdeviceadvisor/package.json
+++ b/clients/client-iotdeviceadvisor/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "jest --coverage --passWithNoTests"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-iotfleethub/jest.config.js
+++ b/clients/client-iotfleethub/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-iotfleethub/package.json
+++ b/clients/client-iotfleethub/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "jest --coverage --passWithNoTests"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-iotfleethub/package.json
+++ b/clients/client-iotfleethub/package.json
@@ -56,9 +56,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-iotsecuretunneling/jest.config.js
+++ b/clients/client-iotsecuretunneling/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-iotsecuretunneling/package.json
+++ b/clients/client-iotsecuretunneling/package.json
@@ -54,9 +54,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-iotsecuretunneling/package.json
+++ b/clients/client-iotsecuretunneling/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-iotsitewise/jest.config.js
+++ b/clients/client-iotsitewise/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-iotsitewise/package.json
+++ b/clients/client-iotsitewise/package.json
@@ -57,9 +57,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-iotsitewise/package.json
+++ b/clients/client-iotsitewise/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "jest --coverage --passWithNoTests"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-iotthingsgraph/jest.config.js
+++ b/clients/client-iotthingsgraph/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-iotthingsgraph/package.json
+++ b/clients/client-iotthingsgraph/package.json
@@ -54,9 +54,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-iotthingsgraph/package.json
+++ b/clients/client-iotthingsgraph/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-iottwinmaker/jest.config.js
+++ b/clients/client-iottwinmaker/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-iottwinmaker/package.json
+++ b/clients/client-iottwinmaker/package.json
@@ -54,9 +54,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-iottwinmaker/package.json
+++ b/clients/client-iottwinmaker/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist-*",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "jest --coverage --passWithNoTests"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-ivs/jest.config.js
+++ b/clients/client-ivs/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-ivs/package.json
+++ b/clients/client-ivs/package.json
@@ -54,9 +54,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-ivs/package.json
+++ b/clients/client-ivs/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "jest --coverage --passWithNoTests"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-kafka/jest.config.js
+++ b/clients/client-kafka/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-kafka/package.json
+++ b/clients/client-kafka/package.json
@@ -54,9 +54,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-kafka/package.json
+++ b/clients/client-kafka/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-kafkaconnect/jest.config.js
+++ b/clients/client-kafkaconnect/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-kafkaconnect/package.json
+++ b/clients/client-kafkaconnect/package.json
@@ -54,9 +54,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-kafkaconnect/package.json
+++ b/clients/client-kafkaconnect/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "jest --coverage --passWithNoTests"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-kendra/jest.config.js
+++ b/clients/client-kendra/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-kendra/package.json
+++ b/clients/client-kendra/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-kendra/package.json
+++ b/clients/client-kendra/package.json
@@ -56,9 +56,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-kinesis-analytics-v2/jest.config.js
+++ b/clients/client-kinesis-analytics-v2/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-kinesis-analytics-v2/package.json
+++ b/clients/client-kinesis-analytics-v2/package.json
@@ -54,9 +54,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-kinesis-analytics-v2/package.json
+++ b/clients/client-kinesis-analytics-v2/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-kinesis-analytics/jest.config.js
+++ b/clients/client-kinesis-analytics/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-kinesis-analytics/package.json
+++ b/clients/client-kinesis-analytics/package.json
@@ -54,9 +54,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-kinesis-analytics/package.json
+++ b/clients/client-kinesis-analytics/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-kinesis-video-archived-media/jest.config.js
+++ b/clients/client-kinesis-video-archived-media/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-kinesis-video-archived-media/package.json
+++ b/clients/client-kinesis-video-archived-media/package.json
@@ -54,9 +54,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-kinesis-video-archived-media/package.json
+++ b/clients/client-kinesis-video-archived-media/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-kinesis-video-media/jest.config.js
+++ b/clients/client-kinesis-video-media/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-kinesis-video-media/package.json
+++ b/clients/client-kinesis-video-media/package.json
@@ -54,9 +54,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-kinesis-video-media/package.json
+++ b/clients/client-kinesis-video-media/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-kinesis-video-signaling/jest.config.js
+++ b/clients/client-kinesis-video-signaling/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-kinesis-video-signaling/package.json
+++ b/clients/client-kinesis-video-signaling/package.json
@@ -54,9 +54,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-kinesis-video-signaling/package.json
+++ b/clients/client-kinesis-video-signaling/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-kinesis-video/jest.config.js
+++ b/clients/client-kinesis-video/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-kinesis-video/package.json
+++ b/clients/client-kinesis-video/package.json
@@ -54,9 +54,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-kinesis-video/package.json
+++ b/clients/client-kinesis-video/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-kinesis/jest.config.js
+++ b/clients/client-kinesis/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-kinesis/package.json
+++ b/clients/client-kinesis/package.json
@@ -58,9 +58,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-kinesis/package.json
+++ b/clients/client-kinesis/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-kms/jest.config.js
+++ b/clients/client-kms/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-kms/package.json
+++ b/clients/client-kms/package.json
@@ -54,9 +54,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-kms/package.json
+++ b/clients/client-kms/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-lakeformation/jest.config.js
+++ b/clients/client-lakeformation/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-lakeformation/package.json
+++ b/clients/client-lakeformation/package.json
@@ -54,9 +54,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-lakeformation/package.json
+++ b/clients/client-lakeformation/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-lambda/jest.config.js
+++ b/clients/client-lambda/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-lambda/package.json
+++ b/clients/client-lambda/package.json
@@ -55,9 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-lambda/package.json
+++ b/clients/client-lambda/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-lex-model-building-service/jest.config.js
+++ b/clients/client-lex-model-building-service/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-lex-model-building-service/package.json
+++ b/clients/client-lex-model-building-service/package.json
@@ -54,9 +54,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-lex-model-building-service/package.json
+++ b/clients/client-lex-model-building-service/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-lex-models-v2/jest.config.js
+++ b/clients/client-lex-models-v2/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-lex-models-v2/package.json
+++ b/clients/client-lex-models-v2/package.json
@@ -55,9 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-lex-models-v2/package.json
+++ b/clients/client-lex-models-v2/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "jest --coverage --passWithNoTests"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-lex-runtime-service/jest.config.js
+++ b/clients/client-lex-runtime-service/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-lex-runtime-service/package.json
+++ b/clients/client-lex-runtime-service/package.json
@@ -58,9 +58,7 @@
     "@types/mocha": "^8.0.4",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-lex-runtime-v2/jest.config.js
+++ b/clients/client-lex-runtime-v2/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-lex-runtime-v2/package.json
+++ b/clients/client-lex-runtime-v2/package.json
@@ -59,9 +59,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-lex-runtime-v2/package.json
+++ b/clients/client-lex-runtime-v2/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "jest --coverage --passWithNoTests"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-license-manager/jest.config.js
+++ b/clients/client-license-manager/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-license-manager/package.json
+++ b/clients/client-license-manager/package.json
@@ -54,9 +54,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-license-manager/package.json
+++ b/clients/client-license-manager/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-lightsail/jest.config.js
+++ b/clients/client-lightsail/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-lightsail/package.json
+++ b/clients/client-lightsail/package.json
@@ -54,9 +54,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-lightsail/package.json
+++ b/clients/client-lightsail/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-location/jest.config.js
+++ b/clients/client-location/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-location/package.json
+++ b/clients/client-location/package.json
@@ -54,9 +54,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-location/package.json
+++ b/clients/client-location/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "jest --coverage --passWithNoTests"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-lookoutequipment/jest.config.js
+++ b/clients/client-lookoutequipment/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-lookoutequipment/package.json
+++ b/clients/client-lookoutequipment/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "jest --coverage --passWithNoTests"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-lookoutequipment/package.json
+++ b/clients/client-lookoutequipment/package.json
@@ -56,9 +56,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-lookoutmetrics/jest.config.js
+++ b/clients/client-lookoutmetrics/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-lookoutmetrics/package.json
+++ b/clients/client-lookoutmetrics/package.json
@@ -54,9 +54,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-lookoutmetrics/package.json
+++ b/clients/client-lookoutmetrics/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "jest --coverage --passWithNoTests"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-lookoutvision/jest.config.js
+++ b/clients/client-lookoutvision/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-lookoutvision/package.json
+++ b/clients/client-lookoutvision/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "jest --coverage --passWithNoTests"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-lookoutvision/package.json
+++ b/clients/client-lookoutvision/package.json
@@ -56,9 +56,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-machine-learning/jest.config.js
+++ b/clients/client-machine-learning/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-machine-learning/package.json
+++ b/clients/client-machine-learning/package.json
@@ -56,9 +56,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-machine-learning/package.json
+++ b/clients/client-machine-learning/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-macie/jest.config.js
+++ b/clients/client-macie/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-macie/package.json
+++ b/clients/client-macie/package.json
@@ -54,9 +54,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-macie/package.json
+++ b/clients/client-macie/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-macie2/jest.config.js
+++ b/clients/client-macie2/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-macie2/package.json
+++ b/clients/client-macie2/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "jest --coverage --passWithNoTests"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-macie2/package.json
+++ b/clients/client-macie2/package.json
@@ -56,9 +56,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-managedblockchain/jest.config.js
+++ b/clients/client-managedblockchain/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-managedblockchain/package.json
+++ b/clients/client-managedblockchain/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-managedblockchain/package.json
+++ b/clients/client-managedblockchain/package.json
@@ -56,9 +56,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-marketplace-catalog/jest.config.js
+++ b/clients/client-marketplace-catalog/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-marketplace-catalog/package.json
+++ b/clients/client-marketplace-catalog/package.json
@@ -54,9 +54,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-marketplace-catalog/package.json
+++ b/clients/client-marketplace-catalog/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-marketplace-commerce-analytics/jest.config.js
+++ b/clients/client-marketplace-commerce-analytics/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-marketplace-commerce-analytics/package.json
+++ b/clients/client-marketplace-commerce-analytics/package.json
@@ -54,9 +54,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-marketplace-commerce-analytics/package.json
+++ b/clients/client-marketplace-commerce-analytics/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-marketplace-entitlement-service/jest.config.js
+++ b/clients/client-marketplace-entitlement-service/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-marketplace-entitlement-service/package.json
+++ b/clients/client-marketplace-entitlement-service/package.json
@@ -54,9 +54,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-marketplace-entitlement-service/package.json
+++ b/clients/client-marketplace-entitlement-service/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-marketplace-metering/jest.config.js
+++ b/clients/client-marketplace-metering/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-marketplace-metering/package.json
+++ b/clients/client-marketplace-metering/package.json
@@ -54,9 +54,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-marketplace-metering/package.json
+++ b/clients/client-marketplace-metering/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-mediaconnect/jest.config.js
+++ b/clients/client-mediaconnect/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-mediaconnect/package.json
+++ b/clients/client-mediaconnect/package.json
@@ -55,9 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-mediaconnect/package.json
+++ b/clients/client-mediaconnect/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-mediaconvert/jest.config.js
+++ b/clients/client-mediaconvert/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-mediaconvert/package.json
+++ b/clients/client-mediaconvert/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-mediaconvert/package.json
+++ b/clients/client-mediaconvert/package.json
@@ -56,9 +56,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-medialive/jest.config.js
+++ b/clients/client-medialive/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-medialive/package.json
+++ b/clients/client-medialive/package.json
@@ -57,9 +57,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-medialive/package.json
+++ b/clients/client-medialive/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-mediapackage-vod/jest.config.js
+++ b/clients/client-mediapackage-vod/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-mediapackage-vod/package.json
+++ b/clients/client-mediapackage-vod/package.json
@@ -54,9 +54,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-mediapackage-vod/package.json
+++ b/clients/client-mediapackage-vod/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-mediapackage/jest.config.js
+++ b/clients/client-mediapackage/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-mediapackage/package.json
+++ b/clients/client-mediapackage/package.json
@@ -54,9 +54,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-mediapackage/package.json
+++ b/clients/client-mediapackage/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-mediastore-data/jest.config.js
+++ b/clients/client-mediastore-data/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-mediastore-data/package.json
+++ b/clients/client-mediastore-data/package.json
@@ -58,9 +58,7 @@
     "@types/mocha": "^8.0.4",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-mediastore/jest.config.js
+++ b/clients/client-mediastore/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-mediastore/package.json
+++ b/clients/client-mediastore/package.json
@@ -54,9 +54,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-mediastore/package.json
+++ b/clients/client-mediastore/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-mediatailor/jest.config.js
+++ b/clients/client-mediatailor/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-mediatailor/package.json
+++ b/clients/client-mediatailor/package.json
@@ -54,9 +54,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-mediatailor/package.json
+++ b/clients/client-mediatailor/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-memorydb/jest.config.js
+++ b/clients/client-memorydb/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-memorydb/package.json
+++ b/clients/client-memorydb/package.json
@@ -54,9 +54,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-memorydb/package.json
+++ b/clients/client-memorydb/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "jest --coverage --passWithNoTests"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-mgn/jest.config.js
+++ b/clients/client-mgn/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-mgn/package.json
+++ b/clients/client-mgn/package.json
@@ -54,9 +54,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-mgn/package.json
+++ b/clients/client-mgn/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "jest --coverage --passWithNoTests"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-migration-hub-refactor-spaces/jest.config.js
+++ b/clients/client-migration-hub-refactor-spaces/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-migration-hub-refactor-spaces/package.json
+++ b/clients/client-migration-hub-refactor-spaces/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist-*",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "jest --coverage --passWithNoTests"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-migration-hub-refactor-spaces/package.json
+++ b/clients/client-migration-hub-refactor-spaces/package.json
@@ -56,9 +56,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-migration-hub/jest.config.js
+++ b/clients/client-migration-hub/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-migration-hub/package.json
+++ b/clients/client-migration-hub/package.json
@@ -54,9 +54,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-migration-hub/package.json
+++ b/clients/client-migration-hub/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-migrationhub-config/jest.config.js
+++ b/clients/client-migrationhub-config/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-migrationhub-config/package.json
+++ b/clients/client-migrationhub-config/package.json
@@ -54,9 +54,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-migrationhub-config/package.json
+++ b/clients/client-migrationhub-config/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-migrationhubstrategy/jest.config.js
+++ b/clients/client-migrationhubstrategy/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-migrationhubstrategy/package.json
+++ b/clients/client-migrationhubstrategy/package.json
@@ -54,9 +54,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-migrationhubstrategy/package.json
+++ b/clients/client-migrationhubstrategy/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist-*",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "jest --coverage --passWithNoTests"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-mobile/jest.config.js
+++ b/clients/client-mobile/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-mobile/package.json
+++ b/clients/client-mobile/package.json
@@ -54,9 +54,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-mobile/package.json
+++ b/clients/client-mobile/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-mq/jest.config.js
+++ b/clients/client-mq/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-mq/package.json
+++ b/clients/client-mq/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-mq/package.json
+++ b/clients/client-mq/package.json
@@ -56,9 +56,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-mturk/jest.config.js
+++ b/clients/client-mturk/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-mturk/package.json
+++ b/clients/client-mturk/package.json
@@ -54,9 +54,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-mturk/package.json
+++ b/clients/client-mturk/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-mwaa/jest.config.js
+++ b/clients/client-mwaa/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-mwaa/package.json
+++ b/clients/client-mwaa/package.json
@@ -54,9 +54,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-mwaa/package.json
+++ b/clients/client-mwaa/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "jest --coverage --passWithNoTests"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-neptune/jest.config.js
+++ b/clients/client-neptune/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-neptune/package.json
+++ b/clients/client-neptune/package.json
@@ -58,9 +58,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-neptune/package.json
+++ b/clients/client-neptune/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-network-firewall/jest.config.js
+++ b/clients/client-network-firewall/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-network-firewall/package.json
+++ b/clients/client-network-firewall/package.json
@@ -54,9 +54,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-network-firewall/package.json
+++ b/clients/client-network-firewall/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "jest --coverage --passWithNoTests"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-networkmanager/jest.config.js
+++ b/clients/client-networkmanager/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-networkmanager/package.json
+++ b/clients/client-networkmanager/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-networkmanager/package.json
+++ b/clients/client-networkmanager/package.json
@@ -56,9 +56,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-nimble/jest.config.js
+++ b/clients/client-nimble/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-nimble/package.json
+++ b/clients/client-nimble/package.json
@@ -57,9 +57,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-nimble/package.json
+++ b/clients/client-nimble/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "jest --coverage --passWithNoTests"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-opensearch/jest.config.js
+++ b/clients/client-opensearch/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-opensearch/package.json
+++ b/clients/client-opensearch/package.json
@@ -54,9 +54,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-opensearch/package.json
+++ b/clients/client-opensearch/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "jest --coverage --passWithNoTests"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-opsworks/jest.config.js
+++ b/clients/client-opsworks/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-opsworks/package.json
+++ b/clients/client-opsworks/package.json
@@ -55,9 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-opsworks/package.json
+++ b/clients/client-opsworks/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-opsworkscm/jest.config.js
+++ b/clients/client-opsworkscm/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-opsworkscm/package.json
+++ b/clients/client-opsworkscm/package.json
@@ -55,9 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-opsworkscm/package.json
+++ b/clients/client-opsworkscm/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-organizations/jest.config.js
+++ b/clients/client-organizations/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-organizations/package.json
+++ b/clients/client-organizations/package.json
@@ -54,9 +54,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-organizations/package.json
+++ b/clients/client-organizations/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-outposts/jest.config.js
+++ b/clients/client-outposts/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-outposts/package.json
+++ b/clients/client-outposts/package.json
@@ -54,9 +54,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-outposts/package.json
+++ b/clients/client-outposts/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-panorama/jest.config.js
+++ b/clients/client-panorama/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-panorama/package.json
+++ b/clients/client-panorama/package.json
@@ -54,9 +54,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-panorama/package.json
+++ b/clients/client-panorama/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist-*",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "jest --coverage --passWithNoTests"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-personalize-events/jest.config.js
+++ b/clients/client-personalize-events/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-personalize-events/package.json
+++ b/clients/client-personalize-events/package.json
@@ -54,9 +54,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-personalize-events/package.json
+++ b/clients/client-personalize-events/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-personalize-runtime/jest.config.js
+++ b/clients/client-personalize-runtime/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-personalize-runtime/package.json
+++ b/clients/client-personalize-runtime/package.json
@@ -54,9 +54,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-personalize-runtime/package.json
+++ b/clients/client-personalize-runtime/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-personalize/jest.config.js
+++ b/clients/client-personalize/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-personalize/package.json
+++ b/clients/client-personalize/package.json
@@ -54,9 +54,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-personalize/package.json
+++ b/clients/client-personalize/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-pi/jest.config.js
+++ b/clients/client-pi/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-pi/package.json
+++ b/clients/client-pi/package.json
@@ -54,9 +54,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-pi/package.json
+++ b/clients/client-pi/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-pinpoint-email/jest.config.js
+++ b/clients/client-pinpoint-email/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-pinpoint-email/package.json
+++ b/clients/client-pinpoint-email/package.json
@@ -54,9 +54,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-pinpoint-email/package.json
+++ b/clients/client-pinpoint-email/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-pinpoint-sms-voice/jest.config.js
+++ b/clients/client-pinpoint-sms-voice/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-pinpoint-sms-voice/package.json
+++ b/clients/client-pinpoint-sms-voice/package.json
@@ -54,9 +54,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-pinpoint-sms-voice/package.json
+++ b/clients/client-pinpoint-sms-voice/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-pinpoint/jest.config.js
+++ b/clients/client-pinpoint/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-pinpoint/package.json
+++ b/clients/client-pinpoint/package.json
@@ -54,9 +54,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-pinpoint/package.json
+++ b/clients/client-pinpoint/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-polly/jest.config.js
+++ b/clients/client-polly/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-polly/package.json
+++ b/clients/client-polly/package.json
@@ -54,9 +54,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-polly/package.json
+++ b/clients/client-polly/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-pricing/jest.config.js
+++ b/clients/client-pricing/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-pricing/package.json
+++ b/clients/client-pricing/package.json
@@ -54,9 +54,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-pricing/package.json
+++ b/clients/client-pricing/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-proton/jest.config.js
+++ b/clients/client-proton/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-proton/package.json
+++ b/clients/client-proton/package.json
@@ -57,9 +57,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-proton/package.json
+++ b/clients/client-proton/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "jest --coverage --passWithNoTests"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-qldb-session/jest.config.js
+++ b/clients/client-qldb-session/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-qldb-session/package.json
+++ b/clients/client-qldb-session/package.json
@@ -54,9 +54,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-qldb-session/package.json
+++ b/clients/client-qldb-session/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-qldb/jest.config.js
+++ b/clients/client-qldb/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-qldb/package.json
+++ b/clients/client-qldb/package.json
@@ -54,9 +54,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-qldb/package.json
+++ b/clients/client-qldb/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-quicksight/jest.config.js
+++ b/clients/client-quicksight/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-quicksight/package.json
+++ b/clients/client-quicksight/package.json
@@ -54,9 +54,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-quicksight/package.json
+++ b/clients/client-quicksight/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-ram/jest.config.js
+++ b/clients/client-ram/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-ram/package.json
+++ b/clients/client-ram/package.json
@@ -54,9 +54,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-ram/package.json
+++ b/clients/client-ram/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-rbin/jest.config.js
+++ b/clients/client-rbin/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-rbin/package.json
+++ b/clients/client-rbin/package.json
@@ -54,9 +54,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-rbin/package.json
+++ b/clients/client-rbin/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist-*",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "jest --coverage --passWithNoTests"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-rds-data/jest.config.js
+++ b/clients/client-rds-data/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-rds-data/package.json
+++ b/clients/client-rds-data/package.json
@@ -54,9 +54,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-rds-data/package.json
+++ b/clients/client-rds-data/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-rds/jest.config.js
+++ b/clients/client-rds/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-rds/package.json
+++ b/clients/client-rds/package.json
@@ -58,9 +58,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-rds/package.json
+++ b/clients/client-rds/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-redshift-data/jest.config.js
+++ b/clients/client-redshift-data/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-redshift-data/package.json
+++ b/clients/client-redshift-data/package.json
@@ -54,9 +54,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-redshift-data/package.json
+++ b/clients/client-redshift-data/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "jest --coverage --passWithNoTests"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-redshift/jest.config.js
+++ b/clients/client-redshift/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-redshift/package.json
+++ b/clients/client-redshift/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-redshift/package.json
+++ b/clients/client-redshift/package.json
@@ -57,9 +57,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-rekognition/jest.config.js
+++ b/clients/client-rekognition/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-rekognition/package.json
+++ b/clients/client-rekognition/package.json
@@ -55,9 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-rekognition/package.json
+++ b/clients/client-rekognition/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-resiliencehub/jest.config.js
+++ b/clients/client-resiliencehub/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-resiliencehub/package.json
+++ b/clients/client-resiliencehub/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist-*",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "jest --coverage --passWithNoTests"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-resiliencehub/package.json
+++ b/clients/client-resiliencehub/package.json
@@ -56,9 +56,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-resource-groups-tagging-api/jest.config.js
+++ b/clients/client-resource-groups-tagging-api/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-resource-groups-tagging-api/package.json
+++ b/clients/client-resource-groups-tagging-api/package.json
@@ -54,9 +54,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-resource-groups-tagging-api/package.json
+++ b/clients/client-resource-groups-tagging-api/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-resource-groups/jest.config.js
+++ b/clients/client-resource-groups/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-resource-groups/package.json
+++ b/clients/client-resource-groups/package.json
@@ -54,9 +54,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-resource-groups/package.json
+++ b/clients/client-resource-groups/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-robomaker/jest.config.js
+++ b/clients/client-robomaker/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-robomaker/package.json
+++ b/clients/client-robomaker/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-robomaker/package.json
+++ b/clients/client-robomaker/package.json
@@ -56,9 +56,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-route-53-domains/jest.config.js
+++ b/clients/client-route-53-domains/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-route-53-domains/package.json
+++ b/clients/client-route-53-domains/package.json
@@ -54,9 +54,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-route-53-domains/package.json
+++ b/clients/client-route-53-domains/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-route-53/jest.config.js
+++ b/clients/client-route-53/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-route-53/package.json
+++ b/clients/client-route-53/package.json
@@ -59,9 +59,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-route-53/package.json
+++ b/clients/client-route-53/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-route53-recovery-cluster/jest.config.js
+++ b/clients/client-route53-recovery-cluster/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-route53-recovery-cluster/package.json
+++ b/clients/client-route53-recovery-cluster/package.json
@@ -54,9 +54,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-route53-recovery-cluster/package.json
+++ b/clients/client-route53-recovery-cluster/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "jest --coverage --passWithNoTests"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-route53-recovery-control-config/jest.config.js
+++ b/clients/client-route53-recovery-control-config/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-route53-recovery-control-config/package.json
+++ b/clients/client-route53-recovery-control-config/package.json
@@ -57,9 +57,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-route53-recovery-control-config/package.json
+++ b/clients/client-route53-recovery-control-config/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "jest --coverage --passWithNoTests"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-route53-recovery-readiness/jest.config.js
+++ b/clients/client-route53-recovery-readiness/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-route53-recovery-readiness/package.json
+++ b/clients/client-route53-recovery-readiness/package.json
@@ -54,9 +54,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-route53-recovery-readiness/package.json
+++ b/clients/client-route53-recovery-readiness/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "jest --coverage --passWithNoTests"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-route53resolver/jest.config.js
+++ b/clients/client-route53resolver/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-route53resolver/package.json
+++ b/clients/client-route53resolver/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-route53resolver/package.json
+++ b/clients/client-route53resolver/package.json
@@ -56,9 +56,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-rum/jest.config.js
+++ b/clients/client-rum/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-rum/package.json
+++ b/clients/client-rum/package.json
@@ -54,9 +54,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-rum/package.json
+++ b/clients/client-rum/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist-*",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "jest --coverage --passWithNoTests"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-s3-control/jest.config.js
+++ b/clients/client-s3-control/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-s3-control/package.json
+++ b/clients/client-s3-control/package.json
@@ -67,9 +67,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-s3/jest.config.js
+++ b/clients/client-s3/jest.config.js
@@ -1,6 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  // filedoesnotexist.spec.ts is added to avoid jest error "Your test suite must contain at least one test."
-  // replace it with **/*.spec.ts once we have a decision on test infrastructure for clients.
-  testMatch: ["filedoesnotexist.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-s3/package.json
+++ b/clients/client-s3/package.json
@@ -75,9 +75,7 @@
     "@types/mocha": "^8.0.4",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-s3outposts/jest.config.js
+++ b/clients/client-s3outposts/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-s3outposts/package.json
+++ b/clients/client-s3outposts/package.json
@@ -54,9 +54,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-s3outposts/package.json
+++ b/clients/client-s3outposts/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "jest --coverage --passWithNoTests"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-sagemaker-a2i-runtime/jest.config.js
+++ b/clients/client-sagemaker-a2i-runtime/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-sagemaker-a2i-runtime/package.json
+++ b/clients/client-sagemaker-a2i-runtime/package.json
@@ -54,9 +54,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-sagemaker-a2i-runtime/package.json
+++ b/clients/client-sagemaker-a2i-runtime/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-sagemaker-edge/jest.config.js
+++ b/clients/client-sagemaker-edge/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-sagemaker-edge/package.json
+++ b/clients/client-sagemaker-edge/package.json
@@ -54,9 +54,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-sagemaker-edge/package.json
+++ b/clients/client-sagemaker-edge/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "jest --coverage --passWithNoTests"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-sagemaker-featurestore-runtime/jest.config.js
+++ b/clients/client-sagemaker-featurestore-runtime/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-sagemaker-featurestore-runtime/package.json
+++ b/clients/client-sagemaker-featurestore-runtime/package.json
@@ -54,9 +54,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-sagemaker-featurestore-runtime/package.json
+++ b/clients/client-sagemaker-featurestore-runtime/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "jest --coverage --passWithNoTests"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-sagemaker-runtime/jest.config.js
+++ b/clients/client-sagemaker-runtime/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-sagemaker-runtime/package.json
+++ b/clients/client-sagemaker-runtime/package.json
@@ -54,9 +54,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-sagemaker-runtime/package.json
+++ b/clients/client-sagemaker-runtime/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-sagemaker/jest.config.js
+++ b/clients/client-sagemaker/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-sagemaker/package.json
+++ b/clients/client-sagemaker/package.json
@@ -57,9 +57,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-sagemaker/package.json
+++ b/clients/client-sagemaker/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-savingsplans/jest.config.js
+++ b/clients/client-savingsplans/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-savingsplans/package.json
+++ b/clients/client-savingsplans/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-savingsplans/package.json
+++ b/clients/client-savingsplans/package.json
@@ -56,9 +56,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-schemas/jest.config.js
+++ b/clients/client-schemas/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-schemas/package.json
+++ b/clients/client-schemas/package.json
@@ -57,9 +57,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-schemas/package.json
+++ b/clients/client-schemas/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-secrets-manager/jest.config.js
+++ b/clients/client-secrets-manager/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-secrets-manager/package.json
+++ b/clients/client-secrets-manager/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-secrets-manager/package.json
+++ b/clients/client-secrets-manager/package.json
@@ -56,9 +56,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-securityhub/jest.config.js
+++ b/clients/client-securityhub/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-securityhub/package.json
+++ b/clients/client-securityhub/package.json
@@ -54,9 +54,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-securityhub/package.json
+++ b/clients/client-securityhub/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-serverlessapplicationrepository/jest.config.js
+++ b/clients/client-serverlessapplicationrepository/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-serverlessapplicationrepository/package.json
+++ b/clients/client-serverlessapplicationrepository/package.json
@@ -54,9 +54,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-serverlessapplicationrepository/package.json
+++ b/clients/client-serverlessapplicationrepository/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-service-catalog-appregistry/jest.config.js
+++ b/clients/client-service-catalog-appregistry/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-service-catalog-appregistry/package.json
+++ b/clients/client-service-catalog-appregistry/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "jest --coverage --passWithNoTests"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-service-catalog-appregistry/package.json
+++ b/clients/client-service-catalog-appregistry/package.json
@@ -56,9 +56,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-service-catalog/jest.config.js
+++ b/clients/client-service-catalog/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-service-catalog/package.json
+++ b/clients/client-service-catalog/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-service-catalog/package.json
+++ b/clients/client-service-catalog/package.json
@@ -56,9 +56,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-service-quotas/jest.config.js
+++ b/clients/client-service-quotas/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-service-quotas/package.json
+++ b/clients/client-service-quotas/package.json
@@ -54,9 +54,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-service-quotas/package.json
+++ b/clients/client-service-quotas/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-servicediscovery/jest.config.js
+++ b/clients/client-servicediscovery/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-servicediscovery/package.json
+++ b/clients/client-servicediscovery/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-servicediscovery/package.json
+++ b/clients/client-servicediscovery/package.json
@@ -56,9 +56,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-ses/jest.config.js
+++ b/clients/client-ses/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-ses/package.json
+++ b/clients/client-ses/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-ses/package.json
+++ b/clients/client-ses/package.json
@@ -57,9 +57,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-sesv2/jest.config.js
+++ b/clients/client-sesv2/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-sesv2/package.json
+++ b/clients/client-sesv2/package.json
@@ -54,9 +54,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-sesv2/package.json
+++ b/clients/client-sesv2/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-sfn/jest.config.js
+++ b/clients/client-sfn/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-sfn/package.json
+++ b/clients/client-sfn/package.json
@@ -54,9 +54,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-sfn/package.json
+++ b/clients/client-sfn/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-shield/jest.config.js
+++ b/clients/client-shield/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-shield/package.json
+++ b/clients/client-shield/package.json
@@ -54,9 +54,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-shield/package.json
+++ b/clients/client-shield/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-signer/jest.config.js
+++ b/clients/client-signer/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-signer/package.json
+++ b/clients/client-signer/package.json
@@ -57,9 +57,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-signer/package.json
+++ b/clients/client-signer/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-sms/jest.config.js
+++ b/clients/client-sms/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-sms/package.json
+++ b/clients/client-sms/package.json
@@ -54,9 +54,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-sms/package.json
+++ b/clients/client-sms/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-snow-device-management/jest.config.js
+++ b/clients/client-snow-device-management/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-snow-device-management/package.json
+++ b/clients/client-snow-device-management/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "jest --coverage --passWithNoTests"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-snow-device-management/package.json
+++ b/clients/client-snow-device-management/package.json
@@ -56,9 +56,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-snowball/jest.config.js
+++ b/clients/client-snowball/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-snowball/package.json
+++ b/clients/client-snowball/package.json
@@ -54,9 +54,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-snowball/package.json
+++ b/clients/client-snowball/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-sns/jest.config.js
+++ b/clients/client-sns/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-sns/package.json
+++ b/clients/client-sns/package.json
@@ -56,9 +56,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-sns/package.json
+++ b/clients/client-sns/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-sqs/jest.config.js
+++ b/clients/client-sqs/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-sqs/package.json
+++ b/clients/client-sqs/package.json
@@ -58,9 +58,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-sqs/package.json
+++ b/clients/client-sqs/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-ssm-contacts/jest.config.js
+++ b/clients/client-ssm-contacts/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-ssm-contacts/package.json
+++ b/clients/client-ssm-contacts/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "jest --coverage --passWithNoTests"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-ssm-contacts/package.json
+++ b/clients/client-ssm-contacts/package.json
@@ -56,9 +56,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-ssm-incidents/jest.config.js
+++ b/clients/client-ssm-incidents/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-ssm-incidents/package.json
+++ b/clients/client-ssm-incidents/package.json
@@ -57,9 +57,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-ssm-incidents/package.json
+++ b/clients/client-ssm-incidents/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "jest --coverage --passWithNoTests"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-ssm/jest.config.js
+++ b/clients/client-ssm/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-ssm/package.json
+++ b/clients/client-ssm/package.json
@@ -57,9 +57,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-ssm/package.json
+++ b/clients/client-ssm/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-sso-admin/jest.config.js
+++ b/clients/client-sso-admin/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-sso-admin/package.json
+++ b/clients/client-sso-admin/package.json
@@ -54,9 +54,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-sso-admin/package.json
+++ b/clients/client-sso-admin/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "jest --coverage --passWithNoTests"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-sso-oidc/jest.config.js
+++ b/clients/client-sso-oidc/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-sso-oidc/package.json
+++ b/clients/client-sso-oidc/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-sso-oidc/package.json
+++ b/clients/client-sso-oidc/package.json
@@ -51,9 +51,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-sso/jest.config.js
+++ b/clients/client-sso/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-sso/package.json
+++ b/clients/client-sso/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-sso/package.json
+++ b/clients/client-sso/package.json
@@ -51,9 +51,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-storage-gateway/jest.config.js
+++ b/clients/client-storage-gateway/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-storage-gateway/package.json
+++ b/clients/client-storage-gateway/package.json
@@ -54,9 +54,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-storage-gateway/package.json
+++ b/clients/client-storage-gateway/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-sts/jest.config.js
+++ b/clients/client-sts/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-sts/package.json
+++ b/clients/client-sts/package.json
@@ -56,9 +56,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-sts/package.json
+++ b/clients/client-sts/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-support/jest.config.js
+++ b/clients/client-support/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-support/package.json
+++ b/clients/client-support/package.json
@@ -54,9 +54,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-support/package.json
+++ b/clients/client-support/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-swf/jest.config.js
+++ b/clients/client-swf/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-swf/package.json
+++ b/clients/client-swf/package.json
@@ -54,9 +54,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-swf/package.json
+++ b/clients/client-swf/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-synthetics/jest.config.js
+++ b/clients/client-synthetics/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-synthetics/package.json
+++ b/clients/client-synthetics/package.json
@@ -54,9 +54,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-synthetics/package.json
+++ b/clients/client-synthetics/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "jest --coverage --passWithNoTests"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-textract/jest.config.js
+++ b/clients/client-textract/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-textract/package.json
+++ b/clients/client-textract/package.json
@@ -54,9 +54,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-textract/package.json
+++ b/clients/client-textract/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-timestream-query/jest.config.js
+++ b/clients/client-timestream-query/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-timestream-query/package.json
+++ b/clients/client-timestream-query/package.json
@@ -57,9 +57,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-timestream-query/package.json
+++ b/clients/client-timestream-query/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "jest --coverage --passWithNoTests"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-timestream-write/jest.config.js
+++ b/clients/client-timestream-write/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-timestream-write/package.json
+++ b/clients/client-timestream-write/package.json
@@ -55,9 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-timestream-write/package.json
+++ b/clients/client-timestream-write/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "jest --coverage --passWithNoTests"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-transcribe-streaming/jest.config.js
+++ b/clients/client-transcribe-streaming/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-transcribe-streaming/package.json
+++ b/clients/client-transcribe-streaming/package.json
@@ -12,7 +12,6 @@
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
     "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "pretest": "yarn build",
     "test:integration": "jest --config jest.integ.config.js"
   },
   "main": "./dist-cjs/index.js",

--- a/clients/client-transcribe-streaming/package.json
+++ b/clients/client-transcribe-streaming/package.json
@@ -61,9 +61,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-transcribe-streaming/package.json
+++ b/clients/client-transcribe-streaming/package.json
@@ -13,7 +13,6 @@
     "clean:docs": "rimraf ./docs",
     "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
     "pretest": "yarn build",
-    "test": "jest --coverage --passWithNoTests",
     "test:integration": "jest --config jest.integ.config.js"
   },
   "main": "./dist-cjs/index.js",

--- a/clients/client-transcribe-streaming/package.json
+++ b/clients/client-transcribe-streaming/package.json
@@ -61,7 +61,9 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
+    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
+    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-transcribe/jest.config.js
+++ b/clients/client-transcribe/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-transcribe/package.json
+++ b/clients/client-transcribe/package.json
@@ -54,9 +54,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-transcribe/package.json
+++ b/clients/client-transcribe/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-transfer/jest.config.js
+++ b/clients/client-transfer/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-transfer/package.json
+++ b/clients/client-transfer/package.json
@@ -54,9 +54,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-transfer/package.json
+++ b/clients/client-transfer/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-translate/jest.config.js
+++ b/clients/client-translate/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-translate/package.json
+++ b/clients/client-translate/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-translate/package.json
+++ b/clients/client-translate/package.json
@@ -56,9 +56,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-voice-id/jest.config.js
+++ b/clients/client-voice-id/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-voice-id/package.json
+++ b/clients/client-voice-id/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist-*",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "jest --coverage --passWithNoTests"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-voice-id/package.json
+++ b/clients/client-voice-id/package.json
@@ -56,9 +56,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-waf-regional/jest.config.js
+++ b/clients/client-waf-regional/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-waf-regional/package.json
+++ b/clients/client-waf-regional/package.json
@@ -54,9 +54,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-waf-regional/package.json
+++ b/clients/client-waf-regional/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-waf/jest.config.js
+++ b/clients/client-waf/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-waf/package.json
+++ b/clients/client-waf/package.json
@@ -54,9 +54,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-waf/package.json
+++ b/clients/client-waf/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-wafv2/jest.config.js
+++ b/clients/client-wafv2/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-wafv2/package.json
+++ b/clients/client-wafv2/package.json
@@ -54,9 +54,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-wafv2/package.json
+++ b/clients/client-wafv2/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-wellarchitected/jest.config.js
+++ b/clients/client-wellarchitected/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-wellarchitected/package.json
+++ b/clients/client-wellarchitected/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "jest --coverage --passWithNoTests"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-wellarchitected/package.json
+++ b/clients/client-wellarchitected/package.json
@@ -56,9 +56,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-wisdom/jest.config.js
+++ b/clients/client-wisdom/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-wisdom/package.json
+++ b/clients/client-wisdom/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist-*",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "jest --coverage --passWithNoTests"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-wisdom/package.json
+++ b/clients/client-wisdom/package.json
@@ -56,9 +56,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-workdocs/jest.config.js
+++ b/clients/client-workdocs/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-workdocs/package.json
+++ b/clients/client-workdocs/package.json
@@ -54,9 +54,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-workdocs/package.json
+++ b/clients/client-workdocs/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-worklink/jest.config.js
+++ b/clients/client-worklink/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-worklink/package.json
+++ b/clients/client-worklink/package.json
@@ -54,9 +54,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-worklink/package.json
+++ b/clients/client-worklink/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-workmail/jest.config.js
+++ b/clients/client-workmail/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-workmail/package.json
+++ b/clients/client-workmail/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-workmail/package.json
+++ b/clients/client-workmail/package.json
@@ -56,9 +56,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-workmailmessageflow/jest.config.js
+++ b/clients/client-workmailmessageflow/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-workmailmessageflow/package.json
+++ b/clients/client-workmailmessageflow/package.json
@@ -54,9 +54,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-workmailmessageflow/package.json
+++ b/clients/client-workmailmessageflow/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-workspaces-web/jest.config.js
+++ b/clients/client-workspaces-web/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-workspaces-web/package.json
+++ b/clients/client-workspaces-web/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist-*",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "jest --coverage --passWithNoTests"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-workspaces-web/package.json
+++ b/clients/client-workspaces-web/package.json
@@ -56,9 +56,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-workspaces/jest.config.js
+++ b/clients/client-workspaces/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-workspaces/package.json
+++ b/clients/client-workspaces/package.json
@@ -54,9 +54,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-workspaces/package.json
+++ b/clients/client-workspaces/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-xray/jest.config.js
+++ b/clients/client-xray/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
-};

--- a/clients/client-xray/package.json
+++ b/clients/client-xray/package.json
@@ -54,9 +54,7 @@
     "@aws-sdk/service-client-documentation-generator": "3.38.0",
     "@types/node": "^12.7.5",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",
     "typescript": "~4.3.5"
   },

--- a/clients/client-xray/package.json
+++ b/clients/client-xray/package.json
@@ -11,8 +11,7 @@
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:dist": "rimraf ./dist",
     "clean:docs": "rimraf ./docs",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
-    "test": "exit 0"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/jest.config.js
+++ b/jest.config.js
@@ -6,7 +6,6 @@ module.exports = {
     "<rootDir>/lib/*/jest.config.js",
     "<rootDir>/private/*/jest.config.js",
     "<rootDir>/packages/*/jest.config.js",
-    "<rootDir>/clients/*/jest.config.js",
   ],
   testPathIgnorePatterns: ["/node_modules/", "<rootDir>/clients/client-.*"],
   coveragePathIgnorePatterns: ["/node_modules/", "<rootDir>/clients/client-.*", "/__fixtures__/"],


### PR DESCRIPTION
### Issue
Refs: https://github.com/awslabs/smithy-typescript/pull/483

### Description
Remove unused jest dependencies and configuration

### Testing
* Verified that the jest dependency is not re-added on running `yarn generate-clients`
* Verified that integration tests written in Jest are successful for `client-transcribe-streaming`
<details>
<summary>Output</summary>

```console
$ pwd
/home/trivikr/workspace/aws-sdk-js-v3/clients/client-transcribe-streaming

$ yarn test:integration
yarn run v1.22.17
$ jest --config jest.integ.config.js
 PASS  test/index.integ.spec.ts (31.82 s)
  TranscribeStream client
    ✓ should stream the transcript (28874 ms)

Test Suites: 1 passed, 1 total
Tests:       1 passed, 1 total
Snapshots:   0 total
Time:        32.275 s
Ran all test suites.
Done in 32.98s.
```

</details>

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
