### PR TITLE
fix(middleware-signing): correct clock skew from error response

### DIFF
--- a/packages/middleware-serde/src/deserializerMiddleware.spec.ts
+++ b/packages/middleware-serde/src/deserializerMiddleware.spec.ts
@@ -62,4 +62,17 @@ describe("deserializerMiddleware", () => {
     expect(mockDeserializer).toHaveBeenCalledTimes(1);
     expect(mockDeserializer).toHaveBeenCalledWith(mockNextResponse.response, mockOptions);
   });
+
+  it("injects $response reference to deserializing exceptions", async () => {
+    const exception = Object.assign(new Error("MockException"), mockNextResponse.response);
+    mockDeserializer.mockReset();
+    mockDeserializer.mockRejectedValueOnce(exception);
+    try {
+      await deserializerMiddleware(mockOptions, mockDeserializer)(mockNext, {})(mockArgs);
+      fail("DeserializerMiddleware should throw");
+    } catch (e) {
+      expect(e).toMatchObject(exception);
+      expect(e.$response).toEqual(mockNextResponse.response);
+    }
+  });
 });

--- a/packages/middleware-serde/src/deserializerMiddleware.ts
+++ b/packages/middleware-serde/src/deserializerMiddleware.ts
@@ -15,9 +15,13 @@ export const deserializerMiddleware =
   (next: DeserializeHandler<Input, Output>, context: HandlerExecutionContext): DeserializeHandler<Input, Output> =>
   async (args: DeserializeHandlerArguments<Input>): Promise<DeserializeHandlerOutput<Output>> => {
     const { response } = await next(args);
-    const parsed = await deserializer(response, options);
-    return {
-      response,
-      output: parsed as Output,
-    };
+    try {
+      const parsed = await deserializer(response, options);
+      return {
+        response,
+        output: parsed as Output,
+      };
+    } catch (error) {
+      throw Object.assign(error, { $response: response });
+    }
   };

--- a/packages/types/src/shapes.ts
+++ b/packages/types/src/shapes.ts
@@ -1,3 +1,4 @@
+import { HttpResponse } from "./http";
 import { MetadataBearer } from "./response";
 
 /**
@@ -45,6 +46,11 @@ export interface SmithyException {
    * Indicates that an error MAY be retried by the client.
    */
   readonly $retryable?: RetryableTrait;
+
+  /**
+   * Reference to low-level HTTP response object.
+   */
+  readonly $response?: HttpResponse;
 }
 
 export type SdkError = Error & Partial<SmithyException> & Partial<MetadataBearer>;


### PR DESCRIPTION
### Issue
Resolves: #3119 

### Description
Currently, SDK cannot correct the clock skew automatically from the error response. This change fixes the issue. Moreover, a new member `$response` is added to the `SmithyException` interface. As a result, users can access the lower level HTTP response from any server-side exceptions. 

### Testing
Unit test

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
