### PR TITLE
chore(clients): move typedocOptions to typedoc.json

### DIFF
--- a/clients/client-accessanalyzer/tsconfig.json
+++ b/clients/client-accessanalyzer/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-accessanalyzer/typedoc.json
+++ b/clients/client-accessanalyzer/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-account/tsconfig.json
+++ b/clients/client-account/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-account/typedoc.json
+++ b/clients/client-account/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-acm-pca/tsconfig.json
+++ b/clients/client-acm-pca/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-acm-pca/typedoc.json
+++ b/clients/client-acm-pca/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-acm/tsconfig.json
+++ b/clients/client-acm/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-acm/typedoc.json
+++ b/clients/client-acm/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-alexa-for-business/tsconfig.json
+++ b/clients/client-alexa-for-business/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-alexa-for-business/typedoc.json
+++ b/clients/client-alexa-for-business/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-amp/tsconfig.json
+++ b/clients/client-amp/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-amp/typedoc.json
+++ b/clients/client-amp/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-amplify/tsconfig.json
+++ b/clients/client-amplify/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-amplify/typedoc.json
+++ b/clients/client-amplify/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-amplifybackend/tsconfig.json
+++ b/clients/client-amplifybackend/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-amplifybackend/typedoc.json
+++ b/clients/client-amplifybackend/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-amplifyuibuilder/tsconfig.json
+++ b/clients/client-amplifyuibuilder/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-amplifyuibuilder/typedoc.json
+++ b/clients/client-amplifyuibuilder/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-api-gateway/tsconfig.json
+++ b/clients/client-api-gateway/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-api-gateway/typedoc.json
+++ b/clients/client-api-gateway/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-apigatewaymanagementapi/tsconfig.json
+++ b/clients/client-apigatewaymanagementapi/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-apigatewaymanagementapi/typedoc.json
+++ b/clients/client-apigatewaymanagementapi/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-apigatewayv2/tsconfig.json
+++ b/clients/client-apigatewayv2/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-apigatewayv2/typedoc.json
+++ b/clients/client-apigatewayv2/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-app-mesh/tsconfig.json
+++ b/clients/client-app-mesh/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-app-mesh/typedoc.json
+++ b/clients/client-app-mesh/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-appconfig/tsconfig.json
+++ b/clients/client-appconfig/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-appconfig/typedoc.json
+++ b/clients/client-appconfig/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-appconfigdata/tsconfig.json
+++ b/clients/client-appconfigdata/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-appconfigdata/typedoc.json
+++ b/clients/client-appconfigdata/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-appflow/tsconfig.json
+++ b/clients/client-appflow/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-appflow/typedoc.json
+++ b/clients/client-appflow/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-appintegrations/tsconfig.json
+++ b/clients/client-appintegrations/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-appintegrations/typedoc.json
+++ b/clients/client-appintegrations/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-application-auto-scaling/tsconfig.json
+++ b/clients/client-application-auto-scaling/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-application-auto-scaling/typedoc.json
+++ b/clients/client-application-auto-scaling/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-application-discovery-service/tsconfig.json
+++ b/clients/client-application-discovery-service/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-application-discovery-service/typedoc.json
+++ b/clients/client-application-discovery-service/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-application-insights/tsconfig.json
+++ b/clients/client-application-insights/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-application-insights/typedoc.json
+++ b/clients/client-application-insights/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-applicationcostprofiler/tsconfig.json
+++ b/clients/client-applicationcostprofiler/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-applicationcostprofiler/typedoc.json
+++ b/clients/client-applicationcostprofiler/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-apprunner/tsconfig.json
+++ b/clients/client-apprunner/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-apprunner/typedoc.json
+++ b/clients/client-apprunner/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-appstream/tsconfig.json
+++ b/clients/client-appstream/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-appstream/typedoc.json
+++ b/clients/client-appstream/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-appsync/tsconfig.json
+++ b/clients/client-appsync/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-appsync/typedoc.json
+++ b/clients/client-appsync/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-athena/tsconfig.json
+++ b/clients/client-athena/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-athena/typedoc.json
+++ b/clients/client-athena/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-auditmanager/tsconfig.json
+++ b/clients/client-auditmanager/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-auditmanager/typedoc.json
+++ b/clients/client-auditmanager/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-auto-scaling-plans/tsconfig.json
+++ b/clients/client-auto-scaling-plans/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-auto-scaling-plans/typedoc.json
+++ b/clients/client-auto-scaling-plans/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-auto-scaling/tsconfig.json
+++ b/clients/client-auto-scaling/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-auto-scaling/typedoc.json
+++ b/clients/client-auto-scaling/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-backup-gateway/tsconfig.json
+++ b/clients/client-backup-gateway/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-backup-gateway/typedoc.json
+++ b/clients/client-backup-gateway/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-backup/tsconfig.json
+++ b/clients/client-backup/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-backup/typedoc.json
+++ b/clients/client-backup/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-batch/tsconfig.json
+++ b/clients/client-batch/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-batch/typedoc.json
+++ b/clients/client-batch/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-braket/tsconfig.json
+++ b/clients/client-braket/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-braket/typedoc.json
+++ b/clients/client-braket/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-budgets/tsconfig.json
+++ b/clients/client-budgets/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-budgets/typedoc.json
+++ b/clients/client-budgets/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-chime-sdk-identity/tsconfig.json
+++ b/clients/client-chime-sdk-identity/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-chime-sdk-identity/typedoc.json
+++ b/clients/client-chime-sdk-identity/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-chime-sdk-meetings/tsconfig.json
+++ b/clients/client-chime-sdk-meetings/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-chime-sdk-meetings/typedoc.json
+++ b/clients/client-chime-sdk-meetings/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-chime-sdk-messaging/tsconfig.json
+++ b/clients/client-chime-sdk-messaging/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-chime-sdk-messaging/typedoc.json
+++ b/clients/client-chime-sdk-messaging/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-chime/tsconfig.json
+++ b/clients/client-chime/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-chime/typedoc.json
+++ b/clients/client-chime/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-cloud9/tsconfig.json
+++ b/clients/client-cloud9/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-cloud9/typedoc.json
+++ b/clients/client-cloud9/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-cloudcontrol/tsconfig.json
+++ b/clients/client-cloudcontrol/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-cloudcontrol/typedoc.json
+++ b/clients/client-cloudcontrol/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-clouddirectory/tsconfig.json
+++ b/clients/client-clouddirectory/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-clouddirectory/typedoc.json
+++ b/clients/client-clouddirectory/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-cloudformation/tsconfig.json
+++ b/clients/client-cloudformation/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-cloudformation/typedoc.json
+++ b/clients/client-cloudformation/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-cloudfront/tsconfig.json
+++ b/clients/client-cloudfront/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-cloudfront/typedoc.json
+++ b/clients/client-cloudfront/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-cloudhsm-v2/tsconfig.json
+++ b/clients/client-cloudhsm-v2/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-cloudhsm-v2/typedoc.json
+++ b/clients/client-cloudhsm-v2/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-cloudhsm/tsconfig.json
+++ b/clients/client-cloudhsm/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-cloudhsm/typedoc.json
+++ b/clients/client-cloudhsm/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-cloudsearch-domain/tsconfig.json
+++ b/clients/client-cloudsearch-domain/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-cloudsearch-domain/typedoc.json
+++ b/clients/client-cloudsearch-domain/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-cloudsearch/tsconfig.json
+++ b/clients/client-cloudsearch/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-cloudsearch/typedoc.json
+++ b/clients/client-cloudsearch/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-cloudtrail/tsconfig.json
+++ b/clients/client-cloudtrail/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-cloudtrail/typedoc.json
+++ b/clients/client-cloudtrail/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-cloudwatch-events/tsconfig.json
+++ b/clients/client-cloudwatch-events/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-cloudwatch-events/typedoc.json
+++ b/clients/client-cloudwatch-events/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-cloudwatch-logs/tsconfig.json
+++ b/clients/client-cloudwatch-logs/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-cloudwatch-logs/typedoc.json
+++ b/clients/client-cloudwatch-logs/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-cloudwatch/tsconfig.json
+++ b/clients/client-cloudwatch/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-cloudwatch/typedoc.json
+++ b/clients/client-cloudwatch/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-codeartifact/tsconfig.json
+++ b/clients/client-codeartifact/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-codeartifact/typedoc.json
+++ b/clients/client-codeartifact/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-codebuild/tsconfig.json
+++ b/clients/client-codebuild/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-codebuild/typedoc.json
+++ b/clients/client-codebuild/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-codecommit/tsconfig.json
+++ b/clients/client-codecommit/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-codecommit/typedoc.json
+++ b/clients/client-codecommit/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-codedeploy/tsconfig.json
+++ b/clients/client-codedeploy/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-codedeploy/typedoc.json
+++ b/clients/client-codedeploy/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-codeguru-reviewer/tsconfig.json
+++ b/clients/client-codeguru-reviewer/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-codeguru-reviewer/typedoc.json
+++ b/clients/client-codeguru-reviewer/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-codeguruprofiler/tsconfig.json
+++ b/clients/client-codeguruprofiler/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-codeguruprofiler/typedoc.json
+++ b/clients/client-codeguruprofiler/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-codepipeline/tsconfig.json
+++ b/clients/client-codepipeline/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-codepipeline/typedoc.json
+++ b/clients/client-codepipeline/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-codestar-connections/tsconfig.json
+++ b/clients/client-codestar-connections/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-codestar-connections/typedoc.json
+++ b/clients/client-codestar-connections/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-codestar-notifications/tsconfig.json
+++ b/clients/client-codestar-notifications/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-codestar-notifications/typedoc.json
+++ b/clients/client-codestar-notifications/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-codestar/tsconfig.json
+++ b/clients/client-codestar/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-codestar/typedoc.json
+++ b/clients/client-codestar/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-cognito-identity-provider/tsconfig.json
+++ b/clients/client-cognito-identity-provider/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-cognito-identity-provider/typedoc.json
+++ b/clients/client-cognito-identity-provider/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-cognito-identity/tsconfig.json
+++ b/clients/client-cognito-identity/tsconfig.json
@@ -15,19 +15,5 @@
     "removeComments": true,
     "types": ["mocha", "node"]
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-cognito-identity/typedoc.json
+++ b/clients/client-cognito-identity/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-cognito-sync/tsconfig.json
+++ b/clients/client-cognito-sync/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-cognito-sync/typedoc.json
+++ b/clients/client-cognito-sync/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-comprehend/tsconfig.json
+++ b/clients/client-comprehend/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-comprehend/typedoc.json
+++ b/clients/client-comprehend/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-comprehendmedical/tsconfig.json
+++ b/clients/client-comprehendmedical/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-comprehendmedical/typedoc.json
+++ b/clients/client-comprehendmedical/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-compute-optimizer/tsconfig.json
+++ b/clients/client-compute-optimizer/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-compute-optimizer/typedoc.json
+++ b/clients/client-compute-optimizer/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-config-service/tsconfig.json
+++ b/clients/client-config-service/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-config-service/typedoc.json
+++ b/clients/client-config-service/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-connect-contact-lens/tsconfig.json
+++ b/clients/client-connect-contact-lens/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-connect-contact-lens/typedoc.json
+++ b/clients/client-connect-contact-lens/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-connect/tsconfig.json
+++ b/clients/client-connect/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-connect/typedoc.json
+++ b/clients/client-connect/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-connectparticipant/tsconfig.json
+++ b/clients/client-connectparticipant/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-connectparticipant/typedoc.json
+++ b/clients/client-connectparticipant/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-cost-and-usage-report-service/tsconfig.json
+++ b/clients/client-cost-and-usage-report-service/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-cost-and-usage-report-service/typedoc.json
+++ b/clients/client-cost-and-usage-report-service/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-cost-explorer/tsconfig.json
+++ b/clients/client-cost-explorer/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-cost-explorer/typedoc.json
+++ b/clients/client-cost-explorer/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-customer-profiles/tsconfig.json
+++ b/clients/client-customer-profiles/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-customer-profiles/typedoc.json
+++ b/clients/client-customer-profiles/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-data-pipeline/tsconfig.json
+++ b/clients/client-data-pipeline/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-data-pipeline/typedoc.json
+++ b/clients/client-data-pipeline/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-database-migration-service/tsconfig.json
+++ b/clients/client-database-migration-service/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-database-migration-service/typedoc.json
+++ b/clients/client-database-migration-service/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-databrew/tsconfig.json
+++ b/clients/client-databrew/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-databrew/typedoc.json
+++ b/clients/client-databrew/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-dataexchange/tsconfig.json
+++ b/clients/client-dataexchange/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-dataexchange/typedoc.json
+++ b/clients/client-dataexchange/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-datasync/tsconfig.json
+++ b/clients/client-datasync/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-datasync/typedoc.json
+++ b/clients/client-datasync/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-dax/tsconfig.json
+++ b/clients/client-dax/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-dax/typedoc.json
+++ b/clients/client-dax/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-detective/tsconfig.json
+++ b/clients/client-detective/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-detective/typedoc.json
+++ b/clients/client-detective/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-device-farm/tsconfig.json
+++ b/clients/client-device-farm/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-device-farm/typedoc.json
+++ b/clients/client-device-farm/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-devops-guru/tsconfig.json
+++ b/clients/client-devops-guru/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-devops-guru/typedoc.json
+++ b/clients/client-devops-guru/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-direct-connect/tsconfig.json
+++ b/clients/client-direct-connect/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-direct-connect/typedoc.json
+++ b/clients/client-direct-connect/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-directory-service/tsconfig.json
+++ b/clients/client-directory-service/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-directory-service/typedoc.json
+++ b/clients/client-directory-service/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-dlm/tsconfig.json
+++ b/clients/client-dlm/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-dlm/typedoc.json
+++ b/clients/client-dlm/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-docdb/tsconfig.json
+++ b/clients/client-docdb/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-docdb/typedoc.json
+++ b/clients/client-docdb/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-drs/tsconfig.json
+++ b/clients/client-drs/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-drs/typedoc.json
+++ b/clients/client-drs/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-dynamodb-streams/tsconfig.json
+++ b/clients/client-dynamodb-streams/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-dynamodb-streams/typedoc.json
+++ b/clients/client-dynamodb-streams/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-dynamodb/tsconfig.json
+++ b/clients/client-dynamodb/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-dynamodb/typedoc.json
+++ b/clients/client-dynamodb/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-ebs/tsconfig.json
+++ b/clients/client-ebs/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-ebs/typedoc.json
+++ b/clients/client-ebs/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-ec2-instance-connect/tsconfig.json
+++ b/clients/client-ec2-instance-connect/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-ec2-instance-connect/typedoc.json
+++ b/clients/client-ec2-instance-connect/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-ec2/tsconfig.json
+++ b/clients/client-ec2/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-ec2/typedoc.json
+++ b/clients/client-ec2/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-ecr-public/tsconfig.json
+++ b/clients/client-ecr-public/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-ecr-public/typedoc.json
+++ b/clients/client-ecr-public/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-ecr/tsconfig.json
+++ b/clients/client-ecr/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-ecr/typedoc.json
+++ b/clients/client-ecr/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-ecs/tsconfig.json
+++ b/clients/client-ecs/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-ecs/typedoc.json
+++ b/clients/client-ecs/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-efs/tsconfig.json
+++ b/clients/client-efs/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-efs/typedoc.json
+++ b/clients/client-efs/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-eks/tsconfig.json
+++ b/clients/client-eks/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-eks/typedoc.json
+++ b/clients/client-eks/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-elastic-beanstalk/tsconfig.json
+++ b/clients/client-elastic-beanstalk/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-elastic-beanstalk/typedoc.json
+++ b/clients/client-elastic-beanstalk/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-elastic-inference/tsconfig.json
+++ b/clients/client-elastic-inference/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-elastic-inference/typedoc.json
+++ b/clients/client-elastic-inference/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-elastic-load-balancing-v2/tsconfig.json
+++ b/clients/client-elastic-load-balancing-v2/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-elastic-load-balancing-v2/typedoc.json
+++ b/clients/client-elastic-load-balancing-v2/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-elastic-load-balancing/tsconfig.json
+++ b/clients/client-elastic-load-balancing/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-elastic-load-balancing/typedoc.json
+++ b/clients/client-elastic-load-balancing/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-elastic-transcoder/tsconfig.json
+++ b/clients/client-elastic-transcoder/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-elastic-transcoder/typedoc.json
+++ b/clients/client-elastic-transcoder/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-elasticache/tsconfig.json
+++ b/clients/client-elasticache/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-elasticache/typedoc.json
+++ b/clients/client-elasticache/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-elasticsearch-service/tsconfig.json
+++ b/clients/client-elasticsearch-service/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-elasticsearch-service/typedoc.json
+++ b/clients/client-elasticsearch-service/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-emr-containers/tsconfig.json
+++ b/clients/client-emr-containers/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-emr-containers/typedoc.json
+++ b/clients/client-emr-containers/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-emr/tsconfig.json
+++ b/clients/client-emr/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-emr/typedoc.json
+++ b/clients/client-emr/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-eventbridge/tsconfig.json
+++ b/clients/client-eventbridge/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-eventbridge/typedoc.json
+++ b/clients/client-eventbridge/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-evidently/tsconfig.json
+++ b/clients/client-evidently/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-evidently/typedoc.json
+++ b/clients/client-evidently/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-finspace-data/tsconfig.json
+++ b/clients/client-finspace-data/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-finspace-data/typedoc.json
+++ b/clients/client-finspace-data/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-finspace/tsconfig.json
+++ b/clients/client-finspace/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-finspace/typedoc.json
+++ b/clients/client-finspace/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-firehose/tsconfig.json
+++ b/clients/client-firehose/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-firehose/typedoc.json
+++ b/clients/client-firehose/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-fis/tsconfig.json
+++ b/clients/client-fis/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-fis/typedoc.json
+++ b/clients/client-fis/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-fms/tsconfig.json
+++ b/clients/client-fms/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-fms/typedoc.json
+++ b/clients/client-fms/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-forecast/tsconfig.json
+++ b/clients/client-forecast/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-forecast/typedoc.json
+++ b/clients/client-forecast/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-forecastquery/tsconfig.json
+++ b/clients/client-forecastquery/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-forecastquery/typedoc.json
+++ b/clients/client-forecastquery/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-frauddetector/tsconfig.json
+++ b/clients/client-frauddetector/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-frauddetector/typedoc.json
+++ b/clients/client-frauddetector/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-fsx/tsconfig.json
+++ b/clients/client-fsx/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-fsx/typedoc.json
+++ b/clients/client-fsx/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-gamelift/tsconfig.json
+++ b/clients/client-gamelift/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-gamelift/typedoc.json
+++ b/clients/client-gamelift/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-glacier/tsconfig.json
+++ b/clients/client-glacier/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-glacier/typedoc.json
+++ b/clients/client-glacier/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-global-accelerator/tsconfig.json
+++ b/clients/client-global-accelerator/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-global-accelerator/typedoc.json
+++ b/clients/client-global-accelerator/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-glue/tsconfig.json
+++ b/clients/client-glue/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-glue/typedoc.json
+++ b/clients/client-glue/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-grafana/tsconfig.json
+++ b/clients/client-grafana/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-grafana/typedoc.json
+++ b/clients/client-grafana/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-greengrass/tsconfig.json
+++ b/clients/client-greengrass/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-greengrass/typedoc.json
+++ b/clients/client-greengrass/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-greengrassv2/tsconfig.json
+++ b/clients/client-greengrassv2/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-greengrassv2/typedoc.json
+++ b/clients/client-greengrassv2/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-groundstation/tsconfig.json
+++ b/clients/client-groundstation/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-groundstation/typedoc.json
+++ b/clients/client-groundstation/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-guardduty/tsconfig.json
+++ b/clients/client-guardduty/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-guardduty/typedoc.json
+++ b/clients/client-guardduty/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-health/tsconfig.json
+++ b/clients/client-health/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-health/typedoc.json
+++ b/clients/client-health/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-healthlake/tsconfig.json
+++ b/clients/client-healthlake/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-healthlake/typedoc.json
+++ b/clients/client-healthlake/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-honeycode/tsconfig.json
+++ b/clients/client-honeycode/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-honeycode/typedoc.json
+++ b/clients/client-honeycode/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-iam/tsconfig.json
+++ b/clients/client-iam/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-iam/typedoc.json
+++ b/clients/client-iam/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-identitystore/tsconfig.json
+++ b/clients/client-identitystore/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-identitystore/typedoc.json
+++ b/clients/client-identitystore/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-imagebuilder/tsconfig.json
+++ b/clients/client-imagebuilder/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-imagebuilder/typedoc.json
+++ b/clients/client-imagebuilder/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-inspector/tsconfig.json
+++ b/clients/client-inspector/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-inspector/typedoc.json
+++ b/clients/client-inspector/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-inspector2/tsconfig.json
+++ b/clients/client-inspector2/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-inspector2/typedoc.json
+++ b/clients/client-inspector2/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-iot-1click-devices-service/tsconfig.json
+++ b/clients/client-iot-1click-devices-service/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-iot-1click-devices-service/typedoc.json
+++ b/clients/client-iot-1click-devices-service/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-iot-1click-projects/tsconfig.json
+++ b/clients/client-iot-1click-projects/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-iot-1click-projects/typedoc.json
+++ b/clients/client-iot-1click-projects/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-iot-data-plane/tsconfig.json
+++ b/clients/client-iot-data-plane/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-iot-data-plane/typedoc.json
+++ b/clients/client-iot-data-plane/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-iot-events-data/tsconfig.json
+++ b/clients/client-iot-events-data/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-iot-events-data/typedoc.json
+++ b/clients/client-iot-events-data/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-iot-events/tsconfig.json
+++ b/clients/client-iot-events/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-iot-events/typedoc.json
+++ b/clients/client-iot-events/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-iot-jobs-data-plane/tsconfig.json
+++ b/clients/client-iot-jobs-data-plane/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-iot-jobs-data-plane/typedoc.json
+++ b/clients/client-iot-jobs-data-plane/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-iot-wireless/tsconfig.json
+++ b/clients/client-iot-wireless/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-iot-wireless/typedoc.json
+++ b/clients/client-iot-wireless/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-iot/tsconfig.json
+++ b/clients/client-iot/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-iot/typedoc.json
+++ b/clients/client-iot/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-iotanalytics/tsconfig.json
+++ b/clients/client-iotanalytics/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-iotanalytics/typedoc.json
+++ b/clients/client-iotanalytics/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-iotdeviceadvisor/tsconfig.json
+++ b/clients/client-iotdeviceadvisor/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-iotdeviceadvisor/typedoc.json
+++ b/clients/client-iotdeviceadvisor/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-iotfleethub/tsconfig.json
+++ b/clients/client-iotfleethub/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-iotfleethub/typedoc.json
+++ b/clients/client-iotfleethub/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-iotsecuretunneling/tsconfig.json
+++ b/clients/client-iotsecuretunneling/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-iotsecuretunneling/typedoc.json
+++ b/clients/client-iotsecuretunneling/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-iotsitewise/tsconfig.json
+++ b/clients/client-iotsitewise/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-iotsitewise/typedoc.json
+++ b/clients/client-iotsitewise/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-iotthingsgraph/tsconfig.json
+++ b/clients/client-iotthingsgraph/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-iotthingsgraph/typedoc.json
+++ b/clients/client-iotthingsgraph/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-iottwinmaker/tsconfig.json
+++ b/clients/client-iottwinmaker/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-iottwinmaker/typedoc.json
+++ b/clients/client-iottwinmaker/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-ivs/tsconfig.json
+++ b/clients/client-ivs/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-ivs/typedoc.json
+++ b/clients/client-ivs/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-kafka/tsconfig.json
+++ b/clients/client-kafka/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-kafka/typedoc.json
+++ b/clients/client-kafka/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-kafkaconnect/tsconfig.json
+++ b/clients/client-kafkaconnect/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-kafkaconnect/typedoc.json
+++ b/clients/client-kafkaconnect/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-kendra/tsconfig.json
+++ b/clients/client-kendra/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-kendra/typedoc.json
+++ b/clients/client-kendra/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-kinesis-analytics-v2/tsconfig.json
+++ b/clients/client-kinesis-analytics-v2/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-kinesis-analytics-v2/typedoc.json
+++ b/clients/client-kinesis-analytics-v2/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-kinesis-analytics/tsconfig.json
+++ b/clients/client-kinesis-analytics/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-kinesis-analytics/typedoc.json
+++ b/clients/client-kinesis-analytics/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-kinesis-video-archived-media/tsconfig.json
+++ b/clients/client-kinesis-video-archived-media/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-kinesis-video-archived-media/typedoc.json
+++ b/clients/client-kinesis-video-archived-media/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-kinesis-video-media/tsconfig.json
+++ b/clients/client-kinesis-video-media/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-kinesis-video-media/typedoc.json
+++ b/clients/client-kinesis-video-media/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-kinesis-video-signaling/tsconfig.json
+++ b/clients/client-kinesis-video-signaling/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-kinesis-video-signaling/typedoc.json
+++ b/clients/client-kinesis-video-signaling/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-kinesis-video/tsconfig.json
+++ b/clients/client-kinesis-video/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-kinesis-video/typedoc.json
+++ b/clients/client-kinesis-video/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-kinesis/tsconfig.json
+++ b/clients/client-kinesis/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-kinesis/typedoc.json
+++ b/clients/client-kinesis/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-kms/tsconfig.json
+++ b/clients/client-kms/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-kms/typedoc.json
+++ b/clients/client-kms/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-lakeformation/tsconfig.json
+++ b/clients/client-lakeformation/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-lakeformation/typedoc.json
+++ b/clients/client-lakeformation/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-lambda/tsconfig.json
+++ b/clients/client-lambda/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-lambda/typedoc.json
+++ b/clients/client-lambda/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-lex-model-building-service/tsconfig.json
+++ b/clients/client-lex-model-building-service/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-lex-model-building-service/typedoc.json
+++ b/clients/client-lex-model-building-service/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-lex-models-v2/tsconfig.json
+++ b/clients/client-lex-models-v2/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-lex-models-v2/typedoc.json
+++ b/clients/client-lex-models-v2/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-lex-runtime-service/tsconfig.json
+++ b/clients/client-lex-runtime-service/tsconfig.json
@@ -15,19 +15,5 @@
     "removeComments": true,
     "types": ["mocha", "node"]
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-lex-runtime-service/typedoc.json
+++ b/clients/client-lex-runtime-service/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-lex-runtime-v2/tsconfig.json
+++ b/clients/client-lex-runtime-v2/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-lex-runtime-v2/typedoc.json
+++ b/clients/client-lex-runtime-v2/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-license-manager/tsconfig.json
+++ b/clients/client-license-manager/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-license-manager/typedoc.json
+++ b/clients/client-license-manager/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-lightsail/tsconfig.json
+++ b/clients/client-lightsail/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-lightsail/typedoc.json
+++ b/clients/client-lightsail/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-location/tsconfig.json
+++ b/clients/client-location/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-location/typedoc.json
+++ b/clients/client-location/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-lookoutequipment/tsconfig.json
+++ b/clients/client-lookoutequipment/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-lookoutequipment/typedoc.json
+++ b/clients/client-lookoutequipment/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-lookoutmetrics/tsconfig.json
+++ b/clients/client-lookoutmetrics/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-lookoutmetrics/typedoc.json
+++ b/clients/client-lookoutmetrics/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-lookoutvision/tsconfig.json
+++ b/clients/client-lookoutvision/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-lookoutvision/typedoc.json
+++ b/clients/client-lookoutvision/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-machine-learning/tsconfig.json
+++ b/clients/client-machine-learning/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-machine-learning/typedoc.json
+++ b/clients/client-machine-learning/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-macie/tsconfig.json
+++ b/clients/client-macie/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-macie/typedoc.json
+++ b/clients/client-macie/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-macie2/tsconfig.json
+++ b/clients/client-macie2/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-macie2/typedoc.json
+++ b/clients/client-macie2/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-managedblockchain/tsconfig.json
+++ b/clients/client-managedblockchain/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-managedblockchain/typedoc.json
+++ b/clients/client-managedblockchain/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-marketplace-catalog/tsconfig.json
+++ b/clients/client-marketplace-catalog/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-marketplace-catalog/typedoc.json
+++ b/clients/client-marketplace-catalog/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-marketplace-commerce-analytics/tsconfig.json
+++ b/clients/client-marketplace-commerce-analytics/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-marketplace-commerce-analytics/typedoc.json
+++ b/clients/client-marketplace-commerce-analytics/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-marketplace-entitlement-service/tsconfig.json
+++ b/clients/client-marketplace-entitlement-service/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-marketplace-entitlement-service/typedoc.json
+++ b/clients/client-marketplace-entitlement-service/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-marketplace-metering/tsconfig.json
+++ b/clients/client-marketplace-metering/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-marketplace-metering/typedoc.json
+++ b/clients/client-marketplace-metering/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-mediaconnect/tsconfig.json
+++ b/clients/client-mediaconnect/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-mediaconnect/typedoc.json
+++ b/clients/client-mediaconnect/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-mediaconvert/tsconfig.json
+++ b/clients/client-mediaconvert/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-mediaconvert/typedoc.json
+++ b/clients/client-mediaconvert/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-medialive/tsconfig.json
+++ b/clients/client-medialive/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-medialive/typedoc.json
+++ b/clients/client-medialive/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-mediapackage-vod/tsconfig.json
+++ b/clients/client-mediapackage-vod/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-mediapackage-vod/typedoc.json
+++ b/clients/client-mediapackage-vod/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-mediapackage/tsconfig.json
+++ b/clients/client-mediapackage/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-mediapackage/typedoc.json
+++ b/clients/client-mediapackage/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-mediastore-data/tsconfig.json
+++ b/clients/client-mediastore-data/tsconfig.json
@@ -15,19 +15,5 @@
     "removeComments": true,
     "types": ["mocha"]
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-mediastore-data/typedoc.json
+++ b/clients/client-mediastore-data/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-mediastore/tsconfig.json
+++ b/clients/client-mediastore/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-mediastore/typedoc.json
+++ b/clients/client-mediastore/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-mediatailor/tsconfig.json
+++ b/clients/client-mediatailor/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-mediatailor/typedoc.json
+++ b/clients/client-mediatailor/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-memorydb/tsconfig.json
+++ b/clients/client-memorydb/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-memorydb/typedoc.json
+++ b/clients/client-memorydb/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-mgn/tsconfig.json
+++ b/clients/client-mgn/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-mgn/typedoc.json
+++ b/clients/client-mgn/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-migration-hub-refactor-spaces/tsconfig.json
+++ b/clients/client-migration-hub-refactor-spaces/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-migration-hub-refactor-spaces/typedoc.json
+++ b/clients/client-migration-hub-refactor-spaces/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-migration-hub/tsconfig.json
+++ b/clients/client-migration-hub/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-migration-hub/typedoc.json
+++ b/clients/client-migration-hub/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-migrationhub-config/tsconfig.json
+++ b/clients/client-migrationhub-config/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-migrationhub-config/typedoc.json
+++ b/clients/client-migrationhub-config/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-migrationhubstrategy/tsconfig.json
+++ b/clients/client-migrationhubstrategy/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-migrationhubstrategy/typedoc.json
+++ b/clients/client-migrationhubstrategy/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-mobile/tsconfig.json
+++ b/clients/client-mobile/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-mobile/typedoc.json
+++ b/clients/client-mobile/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-mq/tsconfig.json
+++ b/clients/client-mq/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-mq/typedoc.json
+++ b/clients/client-mq/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-mturk/tsconfig.json
+++ b/clients/client-mturk/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-mturk/typedoc.json
+++ b/clients/client-mturk/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-mwaa/tsconfig.json
+++ b/clients/client-mwaa/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-mwaa/typedoc.json
+++ b/clients/client-mwaa/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-neptune/tsconfig.json
+++ b/clients/client-neptune/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-neptune/typedoc.json
+++ b/clients/client-neptune/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-network-firewall/tsconfig.json
+++ b/clients/client-network-firewall/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-network-firewall/typedoc.json
+++ b/clients/client-network-firewall/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-networkmanager/tsconfig.json
+++ b/clients/client-networkmanager/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-networkmanager/typedoc.json
+++ b/clients/client-networkmanager/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-nimble/tsconfig.json
+++ b/clients/client-nimble/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-nimble/typedoc.json
+++ b/clients/client-nimble/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-opensearch/tsconfig.json
+++ b/clients/client-opensearch/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-opensearch/typedoc.json
+++ b/clients/client-opensearch/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-opsworks/tsconfig.json
+++ b/clients/client-opsworks/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-opsworks/typedoc.json
+++ b/clients/client-opsworks/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-opsworkscm/tsconfig.json
+++ b/clients/client-opsworkscm/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-opsworkscm/typedoc.json
+++ b/clients/client-opsworkscm/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-organizations/tsconfig.json
+++ b/clients/client-organizations/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-organizations/typedoc.json
+++ b/clients/client-organizations/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-outposts/tsconfig.json
+++ b/clients/client-outposts/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-outposts/typedoc.json
+++ b/clients/client-outposts/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-panorama/tsconfig.json
+++ b/clients/client-panorama/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-panorama/typedoc.json
+++ b/clients/client-panorama/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-personalize-events/tsconfig.json
+++ b/clients/client-personalize-events/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-personalize-events/typedoc.json
+++ b/clients/client-personalize-events/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-personalize-runtime/tsconfig.json
+++ b/clients/client-personalize-runtime/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-personalize-runtime/typedoc.json
+++ b/clients/client-personalize-runtime/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-personalize/tsconfig.json
+++ b/clients/client-personalize/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-personalize/typedoc.json
+++ b/clients/client-personalize/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-pi/tsconfig.json
+++ b/clients/client-pi/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-pi/typedoc.json
+++ b/clients/client-pi/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-pinpoint-email/tsconfig.json
+++ b/clients/client-pinpoint-email/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-pinpoint-email/typedoc.json
+++ b/clients/client-pinpoint-email/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-pinpoint-sms-voice/tsconfig.json
+++ b/clients/client-pinpoint-sms-voice/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-pinpoint-sms-voice/typedoc.json
+++ b/clients/client-pinpoint-sms-voice/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-pinpoint/tsconfig.json
+++ b/clients/client-pinpoint/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-pinpoint/typedoc.json
+++ b/clients/client-pinpoint/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-polly/tsconfig.json
+++ b/clients/client-polly/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-polly/typedoc.json
+++ b/clients/client-polly/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-pricing/tsconfig.json
+++ b/clients/client-pricing/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-pricing/typedoc.json
+++ b/clients/client-pricing/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-proton/tsconfig.json
+++ b/clients/client-proton/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-proton/typedoc.json
+++ b/clients/client-proton/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-qldb-session/tsconfig.json
+++ b/clients/client-qldb-session/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-qldb-session/typedoc.json
+++ b/clients/client-qldb-session/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-qldb/tsconfig.json
+++ b/clients/client-qldb/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-qldb/typedoc.json
+++ b/clients/client-qldb/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-quicksight/tsconfig.json
+++ b/clients/client-quicksight/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-quicksight/typedoc.json
+++ b/clients/client-quicksight/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-ram/tsconfig.json
+++ b/clients/client-ram/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-ram/typedoc.json
+++ b/clients/client-ram/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-rbin/tsconfig.json
+++ b/clients/client-rbin/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-rbin/typedoc.json
+++ b/clients/client-rbin/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-rds-data/tsconfig.json
+++ b/clients/client-rds-data/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-rds-data/typedoc.json
+++ b/clients/client-rds-data/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-rds/tsconfig.json
+++ b/clients/client-rds/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-rds/typedoc.json
+++ b/clients/client-rds/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-redshift-data/tsconfig.json
+++ b/clients/client-redshift-data/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-redshift-data/typedoc.json
+++ b/clients/client-redshift-data/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-redshift/tsconfig.json
+++ b/clients/client-redshift/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-redshift/typedoc.json
+++ b/clients/client-redshift/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-rekognition/tsconfig.json
+++ b/clients/client-rekognition/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-rekognition/typedoc.json
+++ b/clients/client-rekognition/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-resiliencehub/tsconfig.json
+++ b/clients/client-resiliencehub/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-resiliencehub/typedoc.json
+++ b/clients/client-resiliencehub/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-resource-groups-tagging-api/tsconfig.json
+++ b/clients/client-resource-groups-tagging-api/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-resource-groups-tagging-api/typedoc.json
+++ b/clients/client-resource-groups-tagging-api/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-resource-groups/tsconfig.json
+++ b/clients/client-resource-groups/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-resource-groups/typedoc.json
+++ b/clients/client-resource-groups/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-robomaker/tsconfig.json
+++ b/clients/client-robomaker/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-robomaker/typedoc.json
+++ b/clients/client-robomaker/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-route-53-domains/tsconfig.json
+++ b/clients/client-route-53-domains/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-route-53-domains/typedoc.json
+++ b/clients/client-route-53-domains/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-route-53/tsconfig.json
+++ b/clients/client-route-53/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-route-53/typedoc.json
+++ b/clients/client-route-53/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-route53-recovery-cluster/tsconfig.json
+++ b/clients/client-route53-recovery-cluster/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-route53-recovery-cluster/typedoc.json
+++ b/clients/client-route53-recovery-cluster/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-route53-recovery-control-config/tsconfig.json
+++ b/clients/client-route53-recovery-control-config/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-route53-recovery-control-config/typedoc.json
+++ b/clients/client-route53-recovery-control-config/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-route53-recovery-readiness/tsconfig.json
+++ b/clients/client-route53-recovery-readiness/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-route53-recovery-readiness/typedoc.json
+++ b/clients/client-route53-recovery-readiness/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-route53resolver/tsconfig.json
+++ b/clients/client-route53resolver/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-route53resolver/typedoc.json
+++ b/clients/client-route53resolver/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-rum/tsconfig.json
+++ b/clients/client-rum/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-rum/typedoc.json
+++ b/clients/client-rum/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-s3-control/tsconfig.json
+++ b/clients/client-s3-control/tsconfig.json
@@ -15,19 +15,5 @@
     "removeComments": true,
     "types": ["mocha", "node"]
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-s3-control/typedoc.json
+++ b/clients/client-s3-control/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-s3/tsconfig.json
+++ b/clients/client-s3/tsconfig.json
@@ -15,19 +15,5 @@
     "removeComments": true,
     "types": ["mocha", "node"]
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-s3/typedoc.json
+++ b/clients/client-s3/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-s3outposts/tsconfig.json
+++ b/clients/client-s3outposts/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-s3outposts/typedoc.json
+++ b/clients/client-s3outposts/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-sagemaker-a2i-runtime/tsconfig.json
+++ b/clients/client-sagemaker-a2i-runtime/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-sagemaker-a2i-runtime/typedoc.json
+++ b/clients/client-sagemaker-a2i-runtime/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-sagemaker-edge/tsconfig.json
+++ b/clients/client-sagemaker-edge/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-sagemaker-edge/typedoc.json
+++ b/clients/client-sagemaker-edge/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-sagemaker-featurestore-runtime/tsconfig.json
+++ b/clients/client-sagemaker-featurestore-runtime/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-sagemaker-featurestore-runtime/typedoc.json
+++ b/clients/client-sagemaker-featurestore-runtime/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-sagemaker-runtime/tsconfig.json
+++ b/clients/client-sagemaker-runtime/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-sagemaker-runtime/typedoc.json
+++ b/clients/client-sagemaker-runtime/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-sagemaker/tsconfig.json
+++ b/clients/client-sagemaker/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-sagemaker/typedoc.json
+++ b/clients/client-sagemaker/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-savingsplans/tsconfig.json
+++ b/clients/client-savingsplans/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-savingsplans/typedoc.json
+++ b/clients/client-savingsplans/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-schemas/tsconfig.json
+++ b/clients/client-schemas/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-schemas/typedoc.json
+++ b/clients/client-schemas/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-secrets-manager/tsconfig.json
+++ b/clients/client-secrets-manager/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-secrets-manager/typedoc.json
+++ b/clients/client-secrets-manager/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-securityhub/tsconfig.json
+++ b/clients/client-securityhub/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-securityhub/typedoc.json
+++ b/clients/client-securityhub/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-serverlessapplicationrepository/tsconfig.json
+++ b/clients/client-serverlessapplicationrepository/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-serverlessapplicationrepository/typedoc.json
+++ b/clients/client-serverlessapplicationrepository/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-service-catalog-appregistry/tsconfig.json
+++ b/clients/client-service-catalog-appregistry/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-service-catalog-appregistry/typedoc.json
+++ b/clients/client-service-catalog-appregistry/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-service-catalog/tsconfig.json
+++ b/clients/client-service-catalog/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-service-catalog/typedoc.json
+++ b/clients/client-service-catalog/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-service-quotas/tsconfig.json
+++ b/clients/client-service-quotas/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-service-quotas/typedoc.json
+++ b/clients/client-service-quotas/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-servicediscovery/tsconfig.json
+++ b/clients/client-servicediscovery/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-servicediscovery/typedoc.json
+++ b/clients/client-servicediscovery/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-ses/tsconfig.json
+++ b/clients/client-ses/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-ses/typedoc.json
+++ b/clients/client-ses/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-sesv2/tsconfig.json
+++ b/clients/client-sesv2/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-sesv2/typedoc.json
+++ b/clients/client-sesv2/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-sfn/tsconfig.json
+++ b/clients/client-sfn/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-sfn/typedoc.json
+++ b/clients/client-sfn/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-shield/tsconfig.json
+++ b/clients/client-shield/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-shield/typedoc.json
+++ b/clients/client-shield/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-signer/tsconfig.json
+++ b/clients/client-signer/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-signer/typedoc.json
+++ b/clients/client-signer/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-sms/tsconfig.json
+++ b/clients/client-sms/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-sms/typedoc.json
+++ b/clients/client-sms/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-snow-device-management/tsconfig.json
+++ b/clients/client-snow-device-management/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-snow-device-management/typedoc.json
+++ b/clients/client-snow-device-management/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-snowball/tsconfig.json
+++ b/clients/client-snowball/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-snowball/typedoc.json
+++ b/clients/client-snowball/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-sns/tsconfig.json
+++ b/clients/client-sns/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-sns/typedoc.json
+++ b/clients/client-sns/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-sqs/tsconfig.json
+++ b/clients/client-sqs/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-sqs/typedoc.json
+++ b/clients/client-sqs/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-ssm-contacts/tsconfig.json
+++ b/clients/client-ssm-contacts/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-ssm-contacts/typedoc.json
+++ b/clients/client-ssm-contacts/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-ssm-incidents/tsconfig.json
+++ b/clients/client-ssm-incidents/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-ssm-incidents/typedoc.json
+++ b/clients/client-ssm-incidents/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-ssm/tsconfig.json
+++ b/clients/client-ssm/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-ssm/typedoc.json
+++ b/clients/client-ssm/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-sso-admin/tsconfig.json
+++ b/clients/client-sso-admin/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-sso-admin/typedoc.json
+++ b/clients/client-sso-admin/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-sso-oidc/tsconfig.json
+++ b/clients/client-sso-oidc/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-sso-oidc/typedoc.json
+++ b/clients/client-sso-oidc/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-sso/tsconfig.json
+++ b/clients/client-sso/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-sso/typedoc.json
+++ b/clients/client-sso/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-storage-gateway/tsconfig.json
+++ b/clients/client-storage-gateway/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-storage-gateway/typedoc.json
+++ b/clients/client-storage-gateway/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-sts/tsconfig.json
+++ b/clients/client-sts/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-sts/typedoc.json
+++ b/clients/client-sts/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-support/tsconfig.json
+++ b/clients/client-support/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-support/typedoc.json
+++ b/clients/client-support/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-swf/tsconfig.json
+++ b/clients/client-swf/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-swf/typedoc.json
+++ b/clients/client-swf/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-synthetics/tsconfig.json
+++ b/clients/client-synthetics/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-synthetics/typedoc.json
+++ b/clients/client-synthetics/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-textract/tsconfig.json
+++ b/clients/client-textract/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-textract/typedoc.json
+++ b/clients/client-textract/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-timestream-query/tsconfig.json
+++ b/clients/client-timestream-query/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-timestream-query/typedoc.json
+++ b/clients/client-timestream-query/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-timestream-write/tsconfig.json
+++ b/clients/client-timestream-write/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-timestream-write/typedoc.json
+++ b/clients/client-timestream-write/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-transcribe-streaming/tsconfig.json
+++ b/clients/client-transcribe-streaming/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-transcribe-streaming/typedoc.json
+++ b/clients/client-transcribe-streaming/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-transcribe/tsconfig.json
+++ b/clients/client-transcribe/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-transcribe/typedoc.json
+++ b/clients/client-transcribe/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-transfer/tsconfig.json
+++ b/clients/client-transfer/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-transfer/typedoc.json
+++ b/clients/client-transfer/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-translate/tsconfig.json
+++ b/clients/client-translate/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-translate/typedoc.json
+++ b/clients/client-translate/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-voice-id/tsconfig.json
+++ b/clients/client-voice-id/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-voice-id/typedoc.json
+++ b/clients/client-voice-id/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-waf-regional/tsconfig.json
+++ b/clients/client-waf-regional/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-waf-regional/typedoc.json
+++ b/clients/client-waf-regional/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-waf/tsconfig.json
+++ b/clients/client-waf/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-waf/typedoc.json
+++ b/clients/client-waf/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-wafv2/tsconfig.json
+++ b/clients/client-wafv2/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-wafv2/typedoc.json
+++ b/clients/client-wafv2/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-wellarchitected/tsconfig.json
+++ b/clients/client-wellarchitected/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-wellarchitected/typedoc.json
+++ b/clients/client-wellarchitected/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-wisdom/tsconfig.json
+++ b/clients/client-wisdom/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-wisdom/typedoc.json
+++ b/clients/client-wisdom/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-workdocs/tsconfig.json
+++ b/clients/client-workdocs/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-workdocs/typedoc.json
+++ b/clients/client-workdocs/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-worklink/tsconfig.json
+++ b/clients/client-worklink/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-worklink/typedoc.json
+++ b/clients/client-worklink/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-workmail/tsconfig.json
+++ b/clients/client-workmail/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-workmail/typedoc.json
+++ b/clients/client-workmail/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-workmailmessageflow/tsconfig.json
+++ b/clients/client-workmailmessageflow/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-workmailmessageflow/typedoc.json
+++ b/clients/client-workmailmessageflow/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-workspaces-web/tsconfig.json
+++ b/clients/client-workspaces-web/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-workspaces-web/typedoc.json
+++ b/clients/client-workspaces-web/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-workspaces/tsconfig.json
+++ b/clients/client-workspaces/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-workspaces/typedoc.json
+++ b/clients/client-workspaces/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/clients/client-xray/tsconfig.json
+++ b/clients/client-xray/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/clients/client-xray/typedoc.json
+++ b/clients/client-xray/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/private/aws-echo-service/tsconfig.json
+++ b/private/aws-echo-service/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/private/aws-echo-service/typedoc.json
+++ b/private/aws-echo-service/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/private/aws-protocoltests-ec2/tsconfig.json
+++ b/private/aws-protocoltests-ec2/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/private/aws-protocoltests-ec2/typedoc.json
+++ b/private/aws-protocoltests-ec2/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/private/aws-protocoltests-json-10/tsconfig.json
+++ b/private/aws-protocoltests-json-10/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/private/aws-protocoltests-json-10/typedoc.json
+++ b/private/aws-protocoltests-json-10/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/private/aws-protocoltests-json/tsconfig.json
+++ b/private/aws-protocoltests-json/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/private/aws-protocoltests-json/typedoc.json
+++ b/private/aws-protocoltests-json/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/private/aws-protocoltests-query/tsconfig.json
+++ b/private/aws-protocoltests-query/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/private/aws-protocoltests-query/typedoc.json
+++ b/private/aws-protocoltests-query/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/private/aws-protocoltests-restjson/tsconfig.json
+++ b/private/aws-protocoltests-restjson/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/private/aws-protocoltests-restjson/typedoc.json
+++ b/private/aws-protocoltests-restjson/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}

--- a/private/aws-protocoltests-restxml/tsconfig.json
+++ b/private/aws-protocoltests-restxml/tsconfig.json
@@ -14,19 +14,5 @@
     "outDir": "dist-cjs",
     "removeComments": true
   },
-  "typedocOptions": {
-    "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
-    "excludeNotExported": true,
-    "excludePrivate": true,
-    "hideGenerator": true,
-    "ignoreCompilerErrors": true,
-    "includeDeclarations": true,
-    "stripInternal": true,
-    "readme": "README.md",
-    "mode": "file",
-    "out": "docs",
-    "theme": "minimal",
-    "plugin": ["@aws-sdk/service-client-documentation-generator"]
-  },
   "exclude": ["test/**/*"]
 }

--- a/private/aws-protocoltests-restxml/typedoc.json
+++ b/private/aws-protocoltests-restxml/typedoc.json
@@ -1,0 +1,14 @@
+{
+  "exclude": ["**/node_modules/**", "**/*.spec.ts", "**/protocols/*.ts", "**/e2e/*.ts", "**/endpoints.ts"],
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "includeDeclarations": true,
+  "stripInternal": true,
+  "readme": "README.md",
+  "mode": "file",
+  "out": "docs",
+  "theme": "minimal",
+  "plugin": ["@aws-sdk/service-client-documentation-generator"]
+}


### PR DESCRIPTION
### Issue
Refs: https://github.com/awslabs/smithy-typescript/pull/484

### Description
Moves typedocOptions to typedoc.json

### Testing
Verified that docs are generated correctly by running the following commands:
```console
$ yarn build-documentation --clientDocs docs/clients/{{CLIENT}} --theme
$ ./node_modules/.bin/lerna exec --scope '@aws-sdk/client-*' --no-bail --stream -- node ./node_modules/.bin/typedoc --out $(pwd)/docs/clients/$(basename \$LERNA_PACKAGE_NAME) --theme
```

The link to the webserver of docs was shared with reviewer @AllanZhengYP internally:
* main: `http://[IP]:8000/clients/@aws-sdk/client-s3/index.html`
* PR branch: `http://[IP]:8001/clients/@aws-sdk/client-s3/index.html`

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
