### PR TITLE
chore(scripts): remove devDeps defined in monorepo root

### DIFF
--- a/scripts/generate-clients/copy-to-clients.js
+++ b/scripts/generate-clients/copy-to-clients.js
@@ -37,8 +37,8 @@ const mergeManifest = (fromContent = {}, toContent = {}) => {
     if (fromContent[name].constructor.name === "Object") {
       if (name === "devDependencies") {
         // Remove devDeps defined in monorepo root
-        const devDepsDefinedInMonorepoRoot = ["downlevel-dts", "prettier", "typedoc"];
-        devDepsDefinedInMonorepoRoot.forEach((devDep) => delete fromContent[name][devDep]);
+        const devDepsInRoot = ["downlevel-dts", "rimraf", "typedoc", "typescript"];
+        devDepsInRoot.forEach((devDep) => delete fromContent[name][devDep]);
       }
       merged[name] = mergeManifest(fromContent[name], toContent[name]);
       if (name === "scripts" || name === "devDependencies") {

--- a/scripts/generate-clients/copy-to-clients.js
+++ b/scripts/generate-clients/copy-to-clients.js
@@ -35,6 +35,11 @@ const mergeManifest = (fromContent = {}, toContent = {}) => {
   const merged = {};
   for (const name of Object.keys(fromContent)) {
     if (fromContent[name].constructor.name === "Object") {
+      if (name === "devDependencies") {
+        // Remove devDeps defined in monorepo root
+        const devDepsDefinedInMonorepoRoot = ["downlevel-dts", "prettier", "typedoc"];
+        devDepsDefinedInMonorepoRoot.forEach((devDep) => delete fromContent[name][devDep]);
+      }
       merged[name] = mergeManifest(fromContent[name], toContent[name]);
       if (name === "scripts" || name === "devDependencies") {
         // Allow target package.json(toContent) has its own special script or


### PR DESCRIPTION
### Issue
Related to using root tsconfig for all clients in aws-sdk-js-v3
Refs: #1307

### Description
Removes devDeps defined in monorepo root from clients.
Individual devDeps, if present, were removed in https://github.com/aws/aws-sdk-js-v3/pull/3139

### Testing
Testing that the packages work without dependencies is done in https://github.com/aws/aws-sdk-js-v3/pull/3139

Verified that dependencies are not added during client generation with client-acm:
```console
$ sed -n 53,58p clients/client-acm/package.json 
  },
  "devDependencies": {
    "@aws-sdk/service-client-documentation-generator": "3.38.0",
    "@types/node": "^12.7.5"
  },
  "engines": {

$ yarn generate-clients -g codegen/sdk-codegen/aws-models/acm.json -n
...
copying @aws-sdk/client-acm from /local/home/trivikr/workspace/backup/backup-aws-sdk-js-v3/codegen/sdk-codegen/build/smithyprojections/sdk-codegen/acm.2015-12-08/typescript-codegen to /local/home/trivikr/workspace/backup/backup-aws-sdk-js-v3/clients
Done in 13.50s.

$ sed -n 53,58p clients/client-acm/package.json 
  },
  "devDependencies": {
    "@aws-sdk/service-client-documentation-generator": "3.38.0",
    "@types/node": "^12.7.5"
  },
  "engines": {
```

### Additional context
Discussion in lerna https://github.com/lerna/lerna/issues/1079

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
