### PR TITLE
chore(clients): do not clean docs during build

### DIFF
--- a/clients/client-accessanalyzer/package.json
+++ b/clients/client-accessanalyzer/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-account/package.json
+++ b/clients/client-account/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-acm-pca/package.json
+++ b/clients/client-acm-pca/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-acm/package.json
+++ b/clients/client-acm/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-alexa-for-business/package.json
+++ b/clients/client-alexa-for-business/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-amp/package.json
+++ b/clients/client-amp/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-amplify/package.json
+++ b/clients/client-amplify/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-amplifybackend/package.json
+++ b/clients/client-amplifybackend/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-amplifyuibuilder/package.json
+++ b/clients/client-amplifyuibuilder/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-api-gateway/package.json
+++ b/clients/client-api-gateway/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-apigatewaymanagementapi/package.json
+++ b/clients/client-apigatewaymanagementapi/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-apigatewayv2/package.json
+++ b/clients/client-apigatewayv2/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-app-mesh/package.json
+++ b/clients/client-app-mesh/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-appconfig/package.json
+++ b/clients/client-appconfig/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-appconfigdata/package.json
+++ b/clients/client-appconfigdata/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-appflow/package.json
+++ b/clients/client-appflow/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-appintegrations/package.json
+++ b/clients/client-appintegrations/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-application-auto-scaling/package.json
+++ b/clients/client-application-auto-scaling/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-application-discovery-service/package.json
+++ b/clients/client-application-discovery-service/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-application-insights/package.json
+++ b/clients/client-application-insights/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-applicationcostprofiler/package.json
+++ b/clients/client-applicationcostprofiler/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-apprunner/package.json
+++ b/clients/client-apprunner/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-appstream/package.json
+++ b/clients/client-appstream/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-appsync/package.json
+++ b/clients/client-appsync/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-athena/package.json
+++ b/clients/client-athena/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-auditmanager/package.json
+++ b/clients/client-auditmanager/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-auto-scaling-plans/package.json
+++ b/clients/client-auto-scaling-plans/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-auto-scaling/package.json
+++ b/clients/client-auto-scaling/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-backup-gateway/package.json
+++ b/clients/client-backup-gateway/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-backup/package.json
+++ b/clients/client-backup/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-batch/package.json
+++ b/clients/client-batch/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-braket/package.json
+++ b/clients/client-braket/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-budgets/package.json
+++ b/clients/client-budgets/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-chime-sdk-identity/package.json
+++ b/clients/client-chime-sdk-identity/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-chime-sdk-meetings/package.json
+++ b/clients/client-chime-sdk-meetings/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-chime-sdk-messaging/package.json
+++ b/clients/client-chime-sdk-messaging/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-chime/package.json
+++ b/clients/client-chime/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-cloud9/package.json
+++ b/clients/client-cloud9/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-cloudcontrol/package.json
+++ b/clients/client-cloudcontrol/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-clouddirectory/package.json
+++ b/clients/client-clouddirectory/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-cloudformation/package.json
+++ b/clients/client-cloudformation/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-cloudfront/package.json
+++ b/clients/client-cloudfront/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-cloudhsm-v2/package.json
+++ b/clients/client-cloudhsm-v2/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-cloudhsm/package.json
+++ b/clients/client-cloudhsm/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-cloudsearch-domain/package.json
+++ b/clients/client-cloudsearch-domain/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-cloudsearch/package.json
+++ b/clients/client-cloudsearch/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-cloudtrail/package.json
+++ b/clients/client-cloudtrail/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-cloudwatch-events/package.json
+++ b/clients/client-cloudwatch-events/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-cloudwatch-logs/package.json
+++ b/clients/client-cloudwatch-logs/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-cloudwatch/package.json
+++ b/clients/client-cloudwatch/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-codeartifact/package.json
+++ b/clients/client-codeartifact/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-codebuild/package.json
+++ b/clients/client-codebuild/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-codecommit/package.json
+++ b/clients/client-codecommit/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-codedeploy/package.json
+++ b/clients/client-codedeploy/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-codeguru-reviewer/package.json
+++ b/clients/client-codeguru-reviewer/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-codeguruprofiler/package.json
+++ b/clients/client-codeguruprofiler/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-codepipeline/package.json
+++ b/clients/client-codepipeline/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-codestar-connections/package.json
+++ b/clients/client-codestar-connections/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-codestar-notifications/package.json
+++ b/clients/client-codestar-notifications/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-codestar/package.json
+++ b/clients/client-codestar/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-cognito-identity-provider/package.json
+++ b/clients/client-cognito-identity-provider/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-cognito-identity/package.json
+++ b/clients/client-cognito-identity/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-cognito-sync/package.json
+++ b/clients/client-cognito-sync/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-comprehend/package.json
+++ b/clients/client-comprehend/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-comprehendmedical/package.json
+++ b/clients/client-comprehendmedical/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-compute-optimizer/package.json
+++ b/clients/client-compute-optimizer/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-config-service/package.json
+++ b/clients/client-config-service/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-connect-contact-lens/package.json
+++ b/clients/client-connect-contact-lens/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-connect/package.json
+++ b/clients/client-connect/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-connectparticipant/package.json
+++ b/clients/client-connectparticipant/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-cost-and-usage-report-service/package.json
+++ b/clients/client-cost-and-usage-report-service/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-cost-explorer/package.json
+++ b/clients/client-cost-explorer/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-customer-profiles/package.json
+++ b/clients/client-customer-profiles/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-data-pipeline/package.json
+++ b/clients/client-data-pipeline/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-database-migration-service/package.json
+++ b/clients/client-database-migration-service/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-databrew/package.json
+++ b/clients/client-databrew/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-dataexchange/package.json
+++ b/clients/client-dataexchange/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-datasync/package.json
+++ b/clients/client-datasync/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-dax/package.json
+++ b/clients/client-dax/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-detective/package.json
+++ b/clients/client-detective/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-device-farm/package.json
+++ b/clients/client-device-farm/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-devops-guru/package.json
+++ b/clients/client-devops-guru/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-direct-connect/package.json
+++ b/clients/client-direct-connect/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-directory-service/package.json
+++ b/clients/client-directory-service/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-dlm/package.json
+++ b/clients/client-dlm/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-docdb/package.json
+++ b/clients/client-docdb/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-drs/package.json
+++ b/clients/client-drs/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-dynamodb-streams/package.json
+++ b/clients/client-dynamodb-streams/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-dynamodb/package.json
+++ b/clients/client-dynamodb/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-ebs/package.json
+++ b/clients/client-ebs/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-ec2-instance-connect/package.json
+++ b/clients/client-ec2-instance-connect/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-ec2/package.json
+++ b/clients/client-ec2/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-ecr-public/package.json
+++ b/clients/client-ecr-public/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-ecr/package.json
+++ b/clients/client-ecr/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-ecs/package.json
+++ b/clients/client-ecs/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-efs/package.json
+++ b/clients/client-efs/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-eks/package.json
+++ b/clients/client-eks/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-elastic-beanstalk/package.json
+++ b/clients/client-elastic-beanstalk/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-elastic-inference/package.json
+++ b/clients/client-elastic-inference/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-elastic-load-balancing-v2/package.json
+++ b/clients/client-elastic-load-balancing-v2/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-elastic-load-balancing/package.json
+++ b/clients/client-elastic-load-balancing/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-elastic-transcoder/package.json
+++ b/clients/client-elastic-transcoder/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-elasticache/package.json
+++ b/clients/client-elasticache/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-elasticsearch-service/package.json
+++ b/clients/client-elasticsearch-service/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-emr-containers/package.json
+++ b/clients/client-emr-containers/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-emr/package.json
+++ b/clients/client-emr/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-eventbridge/package.json
+++ b/clients/client-eventbridge/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-evidently/package.json
+++ b/clients/client-evidently/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-finspace-data/package.json
+++ b/clients/client-finspace-data/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-finspace/package.json
+++ b/clients/client-finspace/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-firehose/package.json
+++ b/clients/client-firehose/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-fis/package.json
+++ b/clients/client-fis/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-fms/package.json
+++ b/clients/client-fms/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-forecast/package.json
+++ b/clients/client-forecast/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-forecastquery/package.json
+++ b/clients/client-forecastquery/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-frauddetector/package.json
+++ b/clients/client-frauddetector/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-fsx/package.json
+++ b/clients/client-fsx/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-gamelift/package.json
+++ b/clients/client-gamelift/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-glacier/package.json
+++ b/clients/client-glacier/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-global-accelerator/package.json
+++ b/clients/client-global-accelerator/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-glue/package.json
+++ b/clients/client-glue/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-grafana/package.json
+++ b/clients/client-grafana/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-greengrass/package.json
+++ b/clients/client-greengrass/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-greengrassv2/package.json
+++ b/clients/client-greengrassv2/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-groundstation/package.json
+++ b/clients/client-groundstation/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-guardduty/package.json
+++ b/clients/client-guardduty/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-health/package.json
+++ b/clients/client-health/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-healthlake/package.json
+++ b/clients/client-healthlake/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-honeycode/package.json
+++ b/clients/client-honeycode/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-iam/package.json
+++ b/clients/client-iam/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-identitystore/package.json
+++ b/clients/client-identitystore/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-imagebuilder/package.json
+++ b/clients/client-imagebuilder/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-inspector/package.json
+++ b/clients/client-inspector/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-inspector2/package.json
+++ b/clients/client-inspector2/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-iot-1click-devices-service/package.json
+++ b/clients/client-iot-1click-devices-service/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-iot-1click-projects/package.json
+++ b/clients/client-iot-1click-projects/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-iot-data-plane/package.json
+++ b/clients/client-iot-data-plane/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-iot-events-data/package.json
+++ b/clients/client-iot-events-data/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-iot-events/package.json
+++ b/clients/client-iot-events/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-iot-jobs-data-plane/package.json
+++ b/clients/client-iot-jobs-data-plane/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-iot-wireless/package.json
+++ b/clients/client-iot-wireless/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-iot/package.json
+++ b/clients/client-iot/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-iotanalytics/package.json
+++ b/clients/client-iotanalytics/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-iotdeviceadvisor/package.json
+++ b/clients/client-iotdeviceadvisor/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-iotfleethub/package.json
+++ b/clients/client-iotfleethub/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-iotsecuretunneling/package.json
+++ b/clients/client-iotsecuretunneling/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-iotsitewise/package.json
+++ b/clients/client-iotsitewise/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-iotthingsgraph/package.json
+++ b/clients/client-iotthingsgraph/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-iottwinmaker/package.json
+++ b/clients/client-iottwinmaker/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-ivs/package.json
+++ b/clients/client-ivs/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-kafka/package.json
+++ b/clients/client-kafka/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-kafkaconnect/package.json
+++ b/clients/client-kafkaconnect/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-kendra/package.json
+++ b/clients/client-kendra/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-kinesis-analytics-v2/package.json
+++ b/clients/client-kinesis-analytics-v2/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-kinesis-analytics/package.json
+++ b/clients/client-kinesis-analytics/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-kinesis-video-archived-media/package.json
+++ b/clients/client-kinesis-video-archived-media/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-kinesis-video-media/package.json
+++ b/clients/client-kinesis-video-media/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-kinesis-video-signaling/package.json
+++ b/clients/client-kinesis-video-signaling/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-kinesis-video/package.json
+++ b/clients/client-kinesis-video/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-kinesis/package.json
+++ b/clients/client-kinesis/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-kms/package.json
+++ b/clients/client-kms/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-lakeformation/package.json
+++ b/clients/client-lakeformation/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-lambda/package.json
+++ b/clients/client-lambda/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-lex-model-building-service/package.json
+++ b/clients/client-lex-model-building-service/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-lex-models-v2/package.json
+++ b/clients/client-lex-models-v2/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-lex-runtime-service/package.json
+++ b/clients/client-lex-runtime-service/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-lex-runtime-v2/package.json
+++ b/clients/client-lex-runtime-v2/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-license-manager/package.json
+++ b/clients/client-license-manager/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-lightsail/package.json
+++ b/clients/client-lightsail/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-location/package.json
+++ b/clients/client-location/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-lookoutequipment/package.json
+++ b/clients/client-lookoutequipment/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-lookoutmetrics/package.json
+++ b/clients/client-lookoutmetrics/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-lookoutvision/package.json
+++ b/clients/client-lookoutvision/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-machine-learning/package.json
+++ b/clients/client-machine-learning/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-macie/package.json
+++ b/clients/client-macie/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-macie2/package.json
+++ b/clients/client-macie2/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-managedblockchain/package.json
+++ b/clients/client-managedblockchain/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-marketplace-catalog/package.json
+++ b/clients/client-marketplace-catalog/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-marketplace-commerce-analytics/package.json
+++ b/clients/client-marketplace-commerce-analytics/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-marketplace-entitlement-service/package.json
+++ b/clients/client-marketplace-entitlement-service/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-marketplace-metering/package.json
+++ b/clients/client-marketplace-metering/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-mediaconnect/package.json
+++ b/clients/client-mediaconnect/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-mediaconvert/package.json
+++ b/clients/client-mediaconvert/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-medialive/package.json
+++ b/clients/client-medialive/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-mediapackage-vod/package.json
+++ b/clients/client-mediapackage-vod/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-mediapackage/package.json
+++ b/clients/client-mediapackage/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-mediastore-data/package.json
+++ b/clients/client-mediastore-data/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-mediastore/package.json
+++ b/clients/client-mediastore/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-mediatailor/package.json
+++ b/clients/client-mediatailor/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-memorydb/package.json
+++ b/clients/client-memorydb/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-mgn/package.json
+++ b/clients/client-mgn/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-migration-hub-refactor-spaces/package.json
+++ b/clients/client-migration-hub-refactor-spaces/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-migration-hub/package.json
+++ b/clients/client-migration-hub/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-migrationhub-config/package.json
+++ b/clients/client-migrationhub-config/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-migrationhubstrategy/package.json
+++ b/clients/client-migrationhubstrategy/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-mobile/package.json
+++ b/clients/client-mobile/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-mq/package.json
+++ b/clients/client-mq/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-mturk/package.json
+++ b/clients/client-mturk/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-mwaa/package.json
+++ b/clients/client-mwaa/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-neptune/package.json
+++ b/clients/client-neptune/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-network-firewall/package.json
+++ b/clients/client-network-firewall/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-networkmanager/package.json
+++ b/clients/client-networkmanager/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-nimble/package.json
+++ b/clients/client-nimble/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-opensearch/package.json
+++ b/clients/client-opensearch/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-opsworks/package.json
+++ b/clients/client-opsworks/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-opsworkscm/package.json
+++ b/clients/client-opsworkscm/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-organizations/package.json
+++ b/clients/client-organizations/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-outposts/package.json
+++ b/clients/client-outposts/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-panorama/package.json
+++ b/clients/client-panorama/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-personalize-events/package.json
+++ b/clients/client-personalize-events/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-personalize-runtime/package.json
+++ b/clients/client-personalize-runtime/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-personalize/package.json
+++ b/clients/client-personalize/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-pi/package.json
+++ b/clients/client-pi/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-pinpoint-email/package.json
+++ b/clients/client-pinpoint-email/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-pinpoint-sms-voice/package.json
+++ b/clients/client-pinpoint-sms-voice/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-pinpoint/package.json
+++ b/clients/client-pinpoint/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-polly/package.json
+++ b/clients/client-polly/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-pricing/package.json
+++ b/clients/client-pricing/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-proton/package.json
+++ b/clients/client-proton/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-qldb-session/package.json
+++ b/clients/client-qldb-session/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-qldb/package.json
+++ b/clients/client-qldb/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-quicksight/package.json
+++ b/clients/client-quicksight/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-ram/package.json
+++ b/clients/client-ram/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-rbin/package.json
+++ b/clients/client-rbin/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-rds-data/package.json
+++ b/clients/client-rds-data/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-rds/package.json
+++ b/clients/client-rds/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-redshift-data/package.json
+++ b/clients/client-redshift-data/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-redshift/package.json
+++ b/clients/client-redshift/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-rekognition/package.json
+++ b/clients/client-rekognition/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-resiliencehub/package.json
+++ b/clients/client-resiliencehub/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-resource-groups-tagging-api/package.json
+++ b/clients/client-resource-groups-tagging-api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-resource-groups/package.json
+++ b/clients/client-resource-groups/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-robomaker/package.json
+++ b/clients/client-robomaker/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-route-53-domains/package.json
+++ b/clients/client-route-53-domains/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-route-53/package.json
+++ b/clients/client-route-53/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-route53-recovery-cluster/package.json
+++ b/clients/client-route53-recovery-cluster/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-route53-recovery-control-config/package.json
+++ b/clients/client-route53-recovery-control-config/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-route53-recovery-readiness/package.json
+++ b/clients/client-route53-recovery-readiness/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-route53resolver/package.json
+++ b/clients/client-route53resolver/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-rum/package.json
+++ b/clients/client-rum/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-s3-control/package.json
+++ b/clients/client-s3-control/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-s3/package.json
+++ b/clients/client-s3/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-s3outposts/package.json
+++ b/clients/client-s3outposts/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-sagemaker-a2i-runtime/package.json
+++ b/clients/client-sagemaker-a2i-runtime/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-sagemaker-edge/package.json
+++ b/clients/client-sagemaker-edge/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-sagemaker-featurestore-runtime/package.json
+++ b/clients/client-sagemaker-featurestore-runtime/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-sagemaker-runtime/package.json
+++ b/clients/client-sagemaker-runtime/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-sagemaker/package.json
+++ b/clients/client-sagemaker/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-savingsplans/package.json
+++ b/clients/client-savingsplans/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-schemas/package.json
+++ b/clients/client-schemas/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-secrets-manager/package.json
+++ b/clients/client-secrets-manager/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-securityhub/package.json
+++ b/clients/client-securityhub/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-serverlessapplicationrepository/package.json
+++ b/clients/client-serverlessapplicationrepository/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-service-catalog-appregistry/package.json
+++ b/clients/client-service-catalog-appregistry/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-service-catalog/package.json
+++ b/clients/client-service-catalog/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-service-quotas/package.json
+++ b/clients/client-service-quotas/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-servicediscovery/package.json
+++ b/clients/client-servicediscovery/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-ses/package.json
+++ b/clients/client-ses/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-sesv2/package.json
+++ b/clients/client-sesv2/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-sfn/package.json
+++ b/clients/client-sfn/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-shield/package.json
+++ b/clients/client-shield/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-signer/package.json
+++ b/clients/client-signer/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-sms/package.json
+++ b/clients/client-sms/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-snow-device-management/package.json
+++ b/clients/client-snow-device-management/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-snowball/package.json
+++ b/clients/client-snowball/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-sns/package.json
+++ b/clients/client-sns/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-sqs/package.json
+++ b/clients/client-sqs/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-ssm-contacts/package.json
+++ b/clients/client-ssm-contacts/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-ssm-incidents/package.json
+++ b/clients/client-ssm-incidents/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-ssm/package.json
+++ b/clients/client-ssm/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-sso-admin/package.json
+++ b/clients/client-sso-admin/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-sso-oidc/package.json
+++ b/clients/client-sso-oidc/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-sso/package.json
+++ b/clients/client-sso/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-storage-gateway/package.json
+++ b/clients/client-storage-gateway/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-sts/package.json
+++ b/clients/client-sts/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-support/package.json
+++ b/clients/client-support/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-swf/package.json
+++ b/clients/client-swf/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-synthetics/package.json
+++ b/clients/client-synthetics/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-textract/package.json
+++ b/clients/client-textract/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-timestream-query/package.json
+++ b/clients/client-timestream-query/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-timestream-write/package.json
+++ b/clients/client-timestream-write/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-transcribe-streaming/package.json
+++ b/clients/client-transcribe-streaming/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-transcribe/package.json
+++ b/clients/client-transcribe/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-transfer/package.json
+++ b/clients/client-transfer/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-translate/package.json
+++ b/clients/client-translate/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-voice-id/package.json
+++ b/clients/client-voice-id/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-waf-regional/package.json
+++ b/clients/client-waf-regional/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-waf/package.json
+++ b/clients/client-waf/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-wafv2/package.json
+++ b/clients/client-wafv2/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-wellarchitected/package.json
+++ b/clients/client-wellarchitected/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-wisdom/package.json
+++ b/clients/client-wisdom/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-workdocs/package.json
+++ b/clients/client-workdocs/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-worklink/package.json
+++ b/clients/client-worklink/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-workmail/package.json
+++ b/clients/client-workmail/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-workmailmessageflow/package.json
+++ b/clients/client-workmailmessageflow/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-workspaces-web/package.json
+++ b/clients/client-workspaces-web/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-workspaces/package.json
+++ b/clients/client-workspaces/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/clients/client-xray/package.json
+++ b/clients/client-xray/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/private/aws-echo-service/package.json
+++ b/private/aws-echo-service/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/private/aws-protocoltests-ec2/package.json
+++ b/private/aws-protocoltests-ec2/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/private/aws-protocoltests-json-10/package.json
+++ b/private/aws-protocoltests-json-10/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/private/aws-protocoltests-json/package.json
+++ b/private/aws-protocoltests-json/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/private/aws-protocoltests-query/package.json
+++ b/private/aws-protocoltests-query/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/private/aws-protocoltests-restjson/package.json
+++ b/private/aws-protocoltests-restjson/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",

--- a/private/aws-protocoltests-restxml/package.json
+++ b/private/aws-protocoltests-restxml/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "tsc -p tsconfig.json",
-    "build:docs": "yarn clean:docs && typedoc ./",
+    "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "yarn clean:dist && yarn clean:docs",


### PR DESCRIPTION
### Issue
Refs: https://github.com/awslabs/smithy-typescript/pull/485

### Description
The `build:docs` command now calls typedoc directly, so that it can be used in internal release automation.

### Testing
Verified that docs are generated with `build:docs` command in `client-acm` after manually removing typedoc binary

```console
$ client-acm> rm -rf docs

$ client-acm> ls docs
ls: cannot access docs: No such file or directory

$ client-acm> ./node_modules/.bin/typedoc --version
zsh: no such file or directory: ./node_modules/.bin/typedoc

$ client-acm> yarn build:docs
yarn run v1.22.17
$ typedoc
Loaded plugin @aws-sdk/service-client-documentation-generator

Using TypeScript 4.3.5 from /local/home/trivikr/workspace/backup/backup-aws-sdk-js-v3/node_modules/typescript/lib
Warning: You are running in an unsupported TypeScript version! TypeDoc supports 3.9.x || 4.0.x
Deprecated as of 10.7.0. highlight(lang, code, ...args) has been deprecated.
Deprecated as of 10.7.0. Please use highlight(code, options) instead.
https://github.com/highlightjs/highlight.js/issues/2277
Rendering [========================================] 100%

Documentation generated at /local/home/trivikr/workspace/backup/backup-aws-sdk-js-v3/clients/client-acm/docs

Done in 7.74s.

$ client-acm> ls docs
assets  classes  enums  globals.html  index.html  interfaces  modules 
```

Verified that global docs are generated correctly by running the following commands:
```console
$ yarn build-documentation --clientDocs docs/clients/{{CLIENT}} --theme
$ ./node_modules/.bin/lerna exec --scope '@aws-sdk/client-*' --no-bail --stream -- yarn build:docs --out $(pwd)/docs/clients/$(basename \$LERNA_PACKAGE_NAME) --theme
```

The link to the webserver of docs was shared with reviewer @AllanZhengYP internally:
* main: `http://[IP]:8000/clients/@aws-sdk/client-s3/index.html`
* PR branch: `http://[IP]:8001/clients/@aws-sdk/client-s3/index.html`

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
