### PR TITLE
feat(packages): end support for Node.js 10.x

### DIFF
--- a/lib/lib-dynamodb/package.json
+++ b/lib/lib-dynamodb/package.json
@@ -14,7 +14,7 @@
     "test": "jest"
   },
   "engines": {
-    "node": ">= 10.0.0"
+    "node": ">= 12.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/lib/lib-storage/package.json
+++ b/lib/lib-storage/package.json
@@ -14,7 +14,7 @@
     "test": "jest"
   },
   "engines": {
-    "node": ">= 10.0.0"
+    "node": ">= 12.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/packages/abort-controller/package.json
+++ b/packages/abort-controller/package.json
@@ -26,7 +26,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">= 10.0.0"
+    "node": ">= 12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/body-checksum-node/package.json
+++ b/packages/body-checksum-node/package.json
@@ -32,7 +32,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">= 10.0.0"
+    "node": ">= 12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/chunked-stream-reader-node/package.json
+++ b/packages/chunked-stream-reader-node/package.json
@@ -25,7 +25,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">= 10.0.0"
+    "node": ">= 12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/config-resolver/package.json
+++ b/packages/config-resolver/package.json
@@ -28,7 +28,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">= 10.0.0"
+    "node": ">= 12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/credential-provider-cognito-identity/package.json
+++ b/packages/credential-provider-cognito-identity/package.json
@@ -28,7 +28,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">= 10.0.0"
+    "node": ">= 12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/credential-provider-env/package.json
+++ b/packages/credential-provider-env/package.json
@@ -32,7 +32,7 @@
   },
   "types": "./dist-types/index.d.ts",
   "engines": {
-    "node": ">= 10.0.0"
+    "node": ">= 12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/credential-provider-imds/package.json
+++ b/packages/credential-provider-imds/package.json
@@ -35,7 +35,7 @@
   },
   "types": "./dist-types/index.d.ts",
   "engines": {
-    "node": ">= 10.0.0"
+    "node": ">= 12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/credential-provider-ini/package.json
+++ b/packages/credential-provider-ini/package.json
@@ -38,7 +38,7 @@
   },
   "types": "./dist-types/index.d.ts",
   "engines": {
-    "node": ">= 10.0.0"
+    "node": ">= 12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/credential-provider-process/package.json
+++ b/packages/credential-provider-process/package.json
@@ -34,7 +34,7 @@
   },
   "types": "./dist-types/index.d.ts",
   "engines": {
-    "node": ">= 10.0.0"
+    "node": ">= 12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/credential-provider-sso/package.json
+++ b/packages/credential-provider-sso/package.json
@@ -35,7 +35,7 @@
   },
   "types": "./dist-types/index.d.ts",
   "engines": {
-    "node": ">= 10.0.0"
+    "node": ">= 12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/credential-provider-web-identity/package.json
+++ b/packages/credential-provider-web-identity/package.json
@@ -40,7 +40,7 @@
   },
   "types": "./dist-types/index.d.ts",
   "engines": {
-    "node": ">= 10.0.0"
+    "node": ">= 12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/credential-providers/package.json
+++ b/packages/credential-providers/package.json
@@ -47,7 +47,7 @@
   },
   "types": "./dist-types/index.d.ts",
   "engines": {
-    "node": ">= 10.0.0"
+    "node": ">= 12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/endpoint-cache/package.json
+++ b/packages/endpoint-cache/package.json
@@ -26,7 +26,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">= 10.0.0"
+    "node": ">= 12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/eventstream-handler-node/package.json
+++ b/packages/eventstream-handler-node/package.json
@@ -27,7 +27,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">= 10.0.0"
+    "node": ">= 12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/eventstream-serde-browser/package.json
+++ b/packages/eventstream-serde-browser/package.json
@@ -27,7 +27,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">= 10.0.0"
+    "node": ">= 12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/eventstream-serde-config-resolver/package.json
+++ b/packages/eventstream-serde-config-resolver/package.json
@@ -25,7 +25,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">= 10.0.0"
+    "node": ">= 12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/eventstream-serde-node/package.json
+++ b/packages/eventstream-serde-node/package.json
@@ -28,7 +28,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">= 10.0.0"
+    "node": ">= 12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/eventstream-serde-universal/package.json
+++ b/packages/eventstream-serde-universal/package.json
@@ -27,7 +27,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">= 10.0.0"
+    "node": ">= 12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/hash-node/package.json
+++ b/packages/hash-node/package.json
@@ -28,7 +28,7 @@
     "tslib": "^2.3.0"
   },
   "engines": {
-    "node": ">= 10.0.0"
+    "node": ">= 12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/hash-stream-node/package.json
+++ b/packages/hash-stream-node/package.json
@@ -28,7 +28,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">= 10.0.0"
+    "node": ">= 12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/is-array-buffer/package.json
+++ b/packages/is-array-buffer/package.json
@@ -25,7 +25,7 @@
     "tslib": "^2.3.0"
   },
   "engines": {
-    "node": ">= 10.0.0"
+    "node": ">= 12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/karma-credential-loader/package.json
+++ b/packages/karma-credential-loader/package.json
@@ -28,7 +28,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">= 10.0.0"
+    "node": ">= 12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/middleware-apply-body-checksum/package.json
+++ b/packages/middleware-apply-body-checksum/package.json
@@ -27,7 +27,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">= 10.0.0"
+    "node": ">= 12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/middleware-bucket-endpoint/package.json
+++ b/packages/middleware-bucket-endpoint/package.json
@@ -30,7 +30,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">= 10.0.0"
+    "node": ">= 12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/middleware-content-length/package.json
+++ b/packages/middleware-content-length/package.json
@@ -26,7 +26,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">= 10.0.0"
+    "node": ">= 12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/middleware-endpoint-discovery/package.json
+++ b/packages/middleware-endpoint-discovery/package.json
@@ -29,7 +29,7 @@
     "tslib": "^2.3.0"
   },
   "engines": {
-    "node": ">= 10.0.0"
+    "node": ">= 12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/middleware-eventstream/package.json
+++ b/packages/middleware-eventstream/package.json
@@ -26,7 +26,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">= 10.0.0"
+    "node": ">= 12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/middleware-expect-continue/package.json
+++ b/packages/middleware-expect-continue/package.json
@@ -27,7 +27,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">= 10.0.0"
+    "node": ">= 12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/middleware-header-default/package.json
+++ b/packages/middleware-header-default/package.json
@@ -26,7 +26,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">= 10.0.0"
+    "node": ">= 12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/middleware-host-header/package.json
+++ b/packages/middleware-host-header/package.json
@@ -26,7 +26,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">= 10.0.0"
+    "node": ">= 12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/middleware-location-constraint/package.json
+++ b/packages/middleware-location-constraint/package.json
@@ -25,7 +25,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">= 10.0.0"
+    "node": ">= 12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/middleware-logger/package.json
+++ b/packages/middleware-logger/package.json
@@ -28,7 +28,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">= 10.0.0"
+    "node": ">= 12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/middleware-retry/package.json
+++ b/packages/middleware-retry/package.json
@@ -29,7 +29,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">= 10.0.0"
+    "node": ">= 12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/middleware-sdk-api-gateway/package.json
+++ b/packages/middleware-sdk-api-gateway/package.json
@@ -26,7 +26,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">= 10.0.0"
+    "node": ">= 12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/middleware-sdk-ec2/package.json
+++ b/packages/middleware-sdk-ec2/package.json
@@ -28,7 +28,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">= 10.0.0"
+    "node": ">= 12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/middleware-sdk-glacier/package.json
+++ b/packages/middleware-sdk-glacier/package.json
@@ -26,7 +26,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">= 10.0.0"
+    "node": ">= 12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/middleware-sdk-machinelearning/package.json
+++ b/packages/middleware-sdk-machinelearning/package.json
@@ -26,7 +26,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">= 10.0.0"
+    "node": ">= 12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/middleware-sdk-rds/package.json
+++ b/packages/middleware-sdk-rds/package.json
@@ -28,7 +28,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">= 10.0.0"
+    "node": ">= 12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/middleware-sdk-route53/package.json
+++ b/packages/middleware-sdk-route53/package.json
@@ -25,7 +25,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">= 10.0.0"
+    "node": ">= 12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/middleware-sdk-s3-control/package.json
+++ b/packages/middleware-sdk-s3-control/package.json
@@ -29,7 +29,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">= 10.0.0"
+    "node": ">= 12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/middleware-sdk-s3/package.json
+++ b/packages/middleware-sdk-s3/package.json
@@ -38,7 +38,7 @@
     "@aws-sdk/signature-v4-crt": "^3.31.0"
   },
   "engines": {
-    "node": ">= 10.0.0"
+    "node": ">= 12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/middleware-sdk-sqs/package.json
+++ b/packages/middleware-sdk-sqs/package.json
@@ -26,7 +26,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">= 10.0.0"
+    "node": ">= 12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/middleware-sdk-sts/package.json
+++ b/packages/middleware-sdk-sts/package.json
@@ -29,7 +29,7 @@
     "tslib": "^2.3.0"
   },
   "engines": {
-    "node": ">= 10.0.0"
+    "node": ">= 12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/middleware-sdk-transcribe-streaming/package.json
+++ b/packages/middleware-sdk-transcribe-streaming/package.json
@@ -34,7 +34,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">= 10.0.0"
+    "node": ">= 12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/middleware-serde/package.json
+++ b/packages/middleware-serde/package.json
@@ -25,7 +25,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">= 10.0.0"
+    "node": ">= 12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/middleware-signing/package.json
+++ b/packages/middleware-signing/package.json
@@ -28,7 +28,7 @@
     "tslib": "^2.3.0"
   },
   "engines": {
-    "node": ">= 10.0.0"
+    "node": ">= 12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/middleware-ssec/package.json
+++ b/packages/middleware-ssec/package.json
@@ -25,7 +25,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">= 10.0.0"
+    "node": ">= 12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/middleware-stack/package.json
+++ b/packages/middleware-stack/package.json
@@ -27,7 +27,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">= 10.0.0"
+    "node": ">= 12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/middleware-user-agent/package.json
+++ b/packages/middleware-user-agent/package.json
@@ -27,7 +27,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">= 10.0.0"
+    "node": ">= 12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/node-config-provider/package.json
+++ b/packages/node-config-provider/package.json
@@ -30,7 +30,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">= 10.0.0"
+    "node": ">= 12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/node-http-handler/package.json
+++ b/packages/node-http-handler/package.json
@@ -37,7 +37,7 @@
     ]
   },
   "engines": {
-    "node": ">= 10.0.0"
+    "node": ">= 12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/polly-request-presigner/package.json
+++ b/packages/polly-request-presigner/package.json
@@ -32,7 +32,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">= 10.0.0"
+    "node": ">= 12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/property-provider/package.json
+++ b/packages/property-provider/package.json
@@ -25,7 +25,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">= 10.0.0"
+    "node": ">= 12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/protocol-http/package.json
+++ b/packages/protocol-http/package.json
@@ -26,7 +26,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">= 10.0.0"
+    "node": ">= 12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/querystring-builder/package.json
+++ b/packages/querystring-builder/package.json
@@ -26,7 +26,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">= 10.0.0"
+    "node": ">= 12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/querystring-parser/package.json
+++ b/packages/querystring-parser/package.json
@@ -25,7 +25,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">= 10.0.0"
+    "node": ">= 12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/s3-presigned-post/package.json
+++ b/packages/s3-presigned-post/package.json
@@ -32,7 +32,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">= 10.0.0"
+    "node": ">= 12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/s3-request-presigner/package.json
+++ b/packages/s3-request-presigner/package.json
@@ -34,7 +34,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">= 10.0.0"
+    "node": ">= 12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/service-error-classification/package.json
+++ b/packages/service-error-classification/package.json
@@ -22,7 +22,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">= 10.0.0"
+    "node": ">= 12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/sha256-tree-hash/package.json
+++ b/packages/sha256-tree-hash/package.json
@@ -28,7 +28,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">= 10.0.0"
+    "node": ">= 12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/shared-ini-file-loader/package.json
+++ b/packages/shared-ini-file-loader/package.json
@@ -25,7 +25,7 @@
   "module": "./dist-es/index.js",
   "types": "./dist-types/index.d.ts",
   "engines": {
-    "node": ">= 10.0.0"
+    "node": ">= 12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/signature-v4-crt/package.json
+++ b/packages/signature-v4-crt/package.json
@@ -35,7 +35,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">= 10.0.0"
+    "node": ">= 12.0.0"
   },
   "files": [
     "dist-*"

--- a/packages/signature-v4/package.json
+++ b/packages/signature-v4/package.json
@@ -32,7 +32,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">= 10.0.0"
+    "node": ">= 12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/smithy-client/package.json
+++ b/packages/smithy-client/package.json
@@ -26,7 +26,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">= 10.0.0"
+    "node": ">= 12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -22,7 +22,7 @@
   },
   "license": "Apache-2.0",
   "engines": {
-    "node": ">= 10.0.0"
+    "node": ">= 12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/util-arn-parser/package.json
+++ b/packages/util-arn-parser/package.json
@@ -26,7 +26,7 @@
   },
   "types": "./dist-types/index.d.ts",
   "engines": {
-    "node": ">= 10.0.0"
+    "node": ">= 12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/util-base64-node/package.json
+++ b/packages/util-base64-node/package.json
@@ -27,7 +27,7 @@
   },
   "types": "./dist-types/index.d.ts",
   "engines": {
-    "node": ">= 10.0.0"
+    "node": ">= 12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/util-body-length-node/package.json
+++ b/packages/util-body-length-node/package.json
@@ -26,7 +26,7 @@
     "tslib": "^2.3.0"
   },
   "engines": {
-    "node": ">= 10.0.0"
+    "node": ">= 12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/util-buffer-from/package.json
+++ b/packages/util-buffer-from/package.json
@@ -26,7 +26,7 @@
   "module": "./dist-es/index.js",
   "types": "./dist-types/index.d.ts",
   "engines": {
-    "node": ">= 10.0.0"
+    "node": ">= 12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/util-config-provider/package.json
+++ b/packages/util-config-provider/package.json
@@ -27,7 +27,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">= 10.0.0"
+    "node": ">= 12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/util-create-request/package.json
+++ b/packages/util-create-request/package.json
@@ -29,7 +29,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">= 10.0.0"
+    "node": ">= 12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/util-credentials/package.json
+++ b/packages/util-credentials/package.json
@@ -31,7 +31,7 @@
   },
   "types": "./dist-types/index.d.ts",
   "engines": {
-    "node": ">= 10.0.0"
+    "node": ">= 12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/util-dynamodb/package.json
+++ b/packages/util-dynamodb/package.json
@@ -25,7 +25,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">= 10.0.0"
+    "node": ">= 12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/util-format-url/package.json
+++ b/packages/util-format-url/package.json
@@ -26,7 +26,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">= 10.0.0"
+    "node": ">= 12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/util-hex-encoding/package.json
+++ b/packages/util-hex-encoding/package.json
@@ -25,7 +25,7 @@
   },
   "types": "./dist-types/index.d.ts",
   "engines": {
-    "node": ">= 10.0.0"
+    "node": ">= 12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/util-locate-window/package.json
+++ b/packages/util-locate-window/package.json
@@ -25,7 +25,7 @@
   "module": "./dist-es/index.js",
   "types": "./dist-types/index.d.ts",
   "engines": {
-    "node": ">= 10.0.0"
+    "node": ">= 12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/util-uri-escape/package.json
+++ b/packages/util-uri-escape/package.json
@@ -24,7 +24,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">= 10.0.0"
+    "node": ">= 12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/util-user-agent-node/package.json
+++ b/packages/util-user-agent-node/package.json
@@ -28,7 +28,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">= 10.0.0"
+    "node": ">= 12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/util-utf8-node/package.json
+++ b/packages/util-utf8-node/package.json
@@ -30,7 +30,7 @@
   },
   "types": "./dist-types/index.d.ts",
   "engines": {
-    "node": ">= 10.0.0"
+    "node": ">= 12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/util-waiter/package.json
+++ b/packages/util-waiter/package.json
@@ -27,7 +27,7 @@
   "module": "./dist-es/index.js",
   "types": "./dist-types/index.d.ts",
   "engines": {
-    "node": ">= 10.0.0"
+    "node": ">= 12.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/xml-builder/package.json
+++ b/packages/xml-builder/package.json
@@ -25,7 +25,7 @@
   "module": "./dist-es/index.js",
   "types": "./dist-types/index.d.ts",
   "engines": {
-    "node": ">= 10.0.0"
+    "node": ">= 12.0.0"
   },
   "typesVersions": {
     "<4.0": {


### PR DESCRIPTION
### Issue
We announced [the end of support for Node.js 10.x in the AWS SDK for JavaScript (v3)](https://aws.amazon.com/blogs/developer/announcing-the-end-of-support-for-node-js-10-x-in-the-aws-sdk-for-javascript-v3/) starting January 1, 2022 back in July.
The value for engines.node was bumped for clients in https://github.com/aws/aws-sdk-js-v3/pull/3122, but was missed for non-clients.

### Description
Bump engines to node >=12.0.0 in package.json for non-clients

### Testing
N/A

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
