### PR TITLE
chore(typedoc): move root typedocOptions to typedoc.json

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,18 +20,5 @@
     "target": "es5"
   },
   "include": ["packages/", "lib/"],
-  "exclude": ["node_modules/", "**/*.spec.ts"],
-  "typedocOptions": {
-    "readme": "README.md",
-    "mode": "modules",
-    "out": "docs",
-    "exclude": ["**/node_modules/**", "**/*.spec.ts"],
-    "excludeExternals": true,
-    "name": "AWS SDK for JavaScript v3",
-    "ignoreCompilerErrors": true,
-    "theme": "minimal",
-    "hideGenerator": true,
-    "clientDocs": "clients/{{CLIENT}}/docs",
-    "plugin": ["typedoc-plugin-lerna-packages", "@aws-sdk/core-packages-documentation-generator"]
-  }
+  "exclude": ["node_modules/", "**/*.spec.ts"]
 }

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,0 +1,13 @@
+{
+  "clientDocs": "clients/{{CLIENT}}/docs",
+  "exclude": ["**/node_modules/**", "**/*.spec.ts"],
+  "excludeExternals": true,
+  "hideGenerator": true,
+  "ignoreCompilerErrors": true,
+  "mode": "modules",
+  "name": "AWS SDK for JavaScript v3",
+  "out": "docs",
+  "plugin": ["typedoc-plugin-lerna-packages", "@aws-sdk/core-packages-documentation-generator"],
+  "readme": "README.md",
+  "theme": "minimal"
+}


### PR DESCRIPTION
### Issue
Similar to https://github.com/aws/aws-sdk-js-v3/pull/3135, but for non-clients at root

### Description
Moved root typedocOptions to typedoc.json

### Testing
Verified that `build-documentation` script is successful.

```console
$ yarn build-documentation --clientDocs docs/clients/{{CLIENT}} --theme
...
Rendering [========================================] 100%

Documentation generated at /local/home/trivikr/workspace/backup/backup-aws-sdk-js-v3/docs

Done in 11.11s.

$ ls docs
assets  classes  enums  globals.html  index.html  interfaces  modules
```

### Additional context
Add any other context about the PR here.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
