### PR TITLE
feat(scripts): update tsconfig files while copying clients

### DIFF
--- a/scripts/generate-clients/config/tsconfig.cjs.json
+++ b/scripts/generate-clients/config/tsconfig.cjs.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "rootDir": "src",
+    "outDir": "dist-cjs"
+  },
+  "exclude": ["test/**/*"],
+  "extends": "../../tsconfig.cjs.json",
+  "include": ["src/"]
+}

--- a/scripts/generate-clients/config/tsconfig.es.json
+++ b/scripts/generate-clients/config/tsconfig.es.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "rootDir": "src",
+    "outDir": "dist-es",
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"]
+  },
+  "extends": "../../tsconfig.es.json",
+  "include": ["src/"]
+}

--- a/scripts/generate-clients/config/tsconfig.types.json
+++ b/scripts/generate-clients/config/tsconfig.types.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "rootDir": "src",
+    "declarationDir": "dist-types"
+  },
+  "exclude": ["test/**/*", "dist-types/**/*"],
+  "extends": "../../tsconfig.types.json",
+  "include": ["src/"]
+}

--- a/scripts/generate-clients/config/typedoc.json
+++ b/scripts/generate-clients/config/typedoc.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../typedoc.client.json"
+}

--- a/scripts/generate-clients/copy-to-clients.js
+++ b/scripts/generate-clients/copy-to-clients.js
@@ -4,6 +4,9 @@ const { copySync, removeSync } = require("fs-extra");
 const { readdirSync, lstatSync, readFileSync, existsSync, writeFileSync } = require("fs");
 
 const typedocJson = require("./config/typedoc.json");
+const tsconfigCjsJson = require("./config/tsconfig.cjs.json");
+const tsconfigEsJson = require("./config/tsconfig.es.json");
+const tsconfigTypesJson = require("./config/tsconfig.types.json");
 
 const getOverwritableDirectories = (subDirectories, packageName) => {
   const additionalGeneratedFiles = {
@@ -149,6 +152,20 @@ const copyToClients = async (sourceDir, destinationDir) => {
       } else if (overWritableSubs.includes(packageSub) || !existsSync(destSubPath)) {
         if (packageSub === "typedoc.json") {
           writeFileSync(destSubPath, JSON.stringify(typedocJson, null, 2).concat(`\n`));
+        } else if (packageSub.startsWith("tsconfig")) {
+          switch (packageSub) {
+            case "tsconfig.json":
+              const tsconfigCjsPath = join(destPath, "tsconfig.cjs.json");
+              if (existsSync(tsconfigCjsPath)) break;
+              writeFileSync(tsconfigCjsPath, JSON.stringify(tsconfigCjsJson, null, 2).concat(`\n`));
+              break;
+            case "tsconfig.es.json":
+              writeFileSync(destSubPath, JSON.stringify(tsconfigEsJson, null, 2).concat(`\n`));
+              break;
+            case "tsconfig.types.json":
+              writeFileSync(destSubPath, JSON.stringify(tsconfigTypesJson, null, 2).concat(`\n`));
+              break;
+          }
         } else {
           if (lstatSync(packageSubPath).isDirectory()) removeSync(destSubPath);
           copySync(packageSubPath, destSubPath, {

--- a/scripts/generate-clients/copy-to-clients.js
+++ b/scripts/generate-clients/copy-to-clients.js
@@ -40,12 +40,22 @@ const mergeManifest = (fromContent = {}, toContent = {}) => {
         const devDepsInRoot = ["downlevel-dts", "rimraf", "typedoc", "typescript"];
         devDepsInRoot.forEach((devDep) => delete fromContent[name][devDep]);
       }
+
+      // Replace tsconfig.json with tsconfig.cjs.json in scripts
+      if (name === "scripts") {
+        Object.entries(fromContent[name]).forEach(([key, value]) => {
+          fromContent[name][key] = value.replace("tsconfig.json", "tsconfig.cjs.json");
+        });
+      }
+
       merged[name] = mergeManifest(fromContent[name], toContent[name]);
+
       if (name === "scripts" || name === "devDependencies") {
         // Allow target package.json(toContent) has its own special script or
         // dev dependencies that won't be overwritten in codegen
         merged[name] = { ...toContent[name], ...merged[name] };
       }
+
       if (name === "scripts" || name === "dependencies" || name === "devDependencies") {
         // Sort by keys to make sure the order is stable
         merged[name] = Object.fromEntries(Object.entries(merged[name]).sort());

--- a/scripts/generate-clients/copy-to-clients.js
+++ b/scripts/generate-clients/copy-to-clients.js
@@ -3,6 +3,8 @@ const { normalize, join } = require("path");
 const { copySync, removeSync } = require("fs-extra");
 const { readdirSync, lstatSync, readFileSync, existsSync, writeFileSync } = require("fs");
 
+const typedocJson = require("./config/typedoc.json");
+
 const getOverwritableDirectories = (subDirectories, packageName) => {
   const additionalGeneratedFiles = {
     "@aws-sdk/client-sts": ["defaultRoleAssumers.ts", "defaultStsRoleAssumers.ts", "defaultRoleAssumers.spec.ts"],
@@ -144,16 +146,15 @@ const copyToClients = async (sourceDir, destinationDir) => {
           },
         };
         writeFileSync(destSubPath, JSON.stringify(mergedManifest, null, 2).concat(`\n`));
-      } else if (packageSub === "typedoc.json") {
-        const typedocJson = {
-          extends: "../../typedoc.client.json",
-        };
-        writeFileSync(destSubPath, JSON.stringify(typedocJson, null, 2).concat(`\n`));
       } else if (overWritableSubs.includes(packageSub) || !existsSync(destSubPath)) {
-        if (lstatSync(packageSubPath).isDirectory()) removeSync(destSubPath);
-        copySync(packageSubPath, destSubPath, {
-          overwrite: true,
-        });
+        if (packageSub === "typedoc.json") {
+          writeFileSync(destSubPath, JSON.stringify(typedocJson, null, 2).concat(`\n`));
+        } else {
+          if (lstatSync(packageSubPath).isDirectory()) removeSync(destSubPath);
+          copySync(packageSubPath, destSubPath, {
+            overwrite: true,
+          });
+        }
       }
     }
   }


### PR DESCRIPTION
### Issue
Codegen for https://github.com/aws/aws-sdk-js-v3/pull/3151

### Description
Add script to update tsconfig files copying clients

### Testing
Verified with client-acm that:
* The occurrences of `tsconfig.json` are replaced with `tsconfig.cjs.json`
* The tsconfig files are copied correctly

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
