### PR TITLE
fix(md5-js): remove unnecessary exclude from tsconfig

### DIFF
--- a/packages/md5-js/tsconfig.cjs.json
+++ b/packages/md5-js/tsconfig.cjs.json
@@ -4,7 +4,6 @@
     "outDir": "dist-cjs",
     "rootDir": "src"
   },
-  "exclude": ["./build/**"],
   "include": ["src/"],
   "extends": "../../tsconfig.cjs.json"
 }


### PR DESCRIPTION
### Issue
Noticed in build failures while using root TSConfig in clients at #3151

### Description
Removes unnecessary exclude from tsconfig in md5-js

### Testing
Verified that build is successful

```console
$ md5-js> yarn build
yarn run v1.22.17
$ yarn build:cjs && yarn build:es && yarn build:types
$ tsc -p tsconfig.cjs.json
$ tsc -p tsconfig.es.json
$ tsc -p tsconfig.types.json
Done in 4.24s.
```

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
