### PR TITLE
test(aws-protocoltests-json-10): extend from jest.config.base.js

### DIFF
--- a/private/aws-protocoltests-json-10/jest.config.js
+++ b/private/aws-protocoltests-json-10/jest.config.js
@@ -1,4 +1,5 @@
+const base = require("../../jest.config.base.js");
+
 module.exports = {
-  preset: "ts-jest",
-  testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+  ...base,
 };


### PR DESCRIPTION
### Issue
This issue was identified while attempting to use root TSConfig in clients in https://github.com/aws/aws-sdk-js-v3/pull/3149

### Description
Extend jest.config.js in aws-protocoltests-json-10 from jest.config.base.js

### Testing
Verified that unit tests are successfully run in aws-protocoltests-json-10

```console
$ aws-protocoltests-json-10> yarn test
...
Test Suites: 1 passed, 1 total
Tests:       47 passed, 47 total
Snapshots:   0 total
Time:        6.934 s
Ran all test suites.
Done in 7.98s.
```

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
