### PR TITLE
chore(jest): remove unused configuration

### DIFF
--- a/jest.config.integ.js
+++ b/jest.config.integ.js
@@ -1,8 +1,3 @@
-const base = require("./jest.config.base.js");
-
 module.exports = {
-  ...base,
   projects: ["<rootDir>/clients/*/jest.integ.config.js"],
-  testPathIgnorePatterns: ["/node_modules/"],
-  coveragePathIgnorePatterns: ["/node_modules/", "/__fixtures__/"],
 };

--- a/jest.config.js
+++ b/jest.config.js
@@ -7,6 +7,4 @@ module.exports = {
     "<rootDir>/private/*/jest.config.js",
     "<rootDir>/packages/*/jest.config.js",
   ],
-  testPathIgnorePatterns: ["/node_modules/", "<rootDir>/clients/client-.*"],
-  coveragePathIgnorePatterns: ["/node_modules/", "<rootDir>/clients/client-.*", "/__fixtures__/"],
 };

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,7 +1,4 @@
-const base = require("./jest.config.base.js");
-
 module.exports = {
-  ...base,
   projects: [
     "<rootDir>/lib/*/jest.config.js",
     "<rootDir>/private/*/jest.config.js",


### PR DESCRIPTION
### Issue
Improvement noticed while working on root TSConfigs in https://github.com/aws/aws-sdk-js-v3/pull/3151

### Description
Removes unused configuration from `jest.config.js` and `jest.config.integ.js`
The `jest.config.js` uses [projects](https://jestjs.io/docs/configuration#projects-arraystring--projectconfig) configuration to specify which packages should run jest, and doesn't run the test in `<rootDir>`. Rest of the configuration is not used.

### Testing
CI

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
