### PR TITLE
chore(jest): use custom tsconfig for running tests

### DIFF
--- a/jest.config.base.js
+++ b/jest.config.base.js
@@ -1,9 +1,11 @@
+const { compilerOptions } = require("@tsconfig/recommended/tsconfig.json");
+
 module.exports = {
   preset: "ts-jest",
   testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
   globals: {
     "ts-jest": {
-      tsconfig: "tsconfig.test.json",
+      tsconfig: { ...compilerOptions, noImplicitAny: false },
     },
   },
 };

--- a/jest.config.base.js
+++ b/jest.config.base.js
@@ -1,4 +1,9 @@
 module.exports = {
   preset: "ts-jest",
   testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
+  globals: {
+    "ts-jest": {
+      tsconfig: "tsconfig.test.json",
+    },
+  },
 };

--- a/jest.config.base.js
+++ b/jest.config.base.js
@@ -5,7 +5,11 @@ module.exports = {
   testMatch: ["**/*.spec.ts", "!**/*.browser.spec.ts", "!**/*.integ.spec.ts"],
   globals: {
     "ts-jest": {
-      tsconfig: { ...compilerOptions, noImplicitAny: false },
+      tsconfig: {
+        ...compilerOptions,
+        noImplicitAny: false,
+        strictNullChecks: false,
+      },
     },
   },
 };

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "@commitlint/cli": "^11.0.0",
     "@commitlint/config-conventional": "^11.0.0",
     "@mixer/parallel-prettier": "^2.0.1",
+    "@tsconfig/recommended": "^1.0.1",
     "@types/chai-as-promised": "^7.1.2",
     "@types/fs-extra": "^8.0.1",
     "@types/jest": "27.4.0",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "@commitlint/cli": "^11.0.0",
     "@commitlint/config-conventional": "^11.0.0",
     "@mixer/parallel-prettier": "^2.0.1",
-    "@tsconfig/recommended": "^1.0.1",
+    "@tsconfig/recommended": "1.0.1",
     "@types/chai-as-promised": "^7.1.2",
     "@types/fs-extra": "^8.0.1",
     "@types/jest": "27.4.0",

--- a/packages/credential-providers/src/fromTemporaryCredentials.spec.ts
+++ b/packages/credential-providers/src/fromTemporaryCredentials.spec.ts
@@ -1,14 +1,13 @@
 const sendMock = jest.fn();
 jest.mock("@aws-sdk/client-sts", () => ({
-  STSClient: jest.fn().mockImplementation(function (config) {
-    this.config = config;
-    this.send = jest.fn().mockImplementation(async function (command) {
+  STSClient: jest.fn().mockImplementation((config) => ({
+    config,
+    send: jest.fn().mockImplementation(async function (command) {
       // Mock resolving client credentials provider at send()
-      if (typeof this.config.credentials === "function") this.config.credentials = await this.config.credentials();
+      if (typeof config.credentials === "function") config.credentials = await config.credentials();
       return await sendMock(command);
-    });
-    return this;
-  }),
+    }),
+  })),
   AssumeRoleCommand: jest.fn().mockImplementation(function (params) {
     // Return the input so we can assert the input parameters in client's send()
     return {

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,3 @@
+{
+  "extends": "@tsconfig/recommended/tsconfig.json"
+}

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,3 +1,0 @@
-{
-  "extends": "@tsconfig/recommended/tsconfig.json"
-}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1938,6 +1938,11 @@
   resolved "https://registry.yarnpkg.com/@tsconfig/node16/-/node16-1.0.2.tgz#423c77877d0569db20e1fc80885ac4118314010e"
   integrity sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==
 
+"@tsconfig/recommended@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@tsconfig/recommended/-/recommended-1.0.1.tgz#7619bad397e06ead1c5182926c944e0ca6177f52"
+  integrity sha512-2xN+iGTbPBEzGSnVp/Hd64vKJCJWxsi9gfs88x4PPMyEjHJoA3o5BY9r5OLPHIZU2pAQxkSAsJFqn6itClP8mQ==
+
 "@types/babel__core@^7.0.0":
   version "7.1.14"
   resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.1.14.tgz#faaeefc4185ec71c389f4501ee5ec84b170cc402"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1938,7 +1938,7 @@
   resolved "https://registry.yarnpkg.com/@tsconfig/node16/-/node16-1.0.2.tgz#423c77877d0569db20e1fc80885ac4118314010e"
   integrity sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==
 
-"@tsconfig/recommended@^1.0.1":
+"@tsconfig/recommended@1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@tsconfig/recommended/-/recommended-1.0.1.tgz#7619bad397e06ead1c5182926c944e0ca6177f52"
   integrity sha512-2xN+iGTbPBEzGSnVp/Hd64vKJCJWxsi9gfs88x4PPMyEjHJoA3o5BY9r5OLPHIZU2pAQxkSAsJFqn6itClP8mQ==


### PR DESCRIPTION
### Issue
This issue was identified while attempting to use root TSConfig in clients in #3149

### Description
Uses custom tsconfig while running tests

### Testing
CI

### Additional context
PRs to merge before making this PR ready:
* https://github.com/aws/aws-sdk-js-v3/pull/3159
* https://github.com/aws/aws-sdk-js-v3/pull/3160

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
