### PR TITLE
chore: add npm script clean to all packages

### DIFF
--- a/lib/lib-dynamodb/package.json
+++ b/lib/lib-dynamodb/package.json
@@ -11,6 +11,7 @@
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
+    "clean": "rimraf ./dist-*",
     "test": "jest"
   },
   "engines": {

--- a/lib/lib-storage/package.json
+++ b/lib/lib-storage/package.json
@@ -11,6 +11,7 @@
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
+    "clean": "rimraf ./dist-*",
     "test": "jest"
   },
   "engines": {

--- a/packages/abort-controller/package.json
+++ b/packages/abort-controller/package.json
@@ -11,6 +11,7 @@
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
+    "clean": "rimraf ./dist-*",
     "test": "jest"
   },
   "author": {

--- a/packages/body-checksum-browser/package.json
+++ b/packages/body-checksum-browser/package.json
@@ -7,6 +7,7 @@
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
+    "clean": "rimraf ./dist-*",
     "test": "jest"
   },
   "main": "./dist-cjs/index.js",

--- a/packages/body-checksum-node/package.json
+++ b/packages/body-checksum-node/package.json
@@ -7,6 +7,7 @@
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
+    "clean": "rimraf ./dist-*",
     "test": "jest"
   },
   "main": "./dist-cjs/index.js",

--- a/packages/chunked-blob-reader-native/package.json
+++ b/packages/chunked-blob-reader-native/package.json
@@ -7,6 +7,7 @@
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
+    "clean": "rimraf ./dist-*",
     "test": "jest"
   },
   "main": "./dist-cjs/index.js",

--- a/packages/chunked-blob-reader/package.json
+++ b/packages/chunked-blob-reader/package.json
@@ -7,6 +7,7 @@
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
+    "clean": "rimraf ./dist-*",
     "test": "jest"
   },
   "main": "./dist-cjs/index.js",

--- a/packages/chunked-stream-reader-node/package.json
+++ b/packages/chunked-stream-reader-node/package.json
@@ -7,6 +7,7 @@
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
+    "clean": "rimraf ./dist-*",
     "test": "jest"
   },
   "main": "./dist-cjs/index.js",

--- a/packages/config-resolver/package.json
+++ b/packages/config-resolver/package.json
@@ -7,6 +7,7 @@
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
+    "clean": "rimraf ./dist-*",
     "test": "jest"
   },
   "main": "./dist-cjs/index.js",

--- a/packages/core-packages-documentation-generator/package.json
+++ b/packages/core-packages-documentation-generator/package.json
@@ -7,6 +7,7 @@
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
+    "clean": "rimraf ./dist-*",
     "test": "exit 0"
   },
   "main": "./dist-cjs/index.js",

--- a/packages/credential-provider-cognito-identity/package.json
+++ b/packages/credential-provider-cognito-identity/package.json
@@ -7,6 +7,7 @@
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
+    "clean": "rimraf ./dist-*",
     "test": "jest"
   },
   "main": "./dist-cjs/index.js",

--- a/packages/credential-provider-env/package.json
+++ b/packages/credential-provider-env/package.json
@@ -10,6 +10,7 @@
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
+    "clean": "rimraf ./dist-*",
     "test": "jest"
   },
   "keywords": [

--- a/packages/credential-provider-imds/package.json
+++ b/packages/credential-provider-imds/package.json
@@ -10,6 +10,7 @@
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
+    "clean": "rimraf ./dist-*",
     "test": "jest"
   },
   "keywords": [

--- a/packages/credential-provider-ini/package.json
+++ b/packages/credential-provider-ini/package.json
@@ -10,6 +10,7 @@
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
+    "clean": "rimraf ./dist-*",
     "test": "jest"
   },
   "keywords": [

--- a/packages/credential-provider-node/package.json
+++ b/packages/credential-provider-node/package.json
@@ -13,6 +13,7 @@
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
+    "clean": "rimraf ./dist-*",
     "test": "jest"
   },
   "keywords": [

--- a/packages/credential-provider-process/package.json
+++ b/packages/credential-provider-process/package.json
@@ -10,6 +10,7 @@
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
+    "clean": "rimraf ./dist-*",
     "test": "jest"
   },
   "keywords": [

--- a/packages/credential-provider-sso/package.json
+++ b/packages/credential-provider-sso/package.json
@@ -10,6 +10,7 @@
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
+    "clean": "rimraf ./dist-*",
     "test": "jest"
   },
   "keywords": [

--- a/packages/credential-provider-web-identity/package.json
+++ b/packages/credential-provider-web-identity/package.json
@@ -10,6 +10,7 @@
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
+    "clean": "rimraf ./dist-*",
     "test": "jest"
   },
   "browser": {

--- a/packages/credential-providers/package.json
+++ b/packages/credential-providers/package.json
@@ -13,6 +13,7 @@
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
+    "clean": "rimraf ./dist-*",
     "test": "jest"
   },
   "keywords": [

--- a/packages/endpoint-cache/package.json
+++ b/packages/endpoint-cache/package.json
@@ -7,6 +7,7 @@
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
+    "clean": "rimraf ./dist-*",
     "test": "jest --passWithNoTests"
   },
   "author": {

--- a/packages/eventstream-handler-node/package.json
+++ b/packages/eventstream-handler-node/package.json
@@ -7,6 +7,7 @@
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
+    "clean": "rimraf ./dist-*",
     "test": "jest"
   },
   "main": "./dist-cjs/index.js",

--- a/packages/eventstream-marshaller/package.json
+++ b/packages/eventstream-marshaller/package.json
@@ -7,6 +7,7 @@
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
+    "clean": "rimraf ./dist-*",
     "test": "jest --coverage"
   },
   "main": "./dist-cjs/index.js",

--- a/packages/eventstream-serde-browser/package.json
+++ b/packages/eventstream-serde-browser/package.json
@@ -7,6 +7,7 @@
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
+    "clean": "rimraf ./dist-*",
     "test": "jest"
   },
   "main": "./dist-cjs/index.js",

--- a/packages/eventstream-serde-config-resolver/package.json
+++ b/packages/eventstream-serde-config-resolver/package.json
@@ -7,6 +7,7 @@
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
+    "clean": "rimraf ./dist-*",
     "test": "jest"
   },
   "main": "./dist-cjs/index.js",

--- a/packages/eventstream-serde-node/package.json
+++ b/packages/eventstream-serde-node/package.json
@@ -7,6 +7,7 @@
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
+    "clean": "rimraf ./dist-*",
     "test": "jest"
   },
   "main": "./dist-cjs/index.js",

--- a/packages/eventstream-serde-universal/package.json
+++ b/packages/eventstream-serde-universal/package.json
@@ -7,6 +7,7 @@
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
+    "clean": "rimraf ./dist-*",
     "test": "jest"
   },
   "main": "./dist-cjs/index.js",

--- a/packages/fetch-http-handler/package.json
+++ b/packages/fetch-http-handler/package.json
@@ -8,6 +8,7 @@
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
+    "clean": "rimraf ./dist-*",
     "test": "jest --coverage && karma start karma.conf.js"
   },
   "author": {

--- a/packages/hash-blob-browser/package.json
+++ b/packages/hash-blob-browser/package.json
@@ -7,6 +7,7 @@
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
+    "clean": "rimraf ./dist-*",
     "test": "karma start karma.conf.js"
   },
   "main": "./dist-cjs/index.js",

--- a/packages/hash-node/package.json
+++ b/packages/hash-node/package.json
@@ -7,6 +7,7 @@
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
+    "clean": "rimraf ./dist-*",
     "test": "jest"
   },
   "main": "./dist-cjs/index.js",

--- a/packages/hash-stream-node/package.json
+++ b/packages/hash-stream-node/package.json
@@ -7,6 +7,7 @@
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
+    "clean": "rimraf ./dist-*",
     "test": "jest"
   },
   "main": "./dist-cjs/index.js",

--- a/packages/invalid-dependency/package.json
+++ b/packages/invalid-dependency/package.json
@@ -7,6 +7,7 @@
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
+    "clean": "rimraf ./dist-*",
     "test": "jest"
   },
   "main": "./dist-cjs/index.js",

--- a/packages/is-array-buffer/package.json
+++ b/packages/is-array-buffer/package.json
@@ -8,6 +8,7 @@
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
+    "clean": "rimraf ./dist-*",
     "test": "jest"
   },
   "author": {

--- a/packages/karma-credential-loader/package.json
+++ b/packages/karma-credential-loader/package.json
@@ -8,6 +8,7 @@
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
+    "clean": "rimraf ./dist-*",
     "test": "jest --passWithNoTests"
   },
   "main": "./dist-cjs/index.js",

--- a/packages/md5-js/package.json
+++ b/packages/md5-js/package.json
@@ -7,6 +7,7 @@
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
+    "clean": "rimraf ./dist-*",
     "test": "jest"
   },
   "main": "./dist-cjs/index.js",

--- a/packages/middleware-apply-body-checksum/package.json
+++ b/packages/middleware-apply-body-checksum/package.json
@@ -7,6 +7,7 @@
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
+    "clean": "rimraf ./dist-*",
     "test": "jest --coverage"
   },
   "main": "./dist-cjs/index.js",

--- a/packages/middleware-bucket-endpoint/package.json
+++ b/packages/middleware-bucket-endpoint/package.json
@@ -7,6 +7,7 @@
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
+    "clean": "rimraf ./dist-*",
     "test": "jest"
   },
   "main": "./dist-cjs/index.js",

--- a/packages/middleware-content-length/package.json
+++ b/packages/middleware-content-length/package.json
@@ -7,6 +7,7 @@
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
+    "clean": "rimraf ./dist-*",
     "test": "jest"
   },
   "main": "./dist-cjs/index.js",

--- a/packages/middleware-endpoint-discovery/package.json
+++ b/packages/middleware-endpoint-discovery/package.json
@@ -7,6 +7,7 @@
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
+    "clean": "rimraf ./dist-*",
     "test": "jest"
   },
   "main": "./dist-cjs/index.js",

--- a/packages/middleware-eventstream/package.json
+++ b/packages/middleware-eventstream/package.json
@@ -7,6 +7,7 @@
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
+    "clean": "rimraf ./dist-*",
     "test": "jest"
   },
   "main": "./dist-cjs/index.js",

--- a/packages/middleware-expect-continue/package.json
+++ b/packages/middleware-expect-continue/package.json
@@ -7,6 +7,7 @@
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
+    "clean": "rimraf ./dist-*",
     "test": "jest"
   },
   "main": "./dist-cjs/index.js",

--- a/packages/middleware-header-default/package.json
+++ b/packages/middleware-header-default/package.json
@@ -7,6 +7,7 @@
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
+    "clean": "rimraf ./dist-*",
     "test": "jest"
   },
   "main": "./dist-cjs/index.js",

--- a/packages/middleware-host-header/package.json
+++ b/packages/middleware-host-header/package.json
@@ -7,6 +7,7 @@
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
+    "clean": "rimraf ./dist-*",
     "test": "jest"
   },
   "main": "./dist-cjs/index.js",

--- a/packages/middleware-location-constraint/package.json
+++ b/packages/middleware-location-constraint/package.json
@@ -7,6 +7,7 @@
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
+    "clean": "rimraf ./dist-*",
     "test": "jest"
   },
   "main": "./dist-cjs/index.js",

--- a/packages/middleware-logger/package.json
+++ b/packages/middleware-logger/package.json
@@ -7,6 +7,7 @@
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
+    "clean": "rimraf ./dist-*",
     "test": "jest --passWithNoTests"
   },
   "author": {

--- a/packages/middleware-retry/package.json
+++ b/packages/middleware-retry/package.json
@@ -7,6 +7,7 @@
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
+    "clean": "rimraf ./dist-*",
     "test": "jest"
   },
   "main": "./dist-cjs/index.js",

--- a/packages/middleware-sdk-api-gateway/package.json
+++ b/packages/middleware-sdk-api-gateway/package.json
@@ -7,6 +7,7 @@
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
+    "clean": "rimraf ./dist-*",
     "test": "jest"
   },
   "main": "./dist-cjs/index.js",

--- a/packages/middleware-sdk-ec2/package.json
+++ b/packages/middleware-sdk-ec2/package.json
@@ -7,6 +7,7 @@
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
+    "clean": "rimraf ./dist-*",
     "test": "jest"
   },
   "main": "./dist-cjs/index.js",

--- a/packages/middleware-sdk-glacier/package.json
+++ b/packages/middleware-sdk-glacier/package.json
@@ -7,6 +7,7 @@
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
+    "clean": "rimraf ./dist-*",
     "test": "jest"
   },
   "main": "./dist-cjs/index.js",

--- a/packages/middleware-sdk-machinelearning/package.json
+++ b/packages/middleware-sdk-machinelearning/package.json
@@ -7,6 +7,7 @@
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
+    "clean": "rimraf ./dist-*",
     "test": "jest"
   },
   "main": "./dist-cjs/index.js",

--- a/packages/middleware-sdk-rds/package.json
+++ b/packages/middleware-sdk-rds/package.json
@@ -7,6 +7,7 @@
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
+    "clean": "rimraf ./dist-*",
     "test": "jest"
   },
   "main": "./dist-cjs/index.js",

--- a/packages/middleware-sdk-route53/package.json
+++ b/packages/middleware-sdk-route53/package.json
@@ -7,6 +7,7 @@
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
+    "clean": "rimraf ./dist-*",
     "test": "jest"
   },
   "main": "./dist-cjs/index.js",

--- a/packages/middleware-sdk-s3-control/package.json
+++ b/packages/middleware-sdk-s3-control/package.json
@@ -7,6 +7,7 @@
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
+    "clean": "rimraf ./dist-*",
     "test": "jest"
   },
   "main": "./dist-cjs/index.js",

--- a/packages/middleware-sdk-s3/package.json
+++ b/packages/middleware-sdk-s3/package.json
@@ -7,6 +7,7 @@
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
+    "clean": "rimraf ./dist-*",
     "test": "jest"
   },
   "main": "./dist-cjs/index.js",

--- a/packages/middleware-sdk-sqs/package.json
+++ b/packages/middleware-sdk-sqs/package.json
@@ -7,6 +7,7 @@
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
+    "clean": "rimraf ./dist-*",
     "test": "jest"
   },
   "main": "./dist-cjs/index.js",

--- a/packages/middleware-sdk-sts/package.json
+++ b/packages/middleware-sdk-sts/package.json
@@ -7,6 +7,7 @@
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
+    "clean": "rimraf ./dist-*",
     "test": "jest"
   },
   "main": "./dist-cjs/index.js",

--- a/packages/middleware-sdk-transcribe-streaming/package.json
+++ b/packages/middleware-sdk-transcribe-streaming/package.json
@@ -10,6 +10,7 @@
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
+    "clean": "rimraf ./dist-*",
     "pretest": "yarn build",
     "test": "jest --passWithNoTests"
   },

--- a/packages/middleware-serde/package.json
+++ b/packages/middleware-serde/package.json
@@ -7,6 +7,7 @@
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
+    "clean": "rimraf ./dist-*",
     "test": "jest"
   },
   "main": "./dist-cjs/index.js",

--- a/packages/middleware-signing/package.json
+++ b/packages/middleware-signing/package.json
@@ -7,6 +7,7 @@
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
+    "clean": "rimraf ./dist-*",
     "test": "jest"
   },
   "main": "./dist-cjs/index.js",

--- a/packages/middleware-ssec/package.json
+++ b/packages/middleware-ssec/package.json
@@ -7,6 +7,7 @@
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
+    "clean": "rimraf ./dist-*",
     "test": "jest"
   },
   "main": "./dist-cjs/index.js",

--- a/packages/middleware-stack/package.json
+++ b/packages/middleware-stack/package.json
@@ -8,6 +8,7 @@
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
+    "clean": "rimraf ./dist-*",
     "test": "jest"
   },
   "author": {

--- a/packages/middleware-user-agent/package.json
+++ b/packages/middleware-user-agent/package.json
@@ -7,6 +7,7 @@
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
+    "clean": "rimraf ./dist-*",
     "test": "jest --passWithNoTests"
   },
   "main": "./dist-cjs/index.js",

--- a/packages/node-config-provider/package.json
+++ b/packages/node-config-provider/package.json
@@ -8,6 +8,7 @@
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
+    "clean": "rimraf ./dist-*",
     "test": "jest --passWithNoTests"
   },
   "author": {

--- a/packages/node-http-handler/package.json
+++ b/packages/node-http-handler/package.json
@@ -8,6 +8,7 @@
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
+    "clean": "rimraf ./dist-*",
     "test": "jest --coverage"
   },
   "author": {

--- a/packages/polly-request-presigner/package.json
+++ b/packages/polly-request-presigner/package.json
@@ -7,6 +7,7 @@
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
+    "clean": "rimraf ./dist-*",
     "test": "jest"
   },
   "main": "./dist-cjs/index.js",

--- a/packages/property-provider/package.json
+++ b/packages/property-provider/package.json
@@ -7,6 +7,7 @@
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
+    "clean": "rimraf ./dist-*",
     "test": "jest"
   },
   "main": "./dist-cjs/index.js",

--- a/packages/protocol-http/package.json
+++ b/packages/protocol-http/package.json
@@ -7,6 +7,7 @@
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
+    "clean": "rimraf ./dist-*",
     "test": "jest"
   },
   "main": "./dist-cjs/index.js",

--- a/packages/querystring-builder/package.json
+++ b/packages/querystring-builder/package.json
@@ -7,6 +7,7 @@
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
+    "clean": "rimraf ./dist-*",
     "test": "jest"
   },
   "main": "./dist-cjs/index.js",

--- a/packages/querystring-parser/package.json
+++ b/packages/querystring-parser/package.json
@@ -7,6 +7,7 @@
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
+    "clean": "rimraf ./dist-*",
     "test": "jest"
   },
   "main": "./dist-cjs/index.js",

--- a/packages/s3-presigned-post/package.json
+++ b/packages/s3-presigned-post/package.json
@@ -7,6 +7,7 @@
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
+    "clean": "rimraf ./dist-*",
     "test": "jest"
   },
   "main": "./dist-cjs/index.js",

--- a/packages/s3-request-presigner/package.json
+++ b/packages/s3-request-presigner/package.json
@@ -7,6 +7,7 @@
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
+    "clean": "rimraf ./dist-*",
     "test": "jest"
   },
   "main": "./dist-cjs/index.js",

--- a/packages/service-client-documentation-generator/package.json
+++ b/packages/service-client-documentation-generator/package.json
@@ -7,6 +7,7 @@
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
+    "clean": "rimraf ./dist-*",
     "test": "exit 0"
   },
   "main": "./dist-cjs/index.js",

--- a/packages/service-error-classification/package.json
+++ b/packages/service-error-classification/package.json
@@ -7,6 +7,7 @@
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
+    "clean": "rimraf ./dist-*",
     "test": "jest"
   },
   "main": "./dist-cjs/index.js",

--- a/packages/sha256-tree-hash/package.json
+++ b/packages/sha256-tree-hash/package.json
@@ -7,6 +7,7 @@
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
+    "clean": "rimraf ./dist-*",
     "test": "jest"
   },
   "main": "./dist-cjs/index.js",

--- a/packages/shared-ini-file-loader/package.json
+++ b/packages/shared-ini-file-loader/package.json
@@ -13,6 +13,7 @@
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
+    "clean": "rimraf ./dist-*",
     "test": "jest"
   },
   "author": {

--- a/packages/signature-v4-crt/package.json
+++ b/packages/signature-v4-crt/package.json
@@ -11,6 +11,7 @@
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
+    "clean": "rimraf ./dist-*",
     "test": "jest --coverage"
   },
   "author": {

--- a/packages/signature-v4/package.json
+++ b/packages/signature-v4/package.json
@@ -11,6 +11,7 @@
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
+    "clean": "rimraf ./dist-*",
     "test": "jest --coverage"
   },
   "author": {

--- a/packages/smithy-client/package.json
+++ b/packages/smithy-client/package.json
@@ -7,6 +7,7 @@
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
+    "clean": "rimraf ./dist-*",
     "test": "jest --passWithNoTests"
   },
   "main": "./dist-cjs/index.js",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -11,6 +11,7 @@
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
+    "clean": "rimraf ./dist-*",
     "test": "exit 0"
   },
   "author": {

--- a/packages/url-parser/package.json
+++ b/packages/url-parser/package.json
@@ -7,6 +7,7 @@
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
+    "clean": "rimraf ./dist-*",
     "test": "jest"
   },
   "main": "./dist-cjs/index.js",

--- a/packages/util-arn-parser/package.json
+++ b/packages/util-arn-parser/package.json
@@ -10,6 +10,7 @@
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
+    "clean": "rimraf ./dist-*",
     "test": "jest"
   },
   "author": {

--- a/packages/util-base64-browser/package.json
+++ b/packages/util-base64-browser/package.json
@@ -10,6 +10,7 @@
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
+    "clean": "rimraf ./dist-*",
     "test": "jest"
   },
   "author": {

--- a/packages/util-base64-node/package.json
+++ b/packages/util-base64-node/package.json
@@ -10,6 +10,7 @@
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
+    "clean": "rimraf ./dist-*",
     "test": "jest"
   },
   "author": {

--- a/packages/util-body-length-browser/package.json
+++ b/packages/util-body-length-browser/package.json
@@ -8,6 +8,7 @@
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
+    "clean": "rimraf ./dist-*",
     "test": "jest"
   },
   "main": "./dist-cjs/index.js",

--- a/packages/util-body-length-node/package.json
+++ b/packages/util-body-length-node/package.json
@@ -8,6 +8,7 @@
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
+    "clean": "rimraf ./dist-*",
     "test": "jest"
   },
   "devDependencies": {

--- a/packages/util-buffer-from/package.json
+++ b/packages/util-buffer-from/package.json
@@ -7,6 +7,7 @@
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
+    "clean": "rimraf ./dist-*",
     "test": "jest"
   },
   "author": {

--- a/packages/util-config-provider/package.json
+++ b/packages/util-config-provider/package.json
@@ -8,6 +8,7 @@
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
+    "clean": "rimraf ./dist-*",
     "test": "jest --passWithNoTests"
   },
   "author": {

--- a/packages/util-create-request/package.json
+++ b/packages/util-create-request/package.json
@@ -7,6 +7,7 @@
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
+    "clean": "rimraf ./dist-*",
     "test": "jest"
   },
   "main": "./dist-cjs/index.js",

--- a/packages/util-credentials/package.json
+++ b/packages/util-credentials/package.json
@@ -10,6 +10,7 @@
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
+    "clean": "rimraf ./dist-*",
     "test": "jest"
   },
   "keywords": [

--- a/packages/util-dynamodb/package.json
+++ b/packages/util-dynamodb/package.json
@@ -7,6 +7,7 @@
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
+    "clean": "rimraf ./dist-*",
     "test": "jest"
   },
   "main": "./dist-cjs/index.js",

--- a/packages/util-format-url/package.json
+++ b/packages/util-format-url/package.json
@@ -7,6 +7,7 @@
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
+    "clean": "rimraf ./dist-*",
     "test": "jest"
   },
   "main": "./dist-cjs/index.js",

--- a/packages/util-hex-encoding/package.json
+++ b/packages/util-hex-encoding/package.json
@@ -8,6 +8,7 @@
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
+    "clean": "rimraf ./dist-*",
     "test": "jest"
   },
   "author": {

--- a/packages/util-locate-window/package.json
+++ b/packages/util-locate-window/package.json
@@ -7,6 +7,7 @@
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
+    "clean": "rimraf ./dist-*",
     "test": "jest"
   },
   "author": {

--- a/packages/util-uri-escape/package.json
+++ b/packages/util-uri-escape/package.json
@@ -7,6 +7,7 @@
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
+    "clean": "rimraf ./dist-*",
     "test": "jest"
   },
   "main": "./dist-cjs/index.js",

--- a/packages/util-user-agent-browser/package.json
+++ b/packages/util-user-agent-browser/package.json
@@ -7,6 +7,7 @@
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
+    "clean": "rimraf ./dist-*",
     "test": "jest"
   },
   "main": "./dist-cjs/index.js",

--- a/packages/util-user-agent-node/package.json
+++ b/packages/util-user-agent-node/package.json
@@ -7,6 +7,7 @@
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
+    "clean": "rimraf ./dist-*",
     "test": "jest"
   },
   "main": "./dist-cjs/index.js",

--- a/packages/util-utf8-browser/package.json
+++ b/packages/util-utf8-browser/package.json
@@ -10,6 +10,7 @@
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
+    "clean": "rimraf ./dist-*",
     "test": "jest"
   },
   "author": {

--- a/packages/util-utf8-node/package.json
+++ b/packages/util-utf8-node/package.json
@@ -10,6 +10,7 @@
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
+    "clean": "rimraf ./dist-*",
     "test": "jest"
   },
   "author": {

--- a/packages/util-waiter/package.json
+++ b/packages/util-waiter/package.json
@@ -13,6 +13,7 @@
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
+    "clean": "rimraf ./dist-*",
     "test": "jest"
   },
   "author": {

--- a/packages/xml-builder/package.json
+++ b/packages/xml-builder/package.json
@@ -11,6 +11,7 @@
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
+    "clean": "rimraf ./dist-*",
     "test": "jest"
   },
   "author": {


### PR DESCRIPTION
### Issue
Refs: https://github.com/aws/aws-sdk-js-v3/pull/3166

### Description
Adds npm script clean to all packages

<details>
<summary>Script used for adding clean</summary>

```js
import { readdirSync, readFileSync, writeFileSync } from "fs";
import { join } from "path";

const workspaces = ["clients", "private", "packages", "lib"];

workspaces.forEach((workspacesDir) => {
  // Process each workspace in workspace directory
  readdirSync(join(process.cwd(), workspacesDir), { withFileTypes: true })
    .filter((dirent) => dirent.isDirectory())
    .map((dirent) => dirent.name)
    .forEach((workspaceDir) => {
      const cwd = join(process.cwd(), workspacesDir, workspaceDir);

      const packageJsonPath = join(cwd, "package.json");
      const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf8").toString());
      if (!packageJson["scripts"]["clean"]) {
        writeFileSync(
          packageJsonPath,
          JSON.stringify(
            {
              ...packageJson,
              scripts: Object.fromEntries(
                Object.entries({
                  ...packageJson.scripts,
                  clean: "rimraf ./dist-*",
                }).sort()
              ),
            },
            null,
            2
          ).concat(`\n`)
        );
      }
    });
});

```

</details>

### Testing
Verified that running yarn clean deletes the dist-* folder with abort-controller package.

<details>
<summary>Output</summary>

```console
$ abort-controller> ls dist-*
dist-cjs:
AbortController.js  AbortSignal.js  index.js

dist-es:
AbortController.js  AbortSignal.js  index.js

dist-types:
AbortController.d.ts  AbortSignal.d.ts  index.d.ts

$ abort-controller> yarn clean
yarn run v1.22.17
$ rimraf ./dist-*
Done in 0.10s.

$ abort-controller> ls dist-* 
zsh: no matches found: dist-*
```

</details>


---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
