### PR TITLE
chore(clients): populate default variant only if hostname exists

### DIFF
--- a/clients/client-accessanalyzer/src/endpoints.ts
+++ b/clients/client-accessanalyzer/src/endpoints.ts
@@ -5,10 +5,6 @@ const regionHash: RegionHash = {
   "ca-central-1": {
     variants: [
       {
-        hostname: "access-analyzer.ca-central-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "access-analyzer-fips.ca-central-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -17,10 +13,6 @@ const regionHash: RegionHash = {
   "us-east-1": {
     variants: [
       {
-        hostname: "access-analyzer.us-east-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "access-analyzer-fips.us-east-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -28,10 +20,6 @@ const regionHash: RegionHash = {
   },
   "us-east-2": {
     variants: [
-      {
-        hostname: "access-analyzer.us-east-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "access-analyzer-fips.us-east-2.amazonaws.com",
         tags: ["fips"],
@@ -59,10 +47,6 @@ const regionHash: RegionHash = {
   "us-west-1": {
     variants: [
       {
-        hostname: "access-analyzer.us-west-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "access-analyzer-fips.us-west-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -70,10 +54,6 @@ const regionHash: RegionHash = {
   },
   "us-west-2": {
     variants: [
-      {
-        hostname: "access-analyzer.us-west-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "access-analyzer-fips.us-west-2.amazonaws.com",
         tags: ["fips"],

--- a/clients/client-acm-pca/src/endpoints.ts
+++ b/clients/client-acm-pca/src/endpoints.ts
@@ -5,10 +5,6 @@ const regionHash: RegionHash = {
   "ca-central-1": {
     variants: [
       {
-        hostname: "acm-pca.ca-central-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "acm-pca-fips.ca-central-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -17,10 +13,6 @@ const regionHash: RegionHash = {
   "us-east-1": {
     variants: [
       {
-        hostname: "acm-pca.us-east-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "acm-pca-fips.us-east-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -28,10 +20,6 @@ const regionHash: RegionHash = {
   },
   "us-east-2": {
     variants: [
-      {
-        hostname: "acm-pca.us-east-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "acm-pca-fips.us-east-2.amazonaws.com",
         tags: ["fips"],
@@ -42,20 +30,12 @@ const regionHash: RegionHash = {
     variants: [
       {
         hostname: "acm-pca.us-gov-east-1.amazonaws.com",
-        tags: [],
-      },
-      {
-        hostname: "acm-pca.us-gov-east-1.amazonaws.com",
         tags: ["fips"],
       },
     ],
   },
   "us-gov-west-1": {
     variants: [
-      {
-        hostname: "acm-pca.us-gov-west-1.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "acm-pca.us-gov-west-1.amazonaws.com",
         tags: ["fips"],
@@ -65,10 +45,6 @@ const regionHash: RegionHash = {
   "us-west-1": {
     variants: [
       {
-        hostname: "acm-pca.us-west-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "acm-pca-fips.us-west-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -76,10 +52,6 @@ const regionHash: RegionHash = {
   },
   "us-west-2": {
     variants: [
-      {
-        hostname: "acm-pca.us-west-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "acm-pca-fips.us-west-2.amazonaws.com",
         tags: ["fips"],

--- a/clients/client-acm/src/endpoints.ts
+++ b/clients/client-acm/src/endpoints.ts
@@ -5,10 +5,6 @@ const regionHash: RegionHash = {
   "ca-central-1": {
     variants: [
       {
-        hostname: "acm.ca-central-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "acm-fips.ca-central-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -17,10 +13,6 @@ const regionHash: RegionHash = {
   "us-east-1": {
     variants: [
       {
-        hostname: "acm.us-east-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "acm-fips.us-east-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -28,10 +20,6 @@ const regionHash: RegionHash = {
   },
   "us-east-2": {
     variants: [
-      {
-        hostname: "acm.us-east-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "acm-fips.us-east-2.amazonaws.com",
         tags: ["fips"],
@@ -59,10 +47,6 @@ const regionHash: RegionHash = {
   "us-west-1": {
     variants: [
       {
-        hostname: "acm.us-west-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "acm-fips.us-west-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -70,10 +54,6 @@ const regionHash: RegionHash = {
   },
   "us-west-2": {
     variants: [
-      {
-        hostname: "acm.us-west-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "acm-fips.us-west-2.amazonaws.com",
         tags: ["fips"],

--- a/clients/client-appstream/src/endpoints.ts
+++ b/clients/client-appstream/src/endpoints.ts
@@ -5,10 +5,6 @@ const regionHash: RegionHash = {
   "us-east-1": {
     variants: [
       {
-        hostname: "appstream2.us-east-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "appstream2-fips.us-east-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -17,10 +13,6 @@ const regionHash: RegionHash = {
   "us-gov-west-1": {
     variants: [
       {
-        hostname: "appstream2.us-gov-west-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "appstream2-fips.us-gov-west-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -28,10 +20,6 @@ const regionHash: RegionHash = {
   },
   "us-west-2": {
     variants: [
-      {
-        hostname: "appstream2.us-west-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "appstream2-fips.us-west-2.amazonaws.com",
         tags: ["fips"],

--- a/clients/client-athena/src/endpoints.ts
+++ b/clients/client-athena/src/endpoints.ts
@@ -5,10 +5,6 @@ const regionHash: RegionHash = {
   "us-east-1": {
     variants: [
       {
-        hostname: "athena.us-east-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "athena-fips.us-east-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -16,10 +12,6 @@ const regionHash: RegionHash = {
   },
   "us-east-2": {
     variants: [
-      {
-        hostname: "athena.us-east-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "athena-fips.us-east-2.amazonaws.com",
         tags: ["fips"],
@@ -29,10 +21,6 @@ const regionHash: RegionHash = {
   "us-gov-east-1": {
     variants: [
       {
-        hostname: "athena.us-gov-east-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "athena-fips.us-gov-east-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -40,10 +28,6 @@ const regionHash: RegionHash = {
   },
   "us-gov-west-1": {
     variants: [
-      {
-        hostname: "athena.us-gov-west-1.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "athena-fips.us-gov-west-1.amazonaws.com",
         tags: ["fips"],
@@ -53,10 +37,6 @@ const regionHash: RegionHash = {
   "us-west-1": {
     variants: [
       {
-        hostname: "athena.us-west-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "athena-fips.us-west-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -64,10 +44,6 @@ const regionHash: RegionHash = {
   },
   "us-west-2": {
     variants: [
-      {
-        hostname: "athena.us-west-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "athena-fips.us-west-2.amazonaws.com",
         tags: ["fips"],

--- a/clients/client-batch/src/endpoints.ts
+++ b/clients/client-batch/src/endpoints.ts
@@ -5,10 +5,6 @@ const regionHash: RegionHash = {
   "us-east-1": {
     variants: [
       {
-        hostname: "batch.us-east-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "fips.batch.us-east-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -16,10 +12,6 @@ const regionHash: RegionHash = {
   },
   "us-east-2": {
     variants: [
-      {
-        hostname: "batch.us-east-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "fips.batch.us-east-2.amazonaws.com",
         tags: ["fips"],
@@ -30,20 +22,12 @@ const regionHash: RegionHash = {
     variants: [
       {
         hostname: "batch.us-gov-east-1.amazonaws.com",
-        tags: [],
-      },
-      {
-        hostname: "batch.us-gov-east-1.amazonaws.com",
         tags: ["fips"],
       },
     ],
   },
   "us-gov-west-1": {
     variants: [
-      {
-        hostname: "batch.us-gov-west-1.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "batch.us-gov-west-1.amazonaws.com",
         tags: ["fips"],
@@ -53,10 +37,6 @@ const regionHash: RegionHash = {
   "us-west-1": {
     variants: [
       {
-        hostname: "batch.us-west-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "fips.batch.us-west-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -64,10 +44,6 @@ const regionHash: RegionHash = {
   },
   "us-west-2": {
     variants: [
-      {
-        hostname: "batch.us-west-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "fips.batch.us-west-2.amazonaws.com",
         tags: ["fips"],

--- a/clients/client-chime-sdk-identity/src/endpoints.ts
+++ b/clients/client-chime-sdk-identity/src/endpoints.ts
@@ -5,10 +5,6 @@ const regionHash: RegionHash = {
   "us-east-1": {
     variants: [
       {
-        hostname: "identity-chime.us-east-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "identity-chime-fips.us-east-1.amazonaws.com",
         tags: ["fips"],
       },

--- a/clients/client-chime-sdk-meetings/src/endpoints.ts
+++ b/clients/client-chime-sdk-meetings/src/endpoints.ts
@@ -5,10 +5,6 @@ const regionHash: RegionHash = {
   "us-east-1": {
     variants: [
       {
-        hostname: "meetings-chime.us-east-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "meetings-chime-fips.us-east-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -16,10 +12,6 @@ const regionHash: RegionHash = {
   },
   "us-west-2": {
     variants: [
-      {
-        hostname: "meetings-chime.us-west-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "meetings-chime-fips.us-west-2.amazonaws.com",
         tags: ["fips"],

--- a/clients/client-chime-sdk-messaging/src/endpoints.ts
+++ b/clients/client-chime-sdk-messaging/src/endpoints.ts
@@ -5,10 +5,6 @@ const regionHash: RegionHash = {
   "us-east-1": {
     variants: [
       {
-        hostname: "messaging-chime.us-east-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "messaging-chime-fips.us-east-1.amazonaws.com",
         tags: ["fips"],
       },

--- a/clients/client-cloudcontrol/src/endpoints.ts
+++ b/clients/client-cloudcontrol/src/endpoints.ts
@@ -5,10 +5,6 @@ const regionHash: RegionHash = {
   "ca-central-1": {
     variants: [
       {
-        hostname: "cloudcontrolapi.ca-central-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "cloudcontrolapi-fips.ca-central-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -16,10 +12,6 @@ const regionHash: RegionHash = {
   },
   "us-east-1": {
     variants: [
-      {
-        hostname: "cloudcontrolapi.us-east-1.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "cloudcontrolapi-fips.us-east-1.amazonaws.com",
         tags: ["fips"],
@@ -29,10 +21,6 @@ const regionHash: RegionHash = {
   "us-east-2": {
     variants: [
       {
-        hostname: "cloudcontrolapi.us-east-2.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "cloudcontrolapi-fips.us-east-2.amazonaws.com",
         tags: ["fips"],
       },
@@ -40,10 +28,6 @@ const regionHash: RegionHash = {
   },
   "us-gov-east-1": {
     variants: [
-      {
-        hostname: "cloudcontrolapi.us-gov-east-1.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "cloudcontrolapi-fips.us-gov-east-1.amazonaws.com",
         tags: ["fips"],
@@ -53,10 +37,6 @@ const regionHash: RegionHash = {
   "us-gov-west-1": {
     variants: [
       {
-        hostname: "cloudcontrolapi.us-gov-west-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "cloudcontrolapi-fips.us-gov-west-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -65,10 +45,6 @@ const regionHash: RegionHash = {
   "us-west-1": {
     variants: [
       {
-        hostname: "cloudcontrolapi.us-west-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "cloudcontrolapi-fips.us-west-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -76,10 +52,6 @@ const regionHash: RegionHash = {
   },
   "us-west-2": {
     variants: [
-      {
-        hostname: "cloudcontrolapi.us-west-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "cloudcontrolapi-fips.us-west-2.amazonaws.com",
         tags: ["fips"],

--- a/clients/client-cloudformation/src/endpoints.ts
+++ b/clients/client-cloudformation/src/endpoints.ts
@@ -5,10 +5,6 @@ const regionHash: RegionHash = {
   "us-east-1": {
     variants: [
       {
-        hostname: "cloudformation.us-east-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "cloudformation-fips.us-east-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -16,10 +12,6 @@ const regionHash: RegionHash = {
   },
   "us-east-2": {
     variants: [
-      {
-        hostname: "cloudformation.us-east-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "cloudformation-fips.us-east-2.amazonaws.com",
         tags: ["fips"],
@@ -47,10 +39,6 @@ const regionHash: RegionHash = {
   "us-west-1": {
     variants: [
       {
-        hostname: "cloudformation.us-west-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "cloudformation-fips.us-west-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -58,10 +46,6 @@ const regionHash: RegionHash = {
   },
   "us-west-2": {
     variants: [
-      {
-        hostname: "cloudformation.us-west-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "cloudformation-fips.us-west-2.amazonaws.com",
         tags: ["fips"],

--- a/clients/client-cloudtrail/src/endpoints.ts
+++ b/clients/client-cloudtrail/src/endpoints.ts
@@ -5,10 +5,6 @@ const regionHash: RegionHash = {
   "us-east-1": {
     variants: [
       {
-        hostname: "cloudtrail.us-east-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "cloudtrail-fips.us-east-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -16,10 +12,6 @@ const regionHash: RegionHash = {
   },
   "us-east-2": {
     variants: [
-      {
-        hostname: "cloudtrail.us-east-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "cloudtrail-fips.us-east-2.amazonaws.com",
         tags: ["fips"],
@@ -47,10 +39,6 @@ const regionHash: RegionHash = {
   "us-west-1": {
     variants: [
       {
-        hostname: "cloudtrail.us-west-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "cloudtrail-fips.us-west-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -58,10 +46,6 @@ const regionHash: RegionHash = {
   },
   "us-west-2": {
     variants: [
-      {
-        hostname: "cloudtrail.us-west-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "cloudtrail-fips.us-west-2.amazonaws.com",
         tags: ["fips"],

--- a/clients/client-cloudwatch-events/src/endpoints.ts
+++ b/clients/client-cloudwatch-events/src/endpoints.ts
@@ -5,10 +5,6 @@ const regionHash: RegionHash = {
   "us-east-1": {
     variants: [
       {
-        hostname: "events.us-east-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "events-fips.us-east-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -16,10 +12,6 @@ const regionHash: RegionHash = {
   },
   "us-east-2": {
     variants: [
-      {
-        hostname: "events.us-east-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "events-fips.us-east-2.amazonaws.com",
         tags: ["fips"],
@@ -47,10 +39,6 @@ const regionHash: RegionHash = {
   "us-west-1": {
     variants: [
       {
-        hostname: "events.us-west-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "events-fips.us-west-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -58,10 +46,6 @@ const regionHash: RegionHash = {
   },
   "us-west-2": {
     variants: [
-      {
-        hostname: "events.us-west-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "events-fips.us-west-2.amazonaws.com",
         tags: ["fips"],

--- a/clients/client-cloudwatch-logs/src/endpoints.ts
+++ b/clients/client-cloudwatch-logs/src/endpoints.ts
@@ -5,10 +5,6 @@ const regionHash: RegionHash = {
   "us-east-1": {
     variants: [
       {
-        hostname: "logs.us-east-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "logs-fips.us-east-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -16,10 +12,6 @@ const regionHash: RegionHash = {
   },
   "us-east-2": {
     variants: [
-      {
-        hostname: "logs.us-east-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "logs-fips.us-east-2.amazonaws.com",
         tags: ["fips"],
@@ -47,10 +39,6 @@ const regionHash: RegionHash = {
   "us-west-1": {
     variants: [
       {
-        hostname: "logs.us-west-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "logs-fips.us-west-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -58,10 +46,6 @@ const regionHash: RegionHash = {
   },
   "us-west-2": {
     variants: [
-      {
-        hostname: "logs.us-west-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "logs-fips.us-west-2.amazonaws.com",
         tags: ["fips"],

--- a/clients/client-cloudwatch/src/endpoints.ts
+++ b/clients/client-cloudwatch/src/endpoints.ts
@@ -5,10 +5,6 @@ const regionHash: RegionHash = {
   "us-east-1": {
     variants: [
       {
-        hostname: "monitoring.us-east-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "monitoring-fips.us-east-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -16,10 +12,6 @@ const regionHash: RegionHash = {
   },
   "us-east-2": {
     variants: [
-      {
-        hostname: "monitoring.us-east-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "monitoring-fips.us-east-2.amazonaws.com",
         tags: ["fips"],
@@ -30,20 +22,12 @@ const regionHash: RegionHash = {
     variants: [
       {
         hostname: "monitoring.us-gov-east-1.amazonaws.com",
-        tags: [],
-      },
-      {
-        hostname: "monitoring.us-gov-east-1.amazonaws.com",
         tags: ["fips"],
       },
     ],
   },
   "us-gov-west-1": {
     variants: [
-      {
-        hostname: "monitoring.us-gov-west-1.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "monitoring.us-gov-west-1.amazonaws.com",
         tags: ["fips"],
@@ -53,10 +37,6 @@ const regionHash: RegionHash = {
   "us-west-1": {
     variants: [
       {
-        hostname: "monitoring.us-west-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "monitoring-fips.us-west-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -64,10 +44,6 @@ const regionHash: RegionHash = {
   },
   "us-west-2": {
     variants: [
-      {
-        hostname: "monitoring.us-west-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "monitoring-fips.us-west-2.amazonaws.com",
         tags: ["fips"],

--- a/clients/client-codebuild/src/endpoints.ts
+++ b/clients/client-codebuild/src/endpoints.ts
@@ -5,10 +5,6 @@ const regionHash: RegionHash = {
   "us-east-1": {
     variants: [
       {
-        hostname: "codebuild.us-east-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "codebuild-fips.us-east-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -16,10 +12,6 @@ const regionHash: RegionHash = {
   },
   "us-east-2": {
     variants: [
-      {
-        hostname: "codebuild.us-east-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "codebuild-fips.us-east-2.amazonaws.com",
         tags: ["fips"],
@@ -29,10 +21,6 @@ const regionHash: RegionHash = {
   "us-gov-east-1": {
     variants: [
       {
-        hostname: "codebuild.us-gov-east-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "codebuild-fips.us-gov-east-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -40,10 +28,6 @@ const regionHash: RegionHash = {
   },
   "us-gov-west-1": {
     variants: [
-      {
-        hostname: "codebuild.us-gov-west-1.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "codebuild-fips.us-gov-west-1.amazonaws.com",
         tags: ["fips"],
@@ -53,10 +37,6 @@ const regionHash: RegionHash = {
   "us-west-1": {
     variants: [
       {
-        hostname: "codebuild.us-west-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "codebuild-fips.us-west-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -64,10 +44,6 @@ const regionHash: RegionHash = {
   },
   "us-west-2": {
     variants: [
-      {
-        hostname: "codebuild.us-west-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "codebuild-fips.us-west-2.amazonaws.com",
         tags: ["fips"],

--- a/clients/client-codecommit/src/endpoints.ts
+++ b/clients/client-codecommit/src/endpoints.ts
@@ -5,10 +5,6 @@ const regionHash: RegionHash = {
   "ca-central-1": {
     variants: [
       {
-        hostname: "codecommit.ca-central-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "codecommit-fips.ca-central-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -16,10 +12,6 @@ const regionHash: RegionHash = {
   },
   "us-east-1": {
     variants: [
-      {
-        hostname: "codecommit.us-east-1.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "codecommit-fips.us-east-1.amazonaws.com",
         tags: ["fips"],
@@ -29,10 +21,6 @@ const regionHash: RegionHash = {
   "us-east-2": {
     variants: [
       {
-        hostname: "codecommit.us-east-2.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "codecommit-fips.us-east-2.amazonaws.com",
         tags: ["fips"],
       },
@@ -40,10 +28,6 @@ const regionHash: RegionHash = {
   },
   "us-gov-east-1": {
     variants: [
-      {
-        hostname: "codecommit.us-gov-east-1.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "codecommit-fips.us-gov-east-1.amazonaws.com",
         tags: ["fips"],
@@ -53,10 +37,6 @@ const regionHash: RegionHash = {
   "us-gov-west-1": {
     variants: [
       {
-        hostname: "codecommit.us-gov-west-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "codecommit-fips.us-gov-west-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -65,10 +45,6 @@ const regionHash: RegionHash = {
   "us-west-1": {
     variants: [
       {
-        hostname: "codecommit.us-west-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "codecommit-fips.us-west-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -76,10 +52,6 @@ const regionHash: RegionHash = {
   },
   "us-west-2": {
     variants: [
-      {
-        hostname: "codecommit.us-west-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "codecommit-fips.us-west-2.amazonaws.com",
         tags: ["fips"],

--- a/clients/client-codedeploy/src/endpoints.ts
+++ b/clients/client-codedeploy/src/endpoints.ts
@@ -5,10 +5,6 @@ const regionHash: RegionHash = {
   "us-east-1": {
     variants: [
       {
-        hostname: "codedeploy.us-east-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "codedeploy-fips.us-east-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -16,10 +12,6 @@ const regionHash: RegionHash = {
   },
   "us-east-2": {
     variants: [
-      {
-        hostname: "codedeploy.us-east-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "codedeploy-fips.us-east-2.amazonaws.com",
         tags: ["fips"],
@@ -29,10 +21,6 @@ const regionHash: RegionHash = {
   "us-gov-east-1": {
     variants: [
       {
-        hostname: "codedeploy.us-gov-east-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "codedeploy-fips.us-gov-east-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -40,10 +28,6 @@ const regionHash: RegionHash = {
   },
   "us-gov-west-1": {
     variants: [
-      {
-        hostname: "codedeploy.us-gov-west-1.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "codedeploy-fips.us-gov-west-1.amazonaws.com",
         tags: ["fips"],
@@ -53,10 +37,6 @@ const regionHash: RegionHash = {
   "us-west-1": {
     variants: [
       {
-        hostname: "codedeploy.us-west-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "codedeploy-fips.us-west-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -64,10 +44,6 @@ const regionHash: RegionHash = {
   },
   "us-west-2": {
     variants: [
-      {
-        hostname: "codedeploy.us-west-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "codedeploy-fips.us-west-2.amazonaws.com",
         tags: ["fips"],

--- a/clients/client-codepipeline/src/endpoints.ts
+++ b/clients/client-codepipeline/src/endpoints.ts
@@ -5,10 +5,6 @@ const regionHash: RegionHash = {
   "ca-central-1": {
     variants: [
       {
-        hostname: "codepipeline.ca-central-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "codepipeline-fips.ca-central-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -16,10 +12,6 @@ const regionHash: RegionHash = {
   },
   "us-east-1": {
     variants: [
-      {
-        hostname: "codepipeline.us-east-1.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "codepipeline-fips.us-east-1.amazonaws.com",
         tags: ["fips"],
@@ -29,10 +21,6 @@ const regionHash: RegionHash = {
   "us-east-2": {
     variants: [
       {
-        hostname: "codepipeline.us-east-2.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "codepipeline-fips.us-east-2.amazonaws.com",
         tags: ["fips"],
       },
@@ -40,10 +28,6 @@ const regionHash: RegionHash = {
   },
   "us-gov-west-1": {
     variants: [
-      {
-        hostname: "codepipeline.us-gov-west-1.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "codepipeline-fips.us-gov-west-1.amazonaws.com",
         tags: ["fips"],
@@ -53,10 +37,6 @@ const regionHash: RegionHash = {
   "us-west-1": {
     variants: [
       {
-        hostname: "codepipeline.us-west-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "codepipeline-fips.us-west-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -64,10 +44,6 @@ const regionHash: RegionHash = {
   },
   "us-west-2": {
     variants: [
-      {
-        hostname: "codepipeline.us-west-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "codepipeline-fips.us-west-2.amazonaws.com",
         tags: ["fips"],

--- a/clients/client-cognito-identity-provider/src/endpoints.ts
+++ b/clients/client-cognito-identity-provider/src/endpoints.ts
@@ -5,10 +5,6 @@ const regionHash: RegionHash = {
   "us-east-1": {
     variants: [
       {
-        hostname: "cognito-idp.us-east-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "cognito-idp-fips.us-east-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -16,10 +12,6 @@ const regionHash: RegionHash = {
   },
   "us-east-2": {
     variants: [
-      {
-        hostname: "cognito-idp.us-east-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "cognito-idp-fips.us-east-2.amazonaws.com",
         tags: ["fips"],
@@ -29,10 +21,6 @@ const regionHash: RegionHash = {
   "us-gov-west-1": {
     variants: [
       {
-        hostname: "cognito-idp.us-gov-west-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "cognito-idp-fips.us-gov-west-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -41,10 +29,6 @@ const regionHash: RegionHash = {
   "us-west-1": {
     variants: [
       {
-        hostname: "cognito-idp.us-west-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "cognito-idp-fips.us-west-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -52,10 +36,6 @@ const regionHash: RegionHash = {
   },
   "us-west-2": {
     variants: [
-      {
-        hostname: "cognito-idp.us-west-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "cognito-idp-fips.us-west-2.amazonaws.com",
         tags: ["fips"],

--- a/clients/client-cognito-identity/src/endpoints.ts
+++ b/clients/client-cognito-identity/src/endpoints.ts
@@ -5,10 +5,6 @@ const regionHash: RegionHash = {
   "us-east-1": {
     variants: [
       {
-        hostname: "cognito-identity.us-east-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "cognito-identity-fips.us-east-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -16,10 +12,6 @@ const regionHash: RegionHash = {
   },
   "us-east-2": {
     variants: [
-      {
-        hostname: "cognito-identity.us-east-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "cognito-identity-fips.us-east-2.amazonaws.com",
         tags: ["fips"],
@@ -29,10 +21,6 @@ const regionHash: RegionHash = {
   "us-gov-west-1": {
     variants: [
       {
-        hostname: "cognito-identity.us-gov-west-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "cognito-identity-fips.us-gov-west-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -40,10 +28,6 @@ const regionHash: RegionHash = {
   },
   "us-west-2": {
     variants: [
-      {
-        hostname: "cognito-identity.us-west-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "cognito-identity-fips.us-west-2.amazonaws.com",
         tags: ["fips"],

--- a/clients/client-comprehend/src/endpoints.ts
+++ b/clients/client-comprehend/src/endpoints.ts
@@ -5,10 +5,6 @@ const regionHash: RegionHash = {
   "us-east-1": {
     variants: [
       {
-        hostname: "comprehend.us-east-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "comprehend-fips.us-east-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -16,10 +12,6 @@ const regionHash: RegionHash = {
   },
   "us-east-2": {
     variants: [
-      {
-        hostname: "comprehend.us-east-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "comprehend-fips.us-east-2.amazonaws.com",
         tags: ["fips"],
@@ -29,10 +21,6 @@ const regionHash: RegionHash = {
   "us-gov-west-1": {
     variants: [
       {
-        hostname: "comprehend.us-gov-west-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "comprehend-fips.us-gov-west-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -40,10 +28,6 @@ const regionHash: RegionHash = {
   },
   "us-west-2": {
     variants: [
-      {
-        hostname: "comprehend.us-west-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "comprehend-fips.us-west-2.amazonaws.com",
         tags: ["fips"],

--- a/clients/client-comprehendmedical/src/endpoints.ts
+++ b/clients/client-comprehendmedical/src/endpoints.ts
@@ -5,10 +5,6 @@ const regionHash: RegionHash = {
   "us-east-1": {
     variants: [
       {
-        hostname: "comprehendmedical.us-east-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "comprehendmedical-fips.us-east-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -16,10 +12,6 @@ const regionHash: RegionHash = {
   },
   "us-east-2": {
     variants: [
-      {
-        hostname: "comprehendmedical.us-east-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "comprehendmedical-fips.us-east-2.amazonaws.com",
         tags: ["fips"],
@@ -29,10 +21,6 @@ const regionHash: RegionHash = {
   "us-gov-west-1": {
     variants: [
       {
-        hostname: "comprehendmedical.us-gov-west-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "comprehendmedical-fips.us-gov-west-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -40,10 +28,6 @@ const regionHash: RegionHash = {
   },
   "us-west-2": {
     variants: [
-      {
-        hostname: "comprehendmedical.us-west-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "comprehendmedical-fips.us-west-2.amazonaws.com",
         tags: ["fips"],

--- a/clients/client-config-service/src/endpoints.ts
+++ b/clients/client-config-service/src/endpoints.ts
@@ -5,10 +5,6 @@ const regionHash: RegionHash = {
   "us-east-1": {
     variants: [
       {
-        hostname: "config.us-east-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "config-fips.us-east-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -16,10 +12,6 @@ const regionHash: RegionHash = {
   },
   "us-east-2": {
     variants: [
-      {
-        hostname: "config.us-east-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "config-fips.us-east-2.amazonaws.com",
         tags: ["fips"],
@@ -30,20 +22,12 @@ const regionHash: RegionHash = {
     variants: [
       {
         hostname: "config.us-gov-east-1.amazonaws.com",
-        tags: [],
-      },
-      {
-        hostname: "config.us-gov-east-1.amazonaws.com",
         tags: ["fips"],
       },
     ],
   },
   "us-gov-west-1": {
     variants: [
-      {
-        hostname: "config.us-gov-west-1.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "config.us-gov-west-1.amazonaws.com",
         tags: ["fips"],
@@ -53,10 +37,6 @@ const regionHash: RegionHash = {
   "us-west-1": {
     variants: [
       {
-        hostname: "config.us-west-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "config-fips.us-west-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -64,10 +44,6 @@ const regionHash: RegionHash = {
   },
   "us-west-2": {
     variants: [
-      {
-        hostname: "config.us-west-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "config-fips.us-west-2.amazonaws.com",
         tags: ["fips"],

--- a/clients/client-database-migration-service/src/endpoints.ts
+++ b/clients/client-database-migration-service/src/endpoints.ts
@@ -5,10 +5,6 @@ const regionHash: RegionHash = {
   "us-east-1": {
     variants: [
       {
-        hostname: "dms.us-east-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "dms-fips.us-east-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -16,10 +12,6 @@ const regionHash: RegionHash = {
   },
   "us-east-2": {
     variants: [
-      {
-        hostname: "dms.us-east-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "dms-fips.us-east-2.amazonaws.com",
         tags: ["fips"],
@@ -30,20 +22,12 @@ const regionHash: RegionHash = {
     variants: [
       {
         hostname: "dms.us-gov-east-1.amazonaws.com",
-        tags: [],
-      },
-      {
-        hostname: "dms.us-gov-east-1.amazonaws.com",
         tags: ["fips"],
       },
     ],
   },
   "us-gov-west-1": {
     variants: [
-      {
-        hostname: "dms.us-gov-west-1.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "dms.us-gov-west-1.amazonaws.com",
         tags: ["fips"],
@@ -54,20 +38,12 @@ const regionHash: RegionHash = {
     variants: [
       {
         hostname: "dms.us-iso-east-1.c2s.ic.gov",
-        tags: [],
-      },
-      {
-        hostname: "dms.us-iso-east-1.c2s.ic.gov",
         tags: ["fips"],
       },
     ],
   },
   "us-isob-east-1": {
     variants: [
-      {
-        hostname: "dms.us-isob-east-1.sc2s.sgov.gov",
-        tags: [],
-      },
       {
         hostname: "dms.us-isob-east-1.sc2s.sgov.gov",
         tags: ["fips"],
@@ -77,10 +53,6 @@ const regionHash: RegionHash = {
   "us-west-1": {
     variants: [
       {
-        hostname: "dms.us-west-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "dms-fips.us-west-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -88,10 +60,6 @@ const regionHash: RegionHash = {
   },
   "us-west-2": {
     variants: [
-      {
-        hostname: "dms.us-west-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "dms-fips.us-west-2.amazonaws.com",
         tags: ["fips"],

--- a/clients/client-datasync/src/endpoints.ts
+++ b/clients/client-datasync/src/endpoints.ts
@@ -5,10 +5,6 @@ const regionHash: RegionHash = {
   "ca-central-1": {
     variants: [
       {
-        hostname: "datasync.ca-central-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "datasync-fips.ca-central-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -16,10 +12,6 @@ const regionHash: RegionHash = {
   },
   "us-east-1": {
     variants: [
-      {
-        hostname: "datasync.us-east-1.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "datasync-fips.us-east-1.amazonaws.com",
         tags: ["fips"],
@@ -29,10 +21,6 @@ const regionHash: RegionHash = {
   "us-east-2": {
     variants: [
       {
-        hostname: "datasync.us-east-2.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "datasync-fips.us-east-2.amazonaws.com",
         tags: ["fips"],
       },
@@ -40,10 +28,6 @@ const regionHash: RegionHash = {
   },
   "us-gov-east-1": {
     variants: [
-      {
-        hostname: "datasync.us-gov-east-1.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "datasync-fips.us-gov-east-1.amazonaws.com",
         tags: ["fips"],
@@ -53,10 +37,6 @@ const regionHash: RegionHash = {
   "us-gov-west-1": {
     variants: [
       {
-        hostname: "datasync.us-gov-west-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "datasync-fips.us-gov-west-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -65,10 +45,6 @@ const regionHash: RegionHash = {
   "us-west-1": {
     variants: [
       {
-        hostname: "datasync.us-west-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "datasync-fips.us-west-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -76,10 +52,6 @@ const regionHash: RegionHash = {
   },
   "us-west-2": {
     variants: [
-      {
-        hostname: "datasync.us-west-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "datasync-fips.us-west-2.amazonaws.com",
         tags: ["fips"],

--- a/clients/client-detective/src/endpoints.ts
+++ b/clients/client-detective/src/endpoints.ts
@@ -5,10 +5,6 @@ const regionHash: RegionHash = {
   "us-east-1": {
     variants: [
       {
-        hostname: "api.detective.us-east-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "api.detective-fips.us-east-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -16,10 +12,6 @@ const regionHash: RegionHash = {
   },
   "us-east-2": {
     variants: [
-      {
-        hostname: "api.detective.us-east-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "api.detective-fips.us-east-2.amazonaws.com",
         tags: ["fips"],
@@ -29,10 +21,6 @@ const regionHash: RegionHash = {
   "us-gov-east-1": {
     variants: [
       {
-        hostname: "api.detective.us-gov-east-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "api.detective-fips.us-gov-east-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -40,10 +28,6 @@ const regionHash: RegionHash = {
   },
   "us-gov-west-1": {
     variants: [
-      {
-        hostname: "api.detective.us-gov-west-1.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "api.detective-fips.us-gov-west-1.amazonaws.com",
         tags: ["fips"],
@@ -53,10 +37,6 @@ const regionHash: RegionHash = {
   "us-west-1": {
     variants: [
       {
-        hostname: "api.detective.us-west-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "api.detective-fips.us-west-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -64,10 +44,6 @@ const regionHash: RegionHash = {
   },
   "us-west-2": {
     variants: [
-      {
-        hostname: "api.detective.us-west-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "api.detective-fips.us-west-2.amazonaws.com",
         tags: ["fips"],

--- a/clients/client-direct-connect/src/endpoints.ts
+++ b/clients/client-direct-connect/src/endpoints.ts
@@ -5,10 +5,6 @@ const regionHash: RegionHash = {
   "us-east-1": {
     variants: [
       {
-        hostname: "directconnect.us-east-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "directconnect-fips.us-east-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -16,10 +12,6 @@ const regionHash: RegionHash = {
   },
   "us-east-2": {
     variants: [
-      {
-        hostname: "directconnect.us-east-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "directconnect-fips.us-east-2.amazonaws.com",
         tags: ["fips"],
@@ -47,10 +39,6 @@ const regionHash: RegionHash = {
   "us-west-1": {
     variants: [
       {
-        hostname: "directconnect.us-west-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "directconnect-fips.us-west-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -58,10 +46,6 @@ const regionHash: RegionHash = {
   },
   "us-west-2": {
     variants: [
-      {
-        hostname: "directconnect.us-west-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "directconnect-fips.us-west-2.amazonaws.com",
         tags: ["fips"],

--- a/clients/client-directory-service/src/endpoints.ts
+++ b/clients/client-directory-service/src/endpoints.ts
@@ -5,10 +5,6 @@ const regionHash: RegionHash = {
   "ca-central-1": {
     variants: [
       {
-        hostname: "ds.ca-central-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "ds-fips.ca-central-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -16,10 +12,6 @@ const regionHash: RegionHash = {
   },
   "us-east-1": {
     variants: [
-      {
-        hostname: "ds.us-east-1.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "ds-fips.us-east-1.amazonaws.com",
         tags: ["fips"],
@@ -29,10 +21,6 @@ const regionHash: RegionHash = {
   "us-east-2": {
     variants: [
       {
-        hostname: "ds.us-east-2.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "ds-fips.us-east-2.amazonaws.com",
         tags: ["fips"],
       },
@@ -40,10 +28,6 @@ const regionHash: RegionHash = {
   },
   "us-gov-east-1": {
     variants: [
-      {
-        hostname: "ds.us-gov-east-1.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "ds-fips.us-gov-east-1.amazonaws.com",
         tags: ["fips"],
@@ -53,10 +37,6 @@ const regionHash: RegionHash = {
   "us-gov-west-1": {
     variants: [
       {
-        hostname: "ds.us-gov-west-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "ds-fips.us-gov-west-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -65,10 +45,6 @@ const regionHash: RegionHash = {
   "us-west-1": {
     variants: [
       {
-        hostname: "ds.us-west-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "ds-fips.us-west-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -76,10 +52,6 @@ const regionHash: RegionHash = {
   },
   "us-west-2": {
     variants: [
-      {
-        hostname: "ds.us-west-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "ds-fips.us-west-2.amazonaws.com",
         tags: ["fips"],

--- a/clients/client-docdb/src/endpoints.ts
+++ b/clients/client-docdb/src/endpoints.ts
@@ -5,10 +5,6 @@ const regionHash: RegionHash = {
   "ca-central-1": {
     variants: [
       {
-        hostname: "rds.ca-central-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "rds-fips.ca-central-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -17,10 +13,6 @@ const regionHash: RegionHash = {
   "us-east-1": {
     variants: [
       {
-        hostname: "rds.us-east-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "rds-fips.us-east-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -28,10 +20,6 @@ const regionHash: RegionHash = {
   },
   "us-east-2": {
     variants: [
-      {
-        hostname: "rds.us-east-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "rds-fips.us-east-2.amazonaws.com",
         tags: ["fips"],
@@ -42,20 +30,12 @@ const regionHash: RegionHash = {
     variants: [
       {
         hostname: "rds.us-gov-east-1.amazonaws.com",
-        tags: [],
-      },
-      {
-        hostname: "rds.us-gov-east-1.amazonaws.com",
         tags: ["fips"],
       },
     ],
   },
   "us-gov-west-1": {
     variants: [
-      {
-        hostname: "rds.us-gov-west-1.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "rds.us-gov-west-1.amazonaws.com",
         tags: ["fips"],
@@ -65,10 +45,6 @@ const regionHash: RegionHash = {
   "us-west-1": {
     variants: [
       {
-        hostname: "rds.us-west-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "rds-fips.us-west-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -76,10 +52,6 @@ const regionHash: RegionHash = {
   },
   "us-west-2": {
     variants: [
-      {
-        hostname: "rds.us-west-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "rds-fips.us-west-2.amazonaws.com",
         tags: ["fips"],

--- a/clients/client-dynamodb-streams/src/endpoints.ts
+++ b/clients/client-dynamodb-streams/src/endpoints.ts
@@ -15,20 +15,12 @@ const regionHash: RegionHash = {
     variants: [
       {
         hostname: "streams.dynamodb.us-gov-east-1.amazonaws.com",
-        tags: [],
-      },
-      {
-        hostname: "streams.dynamodb.us-gov-east-1.amazonaws.com",
         tags: ["fips"],
       },
     ],
   },
   "us-gov-west-1": {
     variants: [
-      {
-        hostname: "streams.dynamodb.us-gov-west-1.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "streams.dynamodb.us-gov-west-1.amazonaws.com",
         tags: ["fips"],

--- a/clients/client-dynamodb/src/endpoints.ts
+++ b/clients/client-dynamodb/src/endpoints.ts
@@ -5,10 +5,6 @@ const regionHash: RegionHash = {
   "ca-central-1": {
     variants: [
       {
-        hostname: "dynamodb.ca-central-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "dynamodb-fips.ca-central-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -26,10 +22,6 @@ const regionHash: RegionHash = {
   "us-east-1": {
     variants: [
       {
-        hostname: "dynamodb.us-east-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "dynamodb-fips.us-east-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -37,10 +29,6 @@ const regionHash: RegionHash = {
   },
   "us-east-2": {
     variants: [
-      {
-        hostname: "dynamodb.us-east-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "dynamodb-fips.us-east-2.amazonaws.com",
         tags: ["fips"],
@@ -51,20 +39,12 @@ const regionHash: RegionHash = {
     variants: [
       {
         hostname: "dynamodb.us-gov-east-1.amazonaws.com",
-        tags: [],
-      },
-      {
-        hostname: "dynamodb.us-gov-east-1.amazonaws.com",
         tags: ["fips"],
       },
     ],
   },
   "us-gov-west-1": {
     variants: [
-      {
-        hostname: "dynamodb.us-gov-west-1.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "dynamodb.us-gov-west-1.amazonaws.com",
         tags: ["fips"],
@@ -74,10 +54,6 @@ const regionHash: RegionHash = {
   "us-west-1": {
     variants: [
       {
-        hostname: "dynamodb.us-west-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "dynamodb-fips.us-west-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -85,10 +61,6 @@ const regionHash: RegionHash = {
   },
   "us-west-2": {
     variants: [
-      {
-        hostname: "dynamodb.us-west-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "dynamodb-fips.us-west-2.amazonaws.com",
         tags: ["fips"],

--- a/clients/client-ebs/src/endpoints.ts
+++ b/clients/client-ebs/src/endpoints.ts
@@ -5,10 +5,6 @@ const regionHash: RegionHash = {
   "ca-central-1": {
     variants: [
       {
-        hostname: "ebs.ca-central-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "ebs-fips.ca-central-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -16,10 +12,6 @@ const regionHash: RegionHash = {
   },
   "us-east-1": {
     variants: [
-      {
-        hostname: "ebs.us-east-1.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "ebs-fips.us-east-1.amazonaws.com",
         tags: ["fips"],
@@ -29,10 +21,6 @@ const regionHash: RegionHash = {
   "us-east-2": {
     variants: [
       {
-        hostname: "ebs.us-east-2.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "ebs-fips.us-east-2.amazonaws.com",
         tags: ["fips"],
       },
@@ -41,10 +29,6 @@ const regionHash: RegionHash = {
   "us-west-1": {
     variants: [
       {
-        hostname: "ebs.us-west-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "ebs-fips.us-west-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -52,10 +36,6 @@ const regionHash: RegionHash = {
   },
   "us-west-2": {
     variants: [
-      {
-        hostname: "ebs.us-west-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "ebs-fips.us-west-2.amazonaws.com",
         tags: ["fips"],

--- a/clients/client-ec2/src/endpoints.ts
+++ b/clients/client-ec2/src/endpoints.ts
@@ -5,10 +5,6 @@ const regionHash: RegionHash = {
   "ap-south-1": {
     variants: [
       {
-        hostname: "ec2.ap-south-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "api.ec2.ap-south-1.aws",
         tags: ["dualstack"],
       },
@@ -16,10 +12,6 @@ const regionHash: RegionHash = {
   },
   "ca-central-1": {
     variants: [
-      {
-        hostname: "ec2.ca-central-1.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "ec2-fips.ca-central-1.amazonaws.com",
         tags: ["fips"],
@@ -29,10 +21,6 @@ const regionHash: RegionHash = {
   "eu-west-1": {
     variants: [
       {
-        hostname: "ec2.eu-west-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "api.ec2.eu-west-1.aws",
         tags: ["dualstack"],
       },
@@ -41,10 +29,6 @@ const regionHash: RegionHash = {
   "sa-east-1": {
     variants: [
       {
-        hostname: "ec2.sa-east-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "api.ec2.sa-east-1.aws",
         tags: ["dualstack"],
       },
@@ -52,10 +36,6 @@ const regionHash: RegionHash = {
   },
   "us-east-1": {
     variants: [
-      {
-        hostname: "ec2.us-east-1.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "api.ec2.us-east-1.aws",
         tags: ["dualstack"],
@@ -68,10 +48,6 @@ const regionHash: RegionHash = {
   },
   "us-east-2": {
     variants: [
-      {
-        hostname: "ec2.us-east-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "api.ec2.us-east-2.aws",
         tags: ["dualstack"],
@@ -103,10 +79,6 @@ const regionHash: RegionHash = {
   "us-west-1": {
     variants: [
       {
-        hostname: "ec2.us-west-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "ec2-fips.us-west-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -114,10 +86,6 @@ const regionHash: RegionHash = {
   },
   "us-west-2": {
     variants: [
-      {
-        hostname: "ec2.us-west-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "api.ec2.us-west-2.aws",
         tags: ["dualstack"],

--- a/clients/client-ecs/src/endpoints.ts
+++ b/clients/client-ecs/src/endpoints.ts
@@ -5,10 +5,6 @@ const regionHash: RegionHash = {
   "us-east-1": {
     variants: [
       {
-        hostname: "ecs.us-east-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "ecs-fips.us-east-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -16,10 +12,6 @@ const regionHash: RegionHash = {
   },
   "us-east-2": {
     variants: [
-      {
-        hostname: "ecs.us-east-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "ecs-fips.us-east-2.amazonaws.com",
         tags: ["fips"],
@@ -29,10 +21,6 @@ const regionHash: RegionHash = {
   "us-gov-east-1": {
     variants: [
       {
-        hostname: "ecs.us-gov-east-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "ecs-fips.us-gov-east-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -40,10 +28,6 @@ const regionHash: RegionHash = {
   },
   "us-gov-west-1": {
     variants: [
-      {
-        hostname: "ecs.us-gov-west-1.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "ecs-fips.us-gov-west-1.amazonaws.com",
         tags: ["fips"],
@@ -53,10 +37,6 @@ const regionHash: RegionHash = {
   "us-west-1": {
     variants: [
       {
-        hostname: "ecs.us-west-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "ecs-fips.us-west-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -64,10 +44,6 @@ const regionHash: RegionHash = {
   },
   "us-west-2": {
     variants: [
-      {
-        hostname: "ecs.us-west-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "ecs-fips.us-west-2.amazonaws.com",
         tags: ["fips"],

--- a/clients/client-efs/src/endpoints.ts
+++ b/clients/client-efs/src/endpoints.ts
@@ -5,10 +5,6 @@ const regionHash: RegionHash = {
   "af-south-1": {
     variants: [
       {
-        hostname: "elasticfilesystem.af-south-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "elasticfilesystem-fips.af-south-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -16,10 +12,6 @@ const regionHash: RegionHash = {
   },
   "ap-east-1": {
     variants: [
-      {
-        hostname: "elasticfilesystem.ap-east-1.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "elasticfilesystem-fips.ap-east-1.amazonaws.com",
         tags: ["fips"],
@@ -29,10 +21,6 @@ const regionHash: RegionHash = {
   "ap-northeast-1": {
     variants: [
       {
-        hostname: "elasticfilesystem.ap-northeast-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "elasticfilesystem-fips.ap-northeast-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -40,10 +28,6 @@ const regionHash: RegionHash = {
   },
   "ap-northeast-2": {
     variants: [
-      {
-        hostname: "elasticfilesystem.ap-northeast-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "elasticfilesystem-fips.ap-northeast-2.amazonaws.com",
         tags: ["fips"],
@@ -53,10 +37,6 @@ const regionHash: RegionHash = {
   "ap-northeast-3": {
     variants: [
       {
-        hostname: "elasticfilesystem.ap-northeast-3.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "elasticfilesystem-fips.ap-northeast-3.amazonaws.com",
         tags: ["fips"],
       },
@@ -64,10 +44,6 @@ const regionHash: RegionHash = {
   },
   "ap-south-1": {
     variants: [
-      {
-        hostname: "elasticfilesystem.ap-south-1.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "elasticfilesystem-fips.ap-south-1.amazonaws.com",
         tags: ["fips"],
@@ -77,10 +53,6 @@ const regionHash: RegionHash = {
   "ap-southeast-1": {
     variants: [
       {
-        hostname: "elasticfilesystem.ap-southeast-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "elasticfilesystem-fips.ap-southeast-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -88,10 +60,6 @@ const regionHash: RegionHash = {
   },
   "ap-southeast-2": {
     variants: [
-      {
-        hostname: "elasticfilesystem.ap-southeast-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "elasticfilesystem-fips.ap-southeast-2.amazonaws.com",
         tags: ["fips"],
@@ -101,10 +69,6 @@ const regionHash: RegionHash = {
   "ca-central-1": {
     variants: [
       {
-        hostname: "elasticfilesystem.ca-central-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "elasticfilesystem-fips.ca-central-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -112,10 +76,6 @@ const regionHash: RegionHash = {
   },
   "cn-north-1": {
     variants: [
-      {
-        hostname: "elasticfilesystem.cn-north-1.amazonaws.com.cn",
-        tags: [],
-      },
       {
         hostname: "elasticfilesystem-fips.cn-north-1.amazonaws.com.cn",
         tags: ["fips"],
@@ -125,10 +85,6 @@ const regionHash: RegionHash = {
   "cn-northwest-1": {
     variants: [
       {
-        hostname: "elasticfilesystem.cn-northwest-1.amazonaws.com.cn",
-        tags: [],
-      },
-      {
         hostname: "elasticfilesystem-fips.cn-northwest-1.amazonaws.com.cn",
         tags: ["fips"],
       },
@@ -136,10 +92,6 @@ const regionHash: RegionHash = {
   },
   "eu-central-1": {
     variants: [
-      {
-        hostname: "elasticfilesystem.eu-central-1.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "elasticfilesystem-fips.eu-central-1.amazonaws.com",
         tags: ["fips"],
@@ -149,10 +101,6 @@ const regionHash: RegionHash = {
   "eu-north-1": {
     variants: [
       {
-        hostname: "elasticfilesystem.eu-north-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "elasticfilesystem-fips.eu-north-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -160,10 +108,6 @@ const regionHash: RegionHash = {
   },
   "eu-south-1": {
     variants: [
-      {
-        hostname: "elasticfilesystem.eu-south-1.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "elasticfilesystem-fips.eu-south-1.amazonaws.com",
         tags: ["fips"],
@@ -173,10 +117,6 @@ const regionHash: RegionHash = {
   "eu-west-1": {
     variants: [
       {
-        hostname: "elasticfilesystem.eu-west-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "elasticfilesystem-fips.eu-west-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -184,10 +124,6 @@ const regionHash: RegionHash = {
   },
   "eu-west-2": {
     variants: [
-      {
-        hostname: "elasticfilesystem.eu-west-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "elasticfilesystem-fips.eu-west-2.amazonaws.com",
         tags: ["fips"],
@@ -197,10 +133,6 @@ const regionHash: RegionHash = {
   "eu-west-3": {
     variants: [
       {
-        hostname: "elasticfilesystem.eu-west-3.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "elasticfilesystem-fips.eu-west-3.amazonaws.com",
         tags: ["fips"],
       },
@@ -208,10 +140,6 @@ const regionHash: RegionHash = {
   },
   "me-south-1": {
     variants: [
-      {
-        hostname: "elasticfilesystem.me-south-1.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "elasticfilesystem-fips.me-south-1.amazonaws.com",
         tags: ["fips"],
@@ -221,10 +149,6 @@ const regionHash: RegionHash = {
   "sa-east-1": {
     variants: [
       {
-        hostname: "elasticfilesystem.sa-east-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "elasticfilesystem-fips.sa-east-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -232,10 +156,6 @@ const regionHash: RegionHash = {
   },
   "us-east-1": {
     variants: [
-      {
-        hostname: "elasticfilesystem.us-east-1.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "elasticfilesystem-fips.us-east-1.amazonaws.com",
         tags: ["fips"],
@@ -245,10 +165,6 @@ const regionHash: RegionHash = {
   "us-east-2": {
     variants: [
       {
-        hostname: "elasticfilesystem.us-east-2.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "elasticfilesystem-fips.us-east-2.amazonaws.com",
         tags: ["fips"],
       },
@@ -256,10 +172,6 @@ const regionHash: RegionHash = {
   },
   "us-gov-east-1": {
     variants: [
-      {
-        hostname: "elasticfilesystem.us-gov-east-1.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "elasticfilesystem-fips.us-gov-east-1.amazonaws.com",
         tags: ["fips"],
@@ -269,10 +181,6 @@ const regionHash: RegionHash = {
   "us-gov-west-1": {
     variants: [
       {
-        hostname: "elasticfilesystem.us-gov-west-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "elasticfilesystem-fips.us-gov-west-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -280,10 +188,6 @@ const regionHash: RegionHash = {
   },
   "us-iso-east-1": {
     variants: [
-      {
-        hostname: "elasticfilesystem.us-iso-east-1.c2s.ic.gov",
-        tags: [],
-      },
       {
         hostname: "elasticfilesystem-fips.us-iso-east-1.c2s.ic.gov",
         tags: ["fips"],
@@ -293,10 +197,6 @@ const regionHash: RegionHash = {
   "us-west-1": {
     variants: [
       {
-        hostname: "elasticfilesystem.us-west-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "elasticfilesystem-fips.us-west-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -304,10 +204,6 @@ const regionHash: RegionHash = {
   },
   "us-west-2": {
     variants: [
-      {
-        hostname: "elasticfilesystem.us-west-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "elasticfilesystem-fips.us-west-2.amazonaws.com",
         tags: ["fips"],

--- a/clients/client-eks/src/endpoints.ts
+++ b/clients/client-eks/src/endpoints.ts
@@ -5,10 +5,6 @@ const regionHash: RegionHash = {
   "us-east-1": {
     variants: [
       {
-        hostname: "eks.us-east-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "fips.eks.us-east-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -16,10 +12,6 @@ const regionHash: RegionHash = {
   },
   "us-east-2": {
     variants: [
-      {
-        hostname: "eks.us-east-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "fips.eks.us-east-2.amazonaws.com",
         tags: ["fips"],
@@ -30,20 +22,12 @@ const regionHash: RegionHash = {
     variants: [
       {
         hostname: "eks.us-gov-east-1.amazonaws.com",
-        tags: [],
-      },
-      {
-        hostname: "eks.us-gov-east-1.amazonaws.com",
         tags: ["fips"],
       },
     ],
   },
   "us-gov-west-1": {
     variants: [
-      {
-        hostname: "eks.us-gov-west-1.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "eks.us-gov-west-1.amazonaws.com",
         tags: ["fips"],
@@ -53,10 +37,6 @@ const regionHash: RegionHash = {
   "us-west-1": {
     variants: [
       {
-        hostname: "eks.us-west-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "fips.eks.us-west-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -64,10 +44,6 @@ const regionHash: RegionHash = {
   },
   "us-west-2": {
     variants: [
-      {
-        hostname: "eks.us-west-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "fips.eks.us-west-2.amazonaws.com",
         tags: ["fips"],

--- a/clients/client-elastic-beanstalk/src/endpoints.ts
+++ b/clients/client-elastic-beanstalk/src/endpoints.ts
@@ -5,10 +5,6 @@ const regionHash: RegionHash = {
   "us-east-1": {
     variants: [
       {
-        hostname: "elasticbeanstalk.us-east-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "elasticbeanstalk-fips.us-east-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -16,10 +12,6 @@ const regionHash: RegionHash = {
   },
   "us-east-2": {
     variants: [
-      {
-        hostname: "elasticbeanstalk.us-east-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "elasticbeanstalk-fips.us-east-2.amazonaws.com",
         tags: ["fips"],
@@ -47,10 +39,6 @@ const regionHash: RegionHash = {
   "us-west-1": {
     variants: [
       {
-        hostname: "elasticbeanstalk.us-west-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "elasticbeanstalk-fips.us-west-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -58,10 +46,6 @@ const regionHash: RegionHash = {
   },
   "us-west-2": {
     variants: [
-      {
-        hostname: "elasticbeanstalk.us-west-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "elasticbeanstalk-fips.us-west-2.amazonaws.com",
         tags: ["fips"],

--- a/clients/client-elastic-load-balancing-v2/src/endpoints.ts
+++ b/clients/client-elastic-load-balancing-v2/src/endpoints.ts
@@ -5,10 +5,6 @@ const regionHash: RegionHash = {
   "us-east-1": {
     variants: [
       {
-        hostname: "elasticloadbalancing.us-east-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "elasticloadbalancing-fips.us-east-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -16,10 +12,6 @@ const regionHash: RegionHash = {
   },
   "us-east-2": {
     variants: [
-      {
-        hostname: "elasticloadbalancing.us-east-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "elasticloadbalancing-fips.us-east-2.amazonaws.com",
         tags: ["fips"],
@@ -30,20 +22,12 @@ const regionHash: RegionHash = {
     variants: [
       {
         hostname: "elasticloadbalancing.us-gov-east-1.amazonaws.com",
-        tags: [],
-      },
-      {
-        hostname: "elasticloadbalancing.us-gov-east-1.amazonaws.com",
         tags: ["fips"],
       },
     ],
   },
   "us-gov-west-1": {
     variants: [
-      {
-        hostname: "elasticloadbalancing.us-gov-west-1.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "elasticloadbalancing.us-gov-west-1.amazonaws.com",
         tags: ["fips"],
@@ -53,10 +37,6 @@ const regionHash: RegionHash = {
   "us-west-1": {
     variants: [
       {
-        hostname: "elasticloadbalancing.us-west-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "elasticloadbalancing-fips.us-west-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -64,10 +44,6 @@ const regionHash: RegionHash = {
   },
   "us-west-2": {
     variants: [
-      {
-        hostname: "elasticloadbalancing.us-west-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "elasticloadbalancing-fips.us-west-2.amazonaws.com",
         tags: ["fips"],

--- a/clients/client-elastic-load-balancing/src/endpoints.ts
+++ b/clients/client-elastic-load-balancing/src/endpoints.ts
@@ -5,10 +5,6 @@ const regionHash: RegionHash = {
   "us-east-1": {
     variants: [
       {
-        hostname: "elasticloadbalancing.us-east-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "elasticloadbalancing-fips.us-east-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -16,10 +12,6 @@ const regionHash: RegionHash = {
   },
   "us-east-2": {
     variants: [
-      {
-        hostname: "elasticloadbalancing.us-east-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "elasticloadbalancing-fips.us-east-2.amazonaws.com",
         tags: ["fips"],
@@ -30,20 +22,12 @@ const regionHash: RegionHash = {
     variants: [
       {
         hostname: "elasticloadbalancing.us-gov-east-1.amazonaws.com",
-        tags: [],
-      },
-      {
-        hostname: "elasticloadbalancing.us-gov-east-1.amazonaws.com",
         tags: ["fips"],
       },
     ],
   },
   "us-gov-west-1": {
     variants: [
-      {
-        hostname: "elasticloadbalancing.us-gov-west-1.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "elasticloadbalancing.us-gov-west-1.amazonaws.com",
         tags: ["fips"],
@@ -53,10 +37,6 @@ const regionHash: RegionHash = {
   "us-west-1": {
     variants: [
       {
-        hostname: "elasticloadbalancing.us-west-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "elasticloadbalancing-fips.us-west-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -64,10 +44,6 @@ const regionHash: RegionHash = {
   },
   "us-west-2": {
     variants: [
-      {
-        hostname: "elasticloadbalancing.us-west-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "elasticloadbalancing-fips.us-west-2.amazonaws.com",
         tags: ["fips"],

--- a/clients/client-elasticache/src/endpoints.ts
+++ b/clients/client-elasticache/src/endpoints.ts
@@ -5,10 +5,6 @@ const regionHash: RegionHash = {
   "us-east-1": {
     variants: [
       {
-        hostname: "elasticache.us-east-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "elasticache-fips.us-east-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -16,10 +12,6 @@ const regionHash: RegionHash = {
   },
   "us-east-2": {
     variants: [
-      {
-        hostname: "elasticache.us-east-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "elasticache-fips.us-east-2.amazonaws.com",
         tags: ["fips"],
@@ -30,20 +22,12 @@ const regionHash: RegionHash = {
     variants: [
       {
         hostname: "elasticache.us-gov-west-1.amazonaws.com",
-        tags: [],
-      },
-      {
-        hostname: "elasticache.us-gov-west-1.amazonaws.com",
         tags: ["fips"],
       },
     ],
   },
   "us-west-1": {
     variants: [
-      {
-        hostname: "elasticache.us-west-1.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "elasticache-fips.us-west-1.amazonaws.com",
         tags: ["fips"],
@@ -52,10 +36,6 @@ const regionHash: RegionHash = {
   },
   "us-west-2": {
     variants: [
-      {
-        hostname: "elasticache.us-west-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "elasticache-fips.us-west-2.amazonaws.com",
         tags: ["fips"],

--- a/clients/client-elasticsearch-service/src/endpoints.ts
+++ b/clients/client-elasticsearch-service/src/endpoints.ts
@@ -5,10 +5,6 @@ const regionHash: RegionHash = {
   "us-east-1": {
     variants: [
       {
-        hostname: "es.us-east-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "es-fips.us-east-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -16,10 +12,6 @@ const regionHash: RegionHash = {
   },
   "us-east-2": {
     variants: [
-      {
-        hostname: "es.us-east-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "es-fips.us-east-2.amazonaws.com",
         tags: ["fips"],
@@ -29,10 +21,6 @@ const regionHash: RegionHash = {
   "us-gov-east-1": {
     variants: [
       {
-        hostname: "es.us-gov-east-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "es-fips.us-gov-east-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -40,10 +28,6 @@ const regionHash: RegionHash = {
   },
   "us-gov-west-1": {
     variants: [
-      {
-        hostname: "es.us-gov-west-1.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "es-fips.us-gov-west-1.amazonaws.com",
         tags: ["fips"],
@@ -53,10 +37,6 @@ const regionHash: RegionHash = {
   "us-west-1": {
     variants: [
       {
-        hostname: "es.us-west-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "es-fips.us-west-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -64,10 +44,6 @@ const regionHash: RegionHash = {
   },
   "us-west-2": {
     variants: [
-      {
-        hostname: "es.us-west-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "es-fips.us-west-2.amazonaws.com",
         tags: ["fips"],

--- a/clients/client-emr-containers/src/endpoints.ts
+++ b/clients/client-emr-containers/src/endpoints.ts
@@ -5,10 +5,6 @@ const regionHash: RegionHash = {
   "ca-central-1": {
     variants: [
       {
-        hostname: "emr-containers.ca-central-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "emr-containers-fips.ca-central-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -16,10 +12,6 @@ const regionHash: RegionHash = {
   },
   "us-east-1": {
     variants: [
-      {
-        hostname: "emr-containers.us-east-1.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "emr-containers-fips.us-east-1.amazonaws.com",
         tags: ["fips"],
@@ -29,10 +21,6 @@ const regionHash: RegionHash = {
   "us-east-2": {
     variants: [
       {
-        hostname: "emr-containers.us-east-2.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "emr-containers-fips.us-east-2.amazonaws.com",
         tags: ["fips"],
       },
@@ -41,10 +29,6 @@ const regionHash: RegionHash = {
   "us-west-1": {
     variants: [
       {
-        hostname: "emr-containers.us-west-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "emr-containers-fips.us-west-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -52,10 +36,6 @@ const regionHash: RegionHash = {
   },
   "us-west-2": {
     variants: [
-      {
-        hostname: "emr-containers.us-west-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "emr-containers-fips.us-west-2.amazonaws.com",
         tags: ["fips"],

--- a/clients/client-emr/src/endpoints.ts
+++ b/clients/client-emr/src/endpoints.ts
@@ -5,10 +5,6 @@ const regionHash: RegionHash = {
   "ca-central-1": {
     variants: [
       {
-        hostname: "elasticmapreduce.ca-central-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "elasticmapreduce-fips.ca-central-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -17,10 +13,6 @@ const regionHash: RegionHash = {
   "us-east-1": {
     variants: [
       {
-        hostname: "elasticmapreduce.us-east-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "elasticmapreduce-fips.us-east-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -28,10 +20,6 @@ const regionHash: RegionHash = {
   },
   "us-east-2": {
     variants: [
-      {
-        hostname: "elasticmapreduce.us-east-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "elasticmapreduce-fips.us-east-2.amazonaws.com",
         tags: ["fips"],
@@ -42,20 +30,12 @@ const regionHash: RegionHash = {
     variants: [
       {
         hostname: "elasticmapreduce.us-gov-east-1.amazonaws.com",
-        tags: [],
-      },
-      {
-        hostname: "elasticmapreduce.us-gov-east-1.amazonaws.com",
         tags: ["fips"],
       },
     ],
   },
   "us-gov-west-1": {
     variants: [
-      {
-        hostname: "elasticmapreduce.us-gov-west-1.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "elasticmapreduce.us-gov-west-1.amazonaws.com",
         tags: ["fips"],
@@ -65,10 +45,6 @@ const regionHash: RegionHash = {
   "us-west-1": {
     variants: [
       {
-        hostname: "elasticmapreduce.us-west-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "elasticmapreduce-fips.us-west-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -76,10 +52,6 @@ const regionHash: RegionHash = {
   },
   "us-west-2": {
     variants: [
-      {
-        hostname: "elasticmapreduce.us-west-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "elasticmapreduce-fips.us-west-2.amazonaws.com",
         tags: ["fips"],

--- a/clients/client-eventbridge/src/endpoints.ts
+++ b/clients/client-eventbridge/src/endpoints.ts
@@ -5,10 +5,6 @@ const regionHash: RegionHash = {
   "us-east-1": {
     variants: [
       {
-        hostname: "events.us-east-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "events-fips.us-east-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -16,10 +12,6 @@ const regionHash: RegionHash = {
   },
   "us-east-2": {
     variants: [
-      {
-        hostname: "events.us-east-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "events-fips.us-east-2.amazonaws.com",
         tags: ["fips"],
@@ -47,10 +39,6 @@ const regionHash: RegionHash = {
   "us-west-1": {
     variants: [
       {
-        hostname: "events.us-west-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "events-fips.us-west-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -58,10 +46,6 @@ const regionHash: RegionHash = {
   },
   "us-west-2": {
     variants: [
-      {
-        hostname: "events.us-west-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "events-fips.us-west-2.amazonaws.com",
         tags: ["fips"],

--- a/clients/client-firehose/src/endpoints.ts
+++ b/clients/client-firehose/src/endpoints.ts
@@ -5,10 +5,6 @@ const regionHash: RegionHash = {
   "us-east-1": {
     variants: [
       {
-        hostname: "firehose.us-east-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "firehose-fips.us-east-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -16,10 +12,6 @@ const regionHash: RegionHash = {
   },
   "us-east-2": {
     variants: [
-      {
-        hostname: "firehose.us-east-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "firehose-fips.us-east-2.amazonaws.com",
         tags: ["fips"],
@@ -29,10 +21,6 @@ const regionHash: RegionHash = {
   "us-gov-east-1": {
     variants: [
       {
-        hostname: "firehose.us-gov-east-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "firehose-fips.us-gov-east-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -40,10 +28,6 @@ const regionHash: RegionHash = {
   },
   "us-gov-west-1": {
     variants: [
-      {
-        hostname: "firehose.us-gov-west-1.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "firehose-fips.us-gov-west-1.amazonaws.com",
         tags: ["fips"],
@@ -53,10 +37,6 @@ const regionHash: RegionHash = {
   "us-west-1": {
     variants: [
       {
-        hostname: "firehose.us-west-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "firehose-fips.us-west-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -64,10 +44,6 @@ const regionHash: RegionHash = {
   },
   "us-west-2": {
     variants: [
-      {
-        hostname: "firehose.us-west-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "firehose-fips.us-west-2.amazonaws.com",
         tags: ["fips"],

--- a/clients/client-fms/src/endpoints.ts
+++ b/clients/client-fms/src/endpoints.ts
@@ -5,10 +5,6 @@ const regionHash: RegionHash = {
   "af-south-1": {
     variants: [
       {
-        hostname: "fms.af-south-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "fms-fips.af-south-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -16,10 +12,6 @@ const regionHash: RegionHash = {
   },
   "ap-east-1": {
     variants: [
-      {
-        hostname: "fms.ap-east-1.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "fms-fips.ap-east-1.amazonaws.com",
         tags: ["fips"],
@@ -29,10 +21,6 @@ const regionHash: RegionHash = {
   "ap-northeast-1": {
     variants: [
       {
-        hostname: "fms.ap-northeast-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "fms-fips.ap-northeast-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -40,10 +28,6 @@ const regionHash: RegionHash = {
   },
   "ap-northeast-2": {
     variants: [
-      {
-        hostname: "fms.ap-northeast-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "fms-fips.ap-northeast-2.amazonaws.com",
         tags: ["fips"],
@@ -53,10 +37,6 @@ const regionHash: RegionHash = {
   "ap-south-1": {
     variants: [
       {
-        hostname: "fms.ap-south-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "fms-fips.ap-south-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -64,10 +44,6 @@ const regionHash: RegionHash = {
   },
   "ap-southeast-1": {
     variants: [
-      {
-        hostname: "fms.ap-southeast-1.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "fms-fips.ap-southeast-1.amazonaws.com",
         tags: ["fips"],
@@ -77,10 +53,6 @@ const regionHash: RegionHash = {
   "ap-southeast-2": {
     variants: [
       {
-        hostname: "fms.ap-southeast-2.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "fms-fips.ap-southeast-2.amazonaws.com",
         tags: ["fips"],
       },
@@ -88,10 +60,6 @@ const regionHash: RegionHash = {
   },
   "ca-central-1": {
     variants: [
-      {
-        hostname: "fms.ca-central-1.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "fms-fips.ca-central-1.amazonaws.com",
         tags: ["fips"],
@@ -101,10 +69,6 @@ const regionHash: RegionHash = {
   "eu-central-1": {
     variants: [
       {
-        hostname: "fms.eu-central-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "fms-fips.eu-central-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -112,10 +76,6 @@ const regionHash: RegionHash = {
   },
   "eu-south-1": {
     variants: [
-      {
-        hostname: "fms.eu-south-1.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "fms-fips.eu-south-1.amazonaws.com",
         tags: ["fips"],
@@ -125,10 +85,6 @@ const regionHash: RegionHash = {
   "eu-west-1": {
     variants: [
       {
-        hostname: "fms.eu-west-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "fms-fips.eu-west-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -136,10 +92,6 @@ const regionHash: RegionHash = {
   },
   "eu-west-2": {
     variants: [
-      {
-        hostname: "fms.eu-west-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "fms-fips.eu-west-2.amazonaws.com",
         tags: ["fips"],
@@ -149,10 +101,6 @@ const regionHash: RegionHash = {
   "eu-west-3": {
     variants: [
       {
-        hostname: "fms.eu-west-3.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "fms-fips.eu-west-3.amazonaws.com",
         tags: ["fips"],
       },
@@ -160,10 +108,6 @@ const regionHash: RegionHash = {
   },
   "me-south-1": {
     variants: [
-      {
-        hostname: "fms.me-south-1.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "fms-fips.me-south-1.amazonaws.com",
         tags: ["fips"],
@@ -173,10 +117,6 @@ const regionHash: RegionHash = {
   "sa-east-1": {
     variants: [
       {
-        hostname: "fms.sa-east-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "fms-fips.sa-east-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -184,10 +124,6 @@ const regionHash: RegionHash = {
   },
   "us-east-1": {
     variants: [
-      {
-        hostname: "fms.us-east-1.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "fms-fips.us-east-1.amazonaws.com",
         tags: ["fips"],
@@ -197,10 +133,6 @@ const regionHash: RegionHash = {
   "us-east-2": {
     variants: [
       {
-        hostname: "fms.us-east-2.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "fms-fips.us-east-2.amazonaws.com",
         tags: ["fips"],
       },
@@ -208,10 +140,6 @@ const regionHash: RegionHash = {
   },
   "us-gov-east-1": {
     variants: [
-      {
-        hostname: "fms.us-gov-east-1.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "fms-fips.us-gov-east-1.amazonaws.com",
         tags: ["fips"],
@@ -221,10 +149,6 @@ const regionHash: RegionHash = {
   "us-gov-west-1": {
     variants: [
       {
-        hostname: "fms.us-gov-west-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "fms-fips.us-gov-west-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -233,10 +157,6 @@ const regionHash: RegionHash = {
   "us-west-1": {
     variants: [
       {
-        hostname: "fms.us-west-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "fms-fips.us-west-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -244,10 +164,6 @@ const regionHash: RegionHash = {
   },
   "us-west-2": {
     variants: [
-      {
-        hostname: "fms.us-west-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "fms-fips.us-west-2.amazonaws.com",
         tags: ["fips"],

--- a/clients/client-forecast/src/endpoints.ts
+++ b/clients/client-forecast/src/endpoints.ts
@@ -5,10 +5,6 @@ const regionHash: RegionHash = {
   "us-east-1": {
     variants: [
       {
-        hostname: "forecast.us-east-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "forecast-fips.us-east-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -17,10 +13,6 @@ const regionHash: RegionHash = {
   "us-east-2": {
     variants: [
       {
-        hostname: "forecast.us-east-2.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "forecast-fips.us-east-2.amazonaws.com",
         tags: ["fips"],
       },
@@ -28,10 +20,6 @@ const regionHash: RegionHash = {
   },
   "us-west-2": {
     variants: [
-      {
-        hostname: "forecast.us-west-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "forecast-fips.us-west-2.amazonaws.com",
         tags: ["fips"],

--- a/clients/client-forecastquery/src/endpoints.ts
+++ b/clients/client-forecastquery/src/endpoints.ts
@@ -5,10 +5,6 @@ const regionHash: RegionHash = {
   "us-east-1": {
     variants: [
       {
-        hostname: "forecastquery.us-east-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "forecastquery-fips.us-east-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -17,10 +13,6 @@ const regionHash: RegionHash = {
   "us-east-2": {
     variants: [
       {
-        hostname: "forecastquery.us-east-2.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "forecastquery-fips.us-east-2.amazonaws.com",
         tags: ["fips"],
       },
@@ -28,10 +20,6 @@ const regionHash: RegionHash = {
   },
   "us-west-2": {
     variants: [
-      {
-        hostname: "forecastquery.us-west-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "forecastquery-fips.us-west-2.amazonaws.com",
         tags: ["fips"],

--- a/clients/client-fsx/src/endpoints.ts
+++ b/clients/client-fsx/src/endpoints.ts
@@ -5,10 +5,6 @@ const regionHash: RegionHash = {
   "ca-central-1": {
     variants: [
       {
-        hostname: "fsx.ca-central-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "fsx-fips.ca-central-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -16,10 +12,6 @@ const regionHash: RegionHash = {
   },
   "us-east-1": {
     variants: [
-      {
-        hostname: "fsx.us-east-1.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "fsx-fips.us-east-1.amazonaws.com",
         tags: ["fips"],
@@ -29,10 +21,6 @@ const regionHash: RegionHash = {
   "us-east-2": {
     variants: [
       {
-        hostname: "fsx.us-east-2.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "fsx-fips.us-east-2.amazonaws.com",
         tags: ["fips"],
       },
@@ -40,10 +28,6 @@ const regionHash: RegionHash = {
   },
   "us-gov-east-1": {
     variants: [
-      {
-        hostname: "fsx.us-gov-east-1.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "fsx-fips.us-gov-east-1.amazonaws.com",
         tags: ["fips"],
@@ -53,10 +37,6 @@ const regionHash: RegionHash = {
   "us-gov-west-1": {
     variants: [
       {
-        hostname: "fsx.us-gov-west-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "fsx-fips.us-gov-west-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -65,10 +45,6 @@ const regionHash: RegionHash = {
   "us-west-1": {
     variants: [
       {
-        hostname: "fsx.us-west-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "fsx-fips.us-west-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -76,10 +52,6 @@ const regionHash: RegionHash = {
   },
   "us-west-2": {
     variants: [
-      {
-        hostname: "fsx.us-west-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "fsx-fips.us-west-2.amazonaws.com",
         tags: ["fips"],

--- a/clients/client-glacier/src/endpoints.ts
+++ b/clients/client-glacier/src/endpoints.ts
@@ -5,10 +5,6 @@ const regionHash: RegionHash = {
   "ca-central-1": {
     variants: [
       {
-        hostname: "glacier.ca-central-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "glacier-fips.ca-central-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -17,10 +13,6 @@ const regionHash: RegionHash = {
   "us-east-1": {
     variants: [
       {
-        hostname: "glacier.us-east-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "glacier-fips.us-east-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -28,10 +20,6 @@ const regionHash: RegionHash = {
   },
   "us-east-2": {
     variants: [
-      {
-        hostname: "glacier.us-east-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "glacier-fips.us-east-2.amazonaws.com",
         tags: ["fips"],
@@ -59,10 +47,6 @@ const regionHash: RegionHash = {
   "us-west-1": {
     variants: [
       {
-        hostname: "glacier.us-west-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "glacier-fips.us-west-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -70,10 +54,6 @@ const regionHash: RegionHash = {
   },
   "us-west-2": {
     variants: [
-      {
-        hostname: "glacier.us-west-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "glacier-fips.us-west-2.amazonaws.com",
         tags: ["fips"],

--- a/clients/client-glue/src/endpoints.ts
+++ b/clients/client-glue/src/endpoints.ts
@@ -5,10 +5,6 @@ const regionHash: RegionHash = {
   "us-east-1": {
     variants: [
       {
-        hostname: "glue.us-east-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "glue-fips.us-east-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -16,10 +12,6 @@ const regionHash: RegionHash = {
   },
   "us-east-2": {
     variants: [
-      {
-        hostname: "glue.us-east-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "glue-fips.us-east-2.amazonaws.com",
         tags: ["fips"],
@@ -29,10 +21,6 @@ const regionHash: RegionHash = {
   "us-gov-east-1": {
     variants: [
       {
-        hostname: "glue.us-gov-east-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "glue-fips.us-gov-east-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -40,10 +28,6 @@ const regionHash: RegionHash = {
   },
   "us-gov-west-1": {
     variants: [
-      {
-        hostname: "glue.us-gov-west-1.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "glue-fips.us-gov-west-1.amazonaws.com",
         tags: ["fips"],
@@ -53,10 +37,6 @@ const regionHash: RegionHash = {
   "us-west-1": {
     variants: [
       {
-        hostname: "glue.us-west-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "glue-fips.us-west-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -64,10 +44,6 @@ const regionHash: RegionHash = {
   },
   "us-west-2": {
     variants: [
-      {
-        hostname: "glue.us-west-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "glue-fips.us-west-2.amazonaws.com",
         tags: ["fips"],

--- a/clients/client-groundstation/src/endpoints.ts
+++ b/clients/client-groundstation/src/endpoints.ts
@@ -5,10 +5,6 @@ const regionHash: RegionHash = {
   "us-east-1": {
     variants: [
       {
-        hostname: "groundstation.us-east-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "groundstation-fips.us-east-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -17,10 +13,6 @@ const regionHash: RegionHash = {
   "us-east-2": {
     variants: [
       {
-        hostname: "groundstation.us-east-2.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "groundstation-fips.us-east-2.amazonaws.com",
         tags: ["fips"],
       },
@@ -28,10 +20,6 @@ const regionHash: RegionHash = {
   },
   "us-west-2": {
     variants: [
-      {
-        hostname: "groundstation.us-west-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "groundstation-fips.us-west-2.amazonaws.com",
         tags: ["fips"],

--- a/clients/client-guardduty/src/endpoints.ts
+++ b/clients/client-guardduty/src/endpoints.ts
@@ -5,10 +5,6 @@ const regionHash: RegionHash = {
   "us-east-1": {
     variants: [
       {
-        hostname: "guardduty.us-east-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "guardduty-fips.us-east-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -16,10 +12,6 @@ const regionHash: RegionHash = {
   },
   "us-east-2": {
     variants: [
-      {
-        hostname: "guardduty.us-east-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "guardduty-fips.us-east-2.amazonaws.com",
         tags: ["fips"],
@@ -30,20 +22,12 @@ const regionHash: RegionHash = {
     variants: [
       {
         hostname: "guardduty.us-gov-east-1.amazonaws.com",
-        tags: [],
-      },
-      {
-        hostname: "guardduty.us-gov-east-1.amazonaws.com",
         tags: ["fips"],
       },
     ],
   },
   "us-gov-west-1": {
     variants: [
-      {
-        hostname: "guardduty.us-gov-west-1.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "guardduty.us-gov-west-1.amazonaws.com",
         tags: ["fips"],
@@ -53,10 +37,6 @@ const regionHash: RegionHash = {
   "us-west-1": {
     variants: [
       {
-        hostname: "guardduty.us-west-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "guardduty-fips.us-west-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -64,10 +44,6 @@ const regionHash: RegionHash = {
   },
   "us-west-2": {
     variants: [
-      {
-        hostname: "guardduty.us-west-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "guardduty-fips.us-west-2.amazonaws.com",
         tags: ["fips"],

--- a/clients/client-identitystore/src/endpoints.ts
+++ b/clients/client-identitystore/src/endpoints.ts
@@ -6,10 +6,6 @@ const regionHash: RegionHash = {
     variants: [
       {
         hostname: "identitystore.us-gov-west-1.amazonaws.com",
-        tags: [],
-      },
-      {
-        hostname: "identitystore.us-gov-west-1.amazonaws.com",
         tags: ["fips"],
       },
     ],

--- a/clients/client-inspector/src/endpoints.ts
+++ b/clients/client-inspector/src/endpoints.ts
@@ -5,10 +5,6 @@ const regionHash: RegionHash = {
   "us-east-1": {
     variants: [
       {
-        hostname: "inspector.us-east-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "inspector-fips.us-east-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -16,10 +12,6 @@ const regionHash: RegionHash = {
   },
   "us-east-2": {
     variants: [
-      {
-        hostname: "inspector.us-east-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "inspector-fips.us-east-2.amazonaws.com",
         tags: ["fips"],
@@ -29,10 +21,6 @@ const regionHash: RegionHash = {
   "us-gov-east-1": {
     variants: [
       {
-        hostname: "inspector.us-gov-east-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "inspector-fips.us-gov-east-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -40,10 +28,6 @@ const regionHash: RegionHash = {
   },
   "us-gov-west-1": {
     variants: [
-      {
-        hostname: "inspector.us-gov-west-1.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "inspector-fips.us-gov-west-1.amazonaws.com",
         tags: ["fips"],
@@ -53,10 +37,6 @@ const regionHash: RegionHash = {
   "us-west-1": {
     variants: [
       {
-        hostname: "inspector.us-west-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "inspector-fips.us-west-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -64,10 +44,6 @@ const regionHash: RegionHash = {
   },
   "us-west-2": {
     variants: [
-      {
-        hostname: "inspector.us-west-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "inspector-fips.us-west-2.amazonaws.com",
         tags: ["fips"],

--- a/clients/client-iot-data-plane/src/endpoints.ts
+++ b/clients/client-iot-data-plane/src/endpoints.ts
@@ -5,10 +5,6 @@ const regionHash: RegionHash = {
   "ca-central-1": {
     variants: [
       {
-        hostname: "data.iot.ca-central-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "data.iot-fips.ca-central-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -16,10 +12,6 @@ const regionHash: RegionHash = {
   },
   "us-east-1": {
     variants: [
-      {
-        hostname: "data.iot.us-east-1.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "data.iot-fips.us-east-1.amazonaws.com",
         tags: ["fips"],
@@ -29,10 +21,6 @@ const regionHash: RegionHash = {
   "us-east-2": {
     variants: [
       {
-        hostname: "data.iot.us-east-2.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "data.iot-fips.us-east-2.amazonaws.com",
         tags: ["fips"],
       },
@@ -40,10 +28,6 @@ const regionHash: RegionHash = {
   },
   "us-gov-east-1": {
     variants: [
-      {
-        hostname: "data.iot.us-gov-east-1.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "data.iot-fips.us-gov-east-1.amazonaws.com",
         tags: ["fips"],
@@ -53,10 +37,6 @@ const regionHash: RegionHash = {
   "us-gov-west-1": {
     variants: [
       {
-        hostname: "data.iot.us-gov-west-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "data.iot-fips.us-gov-west-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -65,10 +45,6 @@ const regionHash: RegionHash = {
   "us-west-1": {
     variants: [
       {
-        hostname: "data.iot.us-west-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "data.iot-fips.us-west-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -76,10 +52,6 @@ const regionHash: RegionHash = {
   },
   "us-west-2": {
     variants: [
-      {
-        hostname: "data.iot.us-west-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "data.iot-fips.us-west-2.amazonaws.com",
         tags: ["fips"],

--- a/clients/client-iot-jobs-data-plane/src/endpoints.ts
+++ b/clients/client-iot-jobs-data-plane/src/endpoints.ts
@@ -5,10 +5,6 @@ const regionHash: RegionHash = {
   "ca-central-1": {
     variants: [
       {
-        hostname: "data.jobs.iot.ca-central-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "data.jobs.iot-fips.ca-central-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -16,10 +12,6 @@ const regionHash: RegionHash = {
   },
   "us-east-1": {
     variants: [
-      {
-        hostname: "data.jobs.iot.us-east-1.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "data.jobs.iot-fips.us-east-1.amazonaws.com",
         tags: ["fips"],
@@ -29,10 +21,6 @@ const regionHash: RegionHash = {
   "us-east-2": {
     variants: [
       {
-        hostname: "data.jobs.iot.us-east-2.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "data.jobs.iot-fips.us-east-2.amazonaws.com",
         tags: ["fips"],
       },
@@ -40,10 +28,6 @@ const regionHash: RegionHash = {
   },
   "us-gov-east-1": {
     variants: [
-      {
-        hostname: "data.jobs.iot.us-gov-east-1.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "data.jobs.iot-fips.us-gov-east-1.amazonaws.com",
         tags: ["fips"],
@@ -53,10 +37,6 @@ const regionHash: RegionHash = {
   "us-gov-west-1": {
     variants: [
       {
-        hostname: "data.jobs.iot.us-gov-west-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "data.jobs.iot-fips.us-gov-west-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -65,10 +45,6 @@ const regionHash: RegionHash = {
   "us-west-1": {
     variants: [
       {
-        hostname: "data.jobs.iot.us-west-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "data.jobs.iot-fips.us-west-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -76,10 +52,6 @@ const regionHash: RegionHash = {
   },
   "us-west-2": {
     variants: [
-      {
-        hostname: "data.jobs.iot.us-west-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "data.jobs.iot-fips.us-west-2.amazonaws.com",
         tags: ["fips"],

--- a/clients/client-iot/src/endpoints.ts
+++ b/clients/client-iot/src/endpoints.ts
@@ -5,10 +5,6 @@ const regionHash: RegionHash = {
   "ca-central-1": {
     variants: [
       {
-        hostname: "iot.ca-central-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "iot-fips.ca-central-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -16,10 +12,6 @@ const regionHash: RegionHash = {
   },
   "us-east-1": {
     variants: [
-      {
-        hostname: "iot.us-east-1.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "iot-fips.us-east-1.amazonaws.com",
         tags: ["fips"],
@@ -29,10 +21,6 @@ const regionHash: RegionHash = {
   "us-east-2": {
     variants: [
       {
-        hostname: "iot.us-east-2.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "iot-fips.us-east-2.amazonaws.com",
         tags: ["fips"],
       },
@@ -40,10 +28,6 @@ const regionHash: RegionHash = {
   },
   "us-gov-east-1": {
     variants: [
-      {
-        hostname: "iot.us-gov-east-1.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "iot-fips.us-gov-east-1.amazonaws.com",
         tags: ["fips"],
@@ -53,10 +37,6 @@ const regionHash: RegionHash = {
   "us-gov-west-1": {
     variants: [
       {
-        hostname: "iot.us-gov-west-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "iot-fips.us-gov-west-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -65,10 +45,6 @@ const regionHash: RegionHash = {
   "us-west-1": {
     variants: [
       {
-        hostname: "iot.us-west-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "iot-fips.us-west-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -76,10 +52,6 @@ const regionHash: RegionHash = {
   },
   "us-west-2": {
     variants: [
-      {
-        hostname: "iot.us-west-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "iot-fips.us-west-2.amazonaws.com",
         tags: ["fips"],

--- a/clients/client-iotfleethub/src/endpoints.ts
+++ b/clients/client-iotfleethub/src/endpoints.ts
@@ -5,10 +5,6 @@ const regionHash: RegionHash = {
   "ca-central-1": {
     variants: [
       {
-        hostname: "api.fleethub.iot.ca-central-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "api.fleethub.iot-fips.ca-central-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -16,10 +12,6 @@ const regionHash: RegionHash = {
   },
   "us-east-1": {
     variants: [
-      {
-        hostname: "api.fleethub.iot.us-east-1.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "api.fleethub.iot-fips.us-east-1.amazonaws.com",
         tags: ["fips"],
@@ -29,10 +21,6 @@ const regionHash: RegionHash = {
   "us-east-2": {
     variants: [
       {
-        hostname: "api.fleethub.iot.us-east-2.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "api.fleethub.iot-fips.us-east-2.amazonaws.com",
         tags: ["fips"],
       },
@@ -40,10 +28,6 @@ const regionHash: RegionHash = {
   },
   "us-west-2": {
     variants: [
-      {
-        hostname: "api.fleethub.iot.us-west-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "api.fleethub.iot-fips.us-west-2.amazonaws.com",
         tags: ["fips"],

--- a/clients/client-kendra/src/endpoints.ts
+++ b/clients/client-kendra/src/endpoints.ts
@@ -5,10 +5,6 @@ const regionHash: RegionHash = {
   "us-east-1": {
     variants: [
       {
-        hostname: "kendra.us-east-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "kendra-fips.us-east-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -16,10 +12,6 @@ const regionHash: RegionHash = {
   },
   "us-east-2": {
     variants: [
-      {
-        hostname: "kendra.us-east-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "kendra-fips.us-east-2.amazonaws.com",
         tags: ["fips"],
@@ -29,10 +21,6 @@ const regionHash: RegionHash = {
   "us-gov-west-1": {
     variants: [
       {
-        hostname: "kendra.us-gov-west-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "kendra-fips.us-gov-west-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -40,10 +28,6 @@ const regionHash: RegionHash = {
   },
   "us-west-2": {
     variants: [
-      {
-        hostname: "kendra.us-west-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "kendra-fips.us-west-2.amazonaws.com",
         tags: ["fips"],

--- a/clients/client-kinesis/src/endpoints.ts
+++ b/clients/client-kinesis/src/endpoints.ts
@@ -5,10 +5,6 @@ const regionHash: RegionHash = {
   "us-east-1": {
     variants: [
       {
-        hostname: "kinesis.us-east-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "kinesis-fips.us-east-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -16,10 +12,6 @@ const regionHash: RegionHash = {
   },
   "us-east-2": {
     variants: [
-      {
-        hostname: "kinesis.us-east-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "kinesis-fips.us-east-2.amazonaws.com",
         tags: ["fips"],
@@ -47,10 +39,6 @@ const regionHash: RegionHash = {
   "us-west-1": {
     variants: [
       {
-        hostname: "kinesis.us-west-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "kinesis-fips.us-west-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -58,10 +46,6 @@ const regionHash: RegionHash = {
   },
   "us-west-2": {
     variants: [
-      {
-        hostname: "kinesis.us-west-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "kinesis-fips.us-west-2.amazonaws.com",
         tags: ["fips"],

--- a/clients/client-kms/src/endpoints.ts
+++ b/clients/client-kms/src/endpoints.ts
@@ -5,10 +5,6 @@ const regionHash: RegionHash = {
   "af-south-1": {
     variants: [
       {
-        hostname: "kms.af-south-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "kms-fips.af-south-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -16,10 +12,6 @@ const regionHash: RegionHash = {
   },
   "ap-east-1": {
     variants: [
-      {
-        hostname: "kms.ap-east-1.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "kms-fips.ap-east-1.amazonaws.com",
         tags: ["fips"],
@@ -29,10 +21,6 @@ const regionHash: RegionHash = {
   "ap-northeast-1": {
     variants: [
       {
-        hostname: "kms.ap-northeast-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "kms-fips.ap-northeast-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -40,10 +28,6 @@ const regionHash: RegionHash = {
   },
   "ap-northeast-2": {
     variants: [
-      {
-        hostname: "kms.ap-northeast-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "kms-fips.ap-northeast-2.amazonaws.com",
         tags: ["fips"],
@@ -53,10 +37,6 @@ const regionHash: RegionHash = {
   "ap-northeast-3": {
     variants: [
       {
-        hostname: "kms.ap-northeast-3.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "kms-fips.ap-northeast-3.amazonaws.com",
         tags: ["fips"],
       },
@@ -64,10 +44,6 @@ const regionHash: RegionHash = {
   },
   "ap-south-1": {
     variants: [
-      {
-        hostname: "kms.ap-south-1.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "kms-fips.ap-south-1.amazonaws.com",
         tags: ["fips"],
@@ -77,10 +53,6 @@ const regionHash: RegionHash = {
   "ap-southeast-1": {
     variants: [
       {
-        hostname: "kms.ap-southeast-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "kms-fips.ap-southeast-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -88,10 +60,6 @@ const regionHash: RegionHash = {
   },
   "ap-southeast-2": {
     variants: [
-      {
-        hostname: "kms.ap-southeast-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "kms-fips.ap-southeast-2.amazonaws.com",
         tags: ["fips"],
@@ -101,10 +69,6 @@ const regionHash: RegionHash = {
   "ap-southeast-3": {
     variants: [
       {
-        hostname: "kms.ap-southeast-3.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "kms-fips.ap-southeast-3.amazonaws.com",
         tags: ["fips"],
       },
@@ -112,10 +76,6 @@ const regionHash: RegionHash = {
   },
   "ca-central-1": {
     variants: [
-      {
-        hostname: "kms.ca-central-1.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "kms-fips.ca-central-1.amazonaws.com",
         tags: ["fips"],
@@ -125,10 +85,6 @@ const regionHash: RegionHash = {
   "eu-central-1": {
     variants: [
       {
-        hostname: "kms.eu-central-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "kms-fips.eu-central-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -136,10 +92,6 @@ const regionHash: RegionHash = {
   },
   "eu-north-1": {
     variants: [
-      {
-        hostname: "kms.eu-north-1.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "kms-fips.eu-north-1.amazonaws.com",
         tags: ["fips"],
@@ -149,10 +101,6 @@ const regionHash: RegionHash = {
   "eu-south-1": {
     variants: [
       {
-        hostname: "kms.eu-south-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "kms-fips.eu-south-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -160,10 +108,6 @@ const regionHash: RegionHash = {
   },
   "eu-west-1": {
     variants: [
-      {
-        hostname: "kms.eu-west-1.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "kms-fips.eu-west-1.amazonaws.com",
         tags: ["fips"],
@@ -173,10 +117,6 @@ const regionHash: RegionHash = {
   "eu-west-2": {
     variants: [
       {
-        hostname: "kms.eu-west-2.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "kms-fips.eu-west-2.amazonaws.com",
         tags: ["fips"],
       },
@@ -184,10 +124,6 @@ const regionHash: RegionHash = {
   },
   "eu-west-3": {
     variants: [
-      {
-        hostname: "kms.eu-west-3.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "kms-fips.eu-west-3.amazonaws.com",
         tags: ["fips"],
@@ -197,10 +133,6 @@ const regionHash: RegionHash = {
   "me-south-1": {
     variants: [
       {
-        hostname: "kms.me-south-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "kms-fips.me-south-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -208,10 +140,6 @@ const regionHash: RegionHash = {
   },
   "sa-east-1": {
     variants: [
-      {
-        hostname: "kms.sa-east-1.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "kms-fips.sa-east-1.amazonaws.com",
         tags: ["fips"],
@@ -221,10 +149,6 @@ const regionHash: RegionHash = {
   "us-east-1": {
     variants: [
       {
-        hostname: "kms.us-east-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "kms-fips.us-east-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -232,10 +156,6 @@ const regionHash: RegionHash = {
   },
   "us-east-2": {
     variants: [
-      {
-        hostname: "kms.us-east-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "kms-fips.us-east-2.amazonaws.com",
         tags: ["fips"],
@@ -245,10 +165,6 @@ const regionHash: RegionHash = {
   "us-gov-east-1": {
     variants: [
       {
-        hostname: "kms.us-gov-east-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "kms-fips.us-gov-east-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -256,10 +172,6 @@ const regionHash: RegionHash = {
   },
   "us-gov-west-1": {
     variants: [
-      {
-        hostname: "kms.us-gov-west-1.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "kms-fips.us-gov-west-1.amazonaws.com",
         tags: ["fips"],
@@ -269,10 +181,6 @@ const regionHash: RegionHash = {
   "us-iso-east-1": {
     variants: [
       {
-        hostname: "kms.us-iso-east-1.c2s.ic.gov",
-        tags: [],
-      },
-      {
         hostname: "kms-fips.us-iso-east-1.c2s.ic.gov",
         tags: ["fips"],
       },
@@ -280,10 +188,6 @@ const regionHash: RegionHash = {
   },
   "us-iso-west-1": {
     variants: [
-      {
-        hostname: "kms.us-iso-west-1.c2s.ic.gov",
-        tags: [],
-      },
       {
         hostname: "kms-fips.us-iso-west-1.c2s.ic.gov",
         tags: ["fips"],
@@ -293,10 +197,6 @@ const regionHash: RegionHash = {
   "us-isob-east-1": {
     variants: [
       {
-        hostname: "kms.us-isob-east-1.sc2s.sgov.gov",
-        tags: [],
-      },
-      {
         hostname: "kms-fips.us-isob-east-1.sc2s.sgov.gov",
         tags: ["fips"],
       },
@@ -305,10 +205,6 @@ const regionHash: RegionHash = {
   "us-west-1": {
     variants: [
       {
-        hostname: "kms.us-west-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "kms-fips.us-west-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -316,10 +212,6 @@ const regionHash: RegionHash = {
   },
   "us-west-2": {
     variants: [
-      {
-        hostname: "kms.us-west-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "kms-fips.us-west-2.amazonaws.com",
         tags: ["fips"],

--- a/clients/client-lakeformation/src/endpoints.ts
+++ b/clients/client-lakeformation/src/endpoints.ts
@@ -5,10 +5,6 @@ const regionHash: RegionHash = {
   "us-east-1": {
     variants: [
       {
-        hostname: "lakeformation.us-east-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "lakeformation-fips.us-east-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -16,10 +12,6 @@ const regionHash: RegionHash = {
   },
   "us-east-2": {
     variants: [
-      {
-        hostname: "lakeformation.us-east-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "lakeformation-fips.us-east-2.amazonaws.com",
         tags: ["fips"],
@@ -29,10 +21,6 @@ const regionHash: RegionHash = {
   "us-gov-west-1": {
     variants: [
       {
-        hostname: "lakeformation.us-gov-west-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "lakeformation-fips.us-gov-west-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -41,10 +29,6 @@ const regionHash: RegionHash = {
   "us-west-1": {
     variants: [
       {
-        hostname: "lakeformation.us-west-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "lakeformation-fips.us-west-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -52,10 +36,6 @@ const regionHash: RegionHash = {
   },
   "us-west-2": {
     variants: [
-      {
-        hostname: "lakeformation.us-west-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "lakeformation-fips.us-west-2.amazonaws.com",
         tags: ["fips"],

--- a/clients/client-lambda/src/endpoints.ts
+++ b/clients/client-lambda/src/endpoints.ts
@@ -5,10 +5,6 @@ const regionHash: RegionHash = {
   "af-south-1": {
     variants: [
       {
-        hostname: "lambda.af-south-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "lambda.af-south-1.api.aws",
         tags: ["dualstack"],
       },
@@ -16,10 +12,6 @@ const regionHash: RegionHash = {
   },
   "ap-east-1": {
     variants: [
-      {
-        hostname: "lambda.ap-east-1.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "lambda.ap-east-1.api.aws",
         tags: ["dualstack"],
@@ -29,10 +21,6 @@ const regionHash: RegionHash = {
   "ap-northeast-1": {
     variants: [
       {
-        hostname: "lambda.ap-northeast-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "lambda.ap-northeast-1.api.aws",
         tags: ["dualstack"],
       },
@@ -40,10 +28,6 @@ const regionHash: RegionHash = {
   },
   "ap-northeast-2": {
     variants: [
-      {
-        hostname: "lambda.ap-northeast-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "lambda.ap-northeast-2.api.aws",
         tags: ["dualstack"],
@@ -53,10 +37,6 @@ const regionHash: RegionHash = {
   "ap-northeast-3": {
     variants: [
       {
-        hostname: "lambda.ap-northeast-3.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "lambda.ap-northeast-3.api.aws",
         tags: ["dualstack"],
       },
@@ -64,10 +44,6 @@ const regionHash: RegionHash = {
   },
   "ap-south-1": {
     variants: [
-      {
-        hostname: "lambda.ap-south-1.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "lambda.ap-south-1.api.aws",
         tags: ["dualstack"],
@@ -77,10 +53,6 @@ const regionHash: RegionHash = {
   "ap-southeast-1": {
     variants: [
       {
-        hostname: "lambda.ap-southeast-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "lambda.ap-southeast-1.api.aws",
         tags: ["dualstack"],
       },
@@ -88,10 +60,6 @@ const regionHash: RegionHash = {
   },
   "ap-southeast-2": {
     variants: [
-      {
-        hostname: "lambda.ap-southeast-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "lambda.ap-southeast-2.api.aws",
         tags: ["dualstack"],
@@ -101,10 +69,6 @@ const regionHash: RegionHash = {
   "ap-southeast-3": {
     variants: [
       {
-        hostname: "lambda.ap-southeast-3.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "lambda.ap-southeast-3.api.aws",
         tags: ["dualstack"],
       },
@@ -112,10 +76,6 @@ const regionHash: RegionHash = {
   },
   "ca-central-1": {
     variants: [
-      {
-        hostname: "lambda.ca-central-1.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "lambda.ca-central-1.api.aws",
         tags: ["dualstack"],
@@ -125,10 +85,6 @@ const regionHash: RegionHash = {
   "cn-north-1": {
     variants: [
       {
-        hostname: "lambda.cn-north-1.amazonaws.com.cn",
-        tags: [],
-      },
-      {
         hostname: "lambda.cn-north-1.api.amazonwebservices.com.cn",
         tags: ["dualstack"],
       },
@@ -136,10 +92,6 @@ const regionHash: RegionHash = {
   },
   "cn-northwest-1": {
     variants: [
-      {
-        hostname: "lambda.cn-northwest-1.amazonaws.com.cn",
-        tags: [],
-      },
       {
         hostname: "lambda.cn-northwest-1.api.amazonwebservices.com.cn",
         tags: ["dualstack"],
@@ -149,10 +101,6 @@ const regionHash: RegionHash = {
   "eu-central-1": {
     variants: [
       {
-        hostname: "lambda.eu-central-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "lambda.eu-central-1.api.aws",
         tags: ["dualstack"],
       },
@@ -160,10 +108,6 @@ const regionHash: RegionHash = {
   },
   "eu-north-1": {
     variants: [
-      {
-        hostname: "lambda.eu-north-1.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "lambda.eu-north-1.api.aws",
         tags: ["dualstack"],
@@ -173,10 +117,6 @@ const regionHash: RegionHash = {
   "eu-south-1": {
     variants: [
       {
-        hostname: "lambda.eu-south-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "lambda.eu-south-1.api.aws",
         tags: ["dualstack"],
       },
@@ -184,10 +124,6 @@ const regionHash: RegionHash = {
   },
   "eu-west-1": {
     variants: [
-      {
-        hostname: "lambda.eu-west-1.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "lambda.eu-west-1.api.aws",
         tags: ["dualstack"],
@@ -197,10 +133,6 @@ const regionHash: RegionHash = {
   "eu-west-2": {
     variants: [
       {
-        hostname: "lambda.eu-west-2.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "lambda.eu-west-2.api.aws",
         tags: ["dualstack"],
       },
@@ -208,10 +140,6 @@ const regionHash: RegionHash = {
   },
   "eu-west-3": {
     variants: [
-      {
-        hostname: "lambda.eu-west-3.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "lambda.eu-west-3.api.aws",
         tags: ["dualstack"],
@@ -221,10 +149,6 @@ const regionHash: RegionHash = {
   "me-south-1": {
     variants: [
       {
-        hostname: "lambda.me-south-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "lambda.me-south-1.api.aws",
         tags: ["dualstack"],
       },
@@ -233,10 +157,6 @@ const regionHash: RegionHash = {
   "sa-east-1": {
     variants: [
       {
-        hostname: "lambda.sa-east-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "lambda.sa-east-1.api.aws",
         tags: ["dualstack"],
       },
@@ -244,10 +164,6 @@ const regionHash: RegionHash = {
   },
   "us-east-1": {
     variants: [
-      {
-        hostname: "lambda.us-east-1.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "lambda-fips.us-east-1.amazonaws.com",
         tags: ["fips"],
@@ -261,10 +177,6 @@ const regionHash: RegionHash = {
   "us-east-2": {
     variants: [
       {
-        hostname: "lambda.us-east-2.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "lambda-fips.us-east-2.amazonaws.com",
         tags: ["fips"],
       },
@@ -277,10 +189,6 @@ const regionHash: RegionHash = {
   "us-gov-east-1": {
     variants: [
       {
-        hostname: "lambda.us-gov-east-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "lambda-fips.us-gov-east-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -289,10 +197,6 @@ const regionHash: RegionHash = {
   "us-gov-west-1": {
     variants: [
       {
-        hostname: "lambda.us-gov-west-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "lambda-fips.us-gov-west-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -300,10 +204,6 @@ const regionHash: RegionHash = {
   },
   "us-west-1": {
     variants: [
-      {
-        hostname: "lambda.us-west-1.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "lambda-fips.us-west-1.amazonaws.com",
         tags: ["fips"],
@@ -316,10 +216,6 @@ const regionHash: RegionHash = {
   },
   "us-west-2": {
     variants: [
-      {
-        hostname: "lambda.us-west-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "lambda-fips.us-west-2.amazonaws.com",
         tags: ["fips"],

--- a/clients/client-lex-model-building-service/src/endpoints.ts
+++ b/clients/client-lex-model-building-service/src/endpoints.ts
@@ -5,10 +5,6 @@ const regionHash: RegionHash = {
   "us-east-1": {
     variants: [
       {
-        hostname: "models.lex.us-east-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "models-fips.lex.us-east-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -17,10 +13,6 @@ const regionHash: RegionHash = {
   "us-gov-west-1": {
     variants: [
       {
-        hostname: "models.lex.us-gov-west-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "models-fips.lex.us-gov-west-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -28,10 +20,6 @@ const regionHash: RegionHash = {
   },
   "us-west-2": {
     variants: [
-      {
-        hostname: "models.lex.us-west-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "models-fips.lex.us-west-2.amazonaws.com",
         tags: ["fips"],

--- a/clients/client-lex-runtime-service/src/endpoints.ts
+++ b/clients/client-lex-runtime-service/src/endpoints.ts
@@ -5,10 +5,6 @@ const regionHash: RegionHash = {
   "us-east-1": {
     variants: [
       {
-        hostname: "runtime.lex.us-east-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "runtime-fips.lex.us-east-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -17,10 +13,6 @@ const regionHash: RegionHash = {
   "us-gov-west-1": {
     variants: [
       {
-        hostname: "runtime.lex.us-gov-west-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "runtime-fips.lex.us-gov-west-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -28,10 +20,6 @@ const regionHash: RegionHash = {
   },
   "us-west-2": {
     variants: [
-      {
-        hostname: "runtime.lex.us-west-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "runtime-fips.lex.us-west-2.amazonaws.com",
         tags: ["fips"],

--- a/clients/client-license-manager/src/endpoints.ts
+++ b/clients/client-license-manager/src/endpoints.ts
@@ -5,10 +5,6 @@ const regionHash: RegionHash = {
   "us-east-1": {
     variants: [
       {
-        hostname: "license-manager.us-east-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "license-manager-fips.us-east-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -16,10 +12,6 @@ const regionHash: RegionHash = {
   },
   "us-east-2": {
     variants: [
-      {
-        hostname: "license-manager.us-east-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "license-manager-fips.us-east-2.amazonaws.com",
         tags: ["fips"],
@@ -29,10 +21,6 @@ const regionHash: RegionHash = {
   "us-gov-east-1": {
     variants: [
       {
-        hostname: "license-manager.us-gov-east-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "license-manager-fips.us-gov-east-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -40,10 +28,6 @@ const regionHash: RegionHash = {
   },
   "us-gov-west-1": {
     variants: [
-      {
-        hostname: "license-manager.us-gov-west-1.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "license-manager-fips.us-gov-west-1.amazonaws.com",
         tags: ["fips"],
@@ -53,10 +37,6 @@ const regionHash: RegionHash = {
   "us-west-1": {
     variants: [
       {
-        hostname: "license-manager.us-west-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "license-manager-fips.us-west-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -64,10 +44,6 @@ const regionHash: RegionHash = {
   },
   "us-west-2": {
     variants: [
-      {
-        hostname: "license-manager.us-west-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "license-manager-fips.us-west-2.amazonaws.com",
         tags: ["fips"],

--- a/clients/client-macie/src/endpoints.ts
+++ b/clients/client-macie/src/endpoints.ts
@@ -5,10 +5,6 @@ const regionHash: RegionHash = {
   "us-east-1": {
     variants: [
       {
-        hostname: "macie.us-east-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "macie-fips.us-east-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -16,10 +12,6 @@ const regionHash: RegionHash = {
   },
   "us-west-2": {
     variants: [
-      {
-        hostname: "macie.us-west-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "macie-fips.us-west-2.amazonaws.com",
         tags: ["fips"],

--- a/clients/client-macie2/src/endpoints.ts
+++ b/clients/client-macie2/src/endpoints.ts
@@ -5,10 +5,6 @@ const regionHash: RegionHash = {
   "us-east-1": {
     variants: [
       {
-        hostname: "macie2.us-east-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "macie2-fips.us-east-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -16,10 +12,6 @@ const regionHash: RegionHash = {
   },
   "us-east-2": {
     variants: [
-      {
-        hostname: "macie2.us-east-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "macie2-fips.us-east-2.amazonaws.com",
         tags: ["fips"],
@@ -29,10 +21,6 @@ const regionHash: RegionHash = {
   "us-west-1": {
     variants: [
       {
-        hostname: "macie2.us-west-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "macie2-fips.us-west-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -40,10 +28,6 @@ const regionHash: RegionHash = {
   },
   "us-west-2": {
     variants: [
-      {
-        hostname: "macie2.us-west-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "macie2-fips.us-west-2.amazonaws.com",
         tags: ["fips"],

--- a/clients/client-mediaconvert/src/endpoints.ts
+++ b/clients/client-mediaconvert/src/endpoints.ts
@@ -5,10 +5,6 @@ const regionHash: RegionHash = {
   "ca-central-1": {
     variants: [
       {
-        hostname: "mediaconvert.ca-central-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "mediaconvert-fips.ca-central-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -26,10 +22,6 @@ const regionHash: RegionHash = {
   "us-east-1": {
     variants: [
       {
-        hostname: "mediaconvert.us-east-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "mediaconvert-fips.us-east-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -37,10 +29,6 @@ const regionHash: RegionHash = {
   },
   "us-east-2": {
     variants: [
-      {
-        hostname: "mediaconvert.us-east-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "mediaconvert-fips.us-east-2.amazonaws.com",
         tags: ["fips"],
@@ -59,10 +47,6 @@ const regionHash: RegionHash = {
   "us-west-1": {
     variants: [
       {
-        hostname: "mediaconvert.us-west-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "mediaconvert-fips.us-west-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -70,10 +54,6 @@ const regionHash: RegionHash = {
   },
   "us-west-2": {
     variants: [
-      {
-        hostname: "mediaconvert.us-west-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "mediaconvert-fips.us-west-2.amazonaws.com",
         tags: ["fips"],

--- a/clients/client-medialive/src/endpoints.ts
+++ b/clients/client-medialive/src/endpoints.ts
@@ -5,10 +5,6 @@ const regionHash: RegionHash = {
   "us-east-1": {
     variants: [
       {
-        hostname: "medialive.us-east-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "medialive-fips.us-east-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -17,10 +13,6 @@ const regionHash: RegionHash = {
   "us-east-2": {
     variants: [
       {
-        hostname: "medialive.us-east-2.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "medialive-fips.us-east-2.amazonaws.com",
         tags: ["fips"],
       },
@@ -28,10 +20,6 @@ const regionHash: RegionHash = {
   },
   "us-west-2": {
     variants: [
-      {
-        hostname: "medialive.us-west-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "medialive-fips.us-west-2.amazonaws.com",
         tags: ["fips"],

--- a/clients/client-mq/src/endpoints.ts
+++ b/clients/client-mq/src/endpoints.ts
@@ -5,10 +5,6 @@ const regionHash: RegionHash = {
   "us-east-1": {
     variants: [
       {
-        hostname: "mq.us-east-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "mq-fips.us-east-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -16,10 +12,6 @@ const regionHash: RegionHash = {
   },
   "us-east-2": {
     variants: [
-      {
-        hostname: "mq.us-east-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "mq-fips.us-east-2.amazonaws.com",
         tags: ["fips"],
@@ -29,10 +21,6 @@ const regionHash: RegionHash = {
   "us-gov-east-1": {
     variants: [
       {
-        hostname: "mq.us-gov-east-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "mq-fips.us-gov-east-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -40,10 +28,6 @@ const regionHash: RegionHash = {
   },
   "us-gov-west-1": {
     variants: [
-      {
-        hostname: "mq.us-gov-west-1.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "mq-fips.us-gov-west-1.amazonaws.com",
         tags: ["fips"],
@@ -53,10 +37,6 @@ const regionHash: RegionHash = {
   "us-west-1": {
     variants: [
       {
-        hostname: "mq.us-west-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "mq-fips.us-west-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -64,10 +44,6 @@ const regionHash: RegionHash = {
   },
   "us-west-2": {
     variants: [
-      {
-        hostname: "mq.us-west-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "mq-fips.us-west-2.amazonaws.com",
         tags: ["fips"],

--- a/clients/client-neptune/src/endpoints.ts
+++ b/clients/client-neptune/src/endpoints.ts
@@ -5,10 +5,6 @@ const regionHash: RegionHash = {
   "ca-central-1": {
     variants: [
       {
-        hostname: "rds.ca-central-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "rds-fips.ca-central-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -17,10 +13,6 @@ const regionHash: RegionHash = {
   "us-east-1": {
     variants: [
       {
-        hostname: "rds.us-east-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "rds-fips.us-east-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -28,10 +20,6 @@ const regionHash: RegionHash = {
   },
   "us-east-2": {
     variants: [
-      {
-        hostname: "rds.us-east-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "rds-fips.us-east-2.amazonaws.com",
         tags: ["fips"],
@@ -42,20 +30,12 @@ const regionHash: RegionHash = {
     variants: [
       {
         hostname: "rds.us-gov-east-1.amazonaws.com",
-        tags: [],
-      },
-      {
-        hostname: "rds.us-gov-east-1.amazonaws.com",
         tags: ["fips"],
       },
     ],
   },
   "us-gov-west-1": {
     variants: [
-      {
-        hostname: "rds.us-gov-west-1.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "rds.us-gov-west-1.amazonaws.com",
         tags: ["fips"],
@@ -65,10 +45,6 @@ const regionHash: RegionHash = {
   "us-west-1": {
     variants: [
       {
-        hostname: "rds.us-west-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "rds-fips.us-west-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -76,10 +52,6 @@ const regionHash: RegionHash = {
   },
   "us-west-2": {
     variants: [
-      {
-        hostname: "rds.us-west-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "rds-fips.us-west-2.amazonaws.com",
         tags: ["fips"],

--- a/clients/client-network-firewall/src/endpoints.ts
+++ b/clients/client-network-firewall/src/endpoints.ts
@@ -5,10 +5,6 @@ const regionHash: RegionHash = {
   "ca-central-1": {
     variants: [
       {
-        hostname: "network-firewall.ca-central-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "network-firewall-fips.ca-central-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -16,10 +12,6 @@ const regionHash: RegionHash = {
   },
   "us-east-1": {
     variants: [
-      {
-        hostname: "network-firewall.us-east-1.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "network-firewall-fips.us-east-1.amazonaws.com",
         tags: ["fips"],
@@ -29,10 +21,6 @@ const regionHash: RegionHash = {
   "us-east-2": {
     variants: [
       {
-        hostname: "network-firewall.us-east-2.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "network-firewall-fips.us-east-2.amazonaws.com",
         tags: ["fips"],
       },
@@ -40,10 +28,6 @@ const regionHash: RegionHash = {
   },
   "us-gov-east-1": {
     variants: [
-      {
-        hostname: "network-firewall.us-gov-east-1.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "network-firewall-fips.us-gov-east-1.amazonaws.com",
         tags: ["fips"],
@@ -53,10 +37,6 @@ const regionHash: RegionHash = {
   "us-gov-west-1": {
     variants: [
       {
-        hostname: "network-firewall.us-gov-west-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "network-firewall-fips.us-gov-west-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -65,10 +45,6 @@ const regionHash: RegionHash = {
   "us-west-1": {
     variants: [
       {
-        hostname: "network-firewall.us-west-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "network-firewall-fips.us-west-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -76,10 +52,6 @@ const regionHash: RegionHash = {
   },
   "us-west-2": {
     variants: [
-      {
-        hostname: "network-firewall.us-west-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "network-firewall-fips.us-west-2.amazonaws.com",
         tags: ["fips"],

--- a/clients/client-opensearch/src/endpoints.ts
+++ b/clients/client-opensearch/src/endpoints.ts
@@ -5,10 +5,6 @@ const regionHash: RegionHash = {
   "us-east-1": {
     variants: [
       {
-        hostname: "es.us-east-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "es-fips.us-east-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -16,10 +12,6 @@ const regionHash: RegionHash = {
   },
   "us-east-2": {
     variants: [
-      {
-        hostname: "es.us-east-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "es-fips.us-east-2.amazonaws.com",
         tags: ["fips"],
@@ -29,10 +21,6 @@ const regionHash: RegionHash = {
   "us-gov-east-1": {
     variants: [
       {
-        hostname: "es.us-gov-east-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "es-fips.us-gov-east-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -40,10 +28,6 @@ const regionHash: RegionHash = {
   },
   "us-gov-west-1": {
     variants: [
-      {
-        hostname: "es.us-gov-west-1.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "es-fips.us-gov-west-1.amazonaws.com",
         tags: ["fips"],
@@ -53,10 +37,6 @@ const regionHash: RegionHash = {
   "us-west-1": {
     variants: [
       {
-        hostname: "es.us-west-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "es-fips.us-west-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -64,10 +44,6 @@ const regionHash: RegionHash = {
   },
   "us-west-2": {
     variants: [
-      {
-        hostname: "es.us-west-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "es-fips.us-west-2.amazonaws.com",
         tags: ["fips"],

--- a/clients/client-outposts/src/endpoints.ts
+++ b/clients/client-outposts/src/endpoints.ts
@@ -5,10 +5,6 @@ const regionHash: RegionHash = {
   "ca-central-1": {
     variants: [
       {
-        hostname: "outposts.ca-central-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "outposts-fips.ca-central-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -17,10 +13,6 @@ const regionHash: RegionHash = {
   "us-east-1": {
     variants: [
       {
-        hostname: "outposts.us-east-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "outposts-fips.us-east-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -28,10 +20,6 @@ const regionHash: RegionHash = {
   },
   "us-east-2": {
     variants: [
-      {
-        hostname: "outposts.us-east-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "outposts-fips.us-east-2.amazonaws.com",
         tags: ["fips"],
@@ -59,10 +47,6 @@ const regionHash: RegionHash = {
   "us-west-1": {
     variants: [
       {
-        hostname: "outposts.us-west-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "outposts-fips.us-west-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -70,10 +54,6 @@ const regionHash: RegionHash = {
   },
   "us-west-2": {
     variants: [
-      {
-        hostname: "outposts.us-west-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "outposts-fips.us-west-2.amazonaws.com",
         tags: ["fips"],

--- a/clients/client-pinpoint-email/src/endpoints.ts
+++ b/clients/client-pinpoint-email/src/endpoints.ts
@@ -5,10 +5,6 @@ const regionHash: RegionHash = {
   "us-gov-west-1": {
     variants: [
       {
-        hostname: "email.us-gov-west-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "email-fips.us-gov-west-1.amazonaws.com",
         tags: ["fips"],
       },

--- a/clients/client-polly/src/endpoints.ts
+++ b/clients/client-polly/src/endpoints.ts
@@ -5,10 +5,6 @@ const regionHash: RegionHash = {
   "us-east-1": {
     variants: [
       {
-        hostname: "polly.us-east-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "polly-fips.us-east-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -16,10 +12,6 @@ const regionHash: RegionHash = {
   },
   "us-east-2": {
     variants: [
-      {
-        hostname: "polly.us-east-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "polly-fips.us-east-2.amazonaws.com",
         tags: ["fips"],
@@ -29,10 +21,6 @@ const regionHash: RegionHash = {
   "us-gov-west-1": {
     variants: [
       {
-        hostname: "polly.us-gov-west-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "polly-fips.us-gov-west-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -41,10 +29,6 @@ const regionHash: RegionHash = {
   "us-west-1": {
     variants: [
       {
-        hostname: "polly.us-west-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "polly-fips.us-west-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -52,10 +36,6 @@ const regionHash: RegionHash = {
   },
   "us-west-2": {
     variants: [
-      {
-        hostname: "polly.us-west-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "polly-fips.us-west-2.amazonaws.com",
         tags: ["fips"],

--- a/clients/client-qldb-session/src/endpoints.ts
+++ b/clients/client-qldb-session/src/endpoints.ts
@@ -5,10 +5,6 @@ const regionHash: RegionHash = {
   "us-east-1": {
     variants: [
       {
-        hostname: "session.qldb.us-east-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "session.qldb-fips.us-east-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -17,10 +13,6 @@ const regionHash: RegionHash = {
   "us-east-2": {
     variants: [
       {
-        hostname: "session.qldb.us-east-2.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "session.qldb-fips.us-east-2.amazonaws.com",
         tags: ["fips"],
       },
@@ -28,10 +20,6 @@ const regionHash: RegionHash = {
   },
   "us-west-2": {
     variants: [
-      {
-        hostname: "session.qldb.us-west-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "session.qldb-fips.us-west-2.amazonaws.com",
         tags: ["fips"],

--- a/clients/client-qldb/src/endpoints.ts
+++ b/clients/client-qldb/src/endpoints.ts
@@ -5,10 +5,6 @@ const regionHash: RegionHash = {
   "us-east-1": {
     variants: [
       {
-        hostname: "qldb.us-east-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "qldb-fips.us-east-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -17,10 +13,6 @@ const regionHash: RegionHash = {
   "us-east-2": {
     variants: [
       {
-        hostname: "qldb.us-east-2.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "qldb-fips.us-east-2.amazonaws.com",
         tags: ["fips"],
       },
@@ -28,10 +20,6 @@ const regionHash: RegionHash = {
   },
   "us-west-2": {
     variants: [
-      {
-        hostname: "qldb.us-west-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "qldb-fips.us-west-2.amazonaws.com",
         tags: ["fips"],

--- a/clients/client-ram/src/endpoints.ts
+++ b/clients/client-ram/src/endpoints.ts
@@ -5,10 +5,6 @@ const regionHash: RegionHash = {
   "ca-central-1": {
     variants: [
       {
-        hostname: "ram.ca-central-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "ram-fips.ca-central-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -17,10 +13,6 @@ const regionHash: RegionHash = {
   "us-east-1": {
     variants: [
       {
-        hostname: "ram.us-east-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "ram-fips.us-east-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -28,10 +20,6 @@ const regionHash: RegionHash = {
   },
   "us-east-2": {
     variants: [
-      {
-        hostname: "ram.us-east-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "ram-fips.us-east-2.amazonaws.com",
         tags: ["fips"],
@@ -59,10 +47,6 @@ const regionHash: RegionHash = {
   "us-west-1": {
     variants: [
       {
-        hostname: "ram.us-west-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "ram-fips.us-west-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -70,10 +54,6 @@ const regionHash: RegionHash = {
   },
   "us-west-2": {
     variants: [
-      {
-        hostname: "ram.us-west-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "ram-fips.us-west-2.amazonaws.com",
         tags: ["fips"],

--- a/clients/client-rds/src/endpoints.ts
+++ b/clients/client-rds/src/endpoints.ts
@@ -5,10 +5,6 @@ const regionHash: RegionHash = {
   "ca-central-1": {
     variants: [
       {
-        hostname: "rds.ca-central-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "rds-fips.ca-central-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -17,10 +13,6 @@ const regionHash: RegionHash = {
   "us-east-1": {
     variants: [
       {
-        hostname: "rds.us-east-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "rds-fips.us-east-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -28,10 +20,6 @@ const regionHash: RegionHash = {
   },
   "us-east-2": {
     variants: [
-      {
-        hostname: "rds.us-east-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "rds-fips.us-east-2.amazonaws.com",
         tags: ["fips"],
@@ -42,20 +30,12 @@ const regionHash: RegionHash = {
     variants: [
       {
         hostname: "rds.us-gov-east-1.amazonaws.com",
-        tags: [],
-      },
-      {
-        hostname: "rds.us-gov-east-1.amazonaws.com",
         tags: ["fips"],
       },
     ],
   },
   "us-gov-west-1": {
     variants: [
-      {
-        hostname: "rds.us-gov-west-1.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "rds.us-gov-west-1.amazonaws.com",
         tags: ["fips"],
@@ -65,10 +45,6 @@ const regionHash: RegionHash = {
   "us-west-1": {
     variants: [
       {
-        hostname: "rds.us-west-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "rds-fips.us-west-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -76,10 +52,6 @@ const regionHash: RegionHash = {
   },
   "us-west-2": {
     variants: [
-      {
-        hostname: "rds.us-west-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "rds-fips.us-west-2.amazonaws.com",
         tags: ["fips"],

--- a/clients/client-redshift/src/endpoints.ts
+++ b/clients/client-redshift/src/endpoints.ts
@@ -5,10 +5,6 @@ const regionHash: RegionHash = {
   "ca-central-1": {
     variants: [
       {
-        hostname: "redshift.ca-central-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "redshift-fips.ca-central-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -17,10 +13,6 @@ const regionHash: RegionHash = {
   "us-east-1": {
     variants: [
       {
-        hostname: "redshift.us-east-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "redshift-fips.us-east-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -28,10 +20,6 @@ const regionHash: RegionHash = {
   },
   "us-east-2": {
     variants: [
-      {
-        hostname: "redshift.us-east-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "redshift-fips.us-east-2.amazonaws.com",
         tags: ["fips"],
@@ -59,10 +47,6 @@ const regionHash: RegionHash = {
   "us-west-1": {
     variants: [
       {
-        hostname: "redshift.us-west-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "redshift-fips.us-west-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -70,10 +54,6 @@ const regionHash: RegionHash = {
   },
   "us-west-2": {
     variants: [
-      {
-        hostname: "redshift.us-west-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "redshift-fips.us-west-2.amazonaws.com",
         tags: ["fips"],

--- a/clients/client-rekognition/src/endpoints.ts
+++ b/clients/client-rekognition/src/endpoints.ts
@@ -5,10 +5,6 @@ const regionHash: RegionHash = {
   "ca-central-1": {
     variants: [
       {
-        hostname: "rekognition.ca-central-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "rekognition-fips.ca-central-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -16,10 +12,6 @@ const regionHash: RegionHash = {
   },
   "us-east-1": {
     variants: [
-      {
-        hostname: "rekognition.us-east-1.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "rekognition-fips.us-east-1.amazonaws.com",
         tags: ["fips"],
@@ -29,10 +21,6 @@ const regionHash: RegionHash = {
   "us-east-2": {
     variants: [
       {
-        hostname: "rekognition.us-east-2.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "rekognition-fips.us-east-2.amazonaws.com",
         tags: ["fips"],
       },
@@ -40,10 +28,6 @@ const regionHash: RegionHash = {
   },
   "us-gov-west-1": {
     variants: [
-      {
-        hostname: "rekognition.us-gov-west-1.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "rekognition-fips.us-gov-west-1.amazonaws.com",
         tags: ["fips"],
@@ -53,10 +37,6 @@ const regionHash: RegionHash = {
   "us-west-1": {
     variants: [
       {
-        hostname: "rekognition.us-west-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "rekognition-fips.us-west-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -64,10 +44,6 @@ const regionHash: RegionHash = {
   },
   "us-west-2": {
     variants: [
-      {
-        hostname: "rekognition.us-west-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "rekognition-fips.us-west-2.amazonaws.com",
         tags: ["fips"],

--- a/clients/client-resource-groups/src/endpoints.ts
+++ b/clients/client-resource-groups/src/endpoints.ts
@@ -5,10 +5,6 @@ const regionHash: RegionHash = {
   "us-east-1": {
     variants: [
       {
-        hostname: "resource-groups.us-east-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "resource-groups-fips.us-east-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -16,10 +12,6 @@ const regionHash: RegionHash = {
   },
   "us-east-2": {
     variants: [
-      {
-        hostname: "resource-groups.us-east-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "resource-groups-fips.us-east-2.amazonaws.com",
         tags: ["fips"],
@@ -30,20 +22,12 @@ const regionHash: RegionHash = {
     variants: [
       {
         hostname: "resource-groups.us-gov-east-1.amazonaws.com",
-        tags: [],
-      },
-      {
-        hostname: "resource-groups.us-gov-east-1.amazonaws.com",
         tags: ["fips"],
       },
     ],
   },
   "us-gov-west-1": {
     variants: [
-      {
-        hostname: "resource-groups.us-gov-west-1.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "resource-groups.us-gov-west-1.amazonaws.com",
         tags: ["fips"],
@@ -53,10 +37,6 @@ const regionHash: RegionHash = {
   "us-west-1": {
     variants: [
       {
-        hostname: "resource-groups.us-west-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "resource-groups-fips.us-west-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -64,10 +44,6 @@ const regionHash: RegionHash = {
   },
   "us-west-2": {
     variants: [
-      {
-        hostname: "resource-groups.us-west-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "resource-groups-fips.us-west-2.amazonaws.com",
         tags: ["fips"],

--- a/clients/client-s3/src/endpoints.ts
+++ b/clients/client-s3/src/endpoints.ts
@@ -5,10 +5,6 @@ const regionHash: RegionHash = {
   "af-south-1": {
     variants: [
       {
-        hostname: "s3.af-south-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "s3.dualstack.af-south-1.amazonaws.com",
         tags: ["dualstack"],
       },
@@ -16,10 +12,6 @@ const regionHash: RegionHash = {
   },
   "ap-east-1": {
     variants: [
-      {
-        hostname: "s3.ap-east-1.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "s3.dualstack.ap-east-1.amazonaws.com",
         tags: ["dualstack"],
@@ -41,10 +33,6 @@ const regionHash: RegionHash = {
   "ap-northeast-2": {
     variants: [
       {
-        hostname: "s3.ap-northeast-2.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "s3.dualstack.ap-northeast-2.amazonaws.com",
         tags: ["dualstack"],
       },
@@ -53,10 +41,6 @@ const regionHash: RegionHash = {
   "ap-northeast-3": {
     variants: [
       {
-        hostname: "s3.ap-northeast-3.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "s3.dualstack.ap-northeast-3.amazonaws.com",
         tags: ["dualstack"],
       },
@@ -64,10 +48,6 @@ const regionHash: RegionHash = {
   },
   "ap-south-1": {
     variants: [
-      {
-        hostname: "s3.ap-south-1.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "s3.dualstack.ap-south-1.amazonaws.com",
         tags: ["dualstack"],
@@ -101,10 +81,6 @@ const regionHash: RegionHash = {
   "ap-southeast-3": {
     variants: [
       {
-        hostname: "s3.ap-southeast-3.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "s3.dualstack.ap-southeast-3.amazonaws.com",
         tags: ["dualstack"],
       },
@@ -122,10 +98,6 @@ const regionHash: RegionHash = {
   "ca-central-1": {
     variants: [
       {
-        hostname: "s3.ca-central-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "s3-fips.ca-central-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -142,10 +114,6 @@ const regionHash: RegionHash = {
   "cn-north-1": {
     variants: [
       {
-        hostname: "s3.cn-north-1.amazonaws.com.cn",
-        tags: [],
-      },
-      {
         hostname: "s3.dualstack.cn-north-1.amazonaws.com.cn",
         tags: ["dualstack"],
       },
@@ -153,10 +121,6 @@ const regionHash: RegionHash = {
   },
   "cn-northwest-1": {
     variants: [
-      {
-        hostname: "s3.cn-northwest-1.amazonaws.com.cn",
-        tags: [],
-      },
       {
         hostname: "s3.dualstack.cn-northwest-1.amazonaws.com.cn",
         tags: ["dualstack"],
@@ -166,10 +130,6 @@ const regionHash: RegionHash = {
   "eu-central-1": {
     variants: [
       {
-        hostname: "s3.eu-central-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "s3.dualstack.eu-central-1.amazonaws.com",
         tags: ["dualstack"],
       },
@@ -178,10 +138,6 @@ const regionHash: RegionHash = {
   "eu-north-1": {
     variants: [
       {
-        hostname: "s3.eu-north-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "s3.dualstack.eu-north-1.amazonaws.com",
         tags: ["dualstack"],
       },
@@ -189,10 +145,6 @@ const regionHash: RegionHash = {
   },
   "eu-south-1": {
     variants: [
-      {
-        hostname: "s3.eu-south-1.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "s3.dualstack.eu-south-1.amazonaws.com",
         tags: ["dualstack"],
@@ -214,10 +166,6 @@ const regionHash: RegionHash = {
   "eu-west-2": {
     variants: [
       {
-        hostname: "s3.eu-west-2.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "s3.dualstack.eu-west-2.amazonaws.com",
         tags: ["dualstack"],
       },
@@ -226,10 +174,6 @@ const regionHash: RegionHash = {
   "eu-west-3": {
     variants: [
       {
-        hostname: "s3.eu-west-3.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "s3.dualstack.eu-west-3.amazonaws.com",
         tags: ["dualstack"],
       },
@@ -237,10 +181,6 @@ const regionHash: RegionHash = {
   },
   "me-south-1": {
     variants: [
-      {
-        hostname: "s3.me-south-1.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "s3.dualstack.me-south-1.amazonaws.com",
         tags: ["dualstack"],
@@ -290,10 +230,6 @@ const regionHash: RegionHash = {
   },
   "us-east-2": {
     variants: [
-      {
-        hostname: "s3.us-east-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "s3-fips.dualstack.us-east-2.amazonaws.com",
         tags: ["dualstack", "fips"],

--- a/clients/client-sagemaker-runtime/src/endpoints.ts
+++ b/clients/client-sagemaker-runtime/src/endpoints.ts
@@ -5,10 +5,6 @@ const regionHash: RegionHash = {
   "us-east-1": {
     variants: [
       {
-        hostname: "runtime.sagemaker.us-east-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "runtime-fips.sagemaker.us-east-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -16,10 +12,6 @@ const regionHash: RegionHash = {
   },
   "us-east-2": {
     variants: [
-      {
-        hostname: "runtime.sagemaker.us-east-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "runtime-fips.sagemaker.us-east-2.amazonaws.com",
         tags: ["fips"],
@@ -30,20 +22,12 @@ const regionHash: RegionHash = {
     variants: [
       {
         hostname: "runtime.sagemaker.us-gov-west-1.amazonaws.com",
-        tags: [],
-      },
-      {
-        hostname: "runtime.sagemaker.us-gov-west-1.amazonaws.com",
         tags: ["fips"],
       },
     ],
   },
   "us-west-1": {
     variants: [
-      {
-        hostname: "runtime.sagemaker.us-west-1.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "runtime-fips.sagemaker.us-west-1.amazonaws.com",
         tags: ["fips"],
@@ -52,10 +36,6 @@ const regionHash: RegionHash = {
   },
   "us-west-2": {
     variants: [
-      {
-        hostname: "runtime.sagemaker.us-west-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "runtime-fips.sagemaker.us-west-2.amazonaws.com",
         tags: ["fips"],

--- a/clients/client-sagemaker/src/endpoints.ts
+++ b/clients/client-sagemaker/src/endpoints.ts
@@ -5,10 +5,6 @@ const regionHash: RegionHash = {
   "us-east-1": {
     variants: [
       {
-        hostname: "api.sagemaker.us-east-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "api-fips.sagemaker.us-east-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -16,10 +12,6 @@ const regionHash: RegionHash = {
   },
   "us-east-2": {
     variants: [
-      {
-        hostname: "api.sagemaker.us-east-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "api-fips.sagemaker.us-east-2.amazonaws.com",
         tags: ["fips"],
@@ -29,10 +21,6 @@ const regionHash: RegionHash = {
   "us-gov-west-1": {
     variants: [
       {
-        hostname: "api.sagemaker.us-gov-west-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "api-fips.sagemaker.us-gov-west-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -41,10 +29,6 @@ const regionHash: RegionHash = {
   "us-west-1": {
     variants: [
       {
-        hostname: "api.sagemaker.us-west-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "api-fips.sagemaker.us-west-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -52,10 +36,6 @@ const regionHash: RegionHash = {
   },
   "us-west-2": {
     variants: [
-      {
-        hostname: "api.sagemaker.us-west-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "api-fips.sagemaker.us-west-2.amazonaws.com",
         tags: ["fips"],

--- a/clients/client-secrets-manager/src/endpoints.ts
+++ b/clients/client-secrets-manager/src/endpoints.ts
@@ -5,10 +5,6 @@ const regionHash: RegionHash = {
   "us-east-1": {
     variants: [
       {
-        hostname: "secretsmanager.us-east-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "secretsmanager-fips.us-east-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -16,10 +12,6 @@ const regionHash: RegionHash = {
   },
   "us-east-2": {
     variants: [
-      {
-        hostname: "secretsmanager.us-east-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "secretsmanager-fips.us-east-2.amazonaws.com",
         tags: ["fips"],
@@ -29,10 +21,6 @@ const regionHash: RegionHash = {
   "us-gov-east-1": {
     variants: [
       {
-        hostname: "secretsmanager.us-gov-east-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "secretsmanager-fips.us-gov-east-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -40,10 +28,6 @@ const regionHash: RegionHash = {
   },
   "us-gov-west-1": {
     variants: [
-      {
-        hostname: "secretsmanager.us-gov-west-1.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "secretsmanager-fips.us-gov-west-1.amazonaws.com",
         tags: ["fips"],
@@ -53,10 +37,6 @@ const regionHash: RegionHash = {
   "us-west-1": {
     variants: [
       {
-        hostname: "secretsmanager.us-west-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "secretsmanager-fips.us-west-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -64,10 +44,6 @@ const regionHash: RegionHash = {
   },
   "us-west-2": {
     variants: [
-      {
-        hostname: "secretsmanager.us-west-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "secretsmanager-fips.us-west-2.amazonaws.com",
         tags: ["fips"],

--- a/clients/client-securityhub/src/endpoints.ts
+++ b/clients/client-securityhub/src/endpoints.ts
@@ -5,10 +5,6 @@ const regionHash: RegionHash = {
   "us-east-1": {
     variants: [
       {
-        hostname: "securityhub.us-east-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "securityhub-fips.us-east-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -16,10 +12,6 @@ const regionHash: RegionHash = {
   },
   "us-east-2": {
     variants: [
-      {
-        hostname: "securityhub.us-east-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "securityhub-fips.us-east-2.amazonaws.com",
         tags: ["fips"],
@@ -29,10 +21,6 @@ const regionHash: RegionHash = {
   "us-gov-east-1": {
     variants: [
       {
-        hostname: "securityhub.us-gov-east-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "securityhub-fips.us-gov-east-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -40,10 +28,6 @@ const regionHash: RegionHash = {
   },
   "us-gov-west-1": {
     variants: [
-      {
-        hostname: "securityhub.us-gov-west-1.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "securityhub-fips.us-gov-west-1.amazonaws.com",
         tags: ["fips"],
@@ -53,10 +37,6 @@ const regionHash: RegionHash = {
   "us-west-1": {
     variants: [
       {
-        hostname: "securityhub.us-west-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "securityhub-fips.us-west-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -64,10 +44,6 @@ const regionHash: RegionHash = {
   },
   "us-west-2": {
     variants: [
-      {
-        hostname: "securityhub.us-west-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "securityhub-fips.us-west-2.amazonaws.com",
         tags: ["fips"],

--- a/clients/client-service-catalog-appregistry/src/endpoints.ts
+++ b/clients/client-service-catalog-appregistry/src/endpoints.ts
@@ -5,10 +5,6 @@ const regionHash: RegionHash = {
   "ca-central-1": {
     variants: [
       {
-        hostname: "servicecatalog-appregistry.ca-central-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "servicecatalog-appregistry-fips.ca-central-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -17,10 +13,6 @@ const regionHash: RegionHash = {
   "us-east-1": {
     variants: [
       {
-        hostname: "servicecatalog-appregistry.us-east-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "servicecatalog-appregistry-fips.us-east-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -28,10 +20,6 @@ const regionHash: RegionHash = {
   },
   "us-east-2": {
     variants: [
-      {
-        hostname: "servicecatalog-appregistry.us-east-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "servicecatalog-appregistry-fips.us-east-2.amazonaws.com",
         tags: ["fips"],
@@ -42,20 +30,12 @@ const regionHash: RegionHash = {
     variants: [
       {
         hostname: "servicecatalog-appregistry.us-gov-east-1.amazonaws.com",
-        tags: [],
-      },
-      {
-        hostname: "servicecatalog-appregistry.us-gov-east-1.amazonaws.com",
         tags: ["fips"],
       },
     ],
   },
   "us-gov-west-1": {
     variants: [
-      {
-        hostname: "servicecatalog-appregistry.us-gov-west-1.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "servicecatalog-appregistry.us-gov-west-1.amazonaws.com",
         tags: ["fips"],
@@ -65,10 +45,6 @@ const regionHash: RegionHash = {
   "us-west-1": {
     variants: [
       {
-        hostname: "servicecatalog-appregistry.us-west-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "servicecatalog-appregistry-fips.us-west-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -76,10 +52,6 @@ const regionHash: RegionHash = {
   },
   "us-west-2": {
     variants: [
-      {
-        hostname: "servicecatalog-appregistry.us-west-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "servicecatalog-appregistry-fips.us-west-2.amazonaws.com",
         tags: ["fips"],

--- a/clients/client-service-catalog/src/endpoints.ts
+++ b/clients/client-service-catalog/src/endpoints.ts
@@ -5,10 +5,6 @@ const regionHash: RegionHash = {
   "us-east-1": {
     variants: [
       {
-        hostname: "servicecatalog.us-east-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "servicecatalog-fips.us-east-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -16,10 +12,6 @@ const regionHash: RegionHash = {
   },
   "us-east-2": {
     variants: [
-      {
-        hostname: "servicecatalog.us-east-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "servicecatalog-fips.us-east-2.amazonaws.com",
         tags: ["fips"],
@@ -29,10 +21,6 @@ const regionHash: RegionHash = {
   "us-gov-east-1": {
     variants: [
       {
-        hostname: "servicecatalog.us-gov-east-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "servicecatalog-fips.us-gov-east-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -40,10 +28,6 @@ const regionHash: RegionHash = {
   },
   "us-gov-west-1": {
     variants: [
-      {
-        hostname: "servicecatalog.us-gov-west-1.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "servicecatalog-fips.us-gov-west-1.amazonaws.com",
         tags: ["fips"],
@@ -53,10 +37,6 @@ const regionHash: RegionHash = {
   "us-west-1": {
     variants: [
       {
-        hostname: "servicecatalog.us-west-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "servicecatalog-fips.us-west-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -64,10 +44,6 @@ const regionHash: RegionHash = {
   },
   "us-west-2": {
     variants: [
-      {
-        hostname: "servicecatalog.us-west-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "servicecatalog-fips.us-west-2.amazonaws.com",
         tags: ["fips"],

--- a/clients/client-service-quotas/src/endpoints.ts
+++ b/clients/client-service-quotas/src/endpoints.ts
@@ -6,20 +6,12 @@ const regionHash: RegionHash = {
     variants: [
       {
         hostname: "servicequotas.us-gov-east-1.amazonaws.com",
-        tags: [],
-      },
-      {
-        hostname: "servicequotas.us-gov-east-1.amazonaws.com",
         tags: ["fips"],
       },
     ],
   },
   "us-gov-west-1": {
     variants: [
-      {
-        hostname: "servicequotas.us-gov-west-1.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "servicequotas.us-gov-west-1.amazonaws.com",
         tags: ["fips"],

--- a/clients/client-servicediscovery/src/endpoints.ts
+++ b/clients/client-servicediscovery/src/endpoints.ts
@@ -5,10 +5,6 @@ const regionHash: RegionHash = {
   "ca-central-1": {
     variants: [
       {
-        hostname: "servicediscovery.ca-central-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "servicediscovery-fips.ca-central-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -16,10 +12,6 @@ const regionHash: RegionHash = {
   },
   "us-east-1": {
     variants: [
-      {
-        hostname: "servicediscovery.us-east-1.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "servicediscovery-fips.us-east-1.amazonaws.com",
         tags: ["fips"],
@@ -29,10 +21,6 @@ const regionHash: RegionHash = {
   "us-east-2": {
     variants: [
       {
-        hostname: "servicediscovery.us-east-2.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "servicediscovery-fips.us-east-2.amazonaws.com",
         tags: ["fips"],
       },
@@ -40,10 +28,6 @@ const regionHash: RegionHash = {
   },
   "us-gov-east-1": {
     variants: [
-      {
-        hostname: "servicediscovery.us-gov-east-1.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "servicediscovery-fips.us-gov-east-1.amazonaws.com",
         tags: ["fips"],
@@ -53,10 +37,6 @@ const regionHash: RegionHash = {
   "us-gov-west-1": {
     variants: [
       {
-        hostname: "servicediscovery.us-gov-west-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "servicediscovery-fips.us-gov-west-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -65,10 +45,6 @@ const regionHash: RegionHash = {
   "us-west-1": {
     variants: [
       {
-        hostname: "servicediscovery.us-west-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "servicediscovery-fips.us-west-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -76,10 +52,6 @@ const regionHash: RegionHash = {
   },
   "us-west-2": {
     variants: [
-      {
-        hostname: "servicediscovery.us-west-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "servicediscovery-fips.us-west-2.amazonaws.com",
         tags: ["fips"],

--- a/clients/client-ses/src/endpoints.ts
+++ b/clients/client-ses/src/endpoints.ts
@@ -5,10 +5,6 @@ const regionHash: RegionHash = {
   "us-gov-west-1": {
     variants: [
       {
-        hostname: "email.us-gov-west-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "email-fips.us-gov-west-1.amazonaws.com",
         tags: ["fips"],
       },

--- a/clients/client-sesv2/src/endpoints.ts
+++ b/clients/client-sesv2/src/endpoints.ts
@@ -5,10 +5,6 @@ const regionHash: RegionHash = {
   "us-gov-west-1": {
     variants: [
       {
-        hostname: "email.us-gov-west-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "email-fips.us-gov-west-1.amazonaws.com",
         tags: ["fips"],
       },

--- a/clients/client-sfn/src/endpoints.ts
+++ b/clients/client-sfn/src/endpoints.ts
@@ -5,10 +5,6 @@ const regionHash: RegionHash = {
   "us-east-1": {
     variants: [
       {
-        hostname: "states.us-east-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "states-fips.us-east-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -17,10 +13,6 @@ const regionHash: RegionHash = {
   "us-east-2": {
     variants: [
       {
-        hostname: "states.us-east-2.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "states-fips.us-east-2.amazonaws.com",
         tags: ["fips"],
       },
@@ -28,10 +20,6 @@ const regionHash: RegionHash = {
   },
   "us-gov-east-1": {
     variants: [
-      {
-        hostname: "states.us-gov-east-1.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "states-fips.us-gov-east-1.amazonaws.com",
         tags: ["fips"],
@@ -42,20 +30,12 @@ const regionHash: RegionHash = {
     variants: [
       {
         hostname: "states.us-gov-west-1.amazonaws.com",
-        tags: [],
-      },
-      {
-        hostname: "states.us-gov-west-1.amazonaws.com",
         tags: ["fips"],
       },
     ],
   },
   "us-west-1": {
     variants: [
-      {
-        hostname: "states.us-west-1.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "states-fips.us-west-1.amazonaws.com",
         tags: ["fips"],
@@ -64,10 +44,6 @@ const regionHash: RegionHash = {
   },
   "us-west-2": {
     variants: [
-      {
-        hostname: "states.us-west-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "states-fips.us-west-2.amazonaws.com",
         tags: ["fips"],

--- a/clients/client-sms/src/endpoints.ts
+++ b/clients/client-sms/src/endpoints.ts
@@ -5,10 +5,6 @@ const regionHash: RegionHash = {
   "us-east-1": {
     variants: [
       {
-        hostname: "sms.us-east-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "sms-fips.us-east-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -16,10 +12,6 @@ const regionHash: RegionHash = {
   },
   "us-east-2": {
     variants: [
-      {
-        hostname: "sms.us-east-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "sms-fips.us-east-2.amazonaws.com",
         tags: ["fips"],
@@ -29,10 +21,6 @@ const regionHash: RegionHash = {
   "us-gov-east-1": {
     variants: [
       {
-        hostname: "sms.us-gov-east-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "sms-fips.us-gov-east-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -40,10 +28,6 @@ const regionHash: RegionHash = {
   },
   "us-gov-west-1": {
     variants: [
-      {
-        hostname: "sms.us-gov-west-1.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "sms-fips.us-gov-west-1.amazonaws.com",
         tags: ["fips"],
@@ -53,10 +37,6 @@ const regionHash: RegionHash = {
   "us-west-1": {
     variants: [
       {
-        hostname: "sms.us-west-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "sms-fips.us-west-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -64,10 +44,6 @@ const regionHash: RegionHash = {
   },
   "us-west-2": {
     variants: [
-      {
-        hostname: "sms.us-west-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "sms-fips.us-west-2.amazonaws.com",
         tags: ["fips"],

--- a/clients/client-snowball/src/endpoints.ts
+++ b/clients/client-snowball/src/endpoints.ts
@@ -5,10 +5,6 @@ const regionHash: RegionHash = {
   "ap-northeast-1": {
     variants: [
       {
-        hostname: "snowball.ap-northeast-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "snowball-fips.ap-northeast-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -16,10 +12,6 @@ const regionHash: RegionHash = {
   },
   "ap-northeast-2": {
     variants: [
-      {
-        hostname: "snowball.ap-northeast-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "snowball-fips.ap-northeast-2.amazonaws.com",
         tags: ["fips"],
@@ -29,10 +21,6 @@ const regionHash: RegionHash = {
   "ap-northeast-3": {
     variants: [
       {
-        hostname: "snowball.ap-northeast-3.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "snowball-fips.ap-northeast-3.amazonaws.com",
         tags: ["fips"],
       },
@@ -40,10 +28,6 @@ const regionHash: RegionHash = {
   },
   "ap-south-1": {
     variants: [
-      {
-        hostname: "snowball.ap-south-1.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "snowball-fips.ap-south-1.amazonaws.com",
         tags: ["fips"],
@@ -53,10 +37,6 @@ const regionHash: RegionHash = {
   "ap-southeast-1": {
     variants: [
       {
-        hostname: "snowball.ap-southeast-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "snowball-fips.ap-southeast-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -64,10 +44,6 @@ const regionHash: RegionHash = {
   },
   "ap-southeast-2": {
     variants: [
-      {
-        hostname: "snowball.ap-southeast-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "snowball-fips.ap-southeast-2.amazonaws.com",
         tags: ["fips"],
@@ -77,10 +53,6 @@ const regionHash: RegionHash = {
   "ca-central-1": {
     variants: [
       {
-        hostname: "snowball.ca-central-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "snowball-fips.ca-central-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -88,10 +60,6 @@ const regionHash: RegionHash = {
   },
   "cn-north-1": {
     variants: [
-      {
-        hostname: "snowball.cn-north-1.amazonaws.com.cn",
-        tags: [],
-      },
       {
         hostname: "snowball-fips.cn-north-1.amazonaws.com.cn",
         tags: ["fips"],
@@ -101,10 +69,6 @@ const regionHash: RegionHash = {
   "cn-northwest-1": {
     variants: [
       {
-        hostname: "snowball.cn-northwest-1.amazonaws.com.cn",
-        tags: [],
-      },
-      {
         hostname: "snowball-fips.cn-northwest-1.amazonaws.com.cn",
         tags: ["fips"],
       },
@@ -112,10 +76,6 @@ const regionHash: RegionHash = {
   },
   "eu-central-1": {
     variants: [
-      {
-        hostname: "snowball.eu-central-1.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "snowball-fips.eu-central-1.amazonaws.com",
         tags: ["fips"],
@@ -125,10 +85,6 @@ const regionHash: RegionHash = {
   "eu-west-1": {
     variants: [
       {
-        hostname: "snowball.eu-west-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "snowball-fips.eu-west-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -136,10 +92,6 @@ const regionHash: RegionHash = {
   },
   "eu-west-2": {
     variants: [
-      {
-        hostname: "snowball.eu-west-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "snowball-fips.eu-west-2.amazonaws.com",
         tags: ["fips"],
@@ -149,10 +101,6 @@ const regionHash: RegionHash = {
   "eu-west-3": {
     variants: [
       {
-        hostname: "snowball.eu-west-3.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "snowball-fips.eu-west-3.amazonaws.com",
         tags: ["fips"],
       },
@@ -160,10 +108,6 @@ const regionHash: RegionHash = {
   },
   "sa-east-1": {
     variants: [
-      {
-        hostname: "snowball.sa-east-1.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "snowball-fips.sa-east-1.amazonaws.com",
         tags: ["fips"],
@@ -173,10 +117,6 @@ const regionHash: RegionHash = {
   "us-east-1": {
     variants: [
       {
-        hostname: "snowball.us-east-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "snowball-fips.us-east-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -184,10 +124,6 @@ const regionHash: RegionHash = {
   },
   "us-east-2": {
     variants: [
-      {
-        hostname: "snowball.us-east-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "snowball-fips.us-east-2.amazonaws.com",
         tags: ["fips"],
@@ -197,10 +133,6 @@ const regionHash: RegionHash = {
   "us-gov-east-1": {
     variants: [
       {
-        hostname: "snowball.us-gov-east-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "snowball-fips.us-gov-east-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -208,10 +140,6 @@ const regionHash: RegionHash = {
   },
   "us-gov-west-1": {
     variants: [
-      {
-        hostname: "snowball.us-gov-west-1.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "snowball-fips.us-gov-west-1.amazonaws.com",
         tags: ["fips"],
@@ -221,10 +149,6 @@ const regionHash: RegionHash = {
   "us-west-1": {
     variants: [
       {
-        hostname: "snowball.us-west-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "snowball-fips.us-west-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -232,10 +156,6 @@ const regionHash: RegionHash = {
   },
   "us-west-2": {
     variants: [
-      {
-        hostname: "snowball.us-west-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "snowball-fips.us-west-2.amazonaws.com",
         tags: ["fips"],

--- a/clients/client-sns/src/endpoints.ts
+++ b/clients/client-sns/src/endpoints.ts
@@ -5,10 +5,6 @@ const regionHash: RegionHash = {
   "us-east-1": {
     variants: [
       {
-        hostname: "sns.us-east-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "sns-fips.us-east-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -16,10 +12,6 @@ const regionHash: RegionHash = {
   },
   "us-east-2": {
     variants: [
-      {
-        hostname: "sns.us-east-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "sns-fips.us-east-2.amazonaws.com",
         tags: ["fips"],
@@ -47,10 +39,6 @@ const regionHash: RegionHash = {
   "us-west-1": {
     variants: [
       {
-        hostname: "sns.us-west-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "sns-fips.us-west-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -58,10 +46,6 @@ const regionHash: RegionHash = {
   },
   "us-west-2": {
     variants: [
-      {
-        hostname: "sns.us-west-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "sns-fips.us-west-2.amazonaws.com",
         tags: ["fips"],

--- a/clients/client-sqs/src/endpoints.ts
+++ b/clients/client-sqs/src/endpoints.ts
@@ -5,10 +5,6 @@ const regionHash: RegionHash = {
   "us-east-1": {
     variants: [
       {
-        hostname: "sqs.us-east-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "sqs-fips.us-east-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -16,10 +12,6 @@ const regionHash: RegionHash = {
   },
   "us-east-2": {
     variants: [
-      {
-        hostname: "sqs.us-east-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "sqs-fips.us-east-2.amazonaws.com",
         tags: ["fips"],
@@ -47,10 +39,6 @@ const regionHash: RegionHash = {
   "us-west-1": {
     variants: [
       {
-        hostname: "sqs.us-west-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "sqs-fips.us-west-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -58,10 +46,6 @@ const regionHash: RegionHash = {
   },
   "us-west-2": {
     variants: [
-      {
-        hostname: "sqs.us-west-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "sqs-fips.us-west-2.amazonaws.com",
         tags: ["fips"],

--- a/clients/client-ssm/src/endpoints.ts
+++ b/clients/client-ssm/src/endpoints.ts
@@ -5,10 +5,6 @@ const regionHash: RegionHash = {
   "ca-central-1": {
     variants: [
       {
-        hostname: "ssm.ca-central-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "ssm-fips.ca-central-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -17,10 +13,6 @@ const regionHash: RegionHash = {
   "us-east-1": {
     variants: [
       {
-        hostname: "ssm.us-east-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "ssm-fips.us-east-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -28,10 +20,6 @@ const regionHash: RegionHash = {
   },
   "us-east-2": {
     variants: [
-      {
-        hostname: "ssm.us-east-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "ssm-fips.us-east-2.amazonaws.com",
         tags: ["fips"],
@@ -42,20 +30,12 @@ const regionHash: RegionHash = {
     variants: [
       {
         hostname: "ssm.us-gov-east-1.amazonaws.com",
-        tags: [],
-      },
-      {
-        hostname: "ssm.us-gov-east-1.amazonaws.com",
         tags: ["fips"],
       },
     ],
   },
   "us-gov-west-1": {
     variants: [
-      {
-        hostname: "ssm.us-gov-west-1.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "ssm.us-gov-west-1.amazonaws.com",
         tags: ["fips"],
@@ -65,10 +45,6 @@ const regionHash: RegionHash = {
   "us-west-1": {
     variants: [
       {
-        hostname: "ssm.us-west-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "ssm-fips.us-west-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -76,10 +52,6 @@ const regionHash: RegionHash = {
   },
   "us-west-2": {
     variants: [
-      {
-        hostname: "ssm.us-west-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "ssm-fips.us-west-2.amazonaws.com",
         tags: ["fips"],

--- a/clients/client-storage-gateway/src/endpoints.ts
+++ b/clients/client-storage-gateway/src/endpoints.ts
@@ -5,10 +5,6 @@ const regionHash: RegionHash = {
   "ca-central-1": {
     variants: [
       {
-        hostname: "storagegateway.ca-central-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "storagegateway-fips.ca-central-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -16,10 +12,6 @@ const regionHash: RegionHash = {
   },
   "us-east-1": {
     variants: [
-      {
-        hostname: "storagegateway.us-east-1.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "storagegateway-fips.us-east-1.amazonaws.com",
         tags: ["fips"],
@@ -29,10 +21,6 @@ const regionHash: RegionHash = {
   "us-east-2": {
     variants: [
       {
-        hostname: "storagegateway.us-east-2.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "storagegateway-fips.us-east-2.amazonaws.com",
         tags: ["fips"],
       },
@@ -40,10 +28,6 @@ const regionHash: RegionHash = {
   },
   "us-gov-east-1": {
     variants: [
-      {
-        hostname: "storagegateway.us-gov-east-1.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "storagegateway-fips.us-gov-east-1.amazonaws.com",
         tags: ["fips"],
@@ -53,10 +37,6 @@ const regionHash: RegionHash = {
   "us-gov-west-1": {
     variants: [
       {
-        hostname: "storagegateway.us-gov-west-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "storagegateway-fips.us-gov-west-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -65,10 +45,6 @@ const regionHash: RegionHash = {
   "us-west-1": {
     variants: [
       {
-        hostname: "storagegateway.us-west-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "storagegateway-fips.us-west-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -76,10 +52,6 @@ const regionHash: RegionHash = {
   },
   "us-west-2": {
     variants: [
-      {
-        hostname: "storagegateway.us-west-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "storagegateway-fips.us-west-2.amazonaws.com",
         tags: ["fips"],

--- a/clients/client-sts/src/endpoints.ts
+++ b/clients/client-sts/src/endpoints.ts
@@ -14,10 +14,6 @@ const regionHash: RegionHash = {
   "us-east-1": {
     variants: [
       {
-        hostname: "sts.us-east-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "sts-fips.us-east-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -25,10 +21,6 @@ const regionHash: RegionHash = {
   },
   "us-east-2": {
     variants: [
-      {
-        hostname: "sts.us-east-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "sts-fips.us-east-2.amazonaws.com",
         tags: ["fips"],
@@ -39,20 +31,12 @@ const regionHash: RegionHash = {
     variants: [
       {
         hostname: "sts.us-gov-east-1.amazonaws.com",
-        tags: [],
-      },
-      {
-        hostname: "sts.us-gov-east-1.amazonaws.com",
         tags: ["fips"],
       },
     ],
   },
   "us-gov-west-1": {
     variants: [
-      {
-        hostname: "sts.us-gov-west-1.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "sts.us-gov-west-1.amazonaws.com",
         tags: ["fips"],
@@ -62,10 +46,6 @@ const regionHash: RegionHash = {
   "us-west-1": {
     variants: [
       {
-        hostname: "sts.us-west-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "sts-fips.us-west-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -73,10 +53,6 @@ const regionHash: RegionHash = {
   },
   "us-west-2": {
     variants: [
-      {
-        hostname: "sts.us-west-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "sts-fips.us-west-2.amazonaws.com",
         tags: ["fips"],

--- a/clients/client-swf/src/endpoints.ts
+++ b/clients/client-swf/src/endpoints.ts
@@ -5,10 +5,6 @@ const regionHash: RegionHash = {
   "us-east-1": {
     variants: [
       {
-        hostname: "swf.us-east-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "swf-fips.us-east-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -16,10 +12,6 @@ const regionHash: RegionHash = {
   },
   "us-east-2": {
     variants: [
-      {
-        hostname: "swf.us-east-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "swf-fips.us-east-2.amazonaws.com",
         tags: ["fips"],
@@ -47,10 +39,6 @@ const regionHash: RegionHash = {
   "us-west-1": {
     variants: [
       {
-        hostname: "swf.us-west-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "swf-fips.us-west-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -58,10 +46,6 @@ const regionHash: RegionHash = {
   },
   "us-west-2": {
     variants: [
-      {
-        hostname: "swf.us-west-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "swf-fips.us-west-2.amazonaws.com",
         tags: ["fips"],

--- a/clients/client-textract/src/endpoints.ts
+++ b/clients/client-textract/src/endpoints.ts
@@ -5,10 +5,6 @@ const regionHash: RegionHash = {
   "ca-central-1": {
     variants: [
       {
-        hostname: "textract.ca-central-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "textract-fips.ca-central-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -16,10 +12,6 @@ const regionHash: RegionHash = {
   },
   "us-east-1": {
     variants: [
-      {
-        hostname: "textract.us-east-1.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "textract-fips.us-east-1.amazonaws.com",
         tags: ["fips"],
@@ -29,10 +21,6 @@ const regionHash: RegionHash = {
   "us-east-2": {
     variants: [
       {
-        hostname: "textract.us-east-2.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "textract-fips.us-east-2.amazonaws.com",
         tags: ["fips"],
       },
@@ -40,10 +28,6 @@ const regionHash: RegionHash = {
   },
   "us-gov-east-1": {
     variants: [
-      {
-        hostname: "textract.us-gov-east-1.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "textract-fips.us-gov-east-1.amazonaws.com",
         tags: ["fips"],
@@ -53,10 +37,6 @@ const regionHash: RegionHash = {
   "us-gov-west-1": {
     variants: [
       {
-        hostname: "textract.us-gov-west-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "textract-fips.us-gov-west-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -65,10 +45,6 @@ const regionHash: RegionHash = {
   "us-west-1": {
     variants: [
       {
-        hostname: "textract.us-west-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "textract-fips.us-west-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -76,10 +52,6 @@ const regionHash: RegionHash = {
   },
   "us-west-2": {
     variants: [
-      {
-        hostname: "textract.us-west-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "textract-fips.us-west-2.amazonaws.com",
         tags: ["fips"],

--- a/clients/client-transcribe/src/endpoints.ts
+++ b/clients/client-transcribe/src/endpoints.ts
@@ -5,10 +5,6 @@ const regionHash: RegionHash = {
   "ca-central-1": {
     variants: [
       {
-        hostname: "transcribe.ca-central-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "fips.transcribe.ca-central-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -35,10 +31,6 @@ const regionHash: RegionHash = {
   "us-east-1": {
     variants: [
       {
-        hostname: "transcribe.us-east-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "fips.transcribe.us-east-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -46,10 +38,6 @@ const regionHash: RegionHash = {
   },
   "us-east-2": {
     variants: [
-      {
-        hostname: "transcribe.us-east-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "fips.transcribe.us-east-2.amazonaws.com",
         tags: ["fips"],
@@ -59,10 +47,6 @@ const regionHash: RegionHash = {
   "us-gov-east-1": {
     variants: [
       {
-        hostname: "transcribe.us-gov-east-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "fips.transcribe.us-gov-east-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -70,10 +54,6 @@ const regionHash: RegionHash = {
   },
   "us-gov-west-1": {
     variants: [
-      {
-        hostname: "transcribe.us-gov-west-1.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "fips.transcribe.us-gov-west-1.amazonaws.com",
         tags: ["fips"],
@@ -83,10 +63,6 @@ const regionHash: RegionHash = {
   "us-west-1": {
     variants: [
       {
-        hostname: "transcribe.us-west-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "fips.transcribe.us-west-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -94,10 +70,6 @@ const regionHash: RegionHash = {
   },
   "us-west-2": {
     variants: [
-      {
-        hostname: "transcribe.us-west-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "fips.transcribe.us-west-2.amazonaws.com",
         tags: ["fips"],

--- a/clients/client-transfer/src/endpoints.ts
+++ b/clients/client-transfer/src/endpoints.ts
@@ -5,10 +5,6 @@ const regionHash: RegionHash = {
   "ca-central-1": {
     variants: [
       {
-        hostname: "transfer.ca-central-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "transfer-fips.ca-central-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -16,10 +12,6 @@ const regionHash: RegionHash = {
   },
   "us-east-1": {
     variants: [
-      {
-        hostname: "transfer.us-east-1.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "transfer-fips.us-east-1.amazonaws.com",
         tags: ["fips"],
@@ -29,10 +21,6 @@ const regionHash: RegionHash = {
   "us-east-2": {
     variants: [
       {
-        hostname: "transfer.us-east-2.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "transfer-fips.us-east-2.amazonaws.com",
         tags: ["fips"],
       },
@@ -40,10 +28,6 @@ const regionHash: RegionHash = {
   },
   "us-gov-east-1": {
     variants: [
-      {
-        hostname: "transfer.us-gov-east-1.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "transfer-fips.us-gov-east-1.amazonaws.com",
         tags: ["fips"],
@@ -53,10 +37,6 @@ const regionHash: RegionHash = {
   "us-gov-west-1": {
     variants: [
       {
-        hostname: "transfer.us-gov-west-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "transfer-fips.us-gov-west-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -65,10 +45,6 @@ const regionHash: RegionHash = {
   "us-west-1": {
     variants: [
       {
-        hostname: "transfer.us-west-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "transfer-fips.us-west-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -76,10 +52,6 @@ const regionHash: RegionHash = {
   },
   "us-west-2": {
     variants: [
-      {
-        hostname: "transfer.us-west-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "transfer-fips.us-west-2.amazonaws.com",
         tags: ["fips"],

--- a/clients/client-translate/src/endpoints.ts
+++ b/clients/client-translate/src/endpoints.ts
@@ -5,10 +5,6 @@ const regionHash: RegionHash = {
   "us-east-1": {
     variants: [
       {
-        hostname: "translate.us-east-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "translate-fips.us-east-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -16,10 +12,6 @@ const regionHash: RegionHash = {
   },
   "us-east-2": {
     variants: [
-      {
-        hostname: "translate.us-east-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "translate-fips.us-east-2.amazonaws.com",
         tags: ["fips"],
@@ -29,10 +21,6 @@ const regionHash: RegionHash = {
   "us-gov-west-1": {
     variants: [
       {
-        hostname: "translate.us-gov-west-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "translate-fips.us-gov-west-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -40,10 +28,6 @@ const regionHash: RegionHash = {
   },
   "us-west-2": {
     variants: [
-      {
-        hostname: "translate.us-west-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "translate-fips.us-west-2.amazonaws.com",
         tags: ["fips"],

--- a/clients/client-workdocs/src/endpoints.ts
+++ b/clients/client-workdocs/src/endpoints.ts
@@ -5,10 +5,6 @@ const regionHash: RegionHash = {
   "us-east-1": {
     variants: [
       {
-        hostname: "workdocs.us-east-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "workdocs-fips.us-east-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -16,10 +12,6 @@ const regionHash: RegionHash = {
   },
   "us-west-2": {
     variants: [
-      {
-        hostname: "workdocs.us-west-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "workdocs-fips.us-west-2.amazonaws.com",
         tags: ["fips"],

--- a/clients/client-workspaces/src/endpoints.ts
+++ b/clients/client-workspaces/src/endpoints.ts
@@ -5,10 +5,6 @@ const regionHash: RegionHash = {
   "us-east-1": {
     variants: [
       {
-        hostname: "workspaces.us-east-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "workspaces-fips.us-east-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -17,10 +13,6 @@ const regionHash: RegionHash = {
   "us-gov-west-1": {
     variants: [
       {
-        hostname: "workspaces.us-gov-west-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "workspaces-fips.us-gov-west-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -28,10 +20,6 @@ const regionHash: RegionHash = {
   },
   "us-west-2": {
     variants: [
-      {
-        hostname: "workspaces.us-west-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "workspaces-fips.us-west-2.amazonaws.com",
         tags: ["fips"],

--- a/clients/client-xray/src/endpoints.ts
+++ b/clients/client-xray/src/endpoints.ts
@@ -5,10 +5,6 @@ const regionHash: RegionHash = {
   "us-east-1": {
     variants: [
       {
-        hostname: "xray.us-east-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "xray-fips.us-east-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -16,10 +12,6 @@ const regionHash: RegionHash = {
   },
   "us-east-2": {
     variants: [
-      {
-        hostname: "xray.us-east-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "xray-fips.us-east-2.amazonaws.com",
         tags: ["fips"],
@@ -29,10 +21,6 @@ const regionHash: RegionHash = {
   "us-gov-east-1": {
     variants: [
       {
-        hostname: "xray.us-gov-east-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "xray-fips.us-gov-east-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -40,10 +28,6 @@ const regionHash: RegionHash = {
   },
   "us-gov-west-1": {
     variants: [
-      {
-        hostname: "xray.us-gov-west-1.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "xray-fips.us-gov-west-1.amazonaws.com",
         tags: ["fips"],
@@ -53,10 +37,6 @@ const regionHash: RegionHash = {
   "us-west-1": {
     variants: [
       {
-        hostname: "xray.us-west-1.amazonaws.com",
-        tags: [],
-      },
-      {
         hostname: "xray-fips.us-west-1.amazonaws.com",
         tags: ["fips"],
       },
@@ -64,10 +44,6 @@ const regionHash: RegionHash = {
   },
   "us-west-2": {
     variants: [
-      {
-        hostname: "xray.us-west-2.amazonaws.com",
-        tags: [],
-      },
       {
         hostname: "xray-fips.us-west-2.amazonaws.com",
         tags: ["fips"],

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/EndpointGenerator.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/EndpointGenerator.java
@@ -103,13 +103,17 @@ final class EndpointGenerator implements Runnable {
                         resolvedHostname,
                         dnsSuffix);
 
-                    String defaultHostname = getResolvedHostnameWithDnsSuffix(resolvedHostname, dnsSuffix);
-                    ArrayNode defaultVariant = ArrayNode.fromNodes(getDefaultVariant(defaultHostname));
+                    if (config.containsMember("hostname")) {
+                        // Populate default variant only if endpoint entry contains hostname
+                        String defaultHostname = getResolvedHostnameWithDnsSuffix(resolvedHostname, dnsSuffix);
+                        ArrayNode defaultVariant = ArrayNode.fromNodes(getDefaultVariant(defaultHostname));
+                        variants = defaultVariant.merge(variants);
+                    }
 
                     endpoints.put(region,
                         config
                             .withMember("hostname", resolvedHostname)
-                            .withMember("variants", defaultVariant.merge(variants)));
+                            .withMember("variants", variants));
                 }
             }
         }


### PR DESCRIPTION
### Issue
Improvement noticed while working on https://github.com/aws/aws-sdk-js-v3/pull/3172

### Description
Populate default variant only if hostname exists

### Testing
Verified that endpoints tests are successful

```console
$ yarn test:functional
yarn run v1.22.17
$ jest --config tests/functional/jest.config.js
 PASS  tests/functional/signing-names/index.spec.ts
 PASS  tests/functional/endpoints/index.spec.ts

Test Suites: 2 passed, 2 total
Tests:       1506 passed, 1506 total
Snapshots:   0 total
Time:        3.752 s, estimated 7 s
Ran all test suites.
Done in 4.63s.
```

### Additional context
This PR will be made ready once https://github.com/aws/aws-sdk-js-v3/pull/3172 is merged.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
