### PR TITLE
fix(property-provider): only reject if providers are not given to avoid debugger pause

### DIFF
--- a/packages/property-provider/src/chain.ts
+++ b/packages/property-provider/src/chain.ts
@@ -13,15 +13,23 @@ import { ProviderError } from "./ProviderError";
  */
 export function chain<T>(...providers: Array<Provider<T>>): Provider<T> {
   return () => {
-    let promise: Promise<T> = Promise.reject(new ProviderError("No providers in chain"));
+    if(!providers?.length) {
+      return Promise.reject(new ProviderError("No providers in chain"));
+    }
+    
+    let promise: Promise<T>;
     for (const provider of providers) {
-      promise = promise.catch((err: any) => {
-        if (err?.tryNextLink) {
-          return provider();
-        }
+      if(promise) {
+        promise = promise.catch((err: any) => {
+          if (err?.tryNextLink) {
+            return provider();
+          }
 
-        throw err;
-      });
+          throw err;
+        });
+      } else {
+        promise = Promise.resolve().then(provider);  
+      }
     }
 
     return promise;


### PR DESCRIPTION
In VSCode, when you enable the breakpoint "Uncaught exceptions", the debugger falsely pauses in `chain.js`. This is because the method calls `Promise.reject()` without immediately catching it, therefore confusing the debugger.

### Issue
#2263

### Description
The promise now only creates and returns a rejection when truly required. The chain behaviour is kept using an initial `Promise.resolve()` instance.

### Testing
Against my local environment. The debugger no longer pauses and the providers are still behaving as expected. 
