### PR TITLE
chore(protocoltests): remove unused imports

### DIFF
--- a/private/aws-protocoltests-ec2/test/functional/ec2query.spec.ts
+++ b/private/aws-protocoltests-ec2/test/functional/ec2query.spec.ts
@@ -25,7 +25,6 @@ import { XmlListsCommand } from "../../src/commands/XmlListsCommand";
 import { XmlNamespacesCommand } from "../../src/commands/XmlNamespacesCommand";
 import { XmlTimestampsCommand } from "../../src/commands/XmlTimestampsCommand";
 import { EC2ProtocolClient } from "../../src/EC2ProtocolClient";
-import { ComplexError, InvalidGreeting } from "../../src/models/models_0";
 
 /**
  * Throws an expected exception that contains the serialized request.

--- a/private/aws-protocoltests-json-10/test/functional/awsjson1_0.spec.ts
+++ b/private/aws-protocoltests-json-10/test/functional/awsjson1_0.spec.ts
@@ -13,7 +13,6 @@ import { NoInputAndNoOutputCommand } from "../../src/commands/NoInputAndNoOutput
 import { NoInputAndOutputCommand } from "../../src/commands/NoInputAndOutputCommand";
 import { SimpleScalarPropertiesCommand } from "../../src/commands/SimpleScalarPropertiesCommand";
 import { JSONRPC10Client } from "../../src/JSONRPC10Client";
-import { ComplexError, FooError, InvalidGreeting } from "../../src/models/models_0";
 
 /**
  * Throws an expected exception that contains the serialized request.

--- a/private/aws-protocoltests-json/test/functional/awsjson1_1.spec.ts
+++ b/private/aws-protocoltests-json/test/functional/awsjson1_1.spec.ts
@@ -16,7 +16,6 @@ import { OperationWithOptionalInputOutputCommand } from "../../src/commands/Oper
 import { PutAndGetInlineDocumentsCommand } from "../../src/commands/PutAndGetInlineDocumentsCommand";
 import { SimpleScalarPropertiesCommand } from "../../src/commands/SimpleScalarPropertiesCommand";
 import { JsonProtocolClient } from "../../src/JsonProtocolClient";
-import { ComplexError, FooError, InvalidGreeting } from "../../src/models/models_0";
 
 /**
  * Throws an expected exception that contains the serialized request.

--- a/private/aws-protocoltests-query/test/functional/awsquery.spec.ts
+++ b/private/aws-protocoltests-query/test/functional/awsquery.spec.ts
@@ -32,7 +32,6 @@ import { XmlMapsCommand } from "../../src/commands/XmlMapsCommand";
 import { XmlMapsXmlNameCommand } from "../../src/commands/XmlMapsXmlNameCommand";
 import { XmlNamespacesCommand } from "../../src/commands/XmlNamespacesCommand";
 import { XmlTimestampsCommand } from "../../src/commands/XmlTimestampsCommand";
-import { ComplexError, CustomCodeError, InvalidGreeting } from "../../src/models/models_0";
 import { QueryProtocolClient } from "../../src/QueryProtocolClient";
 
 /**

--- a/private/aws-protocoltests-restjson/test/functional/restjson1.spec.ts
+++ b/private/aws-protocoltests-restjson/test/functional/restjson1.spec.ts
@@ -53,7 +53,6 @@ import { TestNoPayloadCommand } from "../../src/commands/TestNoPayloadCommand";
 import { TestPayloadBlobCommand } from "../../src/commands/TestPayloadBlobCommand";
 import { TestPayloadStructureCommand } from "../../src/commands/TestPayloadStructureCommand";
 import { TimestampFormatHeadersCommand } from "../../src/commands/TimestampFormatHeadersCommand";
-import { ComplexError, FooError, InvalidGreeting } from "../../src/models/models_0";
 import { RestJsonProtocolClient } from "../../src/RestJsonProtocolClient";
 
 /**

--- a/private/aws-protocoltests-restxml/test/functional/restxml.spec.ts
+++ b/private/aws-protocoltests-restxml/test/functional/restxml.spec.ts
@@ -58,7 +58,6 @@ import { XmlMapsXmlNameCommand } from "../../src/commands/XmlMapsXmlNameCommand"
 import { XmlNamespacesCommand } from "../../src/commands/XmlNamespacesCommand";
 import { XmlTimestampsCommand } from "../../src/commands/XmlTimestampsCommand";
 import { XmlUnionsCommand } from "../../src/commands/XmlUnionsCommand";
-import { ComplexError, InvalidGreeting } from "../../src/models/models_0";
 import { RestXmlProtocolClient } from "../../src/RestXmlProtocolClient";
 
 /**


### PR DESCRIPTION
### Issue
Refs: https://github.com/awslabs/smithy-typescript/pull/490

### Description
Checks for ErrorName to be thrown, thus removing unused imports

### Testing
Protocol tests

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
