### PR TITLE
chore(tsconfig): use recommendations from @tsconfig/node12 for cjs

### DIFF
--- a/packages/util-locate-window/tsconfig.cjs.json
+++ b/packages/util-locate-window/tsconfig.cjs.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
+    "lib": ["dom", "es2019", "es2020.promise", "es2020.bigint", "es2020.string"],
     "noImplicitAny": true,
     "noImplicitThis": true,
     "noImplicitUseStrict": true,

--- a/tsconfig.cjs.json
+++ b/tsconfig.cjs.json
@@ -1,10 +1,13 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "importHelpers": true,
+    "lib": ["es2019", "es2020.promise", "es2020.bigint", "es2020.string"],
     "module": "commonjs",
-    "noEmitHelpers": true,
-    "target": "ES2018",
+    "target": "es2019",
+
+    "forceConsistentCasingInFileNames": true,
+    "importHelpers": true,
+    "skipLibCheck": true,
     "strict": true
   }
 }


### PR DESCRIPTION
### Issue
Follow-up to https://github.com/aws/aws-sdk-js-v3/pull/3141
The Node.js 10.x was deprecated, but TSConfig still had ES2018 as a target 

### Description
Updates target in `tsconfig.cjs.json` as recommendation from `@tsconfig/node12`
Refs: https://github.com/tsconfig/bases/blob/main/bases/node12.json

### Testing
CI

### Additional Context
We can't extend `@tsconfig/node12` as Typescript extends doesn't support array.
Refs: https://github.com/microsoft/TypeScript/issues/29118

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
