### PR TITLE
chore: revert support for awsQueryError trait

### DIFF
--- a/clients/client-auto-scaling/src/protocols/Aws_query.ts
+++ b/clients/client-auto-scaling/src/protocols/Aws_query.ts
@@ -1376,7 +1376,7 @@ const deserializeAws_queryAttachInstancesCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "ResourceContention":
+    case "ResourceContentionFault":
     case "com.amazonaws.autoscaling#ResourceContentionFault":
       response = {
         ...(await deserializeAws_queryResourceContentionFaultResponse(parsedOutput, context)),
@@ -1438,7 +1438,7 @@ const deserializeAws_queryAttachLoadBalancersCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "ResourceContention":
+    case "ResourceContentionFault":
     case "com.amazonaws.autoscaling#ResourceContentionFault":
       response = {
         ...(await deserializeAws_queryResourceContentionFaultResponse(parsedOutput, context)),
@@ -1503,7 +1503,7 @@ const deserializeAws_queryAttachLoadBalancerTargetGroupsCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "ResourceContention":
+    case "ResourceContentionFault":
     case "com.amazonaws.autoscaling#ResourceContentionFault":
       response = {
         ...(await deserializeAws_queryResourceContentionFaultResponse(parsedOutput, context)),
@@ -1565,7 +1565,7 @@ const deserializeAws_queryBatchDeleteScheduledActionCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "ResourceContention":
+    case "ResourceContentionFault":
     case "com.amazonaws.autoscaling#ResourceContentionFault":
       response = {
         ...(await deserializeAws_queryResourceContentionFaultResponse(parsedOutput, context)),
@@ -1622,7 +1622,7 @@ const deserializeAws_queryBatchPutScheduledUpdateGroupActionCommandError = async
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "AlreadyExists":
+    case "AlreadyExistsFault":
     case "com.amazonaws.autoscaling#AlreadyExistsFault":
       response = {
         ...(await deserializeAws_queryAlreadyExistsFaultResponse(parsedOutput, context)),
@@ -1630,7 +1630,7 @@ const deserializeAws_queryBatchPutScheduledUpdateGroupActionCommandError = async
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "LimitExceeded":
+    case "LimitExceededFault":
     case "com.amazonaws.autoscaling#LimitExceededFault":
       response = {
         ...(await deserializeAws_queryLimitExceededFaultResponse(parsedOutput, context)),
@@ -1638,7 +1638,7 @@ const deserializeAws_queryBatchPutScheduledUpdateGroupActionCommandError = async
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ResourceContention":
+    case "ResourceContentionFault":
     case "com.amazonaws.autoscaling#ResourceContentionFault":
       response = {
         ...(await deserializeAws_queryResourceContentionFaultResponse(parsedOutput, context)),
@@ -1692,7 +1692,7 @@ const deserializeAws_queryCancelInstanceRefreshCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "ActiveInstanceRefreshNotFound":
+    case "ActiveInstanceRefreshNotFoundFault":
     case "com.amazonaws.autoscaling#ActiveInstanceRefreshNotFoundFault":
       response = {
         ...(await deserializeAws_queryActiveInstanceRefreshNotFoundFaultResponse(parsedOutput, context)),
@@ -1700,7 +1700,7 @@ const deserializeAws_queryCancelInstanceRefreshCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "LimitExceeded":
+    case "LimitExceededFault":
     case "com.amazonaws.autoscaling#LimitExceededFault":
       response = {
         ...(await deserializeAws_queryLimitExceededFaultResponse(parsedOutput, context)),
@@ -1708,7 +1708,7 @@ const deserializeAws_queryCancelInstanceRefreshCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ResourceContention":
+    case "ResourceContentionFault":
     case "com.amazonaws.autoscaling#ResourceContentionFault":
       response = {
         ...(await deserializeAws_queryResourceContentionFaultResponse(parsedOutput, context)),
@@ -1762,7 +1762,7 @@ const deserializeAws_queryCompleteLifecycleActionCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "ResourceContention":
+    case "ResourceContentionFault":
     case "com.amazonaws.autoscaling#ResourceContentionFault":
       response = {
         ...(await deserializeAws_queryResourceContentionFaultResponse(parsedOutput, context)),
@@ -1813,7 +1813,7 @@ const deserializeAws_queryCreateAutoScalingGroupCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "AlreadyExists":
+    case "AlreadyExistsFault":
     case "com.amazonaws.autoscaling#AlreadyExistsFault":
       response = {
         ...(await deserializeAws_queryAlreadyExistsFaultResponse(parsedOutput, context)),
@@ -1821,7 +1821,7 @@ const deserializeAws_queryCreateAutoScalingGroupCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "LimitExceeded":
+    case "LimitExceededFault":
     case "com.amazonaws.autoscaling#LimitExceededFault":
       response = {
         ...(await deserializeAws_queryLimitExceededFaultResponse(parsedOutput, context)),
@@ -1829,7 +1829,7 @@ const deserializeAws_queryCreateAutoScalingGroupCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ResourceContention":
+    case "ResourceContentionFault":
     case "com.amazonaws.autoscaling#ResourceContentionFault":
       response = {
         ...(await deserializeAws_queryResourceContentionFaultResponse(parsedOutput, context)),
@@ -1888,7 +1888,7 @@ const deserializeAws_queryCreateLaunchConfigurationCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "AlreadyExists":
+    case "AlreadyExistsFault":
     case "com.amazonaws.autoscaling#AlreadyExistsFault":
       response = {
         ...(await deserializeAws_queryAlreadyExistsFaultResponse(parsedOutput, context)),
@@ -1896,7 +1896,7 @@ const deserializeAws_queryCreateLaunchConfigurationCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "LimitExceeded":
+    case "LimitExceededFault":
     case "com.amazonaws.autoscaling#LimitExceededFault":
       response = {
         ...(await deserializeAws_queryLimitExceededFaultResponse(parsedOutput, context)),
@@ -1904,7 +1904,7 @@ const deserializeAws_queryCreateLaunchConfigurationCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ResourceContention":
+    case "ResourceContentionFault":
     case "com.amazonaws.autoscaling#ResourceContentionFault":
       response = {
         ...(await deserializeAws_queryResourceContentionFaultResponse(parsedOutput, context)),
@@ -1955,7 +1955,7 @@ const deserializeAws_queryCreateOrUpdateTagsCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "AlreadyExists":
+    case "AlreadyExistsFault":
     case "com.amazonaws.autoscaling#AlreadyExistsFault":
       response = {
         ...(await deserializeAws_queryAlreadyExistsFaultResponse(parsedOutput, context)),
@@ -1963,7 +1963,7 @@ const deserializeAws_queryCreateOrUpdateTagsCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "LimitExceeded":
+    case "LimitExceededFault":
     case "com.amazonaws.autoscaling#LimitExceededFault":
       response = {
         ...(await deserializeAws_queryLimitExceededFaultResponse(parsedOutput, context)),
@@ -1971,7 +1971,7 @@ const deserializeAws_queryCreateOrUpdateTagsCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ResourceContention":
+    case "ResourceContentionFault":
     case "com.amazonaws.autoscaling#ResourceContentionFault":
       response = {
         ...(await deserializeAws_queryResourceContentionFaultResponse(parsedOutput, context)),
@@ -1979,7 +1979,7 @@ const deserializeAws_queryCreateOrUpdateTagsCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ResourceInUse":
+    case "ResourceInUseFault":
     case "com.amazonaws.autoscaling#ResourceInUseFault":
       response = {
         ...(await deserializeAws_queryResourceInUseFaultResponse(parsedOutput, context)),
@@ -2030,7 +2030,7 @@ const deserializeAws_queryDeleteAutoScalingGroupCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "ResourceContention":
+    case "ResourceContentionFault":
     case "com.amazonaws.autoscaling#ResourceContentionFault":
       response = {
         ...(await deserializeAws_queryResourceContentionFaultResponse(parsedOutput, context)),
@@ -2038,7 +2038,7 @@ const deserializeAws_queryDeleteAutoScalingGroupCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ResourceInUse":
+    case "ResourceInUseFault":
     case "com.amazonaws.autoscaling#ResourceInUseFault":
       response = {
         ...(await deserializeAws_queryResourceInUseFaultResponse(parsedOutput, context)),
@@ -2046,7 +2046,7 @@ const deserializeAws_queryDeleteAutoScalingGroupCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ScalingActivityInProgress":
+    case "ScalingActivityInProgressFault":
     case "com.amazonaws.autoscaling#ScalingActivityInProgressFault":
       response = {
         ...(await deserializeAws_queryScalingActivityInProgressFaultResponse(parsedOutput, context)),
@@ -2097,7 +2097,7 @@ const deserializeAws_queryDeleteLaunchConfigurationCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "ResourceContention":
+    case "ResourceContentionFault":
     case "com.amazonaws.autoscaling#ResourceContentionFault":
       response = {
         ...(await deserializeAws_queryResourceContentionFaultResponse(parsedOutput, context)),
@@ -2105,7 +2105,7 @@ const deserializeAws_queryDeleteLaunchConfigurationCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ResourceInUse":
+    case "ResourceInUseFault":
     case "com.amazonaws.autoscaling#ResourceInUseFault":
       response = {
         ...(await deserializeAws_queryResourceInUseFaultResponse(parsedOutput, context)),
@@ -2159,7 +2159,7 @@ const deserializeAws_queryDeleteLifecycleHookCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "ResourceContention":
+    case "ResourceContentionFault":
     case "com.amazonaws.autoscaling#ResourceContentionFault":
       response = {
         ...(await deserializeAws_queryResourceContentionFaultResponse(parsedOutput, context)),
@@ -2210,7 +2210,7 @@ const deserializeAws_queryDeleteNotificationConfigurationCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "ResourceContention":
+    case "ResourceContentionFault":
     case "com.amazonaws.autoscaling#ResourceContentionFault":
       response = {
         ...(await deserializeAws_queryResourceContentionFaultResponse(parsedOutput, context)),
@@ -2261,7 +2261,7 @@ const deserializeAws_queryDeletePolicyCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "ResourceContention":
+    case "ResourceContentionFault":
     case "com.amazonaws.autoscaling#ResourceContentionFault":
       response = {
         ...(await deserializeAws_queryResourceContentionFaultResponse(parsedOutput, context)),
@@ -2320,7 +2320,7 @@ const deserializeAws_queryDeleteScheduledActionCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "ResourceContention":
+    case "ResourceContentionFault":
     case "com.amazonaws.autoscaling#ResourceContentionFault":
       response = {
         ...(await deserializeAws_queryResourceContentionFaultResponse(parsedOutput, context)),
@@ -2371,7 +2371,7 @@ const deserializeAws_queryDeleteTagsCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "ResourceContention":
+    case "ResourceContentionFault":
     case "com.amazonaws.autoscaling#ResourceContentionFault":
       response = {
         ...(await deserializeAws_queryResourceContentionFaultResponse(parsedOutput, context)),
@@ -2379,7 +2379,7 @@ const deserializeAws_queryDeleteTagsCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ResourceInUse":
+    case "ResourceInUseFault":
     case "com.amazonaws.autoscaling#ResourceInUseFault":
       response = {
         ...(await deserializeAws_queryResourceInUseFaultResponse(parsedOutput, context)),
@@ -2433,7 +2433,7 @@ const deserializeAws_queryDeleteWarmPoolCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "LimitExceeded":
+    case "LimitExceededFault":
     case "com.amazonaws.autoscaling#LimitExceededFault":
       response = {
         ...(await deserializeAws_queryLimitExceededFaultResponse(parsedOutput, context)),
@@ -2441,7 +2441,7 @@ const deserializeAws_queryDeleteWarmPoolCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ResourceContention":
+    case "ResourceContentionFault":
     case "com.amazonaws.autoscaling#ResourceContentionFault":
       response = {
         ...(await deserializeAws_queryResourceContentionFaultResponse(parsedOutput, context)),
@@ -2449,7 +2449,7 @@ const deserializeAws_queryDeleteWarmPoolCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ResourceInUse":
+    case "ResourceInUseFault":
     case "com.amazonaws.autoscaling#ResourceInUseFault":
       response = {
         ...(await deserializeAws_queryResourceInUseFaultResponse(parsedOutput, context)),
@@ -2457,7 +2457,7 @@ const deserializeAws_queryDeleteWarmPoolCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ScalingActivityInProgress":
+    case "ScalingActivityInProgressFault":
     case "com.amazonaws.autoscaling#ScalingActivityInProgressFault":
       response = {
         ...(await deserializeAws_queryScalingActivityInProgressFaultResponse(parsedOutput, context)),
@@ -2511,7 +2511,7 @@ const deserializeAws_queryDescribeAccountLimitsCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "ResourceContention":
+    case "ResourceContentionFault":
     case "com.amazonaws.autoscaling#ResourceContentionFault":
       response = {
         ...(await deserializeAws_queryResourceContentionFaultResponse(parsedOutput, context)),
@@ -2565,7 +2565,7 @@ const deserializeAws_queryDescribeAdjustmentTypesCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "ResourceContention":
+    case "ResourceContentionFault":
     case "com.amazonaws.autoscaling#ResourceContentionFault":
       response = {
         ...(await deserializeAws_queryResourceContentionFaultResponse(parsedOutput, context)),
@@ -2627,7 +2627,7 @@ const deserializeAws_queryDescribeAutoScalingGroupsCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ResourceContention":
+    case "ResourceContentionFault":
     case "com.amazonaws.autoscaling#ResourceContentionFault":
       response = {
         ...(await deserializeAws_queryResourceContentionFaultResponse(parsedOutput, context)),
@@ -2689,7 +2689,7 @@ const deserializeAws_queryDescribeAutoScalingInstancesCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ResourceContention":
+    case "ResourceContentionFault":
     case "com.amazonaws.autoscaling#ResourceContentionFault":
       response = {
         ...(await deserializeAws_queryResourceContentionFaultResponse(parsedOutput, context)),
@@ -2746,7 +2746,7 @@ const deserializeAws_queryDescribeAutoScalingNotificationTypesCommandError = asy
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "ResourceContention":
+    case "ResourceContentionFault":
     case "com.amazonaws.autoscaling#ResourceContentionFault":
       response = {
         ...(await deserializeAws_queryResourceContentionFaultResponse(parsedOutput, context)),
@@ -2808,7 +2808,7 @@ const deserializeAws_queryDescribeInstanceRefreshesCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ResourceContention":
+    case "ResourceContentionFault":
     case "com.amazonaws.autoscaling#ResourceContentionFault":
       response = {
         ...(await deserializeAws_queryResourceContentionFaultResponse(parsedOutput, context)),
@@ -2870,7 +2870,7 @@ const deserializeAws_queryDescribeLaunchConfigurationsCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ResourceContention":
+    case "ResourceContentionFault":
     case "com.amazonaws.autoscaling#ResourceContentionFault":
       response = {
         ...(await deserializeAws_queryResourceContentionFaultResponse(parsedOutput, context)),
@@ -2924,7 +2924,7 @@ const deserializeAws_queryDescribeLifecycleHooksCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "ResourceContention":
+    case "ResourceContentionFault":
     case "com.amazonaws.autoscaling#ResourceContentionFault":
       response = {
         ...(await deserializeAws_queryResourceContentionFaultResponse(parsedOutput, context)),
@@ -2978,7 +2978,7 @@ const deserializeAws_queryDescribeLifecycleHookTypesCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "ResourceContention":
+    case "ResourceContentionFault":
     case "com.amazonaws.autoscaling#ResourceContentionFault":
       response = {
         ...(await deserializeAws_queryResourceContentionFaultResponse(parsedOutput, context)),
@@ -3040,7 +3040,7 @@ const deserializeAws_queryDescribeLoadBalancersCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ResourceContention":
+    case "ResourceContentionFault":
     case "com.amazonaws.autoscaling#ResourceContentionFault":
       response = {
         ...(await deserializeAws_queryResourceContentionFaultResponse(parsedOutput, context)),
@@ -3105,7 +3105,7 @@ const deserializeAws_queryDescribeLoadBalancerTargetGroupsCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ResourceContention":
+    case "ResourceContentionFault":
     case "com.amazonaws.autoscaling#ResourceContentionFault":
       response = {
         ...(await deserializeAws_queryResourceContentionFaultResponse(parsedOutput, context)),
@@ -3159,7 +3159,7 @@ const deserializeAws_queryDescribeMetricCollectionTypesCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "ResourceContention":
+    case "ResourceContentionFault":
     case "com.amazonaws.autoscaling#ResourceContentionFault":
       response = {
         ...(await deserializeAws_queryResourceContentionFaultResponse(parsedOutput, context)),
@@ -3224,7 +3224,7 @@ const deserializeAws_queryDescribeNotificationConfigurationsCommandError = async
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ResourceContention":
+    case "ResourceContentionFault":
     case "com.amazonaws.autoscaling#ResourceContentionFault":
       response = {
         ...(await deserializeAws_queryResourceContentionFaultResponse(parsedOutput, context)),
@@ -3286,7 +3286,7 @@ const deserializeAws_queryDescribePoliciesCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ResourceContention":
+    case "ResourceContentionFault":
     case "com.amazonaws.autoscaling#ResourceContentionFault":
       response = {
         ...(await deserializeAws_queryResourceContentionFaultResponse(parsedOutput, context)),
@@ -3356,7 +3356,7 @@ const deserializeAws_queryDescribeScalingActivitiesCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ResourceContention":
+    case "ResourceContentionFault":
     case "com.amazonaws.autoscaling#ResourceContentionFault":
       response = {
         ...(await deserializeAws_queryResourceContentionFaultResponse(parsedOutput, context)),
@@ -3410,7 +3410,7 @@ const deserializeAws_queryDescribeScalingProcessTypesCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "ResourceContention":
+    case "ResourceContentionFault":
     case "com.amazonaws.autoscaling#ResourceContentionFault":
       response = {
         ...(await deserializeAws_queryResourceContentionFaultResponse(parsedOutput, context)),
@@ -3472,7 +3472,7 @@ const deserializeAws_queryDescribeScheduledActionsCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ResourceContention":
+    case "ResourceContentionFault":
     case "com.amazonaws.autoscaling#ResourceContentionFault":
       response = {
         ...(await deserializeAws_queryResourceContentionFaultResponse(parsedOutput, context)),
@@ -3534,7 +3534,7 @@ const deserializeAws_queryDescribeTagsCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ResourceContention":
+    case "ResourceContentionFault":
     case "com.amazonaws.autoscaling#ResourceContentionFault":
       response = {
         ...(await deserializeAws_queryResourceContentionFaultResponse(parsedOutput, context)),
@@ -3591,7 +3591,7 @@ const deserializeAws_queryDescribeTerminationPolicyTypesCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "ResourceContention":
+    case "ResourceContentionFault":
     case "com.amazonaws.autoscaling#ResourceContentionFault":
       response = {
         ...(await deserializeAws_queryResourceContentionFaultResponse(parsedOutput, context)),
@@ -3653,7 +3653,7 @@ const deserializeAws_queryDescribeWarmPoolCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "LimitExceeded":
+    case "LimitExceededFault":
     case "com.amazonaws.autoscaling#LimitExceededFault":
       response = {
         ...(await deserializeAws_queryLimitExceededFaultResponse(parsedOutput, context)),
@@ -3661,7 +3661,7 @@ const deserializeAws_queryDescribeWarmPoolCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ResourceContention":
+    case "ResourceContentionFault":
     case "com.amazonaws.autoscaling#ResourceContentionFault":
       response = {
         ...(await deserializeAws_queryResourceContentionFaultResponse(parsedOutput, context)),
@@ -3715,7 +3715,7 @@ const deserializeAws_queryDetachInstancesCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "ResourceContention":
+    case "ResourceContentionFault":
     case "com.amazonaws.autoscaling#ResourceContentionFault":
       response = {
         ...(await deserializeAws_queryResourceContentionFaultResponse(parsedOutput, context)),
@@ -3769,7 +3769,7 @@ const deserializeAws_queryDetachLoadBalancersCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "ResourceContention":
+    case "ResourceContentionFault":
     case "com.amazonaws.autoscaling#ResourceContentionFault":
       response = {
         ...(await deserializeAws_queryResourceContentionFaultResponse(parsedOutput, context)),
@@ -3826,7 +3826,7 @@ const deserializeAws_queryDetachLoadBalancerTargetGroupsCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "ResourceContention":
+    case "ResourceContentionFault":
     case "com.amazonaws.autoscaling#ResourceContentionFault":
       response = {
         ...(await deserializeAws_queryResourceContentionFaultResponse(parsedOutput, context)),
@@ -3877,7 +3877,7 @@ const deserializeAws_queryDisableMetricsCollectionCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "ResourceContention":
+    case "ResourceContentionFault":
     case "com.amazonaws.autoscaling#ResourceContentionFault":
       response = {
         ...(await deserializeAws_queryResourceContentionFaultResponse(parsedOutput, context)),
@@ -3928,7 +3928,7 @@ const deserializeAws_queryEnableMetricsCollectionCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "ResourceContention":
+    case "ResourceContentionFault":
     case "com.amazonaws.autoscaling#ResourceContentionFault":
       response = {
         ...(await deserializeAws_queryResourceContentionFaultResponse(parsedOutput, context)),
@@ -3982,7 +3982,7 @@ const deserializeAws_queryEnterStandbyCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "ResourceContention":
+    case "ResourceContentionFault":
     case "com.amazonaws.autoscaling#ResourceContentionFault":
       response = {
         ...(await deserializeAws_queryResourceContentionFaultResponse(parsedOutput, context)),
@@ -4033,7 +4033,7 @@ const deserializeAws_queryExecutePolicyCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "ResourceContention":
+    case "ResourceContentionFault":
     case "com.amazonaws.autoscaling#ResourceContentionFault":
       response = {
         ...(await deserializeAws_queryResourceContentionFaultResponse(parsedOutput, context)),
@@ -4041,7 +4041,7 @@ const deserializeAws_queryExecutePolicyCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ScalingActivityInProgress":
+    case "ScalingActivityInProgressFault":
     case "com.amazonaws.autoscaling#ScalingActivityInProgressFault":
       response = {
         ...(await deserializeAws_queryScalingActivityInProgressFaultResponse(parsedOutput, context)),
@@ -4095,7 +4095,7 @@ const deserializeAws_queryExitStandbyCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "ResourceContention":
+    case "ResourceContentionFault":
     case "com.amazonaws.autoscaling#ResourceContentionFault":
       response = {
         ...(await deserializeAws_queryResourceContentionFaultResponse(parsedOutput, context)),
@@ -4149,7 +4149,7 @@ const deserializeAws_queryGetPredictiveScalingForecastCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "ResourceContention":
+    case "ResourceContentionFault":
     case "com.amazonaws.autoscaling#ResourceContentionFault":
       response = {
         ...(await deserializeAws_queryResourceContentionFaultResponse(parsedOutput, context)),
@@ -4203,7 +4203,7 @@ const deserializeAws_queryPutLifecycleHookCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "LimitExceeded":
+    case "LimitExceededFault":
     case "com.amazonaws.autoscaling#LimitExceededFault":
       response = {
         ...(await deserializeAws_queryLimitExceededFaultResponse(parsedOutput, context)),
@@ -4211,7 +4211,7 @@ const deserializeAws_queryPutLifecycleHookCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ResourceContention":
+    case "ResourceContentionFault":
     case "com.amazonaws.autoscaling#ResourceContentionFault":
       response = {
         ...(await deserializeAws_queryResourceContentionFaultResponse(parsedOutput, context)),
@@ -4262,7 +4262,7 @@ const deserializeAws_queryPutNotificationConfigurationCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "LimitExceeded":
+    case "LimitExceededFault":
     case "com.amazonaws.autoscaling#LimitExceededFault":
       response = {
         ...(await deserializeAws_queryLimitExceededFaultResponse(parsedOutput, context)),
@@ -4270,7 +4270,7 @@ const deserializeAws_queryPutNotificationConfigurationCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ResourceContention":
+    case "ResourceContentionFault":
     case "com.amazonaws.autoscaling#ResourceContentionFault":
       response = {
         ...(await deserializeAws_queryResourceContentionFaultResponse(parsedOutput, context)),
@@ -4332,7 +4332,7 @@ const deserializeAws_queryPutScalingPolicyCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "LimitExceeded":
+    case "LimitExceededFault":
     case "com.amazonaws.autoscaling#LimitExceededFault":
       response = {
         ...(await deserializeAws_queryLimitExceededFaultResponse(parsedOutput, context)),
@@ -4340,7 +4340,7 @@ const deserializeAws_queryPutScalingPolicyCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ResourceContention":
+    case "ResourceContentionFault":
     case "com.amazonaws.autoscaling#ResourceContentionFault":
       response = {
         ...(await deserializeAws_queryResourceContentionFaultResponse(parsedOutput, context)),
@@ -4399,7 +4399,7 @@ const deserializeAws_queryPutScheduledUpdateGroupActionCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "AlreadyExists":
+    case "AlreadyExistsFault":
     case "com.amazonaws.autoscaling#AlreadyExistsFault":
       response = {
         ...(await deserializeAws_queryAlreadyExistsFaultResponse(parsedOutput, context)),
@@ -4407,7 +4407,7 @@ const deserializeAws_queryPutScheduledUpdateGroupActionCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "LimitExceeded":
+    case "LimitExceededFault":
     case "com.amazonaws.autoscaling#LimitExceededFault":
       response = {
         ...(await deserializeAws_queryLimitExceededFaultResponse(parsedOutput, context)),
@@ -4415,7 +4415,7 @@ const deserializeAws_queryPutScheduledUpdateGroupActionCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ResourceContention":
+    case "ResourceContentionFault":
     case "com.amazonaws.autoscaling#ResourceContentionFault":
       response = {
         ...(await deserializeAws_queryResourceContentionFaultResponse(parsedOutput, context)),
@@ -4469,7 +4469,7 @@ const deserializeAws_queryPutWarmPoolCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "LimitExceeded":
+    case "LimitExceededFault":
     case "com.amazonaws.autoscaling#LimitExceededFault":
       response = {
         ...(await deserializeAws_queryLimitExceededFaultResponse(parsedOutput, context)),
@@ -4477,7 +4477,7 @@ const deserializeAws_queryPutWarmPoolCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ResourceContention":
+    case "ResourceContentionFault":
     case "com.amazonaws.autoscaling#ResourceContentionFault":
       response = {
         ...(await deserializeAws_queryResourceContentionFaultResponse(parsedOutput, context)),
@@ -4534,7 +4534,7 @@ const deserializeAws_queryRecordLifecycleActionHeartbeatCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "ResourceContention":
+    case "ResourceContentionFault":
     case "com.amazonaws.autoscaling#ResourceContentionFault":
       response = {
         ...(await deserializeAws_queryResourceContentionFaultResponse(parsedOutput, context)),
@@ -4585,7 +4585,7 @@ const deserializeAws_queryResumeProcessesCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "ResourceContention":
+    case "ResourceContentionFault":
     case "com.amazonaws.autoscaling#ResourceContentionFault":
       response = {
         ...(await deserializeAws_queryResourceContentionFaultResponse(parsedOutput, context)),
@@ -4593,7 +4593,7 @@ const deserializeAws_queryResumeProcessesCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ResourceInUse":
+    case "ResourceInUseFault":
     case "com.amazonaws.autoscaling#ResourceInUseFault":
       response = {
         ...(await deserializeAws_queryResourceInUseFaultResponse(parsedOutput, context)),
@@ -4644,7 +4644,7 @@ const deserializeAws_querySetDesiredCapacityCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "ResourceContention":
+    case "ResourceContentionFault":
     case "com.amazonaws.autoscaling#ResourceContentionFault":
       response = {
         ...(await deserializeAws_queryResourceContentionFaultResponse(parsedOutput, context)),
@@ -4652,7 +4652,7 @@ const deserializeAws_querySetDesiredCapacityCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ScalingActivityInProgress":
+    case "ScalingActivityInProgressFault":
     case "com.amazonaws.autoscaling#ScalingActivityInProgressFault":
       response = {
         ...(await deserializeAws_queryScalingActivityInProgressFaultResponse(parsedOutput, context)),
@@ -4703,7 +4703,7 @@ const deserializeAws_querySetInstanceHealthCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "ResourceContention":
+    case "ResourceContentionFault":
     case "com.amazonaws.autoscaling#ResourceContentionFault":
       response = {
         ...(await deserializeAws_queryResourceContentionFaultResponse(parsedOutput, context)),
@@ -4757,7 +4757,7 @@ const deserializeAws_querySetInstanceProtectionCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "LimitExceeded":
+    case "LimitExceededFault":
     case "com.amazonaws.autoscaling#LimitExceededFault":
       response = {
         ...(await deserializeAws_queryLimitExceededFaultResponse(parsedOutput, context)),
@@ -4765,7 +4765,7 @@ const deserializeAws_querySetInstanceProtectionCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ResourceContention":
+    case "ResourceContentionFault":
     case "com.amazonaws.autoscaling#ResourceContentionFault":
       response = {
         ...(await deserializeAws_queryResourceContentionFaultResponse(parsedOutput, context)),
@@ -4819,7 +4819,7 @@ const deserializeAws_queryStartInstanceRefreshCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "InstanceRefreshInProgress":
+    case "InstanceRefreshInProgressFault":
     case "com.amazonaws.autoscaling#InstanceRefreshInProgressFault":
       response = {
         ...(await deserializeAws_queryInstanceRefreshInProgressFaultResponse(parsedOutput, context)),
@@ -4827,7 +4827,7 @@ const deserializeAws_queryStartInstanceRefreshCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "LimitExceeded":
+    case "LimitExceededFault":
     case "com.amazonaws.autoscaling#LimitExceededFault":
       response = {
         ...(await deserializeAws_queryLimitExceededFaultResponse(parsedOutput, context)),
@@ -4835,7 +4835,7 @@ const deserializeAws_queryStartInstanceRefreshCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ResourceContention":
+    case "ResourceContentionFault":
     case "com.amazonaws.autoscaling#ResourceContentionFault":
       response = {
         ...(await deserializeAws_queryResourceContentionFaultResponse(parsedOutput, context)),
@@ -4886,7 +4886,7 @@ const deserializeAws_querySuspendProcessesCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "ResourceContention":
+    case "ResourceContentionFault":
     case "com.amazonaws.autoscaling#ResourceContentionFault":
       response = {
         ...(await deserializeAws_queryResourceContentionFaultResponse(parsedOutput, context)),
@@ -4894,7 +4894,7 @@ const deserializeAws_querySuspendProcessesCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ResourceInUse":
+    case "ResourceInUseFault":
     case "com.amazonaws.autoscaling#ResourceInUseFault":
       response = {
         ...(await deserializeAws_queryResourceInUseFaultResponse(parsedOutput, context)),
@@ -4948,7 +4948,7 @@ const deserializeAws_queryTerminateInstanceInAutoScalingGroupCommandError = asyn
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "ResourceContention":
+    case "ResourceContentionFault":
     case "com.amazonaws.autoscaling#ResourceContentionFault":
       response = {
         ...(await deserializeAws_queryResourceContentionFaultResponse(parsedOutput, context)),
@@ -4956,7 +4956,7 @@ const deserializeAws_queryTerminateInstanceInAutoScalingGroupCommandError = asyn
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ScalingActivityInProgress":
+    case "ScalingActivityInProgressFault":
     case "com.amazonaws.autoscaling#ScalingActivityInProgressFault":
       response = {
         ...(await deserializeAws_queryScalingActivityInProgressFaultResponse(parsedOutput, context)),
@@ -5007,7 +5007,7 @@ const deserializeAws_queryUpdateAutoScalingGroupCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "ResourceContention":
+    case "ResourceContentionFault":
     case "com.amazonaws.autoscaling#ResourceContentionFault":
       response = {
         ...(await deserializeAws_queryResourceContentionFaultResponse(parsedOutput, context)),
@@ -5015,7 +5015,7 @@ const deserializeAws_queryUpdateAutoScalingGroupCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ScalingActivityInProgress":
+    case "ScalingActivityInProgressFault":
     case "com.amazonaws.autoscaling#ScalingActivityInProgressFault":
       response = {
         ...(await deserializeAws_queryScalingActivityInProgressFaultResponse(parsedOutput, context)),

--- a/clients/client-cloudformation/src/protocols/Aws_query.ts
+++ b/clients/client-cloudformation/src/protocols/Aws_query.ts
@@ -2049,7 +2049,7 @@ const deserializeAws_queryDeleteChangeSetCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "InvalidChangeSetStatus":
+    case "InvalidChangeSetStatusException":
     case "com.amazonaws.cloudformation#InvalidChangeSetStatusException":
       response = {
         ...(await deserializeAws_queryInvalidChangeSetStatusExceptionResponse(parsedOutput, context)),
@@ -2410,7 +2410,7 @@ const deserializeAws_queryDescribeChangeSetCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "ChangeSetNotFound":
+    case "ChangeSetNotFoundException":
     case "com.amazonaws.cloudformation#ChangeSetNotFoundException":
       response = {
         ...(await deserializeAws_queryChangeSetNotFoundExceptionResponse(parsedOutput, context)),
@@ -3299,7 +3299,7 @@ const deserializeAws_queryExecuteChangeSetCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "ChangeSetNotFound":
+    case "ChangeSetNotFoundException":
     case "com.amazonaws.cloudformation#ChangeSetNotFoundException":
       response = {
         ...(await deserializeAws_queryChangeSetNotFoundExceptionResponse(parsedOutput, context)),
@@ -3315,7 +3315,7 @@ const deserializeAws_queryExecuteChangeSetCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidChangeSetStatus":
+    case "InvalidChangeSetStatusException":
     case "com.amazonaws.cloudformation#InvalidChangeSetStatusException":
       response = {
         ...(await deserializeAws_queryInvalidChangeSetStatusExceptionResponse(parsedOutput, context)),
@@ -3423,7 +3423,7 @@ const deserializeAws_queryGetTemplateCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "ChangeSetNotFound":
+    case "ChangeSetNotFoundException":
     case "com.amazonaws.cloudformation#ChangeSetNotFoundException":
       response = {
         ...(await deserializeAws_queryChangeSetNotFoundExceptionResponse(parsedOutput, context)),
@@ -4303,18 +4303,18 @@ const deserializeAws_queryRecordHandlerProgressCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "ConditionalCheckFailed":
-    case "com.amazonaws.cloudformation#OperationStatusCheckFailedException":
+    case "InvalidStateTransitionException":
+    case "com.amazonaws.cloudformation#InvalidStateTransitionException":
       response = {
-        ...(await deserializeAws_queryOperationStatusCheckFailedExceptionResponse(parsedOutput, context)),
+        ...(await deserializeAws_queryInvalidStateTransitionExceptionResponse(parsedOutput, context)),
         name: errorCode,
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidStateTransition":
-    case "com.amazonaws.cloudformation#InvalidStateTransitionException":
+    case "OperationStatusCheckFailedException":
+    case "com.amazonaws.cloudformation#OperationStatusCheckFailedException":
       response = {
-        ...(await deserializeAws_queryInvalidStateTransitionExceptionResponse(parsedOutput, context)),
+        ...(await deserializeAws_queryOperationStatusCheckFailedExceptionResponse(parsedOutput, context)),
         name: errorCode,
         $metadata: deserializeMetadata(output),
       };

--- a/clients/client-cloudfront/src/protocols/Aws_restXml.ts
+++ b/clients/client-cloudfront/src/protocols/Aws_restXml.ts
@@ -4679,18 +4679,18 @@ const deserializeAws_restXmlCreateDistributionWithTagsCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidTTLOrder":
-    case "com.amazonaws.cloudfront#InvalidTTLOrder":
-      response = {
-        ...(await deserializeAws_restXmlInvalidTTLOrderResponse(parsedOutput, context)),
-        name: errorCode,
-        $metadata: deserializeMetadata(output),
-      };
-      break;
     case "InvalidTagging":
     case "com.amazonaws.cloudfront#InvalidTagging":
       response = {
         ...(await deserializeAws_restXmlInvalidTaggingResponse(parsedOutput, context)),
+        name: errorCode,
+        $metadata: deserializeMetadata(output),
+      };
+      break;
+    case "InvalidTTLOrder":
+    case "com.amazonaws.cloudfront#InvalidTTLOrder":
+      response = {
+        ...(await deserializeAws_restXmlInvalidTTLOrderResponse(parsedOutput, context)),
         name: errorCode,
         $metadata: deserializeMetadata(output),
       };

--- a/clients/client-cloudsearch/src/protocols/Aws_query.ts
+++ b/clients/client-cloudsearch/src/protocols/Aws_query.ts
@@ -640,7 +640,7 @@ const deserializeAws_queryBuildSuggestersCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ResourceNotFound":
+    case "ResourceNotFoundException":
     case "com.amazonaws.cloudsearch#ResourceNotFoundException":
       response = {
         ...(await deserializeAws_queryResourceNotFoundExceptionResponse(parsedOutput, context)),
@@ -718,7 +718,7 @@ const deserializeAws_queryCreateDomainCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "LimitExceeded":
+    case "LimitExceededException":
     case "com.amazonaws.cloudsearch#LimitExceededException":
       response = {
         ...(await deserializeAws_queryLimitExceededExceptionResponse(parsedOutput, context)),
@@ -726,7 +726,7 @@ const deserializeAws_queryCreateDomainCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ResourceAlreadyExists":
+    case "ResourceAlreadyExistsException":
     case "com.amazonaws.cloudsearch#ResourceAlreadyExistsException":
       response = {
         ...(await deserializeAws_queryResourceAlreadyExistsExceptionResponse(parsedOutput, context)),
@@ -804,7 +804,7 @@ const deserializeAws_queryDefineAnalysisSchemeCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidType":
+    case "InvalidTypeException":
     case "com.amazonaws.cloudsearch#InvalidTypeException":
       response = {
         ...(await deserializeAws_queryInvalidTypeExceptionResponse(parsedOutput, context)),
@@ -812,7 +812,7 @@ const deserializeAws_queryDefineAnalysisSchemeCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "LimitExceeded":
+    case "LimitExceededException":
     case "com.amazonaws.cloudsearch#LimitExceededException":
       response = {
         ...(await deserializeAws_queryLimitExceededExceptionResponse(parsedOutput, context)),
@@ -820,7 +820,7 @@ const deserializeAws_queryDefineAnalysisSchemeCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ResourceNotFound":
+    case "ResourceNotFoundException":
     case "com.amazonaws.cloudsearch#ResourceNotFoundException":
       response = {
         ...(await deserializeAws_queryResourceNotFoundExceptionResponse(parsedOutput, context)),
@@ -898,7 +898,7 @@ const deserializeAws_queryDefineExpressionCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidType":
+    case "InvalidTypeException":
     case "com.amazonaws.cloudsearch#InvalidTypeException":
       response = {
         ...(await deserializeAws_queryInvalidTypeExceptionResponse(parsedOutput, context)),
@@ -906,7 +906,7 @@ const deserializeAws_queryDefineExpressionCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "LimitExceeded":
+    case "LimitExceededException":
     case "com.amazonaws.cloudsearch#LimitExceededException":
       response = {
         ...(await deserializeAws_queryLimitExceededExceptionResponse(parsedOutput, context)),
@@ -914,7 +914,7 @@ const deserializeAws_queryDefineExpressionCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ResourceNotFound":
+    case "ResourceNotFoundException":
     case "com.amazonaws.cloudsearch#ResourceNotFoundException":
       response = {
         ...(await deserializeAws_queryResourceNotFoundExceptionResponse(parsedOutput, context)),
@@ -992,7 +992,7 @@ const deserializeAws_queryDefineIndexFieldCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidType":
+    case "InvalidTypeException":
     case "com.amazonaws.cloudsearch#InvalidTypeException":
       response = {
         ...(await deserializeAws_queryInvalidTypeExceptionResponse(parsedOutput, context)),
@@ -1000,7 +1000,7 @@ const deserializeAws_queryDefineIndexFieldCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "LimitExceeded":
+    case "LimitExceededException":
     case "com.amazonaws.cloudsearch#LimitExceededException":
       response = {
         ...(await deserializeAws_queryLimitExceededExceptionResponse(parsedOutput, context)),
@@ -1008,7 +1008,7 @@ const deserializeAws_queryDefineIndexFieldCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ResourceNotFound":
+    case "ResourceNotFoundException":
     case "com.amazonaws.cloudsearch#ResourceNotFoundException":
       response = {
         ...(await deserializeAws_queryResourceNotFoundExceptionResponse(parsedOutput, context)),
@@ -1086,7 +1086,7 @@ const deserializeAws_queryDefineSuggesterCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidType":
+    case "InvalidTypeException":
     case "com.amazonaws.cloudsearch#InvalidTypeException":
       response = {
         ...(await deserializeAws_queryInvalidTypeExceptionResponse(parsedOutput, context)),
@@ -1094,7 +1094,7 @@ const deserializeAws_queryDefineSuggesterCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "LimitExceeded":
+    case "LimitExceededException":
     case "com.amazonaws.cloudsearch#LimitExceededException":
       response = {
         ...(await deserializeAws_queryLimitExceededExceptionResponse(parsedOutput, context)),
@@ -1102,7 +1102,7 @@ const deserializeAws_queryDefineSuggesterCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ResourceNotFound":
+    case "ResourceNotFoundException":
     case "com.amazonaws.cloudsearch#ResourceNotFoundException":
       response = {
         ...(await deserializeAws_queryResourceNotFoundExceptionResponse(parsedOutput, context)),
@@ -1180,7 +1180,7 @@ const deserializeAws_queryDeleteAnalysisSchemeCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidType":
+    case "InvalidTypeException":
     case "com.amazonaws.cloudsearch#InvalidTypeException":
       response = {
         ...(await deserializeAws_queryInvalidTypeExceptionResponse(parsedOutput, context)),
@@ -1188,7 +1188,7 @@ const deserializeAws_queryDeleteAnalysisSchemeCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ResourceNotFound":
+    case "ResourceNotFoundException":
     case "com.amazonaws.cloudsearch#ResourceNotFoundException":
       response = {
         ...(await deserializeAws_queryResourceNotFoundExceptionResponse(parsedOutput, context)),
@@ -1328,7 +1328,7 @@ const deserializeAws_queryDeleteExpressionCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidType":
+    case "InvalidTypeException":
     case "com.amazonaws.cloudsearch#InvalidTypeException":
       response = {
         ...(await deserializeAws_queryInvalidTypeExceptionResponse(parsedOutput, context)),
@@ -1336,7 +1336,7 @@ const deserializeAws_queryDeleteExpressionCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ResourceNotFound":
+    case "ResourceNotFoundException":
     case "com.amazonaws.cloudsearch#ResourceNotFoundException":
       response = {
         ...(await deserializeAws_queryResourceNotFoundExceptionResponse(parsedOutput, context)),
@@ -1414,7 +1414,7 @@ const deserializeAws_queryDeleteIndexFieldCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidType":
+    case "InvalidTypeException":
     case "com.amazonaws.cloudsearch#InvalidTypeException":
       response = {
         ...(await deserializeAws_queryInvalidTypeExceptionResponse(parsedOutput, context)),
@@ -1422,7 +1422,7 @@ const deserializeAws_queryDeleteIndexFieldCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ResourceNotFound":
+    case "ResourceNotFoundException":
     case "com.amazonaws.cloudsearch#ResourceNotFoundException":
       response = {
         ...(await deserializeAws_queryResourceNotFoundExceptionResponse(parsedOutput, context)),
@@ -1500,7 +1500,7 @@ const deserializeAws_queryDeleteSuggesterCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidType":
+    case "InvalidTypeException":
     case "com.amazonaws.cloudsearch#InvalidTypeException":
       response = {
         ...(await deserializeAws_queryInvalidTypeExceptionResponse(parsedOutput, context)),
@@ -1508,7 +1508,7 @@ const deserializeAws_queryDeleteSuggesterCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ResourceNotFound":
+    case "ResourceNotFoundException":
     case "com.amazonaws.cloudsearch#ResourceNotFoundException":
       response = {
         ...(await deserializeAws_queryResourceNotFoundExceptionResponse(parsedOutput, context)),
@@ -1586,7 +1586,7 @@ const deserializeAws_queryDescribeAnalysisSchemesCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ResourceNotFound":
+    case "ResourceNotFoundException":
     case "com.amazonaws.cloudsearch#ResourceNotFoundException":
       response = {
         ...(await deserializeAws_queryResourceNotFoundExceptionResponse(parsedOutput, context)),
@@ -1648,7 +1648,7 @@ const deserializeAws_queryDescribeAvailabilityOptionsCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "DisabledAction":
+    case "DisabledOperationException":
     case "com.amazonaws.cloudsearch#DisabledOperationException":
       response = {
         ...(await deserializeAws_queryDisabledOperationExceptionResponse(parsedOutput, context)),
@@ -1664,7 +1664,7 @@ const deserializeAws_queryDescribeAvailabilityOptionsCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidType":
+    case "InvalidTypeException":
     case "com.amazonaws.cloudsearch#InvalidTypeException":
       response = {
         ...(await deserializeAws_queryInvalidTypeExceptionResponse(parsedOutput, context)),
@@ -1672,7 +1672,7 @@ const deserializeAws_queryDescribeAvailabilityOptionsCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "LimitExceeded":
+    case "LimitExceededException":
     case "com.amazonaws.cloudsearch#LimitExceededException":
       response = {
         ...(await deserializeAws_queryLimitExceededExceptionResponse(parsedOutput, context)),
@@ -1680,7 +1680,7 @@ const deserializeAws_queryDescribeAvailabilityOptionsCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ResourceNotFound":
+    case "ResourceNotFoundException":
     case "com.amazonaws.cloudsearch#ResourceNotFoundException":
       response = {
         ...(await deserializeAws_queryResourceNotFoundExceptionResponse(parsedOutput, context)),
@@ -1745,7 +1745,7 @@ const deserializeAws_queryDescribeDomainEndpointOptionsCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "DisabledAction":
+    case "DisabledOperationException":
     case "com.amazonaws.cloudsearch#DisabledOperationException":
       response = {
         ...(await deserializeAws_queryDisabledOperationExceptionResponse(parsedOutput, context)),
@@ -1761,7 +1761,7 @@ const deserializeAws_queryDescribeDomainEndpointOptionsCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "LimitExceeded":
+    case "LimitExceededException":
     case "com.amazonaws.cloudsearch#LimitExceededException":
       response = {
         ...(await deserializeAws_queryLimitExceededExceptionResponse(parsedOutput, context)),
@@ -1769,7 +1769,7 @@ const deserializeAws_queryDescribeDomainEndpointOptionsCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ResourceNotFound":
+    case "ResourceNotFoundException":
     case "com.amazonaws.cloudsearch#ResourceNotFoundException":
       response = {
         ...(await deserializeAws_queryResourceNotFoundExceptionResponse(parsedOutput, context)),
@@ -1901,7 +1901,7 @@ const deserializeAws_queryDescribeExpressionsCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ResourceNotFound":
+    case "ResourceNotFoundException":
     case "com.amazonaws.cloudsearch#ResourceNotFoundException":
       response = {
         ...(await deserializeAws_queryResourceNotFoundExceptionResponse(parsedOutput, context)),
@@ -1971,7 +1971,7 @@ const deserializeAws_queryDescribeIndexFieldsCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ResourceNotFound":
+    case "ResourceNotFoundException":
     case "com.amazonaws.cloudsearch#ResourceNotFoundException":
       response = {
         ...(await deserializeAws_queryResourceNotFoundExceptionResponse(parsedOutput, context)),
@@ -2041,7 +2041,7 @@ const deserializeAws_queryDescribeScalingParametersCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ResourceNotFound":
+    case "ResourceNotFoundException":
     case "com.amazonaws.cloudsearch#ResourceNotFoundException":
       response = {
         ...(await deserializeAws_queryResourceNotFoundExceptionResponse(parsedOutput, context)),
@@ -2114,7 +2114,7 @@ const deserializeAws_queryDescribeServiceAccessPoliciesCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ResourceNotFound":
+    case "ResourceNotFoundException":
     case "com.amazonaws.cloudsearch#ResourceNotFoundException":
       response = {
         ...(await deserializeAws_queryResourceNotFoundExceptionResponse(parsedOutput, context)),
@@ -2184,7 +2184,7 @@ const deserializeAws_queryDescribeSuggestersCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ResourceNotFound":
+    case "ResourceNotFoundException":
     case "com.amazonaws.cloudsearch#ResourceNotFoundException":
       response = {
         ...(await deserializeAws_queryResourceNotFoundExceptionResponse(parsedOutput, context)),
@@ -2254,7 +2254,7 @@ const deserializeAws_queryIndexDocumentsCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ResourceNotFound":
+    case "ResourceNotFoundException":
     case "com.amazonaws.cloudsearch#ResourceNotFoundException":
       response = {
         ...(await deserializeAws_queryResourceNotFoundExceptionResponse(parsedOutput, context)),
@@ -2378,7 +2378,7 @@ const deserializeAws_queryUpdateAvailabilityOptionsCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "DisabledAction":
+    case "DisabledOperationException":
     case "com.amazonaws.cloudsearch#DisabledOperationException":
       response = {
         ...(await deserializeAws_queryDisabledOperationExceptionResponse(parsedOutput, context)),
@@ -2394,7 +2394,7 @@ const deserializeAws_queryUpdateAvailabilityOptionsCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidType":
+    case "InvalidTypeException":
     case "com.amazonaws.cloudsearch#InvalidTypeException":
       response = {
         ...(await deserializeAws_queryInvalidTypeExceptionResponse(parsedOutput, context)),
@@ -2402,7 +2402,7 @@ const deserializeAws_queryUpdateAvailabilityOptionsCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "LimitExceeded":
+    case "LimitExceededException":
     case "com.amazonaws.cloudsearch#LimitExceededException":
       response = {
         ...(await deserializeAws_queryLimitExceededExceptionResponse(parsedOutput, context)),
@@ -2410,7 +2410,7 @@ const deserializeAws_queryUpdateAvailabilityOptionsCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ResourceNotFound":
+    case "ResourceNotFoundException":
     case "com.amazonaws.cloudsearch#ResourceNotFoundException":
       response = {
         ...(await deserializeAws_queryResourceNotFoundExceptionResponse(parsedOutput, context)),
@@ -2480,7 +2480,7 @@ const deserializeAws_queryUpdateDomainEndpointOptionsCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "DisabledAction":
+    case "DisabledOperationException":
     case "com.amazonaws.cloudsearch#DisabledOperationException":
       response = {
         ...(await deserializeAws_queryDisabledOperationExceptionResponse(parsedOutput, context)),
@@ -2496,7 +2496,7 @@ const deserializeAws_queryUpdateDomainEndpointOptionsCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidType":
+    case "InvalidTypeException":
     case "com.amazonaws.cloudsearch#InvalidTypeException":
       response = {
         ...(await deserializeAws_queryInvalidTypeExceptionResponse(parsedOutput, context)),
@@ -2504,7 +2504,7 @@ const deserializeAws_queryUpdateDomainEndpointOptionsCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "LimitExceeded":
+    case "LimitExceededException":
     case "com.amazonaws.cloudsearch#LimitExceededException":
       response = {
         ...(await deserializeAws_queryLimitExceededExceptionResponse(parsedOutput, context)),
@@ -2512,7 +2512,7 @@ const deserializeAws_queryUpdateDomainEndpointOptionsCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ResourceNotFound":
+    case "ResourceNotFoundException":
     case "com.amazonaws.cloudsearch#ResourceNotFoundException":
       response = {
         ...(await deserializeAws_queryResourceNotFoundExceptionResponse(parsedOutput, context)),
@@ -2590,7 +2590,7 @@ const deserializeAws_queryUpdateScalingParametersCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidType":
+    case "InvalidTypeException":
     case "com.amazonaws.cloudsearch#InvalidTypeException":
       response = {
         ...(await deserializeAws_queryInvalidTypeExceptionResponse(parsedOutput, context)),
@@ -2598,7 +2598,7 @@ const deserializeAws_queryUpdateScalingParametersCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "LimitExceeded":
+    case "LimitExceededException":
     case "com.amazonaws.cloudsearch#LimitExceededException":
       response = {
         ...(await deserializeAws_queryLimitExceededExceptionResponse(parsedOutput, context)),
@@ -2606,7 +2606,7 @@ const deserializeAws_queryUpdateScalingParametersCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ResourceNotFound":
+    case "ResourceNotFoundException":
     case "com.amazonaws.cloudsearch#ResourceNotFoundException":
       response = {
         ...(await deserializeAws_queryResourceNotFoundExceptionResponse(parsedOutput, context)),
@@ -2684,7 +2684,7 @@ const deserializeAws_queryUpdateServiceAccessPoliciesCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidType":
+    case "InvalidTypeException":
     case "com.amazonaws.cloudsearch#InvalidTypeException":
       response = {
         ...(await deserializeAws_queryInvalidTypeExceptionResponse(parsedOutput, context)),
@@ -2692,7 +2692,7 @@ const deserializeAws_queryUpdateServiceAccessPoliciesCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "LimitExceeded":
+    case "LimitExceededException":
     case "com.amazonaws.cloudsearch#LimitExceededException":
       response = {
         ...(await deserializeAws_queryLimitExceededExceptionResponse(parsedOutput, context)),
@@ -2700,7 +2700,7 @@ const deserializeAws_queryUpdateServiceAccessPoliciesCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ResourceNotFound":
+    case "ResourceNotFoundException":
     case "com.amazonaws.cloudsearch#ResourceNotFoundException":
       response = {
         ...(await deserializeAws_queryResourceNotFoundExceptionResponse(parsedOutput, context)),

--- a/clients/client-cloudwatch/src/protocols/Aws_query.ts
+++ b/clients/client-cloudwatch/src/protocols/Aws_query.ts
@@ -861,7 +861,7 @@ const deserializeAws_queryDeleteAnomalyDetectorCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "InternalServiceError":
+    case "InternalServiceFault":
     case "com.amazonaws.cloudwatch#InternalServiceFault":
       response = {
         ...(await deserializeAws_queryInternalServiceFaultResponse(parsedOutput, context)),
@@ -869,7 +869,7 @@ const deserializeAws_queryDeleteAnomalyDetectorCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidParameterCombination":
+    case "InvalidParameterCombinationException":
     case "com.amazonaws.cloudwatch#InvalidParameterCombinationException":
       response = {
         ...(await deserializeAws_queryInvalidParameterCombinationExceptionResponse(parsedOutput, context)),
@@ -877,7 +877,7 @@ const deserializeAws_queryDeleteAnomalyDetectorCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidParameterValue":
+    case "InvalidParameterValueException":
     case "com.amazonaws.cloudwatch#InvalidParameterValueException":
       response = {
         ...(await deserializeAws_queryInvalidParameterValueExceptionResponse(parsedOutput, context)),
@@ -885,7 +885,7 @@ const deserializeAws_queryDeleteAnomalyDetectorCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "MissingParameter":
+    case "MissingRequiredParameterException":
     case "com.amazonaws.cloudwatch#MissingRequiredParameterException":
       response = {
         ...(await deserializeAws_queryMissingRequiredParameterExceptionResponse(parsedOutput, context)),
@@ -947,7 +947,15 @@ const deserializeAws_queryDeleteDashboardsCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "InternalServiceError":
+    case "DashboardNotFoundError":
+    case "com.amazonaws.cloudwatch#DashboardNotFoundError":
+      response = {
+        ...(await deserializeAws_queryDashboardNotFoundErrorResponse(parsedOutput, context)),
+        name: errorCode,
+        $metadata: deserializeMetadata(output),
+      };
+      break;
+    case "InternalServiceFault":
     case "com.amazonaws.cloudwatch#InternalServiceFault":
       response = {
         ...(await deserializeAws_queryInternalServiceFaultResponse(parsedOutput, context)),
@@ -955,18 +963,10 @@ const deserializeAws_queryDeleteDashboardsCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidParameterValue":
+    case "InvalidParameterValueException":
     case "com.amazonaws.cloudwatch#InvalidParameterValueException":
       response = {
         ...(await deserializeAws_queryInvalidParameterValueExceptionResponse(parsedOutput, context)),
-        name: errorCode,
-        $metadata: deserializeMetadata(output),
-      };
-      break;
-    case "ResourceNotFound":
-    case "com.amazonaws.cloudwatch#DashboardNotFoundError":
-      response = {
-        ...(await deserializeAws_queryDashboardNotFoundErrorResponse(parsedOutput, context)),
         name: errorCode,
         $metadata: deserializeMetadata(output),
       };
@@ -1017,7 +1017,7 @@ const deserializeAws_queryDeleteInsightRulesCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "InvalidParameterValue":
+    case "InvalidParameterValueException":
     case "com.amazonaws.cloudwatch#InvalidParameterValueException":
       response = {
         ...(await deserializeAws_queryInvalidParameterValueExceptionResponse(parsedOutput, context)),
@@ -1025,7 +1025,7 @@ const deserializeAws_queryDeleteInsightRulesCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "MissingParameter":
+    case "MissingRequiredParameterException":
     case "com.amazonaws.cloudwatch#MissingRequiredParameterException":
       response = {
         ...(await deserializeAws_queryMissingRequiredParameterExceptionResponse(parsedOutput, context)),
@@ -1079,7 +1079,7 @@ const deserializeAws_queryDeleteMetricStreamCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "InternalServiceError":
+    case "InternalServiceFault":
     case "com.amazonaws.cloudwatch#InternalServiceFault":
       response = {
         ...(await deserializeAws_queryInternalServiceFaultResponse(parsedOutput, context)),
@@ -1087,7 +1087,7 @@ const deserializeAws_queryDeleteMetricStreamCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidParameterValue":
+    case "InvalidParameterValueException":
     case "com.amazonaws.cloudwatch#InvalidParameterValueException":
       response = {
         ...(await deserializeAws_queryInvalidParameterValueExceptionResponse(parsedOutput, context)),
@@ -1095,7 +1095,7 @@ const deserializeAws_queryDeleteMetricStreamCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "MissingParameter":
+    case "MissingRequiredParameterException":
     case "com.amazonaws.cloudwatch#MissingRequiredParameterException":
       response = {
         ...(await deserializeAws_queryMissingRequiredParameterExceptionResponse(parsedOutput, context)),
@@ -1303,7 +1303,7 @@ const deserializeAws_queryDescribeAnomalyDetectorsCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "InternalServiceError":
+    case "InternalServiceFault":
     case "com.amazonaws.cloudwatch#InternalServiceFault":
       response = {
         ...(await deserializeAws_queryInternalServiceFaultResponse(parsedOutput, context)),
@@ -1319,7 +1319,7 @@ const deserializeAws_queryDescribeAnomalyDetectorsCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidParameterCombination":
+    case "InvalidParameterCombinationException":
     case "com.amazonaws.cloudwatch#InvalidParameterCombinationException":
       response = {
         ...(await deserializeAws_queryInvalidParameterCombinationExceptionResponse(parsedOutput, context)),
@@ -1327,7 +1327,7 @@ const deserializeAws_queryDescribeAnomalyDetectorsCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidParameterValue":
+    case "InvalidParameterValueException":
     case "com.amazonaws.cloudwatch#InvalidParameterValueException":
       response = {
         ...(await deserializeAws_queryInvalidParameterValueExceptionResponse(parsedOutput, context)),
@@ -1478,7 +1478,7 @@ const deserializeAws_queryDisableInsightRulesCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "InvalidParameterValue":
+    case "InvalidParameterValueException":
     case "com.amazonaws.cloudwatch#InvalidParameterValueException":
       response = {
         ...(await deserializeAws_queryInvalidParameterValueExceptionResponse(parsedOutput, context)),
@@ -1486,7 +1486,7 @@ const deserializeAws_queryDisableInsightRulesCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "MissingParameter":
+    case "MissingRequiredParameterException":
     case "com.amazonaws.cloudwatch#MissingRequiredParameterException":
       response = {
         ...(await deserializeAws_queryMissingRequiredParameterExceptionResponse(parsedOutput, context)),
@@ -1583,7 +1583,7 @@ const deserializeAws_queryEnableInsightRulesCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "InvalidParameterValue":
+    case "InvalidParameterValueException":
     case "com.amazonaws.cloudwatch#InvalidParameterValueException":
       response = {
         ...(await deserializeAws_queryInvalidParameterValueExceptionResponse(parsedOutput, context)),
@@ -1599,7 +1599,7 @@ const deserializeAws_queryEnableInsightRulesCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "MissingParameter":
+    case "MissingRequiredParameterException":
     case "com.amazonaws.cloudwatch#MissingRequiredParameterException":
       response = {
         ...(await deserializeAws_queryMissingRequiredParameterExceptionResponse(parsedOutput, context)),
@@ -1653,7 +1653,15 @@ const deserializeAws_queryGetDashboardCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "InternalServiceError":
+    case "DashboardNotFoundError":
+    case "com.amazonaws.cloudwatch#DashboardNotFoundError":
+      response = {
+        ...(await deserializeAws_queryDashboardNotFoundErrorResponse(parsedOutput, context)),
+        name: errorCode,
+        $metadata: deserializeMetadata(output),
+      };
+      break;
+    case "InternalServiceFault":
     case "com.amazonaws.cloudwatch#InternalServiceFault":
       response = {
         ...(await deserializeAws_queryInternalServiceFaultResponse(parsedOutput, context)),
@@ -1661,18 +1669,10 @@ const deserializeAws_queryGetDashboardCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidParameterValue":
+    case "InvalidParameterValueException":
     case "com.amazonaws.cloudwatch#InvalidParameterValueException":
       response = {
         ...(await deserializeAws_queryInvalidParameterValueExceptionResponse(parsedOutput, context)),
-        name: errorCode,
-        $metadata: deserializeMetadata(output),
-      };
-      break;
-    case "ResourceNotFound":
-    case "com.amazonaws.cloudwatch#DashboardNotFoundError":
-      response = {
-        ...(await deserializeAws_queryDashboardNotFoundErrorResponse(parsedOutput, context)),
         name: errorCode,
         $metadata: deserializeMetadata(output),
       };
@@ -1723,7 +1723,7 @@ const deserializeAws_queryGetInsightRuleReportCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "InvalidParameterValue":
+    case "InvalidParameterValueException":
     case "com.amazonaws.cloudwatch#InvalidParameterValueException":
       response = {
         ...(await deserializeAws_queryInvalidParameterValueExceptionResponse(parsedOutput, context)),
@@ -1731,7 +1731,7 @@ const deserializeAws_queryGetInsightRuleReportCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "MissingParameter":
+    case "MissingRequiredParameterException":
     case "com.amazonaws.cloudwatch#MissingRequiredParameterException":
       response = {
         ...(await deserializeAws_queryMissingRequiredParameterExceptionResponse(parsedOutput, context)),
@@ -1847,7 +1847,7 @@ const deserializeAws_queryGetMetricStatisticsCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "InternalServiceError":
+    case "InternalServiceFault":
     case "com.amazonaws.cloudwatch#InternalServiceFault":
       response = {
         ...(await deserializeAws_queryInternalServiceFaultResponse(parsedOutput, context)),
@@ -1855,7 +1855,7 @@ const deserializeAws_queryGetMetricStatisticsCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidParameterCombination":
+    case "InvalidParameterCombinationException":
     case "com.amazonaws.cloudwatch#InvalidParameterCombinationException":
       response = {
         ...(await deserializeAws_queryInvalidParameterCombinationExceptionResponse(parsedOutput, context)),
@@ -1863,7 +1863,7 @@ const deserializeAws_queryGetMetricStatisticsCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidParameterValue":
+    case "InvalidParameterValueException":
     case "com.amazonaws.cloudwatch#InvalidParameterValueException":
       response = {
         ...(await deserializeAws_queryInvalidParameterValueExceptionResponse(parsedOutput, context)),
@@ -1871,7 +1871,7 @@ const deserializeAws_queryGetMetricStatisticsCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "MissingParameter":
+    case "MissingRequiredParameterException":
     case "com.amazonaws.cloudwatch#MissingRequiredParameterException":
       response = {
         ...(await deserializeAws_queryMissingRequiredParameterExceptionResponse(parsedOutput, context)),
@@ -1925,7 +1925,7 @@ const deserializeAws_queryGetMetricStreamCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "InternalServiceError":
+    case "InternalServiceFault":
     case "com.amazonaws.cloudwatch#InternalServiceFault":
       response = {
         ...(await deserializeAws_queryInternalServiceFaultResponse(parsedOutput, context)),
@@ -1933,7 +1933,7 @@ const deserializeAws_queryGetMetricStreamCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidParameterCombination":
+    case "InvalidParameterCombinationException":
     case "com.amazonaws.cloudwatch#InvalidParameterCombinationException":
       response = {
         ...(await deserializeAws_queryInvalidParameterCombinationExceptionResponse(parsedOutput, context)),
@@ -1941,7 +1941,7 @@ const deserializeAws_queryGetMetricStreamCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidParameterValue":
+    case "InvalidParameterValueException":
     case "com.amazonaws.cloudwatch#InvalidParameterValueException":
       response = {
         ...(await deserializeAws_queryInvalidParameterValueExceptionResponse(parsedOutput, context)),
@@ -1949,7 +1949,7 @@ const deserializeAws_queryGetMetricStreamCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "MissingParameter":
+    case "MissingRequiredParameterException":
     case "com.amazonaws.cloudwatch#MissingRequiredParameterException":
       response = {
         ...(await deserializeAws_queryMissingRequiredParameterExceptionResponse(parsedOutput, context)),
@@ -2057,7 +2057,7 @@ const deserializeAws_queryListDashboardsCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "InternalServiceError":
+    case "InternalServiceFault":
     case "com.amazonaws.cloudwatch#InternalServiceFault":
       response = {
         ...(await deserializeAws_queryInternalServiceFaultResponse(parsedOutput, context)),
@@ -2065,7 +2065,7 @@ const deserializeAws_queryListDashboardsCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidParameterValue":
+    case "InvalidParameterValueException":
     case "com.amazonaws.cloudwatch#InvalidParameterValueException":
       response = {
         ...(await deserializeAws_queryInvalidParameterValueExceptionResponse(parsedOutput, context)),
@@ -2119,7 +2119,7 @@ const deserializeAws_queryListMetricsCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "InternalServiceError":
+    case "InternalServiceFault":
     case "com.amazonaws.cloudwatch#InternalServiceFault":
       response = {
         ...(await deserializeAws_queryInternalServiceFaultResponse(parsedOutput, context)),
@@ -2127,7 +2127,7 @@ const deserializeAws_queryListMetricsCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidParameterValue":
+    case "InvalidParameterValueException":
     case "com.amazonaws.cloudwatch#InvalidParameterValueException":
       response = {
         ...(await deserializeAws_queryInvalidParameterValueExceptionResponse(parsedOutput, context)),
@@ -2181,7 +2181,7 @@ const deserializeAws_queryListMetricStreamsCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "InternalServiceError":
+    case "InternalServiceFault":
     case "com.amazonaws.cloudwatch#InternalServiceFault":
       response = {
         ...(await deserializeAws_queryInternalServiceFaultResponse(parsedOutput, context)),
@@ -2197,7 +2197,7 @@ const deserializeAws_queryListMetricStreamsCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidParameterValue":
+    case "InvalidParameterValueException":
     case "com.amazonaws.cloudwatch#InvalidParameterValueException":
       response = {
         ...(await deserializeAws_queryInvalidParameterValueExceptionResponse(parsedOutput, context)),
@@ -2205,7 +2205,7 @@ const deserializeAws_queryListMetricStreamsCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "MissingParameter":
+    case "MissingRequiredParameterException":
     case "com.amazonaws.cloudwatch#MissingRequiredParameterException":
       response = {
         ...(await deserializeAws_queryMissingRequiredParameterExceptionResponse(parsedOutput, context)),
@@ -2259,7 +2259,7 @@ const deserializeAws_queryListTagsForResourceCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "InternalServiceError":
+    case "InternalServiceFault":
     case "com.amazonaws.cloudwatch#InternalServiceFault":
       response = {
         ...(await deserializeAws_queryInternalServiceFaultResponse(parsedOutput, context)),
@@ -2267,7 +2267,7 @@ const deserializeAws_queryListTagsForResourceCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidParameterValue":
+    case "InvalidParameterValueException":
     case "com.amazonaws.cloudwatch#InvalidParameterValueException":
       response = {
         ...(await deserializeAws_queryInvalidParameterValueExceptionResponse(parsedOutput, context)),
@@ -2329,7 +2329,7 @@ const deserializeAws_queryPutAnomalyDetectorCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "InternalServiceError":
+    case "InternalServiceFault":
     case "com.amazonaws.cloudwatch#InternalServiceFault":
       response = {
         ...(await deserializeAws_queryInternalServiceFaultResponse(parsedOutput, context)),
@@ -2337,7 +2337,7 @@ const deserializeAws_queryPutAnomalyDetectorCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidParameterCombination":
+    case "InvalidParameterCombinationException":
     case "com.amazonaws.cloudwatch#InvalidParameterCombinationException":
       response = {
         ...(await deserializeAws_queryInvalidParameterCombinationExceptionResponse(parsedOutput, context)),
@@ -2345,7 +2345,7 @@ const deserializeAws_queryPutAnomalyDetectorCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidParameterValue":
+    case "InvalidParameterValueException":
     case "com.amazonaws.cloudwatch#InvalidParameterValueException":
       response = {
         ...(await deserializeAws_queryInvalidParameterValueExceptionResponse(parsedOutput, context)),
@@ -2361,7 +2361,7 @@ const deserializeAws_queryPutAnomalyDetectorCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "MissingParameter":
+    case "MissingRequiredParameterException":
     case "com.amazonaws.cloudwatch#MissingRequiredParameterException":
       response = {
         ...(await deserializeAws_queryMissingRequiredParameterExceptionResponse(parsedOutput, context)),
@@ -2412,7 +2412,7 @@ const deserializeAws_queryPutCompositeAlarmCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "LimitExceeded":
+    case "LimitExceededFault":
     case "com.amazonaws.cloudwatch#LimitExceededFault":
       response = {
         ...(await deserializeAws_queryLimitExceededFaultResponse(parsedOutput, context)),
@@ -2466,18 +2466,18 @@ const deserializeAws_queryPutDashboardCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "InternalServiceError":
-    case "com.amazonaws.cloudwatch#InternalServiceFault":
+    case "DashboardInvalidInputError":
+    case "com.amazonaws.cloudwatch#DashboardInvalidInputError":
       response = {
-        ...(await deserializeAws_queryInternalServiceFaultResponse(parsedOutput, context)),
+        ...(await deserializeAws_queryDashboardInvalidInputErrorResponse(parsedOutput, context)),
         name: errorCode,
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidParameterInput":
-    case "com.amazonaws.cloudwatch#DashboardInvalidInputError":
+    case "InternalServiceFault":
+    case "com.amazonaws.cloudwatch#InternalServiceFault":
       response = {
-        ...(await deserializeAws_queryDashboardInvalidInputErrorResponse(parsedOutput, context)),
+        ...(await deserializeAws_queryInternalServiceFaultResponse(parsedOutput, context)),
         name: errorCode,
         $metadata: deserializeMetadata(output),
       };
@@ -2528,7 +2528,7 @@ const deserializeAws_queryPutInsightRuleCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "InvalidParameterValue":
+    case "InvalidParameterValueException":
     case "com.amazonaws.cloudwatch#InvalidParameterValueException":
       response = {
         ...(await deserializeAws_queryInvalidParameterValueExceptionResponse(parsedOutput, context)),
@@ -2544,7 +2544,7 @@ const deserializeAws_queryPutInsightRuleCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "MissingParameter":
+    case "MissingRequiredParameterException":
     case "com.amazonaws.cloudwatch#MissingRequiredParameterException":
       response = {
         ...(await deserializeAws_queryMissingRequiredParameterExceptionResponse(parsedOutput, context)),
@@ -2595,7 +2595,7 @@ const deserializeAws_queryPutMetricAlarmCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "LimitExceeded":
+    case "LimitExceededFault":
     case "com.amazonaws.cloudwatch#LimitExceededFault":
       response = {
         ...(await deserializeAws_queryLimitExceededFaultResponse(parsedOutput, context)),
@@ -2646,7 +2646,7 @@ const deserializeAws_queryPutMetricDataCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "InternalServiceError":
+    case "InternalServiceFault":
     case "com.amazonaws.cloudwatch#InternalServiceFault":
       response = {
         ...(await deserializeAws_queryInternalServiceFaultResponse(parsedOutput, context)),
@@ -2654,7 +2654,7 @@ const deserializeAws_queryPutMetricDataCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidParameterCombination":
+    case "InvalidParameterCombinationException":
     case "com.amazonaws.cloudwatch#InvalidParameterCombinationException":
       response = {
         ...(await deserializeAws_queryInvalidParameterCombinationExceptionResponse(parsedOutput, context)),
@@ -2662,7 +2662,7 @@ const deserializeAws_queryPutMetricDataCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidParameterValue":
+    case "InvalidParameterValueException":
     case "com.amazonaws.cloudwatch#InvalidParameterValueException":
       response = {
         ...(await deserializeAws_queryInvalidParameterValueExceptionResponse(parsedOutput, context)),
@@ -2670,7 +2670,7 @@ const deserializeAws_queryPutMetricDataCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "MissingParameter":
+    case "MissingRequiredParameterException":
     case "com.amazonaws.cloudwatch#MissingRequiredParameterException":
       response = {
         ...(await deserializeAws_queryMissingRequiredParameterExceptionResponse(parsedOutput, context)),
@@ -2732,7 +2732,7 @@ const deserializeAws_queryPutMetricStreamCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InternalServiceError":
+    case "InternalServiceFault":
     case "com.amazonaws.cloudwatch#InternalServiceFault":
       response = {
         ...(await deserializeAws_queryInternalServiceFaultResponse(parsedOutput, context)),
@@ -2740,7 +2740,7 @@ const deserializeAws_queryPutMetricStreamCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidParameterCombination":
+    case "InvalidParameterCombinationException":
     case "com.amazonaws.cloudwatch#InvalidParameterCombinationException":
       response = {
         ...(await deserializeAws_queryInvalidParameterCombinationExceptionResponse(parsedOutput, context)),
@@ -2748,7 +2748,7 @@ const deserializeAws_queryPutMetricStreamCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidParameterValue":
+    case "InvalidParameterValueException":
     case "com.amazonaws.cloudwatch#InvalidParameterValueException":
       response = {
         ...(await deserializeAws_queryInvalidParameterValueExceptionResponse(parsedOutput, context)),
@@ -2756,7 +2756,7 @@ const deserializeAws_queryPutMetricStreamCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "MissingParameter":
+    case "MissingRequiredParameterException":
     case "com.amazonaws.cloudwatch#MissingRequiredParameterException":
       response = {
         ...(await deserializeAws_queryMissingRequiredParameterExceptionResponse(parsedOutput, context)),
@@ -2807,7 +2807,7 @@ const deserializeAws_querySetAlarmStateCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "InvalidFormat":
+    case "InvalidFormatFault":
     case "com.amazonaws.cloudwatch#InvalidFormatFault":
       response = {
         ...(await deserializeAws_queryInvalidFormatFaultResponse(parsedOutput, context)),
@@ -2869,7 +2869,7 @@ const deserializeAws_queryStartMetricStreamsCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "InternalServiceError":
+    case "InternalServiceFault":
     case "com.amazonaws.cloudwatch#InternalServiceFault":
       response = {
         ...(await deserializeAws_queryInternalServiceFaultResponse(parsedOutput, context)),
@@ -2877,7 +2877,7 @@ const deserializeAws_queryStartMetricStreamsCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidParameterValue":
+    case "InvalidParameterValueException":
     case "com.amazonaws.cloudwatch#InvalidParameterValueException":
       response = {
         ...(await deserializeAws_queryInvalidParameterValueExceptionResponse(parsedOutput, context)),
@@ -2885,7 +2885,7 @@ const deserializeAws_queryStartMetricStreamsCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "MissingParameter":
+    case "MissingRequiredParameterException":
     case "com.amazonaws.cloudwatch#MissingRequiredParameterException":
       response = {
         ...(await deserializeAws_queryMissingRequiredParameterExceptionResponse(parsedOutput, context)),
@@ -2939,7 +2939,7 @@ const deserializeAws_queryStopMetricStreamsCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "InternalServiceError":
+    case "InternalServiceFault":
     case "com.amazonaws.cloudwatch#InternalServiceFault":
       response = {
         ...(await deserializeAws_queryInternalServiceFaultResponse(parsedOutput, context)),
@@ -2947,7 +2947,7 @@ const deserializeAws_queryStopMetricStreamsCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidParameterValue":
+    case "InvalidParameterValueException":
     case "com.amazonaws.cloudwatch#InvalidParameterValueException":
       response = {
         ...(await deserializeAws_queryInvalidParameterValueExceptionResponse(parsedOutput, context)),
@@ -2955,7 +2955,7 @@ const deserializeAws_queryStopMetricStreamsCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "MissingParameter":
+    case "MissingRequiredParameterException":
     case "com.amazonaws.cloudwatch#MissingRequiredParameterException":
       response = {
         ...(await deserializeAws_queryMissingRequiredParameterExceptionResponse(parsedOutput, context)),
@@ -3017,7 +3017,7 @@ const deserializeAws_queryTagResourceCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InternalServiceError":
+    case "InternalServiceFault":
     case "com.amazonaws.cloudwatch#InternalServiceFault":
       response = {
         ...(await deserializeAws_queryInternalServiceFaultResponse(parsedOutput, context)),
@@ -3025,7 +3025,7 @@ const deserializeAws_queryTagResourceCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidParameterValue":
+    case "InvalidParameterValueException":
     case "com.amazonaws.cloudwatch#InvalidParameterValueException":
       response = {
         ...(await deserializeAws_queryInvalidParameterValueExceptionResponse(parsedOutput, context)),
@@ -3095,7 +3095,7 @@ const deserializeAws_queryUntagResourceCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InternalServiceError":
+    case "InternalServiceFault":
     case "com.amazonaws.cloudwatch#InternalServiceFault":
       response = {
         ...(await deserializeAws_queryInternalServiceFaultResponse(parsedOutput, context)),
@@ -3103,7 +3103,7 @@ const deserializeAws_queryUntagResourceCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidParameterValue":
+    case "InvalidParameterValueException":
     case "com.amazonaws.cloudwatch#InvalidParameterValueException":
       response = {
         ...(await deserializeAws_queryInvalidParameterValueExceptionResponse(parsedOutput, context)),

--- a/clients/client-cognito-identity-provider/src/protocols/Aws_json1_1.ts
+++ b/clients/client-cognito-identity-provider/src/protocols/Aws_json1_1.ts
@@ -2366,18 +2366,18 @@ const deserializeAws_json1_1AdminCreateUserCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "UserNotFoundException":
-    case "com.amazonaws.cognitoidentityprovider#UserNotFoundException":
-      response = {
-        ...(await deserializeAws_json1_1UserNotFoundExceptionResponse(parsedOutput, context)),
-        name: errorCode,
-        $metadata: deserializeMetadata(output),
-      };
-      break;
     case "UsernameExistsException":
     case "com.amazonaws.cognitoidentityprovider#UsernameExistsException":
       response = {
         ...(await deserializeAws_json1_1UsernameExistsExceptionResponse(parsedOutput, context)),
+        name: errorCode,
+        $metadata: deserializeMetadata(output),
+      };
+      break;
+    case "UserNotFoundException":
+    case "com.amazonaws.cognitoidentityprovider#UserNotFoundException":
+      response = {
+        ...(await deserializeAws_json1_1UserNotFoundExceptionResponse(parsedOutput, context)),
         name: errorCode,
         $metadata: deserializeMetadata(output),
       };
@@ -5233,6 +5233,14 @@ const deserializeAws_json1_1ConfirmDeviceCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
+    case "UsernameExistsException":
+    case "com.amazonaws.cognitoidentityprovider#UsernameExistsException":
+      response = {
+        ...(await deserializeAws_json1_1UsernameExistsExceptionResponse(parsedOutput, context)),
+        name: errorCode,
+        $metadata: deserializeMetadata(output),
+      };
+      break;
     case "UserNotConfirmedException":
     case "com.amazonaws.cognitoidentityprovider#UserNotConfirmedException":
       response = {
@@ -5245,14 +5253,6 @@ const deserializeAws_json1_1ConfirmDeviceCommandError = async (
     case "com.amazonaws.cognitoidentityprovider#UserNotFoundException":
       response = {
         ...(await deserializeAws_json1_1UserNotFoundExceptionResponse(parsedOutput, context)),
-        name: errorCode,
-        $metadata: deserializeMetadata(output),
-      };
-      break;
-    case "UsernameExistsException":
-    case "com.amazonaws.cognitoidentityprovider#UsernameExistsException":
-      response = {
-        ...(await deserializeAws_json1_1UsernameExistsExceptionResponse(parsedOutput, context)),
         name: errorCode,
         $metadata: deserializeMetadata(output),
       };

--- a/clients/client-docdb/src/protocols/Aws_query.ts
+++ b/clients/client-docdb/src/protocols/Aws_query.ts
@@ -1266,7 +1266,7 @@ const deserializeAws_queryAddSourceIdentifierToSubscriptionCommandError = async 
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "SourceNotFound":
+    case "SourceNotFoundFault":
     case "com.amazonaws.docdb#SourceNotFoundFault":
       response = {
         ...(await deserializeAws_querySourceNotFoundFaultResponse(parsedOutput, context)),
@@ -1274,7 +1274,7 @@ const deserializeAws_queryAddSourceIdentifierToSubscriptionCommandError = async 
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "SubscriptionNotFound":
+    case "SubscriptionNotFoundFault":
     case "com.amazonaws.docdb#SubscriptionNotFoundFault":
       response = {
         ...(await deserializeAws_querySubscriptionNotFoundFaultResponse(parsedOutput, context)),
@@ -1333,7 +1333,7 @@ const deserializeAws_queryAddTagsToResourceCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "DBInstanceNotFound":
+    case "DBInstanceNotFoundFault":
     case "com.amazonaws.docdb#DBInstanceNotFoundFault":
       response = {
         ...(await deserializeAws_queryDBInstanceNotFoundFaultResponse(parsedOutput, context)),
@@ -1341,7 +1341,7 @@ const deserializeAws_queryAddTagsToResourceCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "DBSnapshotNotFound":
+    case "DBSnapshotNotFoundFault":
     case "com.amazonaws.docdb#DBSnapshotNotFoundFault":
       response = {
         ...(await deserializeAws_queryDBSnapshotNotFoundFaultResponse(parsedOutput, context)),
@@ -1403,7 +1403,7 @@ const deserializeAws_queryApplyPendingMaintenanceActionCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidDBInstanceState":
+    case "InvalidDBInstanceStateFault":
     case "com.amazonaws.docdb#InvalidDBInstanceStateFault":
       response = {
         ...(await deserializeAws_queryInvalidDBInstanceStateFaultResponse(parsedOutput, context)),
@@ -1465,7 +1465,7 @@ const deserializeAws_queryCopyDBClusterParameterGroupCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "DBParameterGroupAlreadyExists":
+    case "DBParameterGroupAlreadyExistsFault":
     case "com.amazonaws.docdb#DBParameterGroupAlreadyExistsFault":
       response = {
         ...(await deserializeAws_queryDBParameterGroupAlreadyExistsFaultResponse(parsedOutput, context)),
@@ -1473,7 +1473,7 @@ const deserializeAws_queryCopyDBClusterParameterGroupCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "DBParameterGroupNotFound":
+    case "DBParameterGroupNotFoundFault":
     case "com.amazonaws.docdb#DBParameterGroupNotFoundFault":
       response = {
         ...(await deserializeAws_queryDBParameterGroupNotFoundFaultResponse(parsedOutput, context)),
@@ -1481,7 +1481,7 @@ const deserializeAws_queryCopyDBClusterParameterGroupCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "DBParameterGroupQuotaExceeded":
+    case "DBParameterGroupQuotaExceededFault":
     case "com.amazonaws.docdb#DBParameterGroupQuotaExceededFault":
       response = {
         ...(await deserializeAws_queryDBParameterGroupQuotaExceededFaultResponse(parsedOutput, context)),
@@ -1575,7 +1575,7 @@ const deserializeAws_queryCopyDBClusterSnapshotCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "SnapshotQuotaExceeded":
+    case "SnapshotQuotaExceededFault":
     case "com.amazonaws.docdb#SnapshotQuotaExceededFault":
       response = {
         ...(await deserializeAws_querySnapshotQuotaExceededFaultResponse(parsedOutput, context)),
@@ -1645,7 +1645,7 @@ const deserializeAws_queryCreateDBClusterCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "DBClusterParameterGroupNotFound":
+    case "DBClusterParameterGroupNotFoundFault":
     case "com.amazonaws.docdb#DBClusterParameterGroupNotFoundFault":
       response = {
         ...(await deserializeAws_queryDBClusterParameterGroupNotFoundFaultResponse(parsedOutput, context)),
@@ -1661,7 +1661,7 @@ const deserializeAws_queryCreateDBClusterCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "DBInstanceNotFound":
+    case "DBInstanceNotFoundFault":
     case "com.amazonaws.docdb#DBInstanceNotFoundFault":
       response = {
         ...(await deserializeAws_queryDBInstanceNotFoundFaultResponse(parsedOutput, context)),
@@ -1693,7 +1693,7 @@ const deserializeAws_queryCreateDBClusterCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InsufficientStorageClusterCapacity":
+    case "InsufficientStorageClusterCapacityFault":
     case "com.amazonaws.docdb#InsufficientStorageClusterCapacityFault":
       response = {
         ...(await deserializeAws_queryInsufficientStorageClusterCapacityFaultResponse(parsedOutput, context)),
@@ -1709,7 +1709,7 @@ const deserializeAws_queryCreateDBClusterCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidDBInstanceState":
+    case "InvalidDBInstanceStateFault":
     case "com.amazonaws.docdb#InvalidDBInstanceStateFault":
       response = {
         ...(await deserializeAws_queryInvalidDBInstanceStateFaultResponse(parsedOutput, context)),
@@ -1757,7 +1757,7 @@ const deserializeAws_queryCreateDBClusterCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "StorageQuotaExceeded":
+    case "StorageQuotaExceededFault":
     case "com.amazonaws.docdb#StorageQuotaExceededFault":
       response = {
         ...(await deserializeAws_queryStorageQuotaExceededFaultResponse(parsedOutput, context)),
@@ -1811,7 +1811,7 @@ const deserializeAws_queryCreateDBClusterParameterGroupCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "DBParameterGroupAlreadyExists":
+    case "DBParameterGroupAlreadyExistsFault":
     case "com.amazonaws.docdb#DBParameterGroupAlreadyExistsFault":
       response = {
         ...(await deserializeAws_queryDBParameterGroupAlreadyExistsFaultResponse(parsedOutput, context)),
@@ -1819,7 +1819,7 @@ const deserializeAws_queryCreateDBClusterParameterGroupCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "DBParameterGroupQuotaExceeded":
+    case "DBParameterGroupQuotaExceededFault":
     case "com.amazonaws.docdb#DBParameterGroupQuotaExceededFault":
       response = {
         ...(await deserializeAws_queryDBParameterGroupQuotaExceededFaultResponse(parsedOutput, context)),
@@ -1905,7 +1905,7 @@ const deserializeAws_queryCreateDBClusterSnapshotCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "SnapshotQuotaExceeded":
+    case "SnapshotQuotaExceededFault":
     case "com.amazonaws.docdb#SnapshotQuotaExceededFault":
       response = {
         ...(await deserializeAws_querySnapshotQuotaExceededFaultResponse(parsedOutput, context)),
@@ -1959,7 +1959,7 @@ const deserializeAws_queryCreateDBInstanceCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "AuthorizationNotFound":
+    case "AuthorizationNotFoundFault":
     case "com.amazonaws.docdb#AuthorizationNotFoundFault":
       response = {
         ...(await deserializeAws_queryAuthorizationNotFoundFaultResponse(parsedOutput, context)),
@@ -1975,7 +1975,7 @@ const deserializeAws_queryCreateDBInstanceCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "DBInstanceAlreadyExists":
+    case "DBInstanceAlreadyExistsFault":
     case "com.amazonaws.docdb#DBInstanceAlreadyExistsFault":
       response = {
         ...(await deserializeAws_queryDBInstanceAlreadyExistsFaultResponse(parsedOutput, context)),
@@ -1983,7 +1983,7 @@ const deserializeAws_queryCreateDBInstanceCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "DBParameterGroupNotFound":
+    case "DBParameterGroupNotFoundFault":
     case "com.amazonaws.docdb#DBParameterGroupNotFoundFault":
       response = {
         ...(await deserializeAws_queryDBParameterGroupNotFoundFaultResponse(parsedOutput, context)),
@@ -1991,7 +1991,7 @@ const deserializeAws_queryCreateDBInstanceCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "DBSecurityGroupNotFound":
+    case "DBSecurityGroupNotFoundFault":
     case "com.amazonaws.docdb#DBSecurityGroupNotFoundFault":
       response = {
         ...(await deserializeAws_queryDBSecurityGroupNotFoundFaultResponse(parsedOutput, context)),
@@ -2015,7 +2015,7 @@ const deserializeAws_queryCreateDBInstanceCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InstanceQuotaExceeded":
+    case "InstanceQuotaExceededFault":
     case "com.amazonaws.docdb#InstanceQuotaExceededFault":
       response = {
         ...(await deserializeAws_queryInstanceQuotaExceededFaultResponse(parsedOutput, context)),
@@ -2023,7 +2023,7 @@ const deserializeAws_queryCreateDBInstanceCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InsufficientDBInstanceCapacity":
+    case "InsufficientDBInstanceCapacityFault":
     case "com.amazonaws.docdb#InsufficientDBInstanceCapacityFault":
       response = {
         ...(await deserializeAws_queryInsufficientDBInstanceCapacityFaultResponse(parsedOutput, context)),
@@ -2063,7 +2063,7 @@ const deserializeAws_queryCreateDBInstanceCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "StorageQuotaExceeded":
+    case "StorageQuotaExceededFault":
     case "com.amazonaws.docdb#StorageQuotaExceededFault":
       response = {
         ...(await deserializeAws_queryStorageQuotaExceededFaultResponse(parsedOutput, context)),
@@ -2071,7 +2071,7 @@ const deserializeAws_queryCreateDBInstanceCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "StorageTypeNotSupported":
+    case "StorageTypeNotSupportedFault":
     case "com.amazonaws.docdb#StorageTypeNotSupportedFault":
       response = {
         ...(await deserializeAws_queryStorageTypeNotSupportedFaultResponse(parsedOutput, context)),
@@ -2125,7 +2125,7 @@ const deserializeAws_queryCreateDBSubnetGroupCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "DBSubnetGroupAlreadyExists":
+    case "DBSubnetGroupAlreadyExistsFault":
     case "com.amazonaws.docdb#DBSubnetGroupAlreadyExistsFault":
       response = {
         ...(await deserializeAws_queryDBSubnetGroupAlreadyExistsFaultResponse(parsedOutput, context)),
@@ -2141,7 +2141,7 @@ const deserializeAws_queryCreateDBSubnetGroupCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "DBSubnetGroupQuotaExceeded":
+    case "DBSubnetGroupQuotaExceededFault":
     case "com.amazonaws.docdb#DBSubnetGroupQuotaExceededFault":
       response = {
         ...(await deserializeAws_queryDBSubnetGroupQuotaExceededFaultResponse(parsedOutput, context)),
@@ -2211,7 +2211,7 @@ const deserializeAws_queryCreateEventSubscriptionCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "EventSubscriptionQuotaExceeded":
+    case "EventSubscriptionQuotaExceededFault":
     case "com.amazonaws.docdb#EventSubscriptionQuotaExceededFault":
       response = {
         ...(await deserializeAws_queryEventSubscriptionQuotaExceededFaultResponse(parsedOutput, context)),
@@ -2219,7 +2219,7 @@ const deserializeAws_queryCreateEventSubscriptionCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "SNSInvalidTopic":
+    case "SNSInvalidTopicFault":
     case "com.amazonaws.docdb#SNSInvalidTopicFault":
       response = {
         ...(await deserializeAws_querySNSInvalidTopicFaultResponse(parsedOutput, context)),
@@ -2227,7 +2227,7 @@ const deserializeAws_queryCreateEventSubscriptionCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "SNSNoAuthorization":
+    case "SNSNoAuthorizationFault":
     case "com.amazonaws.docdb#SNSNoAuthorizationFault":
       response = {
         ...(await deserializeAws_querySNSNoAuthorizationFaultResponse(parsedOutput, context)),
@@ -2235,7 +2235,7 @@ const deserializeAws_queryCreateEventSubscriptionCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "SNSTopicArnNotFound":
+    case "SNSTopicArnNotFoundFault":
     case "com.amazonaws.docdb#SNSTopicArnNotFoundFault":
       response = {
         ...(await deserializeAws_querySNSTopicArnNotFoundFaultResponse(parsedOutput, context)),
@@ -2243,7 +2243,7 @@ const deserializeAws_queryCreateEventSubscriptionCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "SourceNotFound":
+    case "SourceNotFoundFault":
     case "com.amazonaws.docdb#SourceNotFoundFault":
       response = {
         ...(await deserializeAws_querySourceNotFoundFaultResponse(parsedOutput, context)),
@@ -2251,7 +2251,7 @@ const deserializeAws_queryCreateEventSubscriptionCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "SubscriptionAlreadyExist":
+    case "SubscriptionAlreadyExistFault":
     case "com.amazonaws.docdb#SubscriptionAlreadyExistFault":
       response = {
         ...(await deserializeAws_querySubscriptionAlreadyExistFaultResponse(parsedOutput, context)),
@@ -2259,7 +2259,7 @@ const deserializeAws_queryCreateEventSubscriptionCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "SubscriptionCategoryNotFound":
+    case "SubscriptionCategoryNotFoundFault":
     case "com.amazonaws.docdb#SubscriptionCategoryNotFoundFault":
       response = {
         ...(await deserializeAws_querySubscriptionCategoryNotFoundFaultResponse(parsedOutput, context)),
@@ -2423,7 +2423,7 @@ const deserializeAws_queryDeleteDBClusterCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "SnapshotQuotaExceeded":
+    case "SnapshotQuotaExceededFault":
     case "com.amazonaws.docdb#SnapshotQuotaExceededFault":
       response = {
         ...(await deserializeAws_querySnapshotQuotaExceededFaultResponse(parsedOutput, context)),
@@ -2474,7 +2474,7 @@ const deserializeAws_queryDeleteDBClusterParameterGroupCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "DBParameterGroupNotFound":
+    case "DBParameterGroupNotFoundFault":
     case "com.amazonaws.docdb#DBParameterGroupNotFoundFault":
       response = {
         ...(await deserializeAws_queryDBParameterGroupNotFoundFaultResponse(parsedOutput, context)),
@@ -2482,7 +2482,7 @@ const deserializeAws_queryDeleteDBClusterParameterGroupCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidDBParameterGroupState":
+    case "InvalidDBParameterGroupStateFault":
     case "com.amazonaws.docdb#InvalidDBParameterGroupStateFault":
       response = {
         ...(await deserializeAws_queryInvalidDBParameterGroupStateFaultResponse(parsedOutput, context)),
@@ -2598,7 +2598,7 @@ const deserializeAws_queryDeleteDBInstanceCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "DBInstanceNotFound":
+    case "DBInstanceNotFoundFault":
     case "com.amazonaws.docdb#DBInstanceNotFoundFault":
       response = {
         ...(await deserializeAws_queryDBInstanceNotFoundFaultResponse(parsedOutput, context)),
@@ -2606,7 +2606,7 @@ const deserializeAws_queryDeleteDBInstanceCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "DBSnapshotAlreadyExists":
+    case "DBSnapshotAlreadyExistsFault":
     case "com.amazonaws.docdb#DBSnapshotAlreadyExistsFault":
       response = {
         ...(await deserializeAws_queryDBSnapshotAlreadyExistsFaultResponse(parsedOutput, context)),
@@ -2622,7 +2622,7 @@ const deserializeAws_queryDeleteDBInstanceCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidDBInstanceState":
+    case "InvalidDBInstanceStateFault":
     case "com.amazonaws.docdb#InvalidDBInstanceStateFault":
       response = {
         ...(await deserializeAws_queryInvalidDBInstanceStateFaultResponse(parsedOutput, context)),
@@ -2630,7 +2630,7 @@ const deserializeAws_queryDeleteDBInstanceCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "SnapshotQuotaExceeded":
+    case "SnapshotQuotaExceededFault":
     case "com.amazonaws.docdb#SnapshotQuotaExceededFault":
       response = {
         ...(await deserializeAws_querySnapshotQuotaExceededFaultResponse(parsedOutput, context)),
@@ -2751,7 +2751,7 @@ const deserializeAws_queryDeleteEventSubscriptionCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "InvalidEventSubscriptionState":
+    case "InvalidEventSubscriptionStateFault":
     case "com.amazonaws.docdb#InvalidEventSubscriptionStateFault":
       response = {
         ...(await deserializeAws_queryInvalidEventSubscriptionStateFaultResponse(parsedOutput, context)),
@@ -2759,7 +2759,7 @@ const deserializeAws_queryDeleteEventSubscriptionCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "SubscriptionNotFound":
+    case "SubscriptionNotFoundFault":
     case "com.amazonaws.docdb#SubscriptionNotFoundFault":
       response = {
         ...(await deserializeAws_querySubscriptionNotFoundFaultResponse(parsedOutput, context)),
@@ -2875,7 +2875,7 @@ const deserializeAws_queryDescribeCertificatesCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "CertificateNotFound":
+    case "CertificateNotFoundFault":
     case "com.amazonaws.docdb#CertificateNotFoundFault":
       response = {
         ...(await deserializeAws_queryCertificateNotFoundFaultResponse(parsedOutput, context)),
@@ -2929,7 +2929,7 @@ const deserializeAws_queryDescribeDBClusterParameterGroupsCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "DBParameterGroupNotFound":
+    case "DBParameterGroupNotFoundFault":
     case "com.amazonaws.docdb#DBParameterGroupNotFoundFault":
       response = {
         ...(await deserializeAws_queryDBParameterGroupNotFoundFaultResponse(parsedOutput, context)),
@@ -2983,7 +2983,7 @@ const deserializeAws_queryDescribeDBClusterParametersCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "DBParameterGroupNotFound":
+    case "DBParameterGroupNotFoundFault":
     case "com.amazonaws.docdb#DBParameterGroupNotFoundFault":
       response = {
         ...(await deserializeAws_queryDBParameterGroupNotFoundFaultResponse(parsedOutput, context)),
@@ -3248,7 +3248,7 @@ const deserializeAws_queryDescribeDBInstancesCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "DBInstanceNotFound":
+    case "DBInstanceNotFoundFault":
     case "com.amazonaws.docdb#DBInstanceNotFoundFault":
       response = {
         ...(await deserializeAws_queryDBInstanceNotFoundFaultResponse(parsedOutput, context)),
@@ -3497,7 +3497,7 @@ const deserializeAws_queryDescribeEventSubscriptionsCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "SubscriptionNotFound":
+    case "SubscriptionNotFoundFault":
     case "com.amazonaws.docdb#SubscriptionNotFoundFault":
       response = {
         ...(await deserializeAws_querySubscriptionNotFoundFaultResponse(parsedOutput, context)),
@@ -3727,7 +3727,7 @@ const deserializeAws_queryFailoverDBClusterCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidDBInstanceState":
+    case "InvalidDBInstanceStateFault":
     case "com.amazonaws.docdb#InvalidDBInstanceStateFault":
       response = {
         ...(await deserializeAws_queryInvalidDBInstanceStateFaultResponse(parsedOutput, context)),
@@ -3789,7 +3789,7 @@ const deserializeAws_queryListTagsForResourceCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "DBInstanceNotFound":
+    case "DBInstanceNotFoundFault":
     case "com.amazonaws.docdb#DBInstanceNotFoundFault":
       response = {
         ...(await deserializeAws_queryDBInstanceNotFoundFaultResponse(parsedOutput, context)),
@@ -3797,7 +3797,7 @@ const deserializeAws_queryListTagsForResourceCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "DBSnapshotNotFound":
+    case "DBSnapshotNotFoundFault":
     case "com.amazonaws.docdb#DBSnapshotNotFoundFault":
       response = {
         ...(await deserializeAws_queryDBSnapshotNotFoundFaultResponse(parsedOutput, context)),
@@ -3867,7 +3867,7 @@ const deserializeAws_queryModifyDBClusterCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "DBClusterParameterGroupNotFound":
+    case "DBClusterParameterGroupNotFoundFault":
     case "com.amazonaws.docdb#DBClusterParameterGroupNotFoundFault":
       response = {
         ...(await deserializeAws_queryDBClusterParameterGroupNotFoundFaultResponse(parsedOutput, context)),
@@ -3891,7 +3891,7 @@ const deserializeAws_queryModifyDBClusterCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidDBInstanceState":
+    case "InvalidDBInstanceStateFault":
     case "com.amazonaws.docdb#InvalidDBInstanceStateFault":
       response = {
         ...(await deserializeAws_queryInvalidDBInstanceStateFaultResponse(parsedOutput, context)),
@@ -3899,7 +3899,7 @@ const deserializeAws_queryModifyDBClusterCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidDBSecurityGroupState":
+    case "InvalidDBSecurityGroupStateFault":
     case "com.amazonaws.docdb#InvalidDBSecurityGroupStateFault":
       response = {
         ...(await deserializeAws_queryInvalidDBSecurityGroupStateFaultResponse(parsedOutput, context)),
@@ -3931,7 +3931,7 @@ const deserializeAws_queryModifyDBClusterCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "StorageQuotaExceeded":
+    case "StorageQuotaExceededFault":
     case "com.amazonaws.docdb#StorageQuotaExceededFault":
       response = {
         ...(await deserializeAws_queryStorageQuotaExceededFaultResponse(parsedOutput, context)),
@@ -3985,7 +3985,7 @@ const deserializeAws_queryModifyDBClusterParameterGroupCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "DBParameterGroupNotFound":
+    case "DBParameterGroupNotFoundFault":
     case "com.amazonaws.docdb#DBParameterGroupNotFoundFault":
       response = {
         ...(await deserializeAws_queryDBParameterGroupNotFoundFaultResponse(parsedOutput, context)),
@@ -3993,7 +3993,7 @@ const deserializeAws_queryModifyDBClusterParameterGroupCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidDBParameterGroupState":
+    case "InvalidDBParameterGroupStateFault":
     case "com.amazonaws.docdb#InvalidDBParameterGroupStateFault":
       response = {
         ...(await deserializeAws_queryInvalidDBParameterGroupStateFaultResponse(parsedOutput, context)),
@@ -4066,7 +4066,7 @@ const deserializeAws_queryModifyDBClusterSnapshotAttributeCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "SharedSnapshotQuotaExceeded":
+    case "SharedSnapshotQuotaExceededFault":
     case "com.amazonaws.docdb#SharedSnapshotQuotaExceededFault":
       response = {
         ...(await deserializeAws_querySharedSnapshotQuotaExceededFaultResponse(parsedOutput, context)),
@@ -4120,7 +4120,7 @@ const deserializeAws_queryModifyDBInstanceCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "AuthorizationNotFound":
+    case "AuthorizationNotFoundFault":
     case "com.amazonaws.docdb#AuthorizationNotFoundFault":
       response = {
         ...(await deserializeAws_queryAuthorizationNotFoundFaultResponse(parsedOutput, context)),
@@ -4128,7 +4128,7 @@ const deserializeAws_queryModifyDBInstanceCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "CertificateNotFound":
+    case "CertificateNotFoundFault":
     case "com.amazonaws.docdb#CertificateNotFoundFault":
       response = {
         ...(await deserializeAws_queryCertificateNotFoundFaultResponse(parsedOutput, context)),
@@ -4136,7 +4136,7 @@ const deserializeAws_queryModifyDBInstanceCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "DBInstanceAlreadyExists":
+    case "DBInstanceAlreadyExistsFault":
     case "com.amazonaws.docdb#DBInstanceAlreadyExistsFault":
       response = {
         ...(await deserializeAws_queryDBInstanceAlreadyExistsFaultResponse(parsedOutput, context)),
@@ -4144,7 +4144,7 @@ const deserializeAws_queryModifyDBInstanceCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "DBInstanceNotFound":
+    case "DBInstanceNotFoundFault":
     case "com.amazonaws.docdb#DBInstanceNotFoundFault":
       response = {
         ...(await deserializeAws_queryDBInstanceNotFoundFaultResponse(parsedOutput, context)),
@@ -4152,7 +4152,7 @@ const deserializeAws_queryModifyDBInstanceCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "DBParameterGroupNotFound":
+    case "DBParameterGroupNotFoundFault":
     case "com.amazonaws.docdb#DBParameterGroupNotFoundFault":
       response = {
         ...(await deserializeAws_queryDBParameterGroupNotFoundFaultResponse(parsedOutput, context)),
@@ -4160,7 +4160,7 @@ const deserializeAws_queryModifyDBInstanceCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "DBSecurityGroupNotFound":
+    case "DBSecurityGroupNotFoundFault":
     case "com.amazonaws.docdb#DBSecurityGroupNotFoundFault":
       response = {
         ...(await deserializeAws_queryDBSecurityGroupNotFoundFaultResponse(parsedOutput, context)),
@@ -4168,7 +4168,7 @@ const deserializeAws_queryModifyDBInstanceCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "DBUpgradeDependencyFailure":
+    case "DBUpgradeDependencyFailureFault":
     case "com.amazonaws.docdb#DBUpgradeDependencyFailureFault":
       response = {
         ...(await deserializeAws_queryDBUpgradeDependencyFailureFaultResponse(parsedOutput, context)),
@@ -4176,7 +4176,7 @@ const deserializeAws_queryModifyDBInstanceCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InsufficientDBInstanceCapacity":
+    case "InsufficientDBInstanceCapacityFault":
     case "com.amazonaws.docdb#InsufficientDBInstanceCapacityFault":
       response = {
         ...(await deserializeAws_queryInsufficientDBInstanceCapacityFaultResponse(parsedOutput, context)),
@@ -4184,7 +4184,7 @@ const deserializeAws_queryModifyDBInstanceCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidDBInstanceState":
+    case "InvalidDBInstanceStateFault":
     case "com.amazonaws.docdb#InvalidDBInstanceStateFault":
       response = {
         ...(await deserializeAws_queryInvalidDBInstanceStateFaultResponse(parsedOutput, context)),
@@ -4192,7 +4192,7 @@ const deserializeAws_queryModifyDBInstanceCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidDBSecurityGroupState":
+    case "InvalidDBSecurityGroupStateFault":
     case "com.amazonaws.docdb#InvalidDBSecurityGroupStateFault":
       response = {
         ...(await deserializeAws_queryInvalidDBSecurityGroupStateFaultResponse(parsedOutput, context)),
@@ -4208,7 +4208,7 @@ const deserializeAws_queryModifyDBInstanceCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "StorageQuotaExceeded":
+    case "StorageQuotaExceededFault":
     case "com.amazonaws.docdb#StorageQuotaExceededFault":
       response = {
         ...(await deserializeAws_queryStorageQuotaExceededFaultResponse(parsedOutput, context)),
@@ -4216,7 +4216,7 @@ const deserializeAws_queryModifyDBInstanceCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "StorageTypeNotSupported":
+    case "StorageTypeNotSupportedFault":
     case "com.amazonaws.docdb#StorageTypeNotSupportedFault":
       response = {
         ...(await deserializeAws_queryStorageTypeNotSupportedFaultResponse(parsedOutput, context)),
@@ -4356,7 +4356,7 @@ const deserializeAws_queryModifyEventSubscriptionCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "EventSubscriptionQuotaExceeded":
+    case "EventSubscriptionQuotaExceededFault":
     case "com.amazonaws.docdb#EventSubscriptionQuotaExceededFault":
       response = {
         ...(await deserializeAws_queryEventSubscriptionQuotaExceededFaultResponse(parsedOutput, context)),
@@ -4364,7 +4364,7 @@ const deserializeAws_queryModifyEventSubscriptionCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "SNSInvalidTopic":
+    case "SNSInvalidTopicFault":
     case "com.amazonaws.docdb#SNSInvalidTopicFault":
       response = {
         ...(await deserializeAws_querySNSInvalidTopicFaultResponse(parsedOutput, context)),
@@ -4372,7 +4372,7 @@ const deserializeAws_queryModifyEventSubscriptionCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "SNSNoAuthorization":
+    case "SNSNoAuthorizationFault":
     case "com.amazonaws.docdb#SNSNoAuthorizationFault":
       response = {
         ...(await deserializeAws_querySNSNoAuthorizationFaultResponse(parsedOutput, context)),
@@ -4380,7 +4380,7 @@ const deserializeAws_queryModifyEventSubscriptionCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "SNSTopicArnNotFound":
+    case "SNSTopicArnNotFoundFault":
     case "com.amazonaws.docdb#SNSTopicArnNotFoundFault":
       response = {
         ...(await deserializeAws_querySNSTopicArnNotFoundFaultResponse(parsedOutput, context)),
@@ -4388,7 +4388,7 @@ const deserializeAws_queryModifyEventSubscriptionCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "SubscriptionCategoryNotFound":
+    case "SubscriptionCategoryNotFoundFault":
     case "com.amazonaws.docdb#SubscriptionCategoryNotFoundFault":
       response = {
         ...(await deserializeAws_querySubscriptionCategoryNotFoundFaultResponse(parsedOutput, context)),
@@ -4396,7 +4396,7 @@ const deserializeAws_queryModifyEventSubscriptionCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "SubscriptionNotFound":
+    case "SubscriptionNotFoundFault":
     case "com.amazonaws.docdb#SubscriptionNotFoundFault":
       response = {
         ...(await deserializeAws_querySubscriptionNotFoundFaultResponse(parsedOutput, context)),
@@ -4512,7 +4512,7 @@ const deserializeAws_queryRebootDBInstanceCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "DBInstanceNotFound":
+    case "DBInstanceNotFoundFault":
     case "com.amazonaws.docdb#DBInstanceNotFoundFault":
       response = {
         ...(await deserializeAws_queryDBInstanceNotFoundFaultResponse(parsedOutput, context)),
@@ -4520,7 +4520,7 @@ const deserializeAws_queryRebootDBInstanceCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidDBInstanceState":
+    case "InvalidDBInstanceStateFault":
     case "com.amazonaws.docdb#InvalidDBInstanceStateFault":
       response = {
         ...(await deserializeAws_queryInvalidDBInstanceStateFaultResponse(parsedOutput, context)),
@@ -4647,7 +4647,7 @@ const deserializeAws_queryRemoveSourceIdentifierFromSubscriptionCommandError = a
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "SourceNotFound":
+    case "SourceNotFoundFault":
     case "com.amazonaws.docdb#SourceNotFoundFault":
       response = {
         ...(await deserializeAws_querySourceNotFoundFaultResponse(parsedOutput, context)),
@@ -4655,7 +4655,7 @@ const deserializeAws_queryRemoveSourceIdentifierFromSubscriptionCommandError = a
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "SubscriptionNotFound":
+    case "SubscriptionNotFoundFault":
     case "com.amazonaws.docdb#SubscriptionNotFoundFault":
       response = {
         ...(await deserializeAws_querySubscriptionNotFoundFaultResponse(parsedOutput, context)),
@@ -4714,7 +4714,7 @@ const deserializeAws_queryRemoveTagsFromResourceCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "DBInstanceNotFound":
+    case "DBInstanceNotFoundFault":
     case "com.amazonaws.docdb#DBInstanceNotFoundFault":
       response = {
         ...(await deserializeAws_queryDBInstanceNotFoundFaultResponse(parsedOutput, context)),
@@ -4722,7 +4722,7 @@ const deserializeAws_queryRemoveTagsFromResourceCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "DBSnapshotNotFound":
+    case "DBSnapshotNotFoundFault":
     case "com.amazonaws.docdb#DBSnapshotNotFoundFault":
       response = {
         ...(await deserializeAws_queryDBSnapshotNotFoundFaultResponse(parsedOutput, context)),
@@ -4776,7 +4776,7 @@ const deserializeAws_queryResetDBClusterParameterGroupCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "DBParameterGroupNotFound":
+    case "DBParameterGroupNotFoundFault":
     case "com.amazonaws.docdb#DBParameterGroupNotFoundFault":
       response = {
         ...(await deserializeAws_queryDBParameterGroupNotFoundFaultResponse(parsedOutput, context)),
@@ -4784,7 +4784,7 @@ const deserializeAws_queryResetDBClusterParameterGroupCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidDBParameterGroupState":
+    case "InvalidDBParameterGroupStateFault":
     case "com.amazonaws.docdb#InvalidDBParameterGroupStateFault":
       response = {
         ...(await deserializeAws_queryInvalidDBParameterGroupStateFaultResponse(parsedOutput, context)),
@@ -4862,7 +4862,7 @@ const deserializeAws_queryRestoreDBClusterFromSnapshotCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "DBSnapshotNotFound":
+    case "DBSnapshotNotFoundFault":
     case "com.amazonaws.docdb#DBSnapshotNotFoundFault":
       response = {
         ...(await deserializeAws_queryDBSnapshotNotFoundFaultResponse(parsedOutput, context)),
@@ -4886,7 +4886,7 @@ const deserializeAws_queryRestoreDBClusterFromSnapshotCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InsufficientStorageClusterCapacity":
+    case "InsufficientStorageClusterCapacityFault":
     case "com.amazonaws.docdb#InsufficientStorageClusterCapacityFault":
       response = {
         ...(await deserializeAws_queryInsufficientStorageClusterCapacityFaultResponse(parsedOutput, context)),
@@ -4902,7 +4902,7 @@ const deserializeAws_queryRestoreDBClusterFromSnapshotCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidDBSnapshotState":
+    case "InvalidDBSnapshotStateFault":
     case "com.amazonaws.docdb#InvalidDBSnapshotStateFault":
       response = {
         ...(await deserializeAws_queryInvalidDBSnapshotStateFaultResponse(parsedOutput, context)),
@@ -4942,7 +4942,7 @@ const deserializeAws_queryRestoreDBClusterFromSnapshotCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "StorageQuotaExceeded":
+    case "StorageQuotaExceededFault":
     case "com.amazonaws.docdb#StorageQuotaExceededFault":
       response = {
         ...(await deserializeAws_queryStorageQuotaExceededFaultResponse(parsedOutput, context)),
@@ -5044,7 +5044,7 @@ const deserializeAws_queryRestoreDBClusterToPointInTimeCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InsufficientStorageClusterCapacity":
+    case "InsufficientStorageClusterCapacityFault":
     case "com.amazonaws.docdb#InsufficientStorageClusterCapacityFault":
       response = {
         ...(await deserializeAws_queryInsufficientStorageClusterCapacityFaultResponse(parsedOutput, context)),
@@ -5068,7 +5068,7 @@ const deserializeAws_queryRestoreDBClusterToPointInTimeCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidDBSnapshotState":
+    case "InvalidDBSnapshotStateFault":
     case "com.amazonaws.docdb#InvalidDBSnapshotStateFault":
       response = {
         ...(await deserializeAws_queryInvalidDBSnapshotStateFaultResponse(parsedOutput, context)),
@@ -5108,7 +5108,7 @@ const deserializeAws_queryRestoreDBClusterToPointInTimeCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "StorageQuotaExceeded":
+    case "StorageQuotaExceededFault":
     case "com.amazonaws.docdb#StorageQuotaExceededFault":
       response = {
         ...(await deserializeAws_queryStorageQuotaExceededFaultResponse(parsedOutput, context)),
@@ -5178,7 +5178,7 @@ const deserializeAws_queryStartDBClusterCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidDBInstanceState":
+    case "InvalidDBInstanceStateFault":
     case "com.amazonaws.docdb#InvalidDBInstanceStateFault":
       response = {
         ...(await deserializeAws_queryInvalidDBInstanceStateFaultResponse(parsedOutput, context)),
@@ -5248,7 +5248,7 @@ const deserializeAws_queryStopDBClusterCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidDBInstanceState":
+    case "InvalidDBInstanceStateFault":
     case "com.amazonaws.docdb#InvalidDBInstanceStateFault":
       response = {
         ...(await deserializeAws_queryInvalidDBInstanceStateFaultResponse(parsedOutput, context)),

--- a/clients/client-elastic-beanstalk/src/protocols/Aws_query.ts
+++ b/clients/client-elastic-beanstalk/src/protocols/Aws_query.ts
@@ -1461,18 +1461,18 @@ const deserializeAws_queryCreateApplicationVersionCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "TooManyApplicationVersionsException":
-    case "com.amazonaws.elasticbeanstalk#TooManyApplicationVersionsException":
-      response = {
-        ...(await deserializeAws_queryTooManyApplicationVersionsExceptionResponse(parsedOutput, context)),
-        name: errorCode,
-        $metadata: deserializeMetadata(output),
-      };
-      break;
     case "TooManyApplicationsException":
     case "com.amazonaws.elasticbeanstalk#TooManyApplicationsException":
       response = {
         ...(await deserializeAws_queryTooManyApplicationsExceptionResponse(parsedOutput, context)),
+        name: errorCode,
+        $metadata: deserializeMetadata(output),
+      };
+      break;
+    case "TooManyApplicationVersionsException":
+    case "com.amazonaws.elasticbeanstalk#TooManyApplicationVersionsException":
+      response = {
+        ...(await deserializeAws_queryTooManyApplicationVersionsExceptionResponse(parsedOutput, context)),
         name: errorCode,
         $metadata: deserializeMetadata(output),
       };
@@ -1792,7 +1792,7 @@ const deserializeAws_queryDeleteApplicationCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "OperationInProgressFailure":
+    case "OperationInProgressException":
     case "com.amazonaws.elasticbeanstalk#OperationInProgressException":
       response = {
         ...(await deserializeAws_queryOperationInProgressExceptionResponse(parsedOutput, context)),
@@ -1851,7 +1851,7 @@ const deserializeAws_queryDeleteApplicationVersionCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "OperationInProgressFailure":
+    case "OperationInProgressException":
     case "com.amazonaws.elasticbeanstalk#OperationInProgressException":
       response = {
         ...(await deserializeAws_queryOperationInProgressExceptionResponse(parsedOutput, context)),
@@ -1867,7 +1867,7 @@ const deserializeAws_queryDeleteApplicationVersionCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "SourceBundleDeletionFailure":
+    case "SourceBundleDeletionException":
     case "com.amazonaws.elasticbeanstalk#SourceBundleDeletionException":
       response = {
         ...(await deserializeAws_querySourceBundleDeletionExceptionResponse(parsedOutput, context)),
@@ -1918,7 +1918,7 @@ const deserializeAws_queryDeleteConfigurationTemplateCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "OperationInProgressFailure":
+    case "OperationInProgressException":
     case "com.amazonaws.elasticbeanstalk#OperationInProgressException":
       response = {
         ...(await deserializeAws_queryOperationInProgressExceptionResponse(parsedOutput, context)),
@@ -2031,7 +2031,7 @@ const deserializeAws_queryDeletePlatformVersionCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "OperationInProgressFailure":
+    case "OperationInProgressException":
     case "com.amazonaws.elasticbeanstalk#OperationInProgressException":
       response = {
         ...(await deserializeAws_queryOperationInProgressExceptionResponse(parsedOutput, context)),
@@ -3632,7 +3632,7 @@ const deserializeAws_queryUpdateTagsForResourceCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "OperationInProgressFailure":
+    case "OperationInProgressException":
     case "com.amazonaws.elasticbeanstalk#OperationInProgressException":
       response = {
         ...(await deserializeAws_queryOperationInProgressExceptionResponse(parsedOutput, context)),

--- a/clients/client-elastic-load-balancing-v2/src/protocols/Aws_query.ts
+++ b/clients/client-elastic-load-balancing-v2/src/protocols/Aws_query.ts
@@ -809,7 +809,7 @@ const deserializeAws_queryAddListenerCertificatesCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "CertificateNotFound":
+    case "CertificateNotFoundException":
     case "com.amazonaws.elasticloadbalancingv2#CertificateNotFoundException":
       response = {
         ...(await deserializeAws_queryCertificateNotFoundExceptionResponse(parsedOutput, context)),
@@ -817,7 +817,7 @@ const deserializeAws_queryAddListenerCertificatesCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ListenerNotFound":
+    case "ListenerNotFoundException":
     case "com.amazonaws.elasticloadbalancingv2#ListenerNotFoundException":
       response = {
         ...(await deserializeAws_queryListenerNotFoundExceptionResponse(parsedOutput, context)),
@@ -825,7 +825,7 @@ const deserializeAws_queryAddListenerCertificatesCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "TooManyCertificates":
+    case "TooManyCertificatesException":
     case "com.amazonaws.elasticloadbalancingv2#TooManyCertificatesException":
       response = {
         ...(await deserializeAws_queryTooManyCertificatesExceptionResponse(parsedOutput, context)),
@@ -879,7 +879,7 @@ const deserializeAws_queryAddTagsCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "DuplicateTagKeys":
+    case "DuplicateTagKeysException":
     case "com.amazonaws.elasticloadbalancingv2#DuplicateTagKeysException":
       response = {
         ...(await deserializeAws_queryDuplicateTagKeysExceptionResponse(parsedOutput, context)),
@@ -887,7 +887,7 @@ const deserializeAws_queryAddTagsCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ListenerNotFound":
+    case "ListenerNotFoundException":
     case "com.amazonaws.elasticloadbalancingv2#ListenerNotFoundException":
       response = {
         ...(await deserializeAws_queryListenerNotFoundExceptionResponse(parsedOutput, context)),
@@ -895,7 +895,7 @@ const deserializeAws_queryAddTagsCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "LoadBalancerNotFound":
+    case "LoadBalancerNotFoundException":
     case "com.amazonaws.elasticloadbalancingv2#LoadBalancerNotFoundException":
       response = {
         ...(await deserializeAws_queryLoadBalancerNotFoundExceptionResponse(parsedOutput, context)),
@@ -903,7 +903,7 @@ const deserializeAws_queryAddTagsCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "RuleNotFound":
+    case "RuleNotFoundException":
     case "com.amazonaws.elasticloadbalancingv2#RuleNotFoundException":
       response = {
         ...(await deserializeAws_queryRuleNotFoundExceptionResponse(parsedOutput, context)),
@@ -911,7 +911,7 @@ const deserializeAws_queryAddTagsCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "TargetGroupNotFound":
+    case "TargetGroupNotFoundException":
     case "com.amazonaws.elasticloadbalancingv2#TargetGroupNotFoundException":
       response = {
         ...(await deserializeAws_queryTargetGroupNotFoundExceptionResponse(parsedOutput, context)),
@@ -919,7 +919,7 @@ const deserializeAws_queryAddTagsCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "TooManyTags":
+    case "TooManyTagsException":
     case "com.amazonaws.elasticloadbalancingv2#TooManyTagsException":
       response = {
         ...(await deserializeAws_queryTooManyTagsExceptionResponse(parsedOutput, context)),
@@ -973,7 +973,7 @@ const deserializeAws_queryCreateListenerCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "ALPNPolicyNotFound":
+    case "ALPNPolicyNotSupportedException":
     case "com.amazonaws.elasticloadbalancingv2#ALPNPolicyNotSupportedException":
       response = {
         ...(await deserializeAws_queryALPNPolicyNotSupportedExceptionResponse(parsedOutput, context)),
@@ -981,7 +981,7 @@ const deserializeAws_queryCreateListenerCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "CertificateNotFound":
+    case "CertificateNotFoundException":
     case "com.amazonaws.elasticloadbalancingv2#CertificateNotFoundException":
       response = {
         ...(await deserializeAws_queryCertificateNotFoundExceptionResponse(parsedOutput, context)),
@@ -989,7 +989,7 @@ const deserializeAws_queryCreateListenerCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "DuplicateListener":
+    case "DuplicateListenerException":
     case "com.amazonaws.elasticloadbalancingv2#DuplicateListenerException":
       response = {
         ...(await deserializeAws_queryDuplicateListenerExceptionResponse(parsedOutput, context)),
@@ -997,7 +997,7 @@ const deserializeAws_queryCreateListenerCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "IncompatibleProtocols":
+    case "IncompatibleProtocolsException":
     case "com.amazonaws.elasticloadbalancingv2#IncompatibleProtocolsException":
       response = {
         ...(await deserializeAws_queryIncompatibleProtocolsExceptionResponse(parsedOutput, context)),
@@ -1005,7 +1005,7 @@ const deserializeAws_queryCreateListenerCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidConfigurationRequest":
+    case "InvalidConfigurationRequestException":
     case "com.amazonaws.elasticloadbalancingv2#InvalidConfigurationRequestException":
       response = {
         ...(await deserializeAws_queryInvalidConfigurationRequestExceptionResponse(parsedOutput, context)),
@@ -1013,7 +1013,7 @@ const deserializeAws_queryCreateListenerCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidLoadBalancerAction":
+    case "InvalidLoadBalancerActionException":
     case "com.amazonaws.elasticloadbalancingv2#InvalidLoadBalancerActionException":
       response = {
         ...(await deserializeAws_queryInvalidLoadBalancerActionExceptionResponse(parsedOutput, context)),
@@ -1021,7 +1021,7 @@ const deserializeAws_queryCreateListenerCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "LoadBalancerNotFound":
+    case "LoadBalancerNotFoundException":
     case "com.amazonaws.elasticloadbalancingv2#LoadBalancerNotFoundException":
       response = {
         ...(await deserializeAws_queryLoadBalancerNotFoundExceptionResponse(parsedOutput, context)),
@@ -1029,7 +1029,7 @@ const deserializeAws_queryCreateListenerCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "SSLPolicyNotFound":
+    case "SSLPolicyNotFoundException":
     case "com.amazonaws.elasticloadbalancingv2#SSLPolicyNotFoundException":
       response = {
         ...(await deserializeAws_querySSLPolicyNotFoundExceptionResponse(parsedOutput, context)),
@@ -1037,7 +1037,7 @@ const deserializeAws_queryCreateListenerCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "TargetGroupAssociationLimit":
+    case "TargetGroupAssociationLimitException":
     case "com.amazonaws.elasticloadbalancingv2#TargetGroupAssociationLimitException":
       response = {
         ...(await deserializeAws_queryTargetGroupAssociationLimitExceptionResponse(parsedOutput, context)),
@@ -1045,7 +1045,7 @@ const deserializeAws_queryCreateListenerCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "TargetGroupNotFound":
+    case "TargetGroupNotFoundException":
     case "com.amazonaws.elasticloadbalancingv2#TargetGroupNotFoundException":
       response = {
         ...(await deserializeAws_queryTargetGroupNotFoundExceptionResponse(parsedOutput, context)),
@@ -1053,7 +1053,7 @@ const deserializeAws_queryCreateListenerCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "TooManyActions":
+    case "TooManyActionsException":
     case "com.amazonaws.elasticloadbalancingv2#TooManyActionsException":
       response = {
         ...(await deserializeAws_queryTooManyActionsExceptionResponse(parsedOutput, context)),
@@ -1061,7 +1061,7 @@ const deserializeAws_queryCreateListenerCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "TooManyCertificates":
+    case "TooManyCertificatesException":
     case "com.amazonaws.elasticloadbalancingv2#TooManyCertificatesException":
       response = {
         ...(await deserializeAws_queryTooManyCertificatesExceptionResponse(parsedOutput, context)),
@@ -1069,7 +1069,7 @@ const deserializeAws_queryCreateListenerCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "TooManyListeners":
+    case "TooManyListenersException":
     case "com.amazonaws.elasticloadbalancingv2#TooManyListenersException":
       response = {
         ...(await deserializeAws_queryTooManyListenersExceptionResponse(parsedOutput, context)),
@@ -1077,7 +1077,7 @@ const deserializeAws_queryCreateListenerCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "TooManyRegistrationsForTargetId":
+    case "TooManyRegistrationsForTargetIdException":
     case "com.amazonaws.elasticloadbalancingv2#TooManyRegistrationsForTargetIdException":
       response = {
         ...(await deserializeAws_queryTooManyRegistrationsForTargetIdExceptionResponse(parsedOutput, context)),
@@ -1085,7 +1085,7 @@ const deserializeAws_queryCreateListenerCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "TooManyTags":
+    case "TooManyTagsException":
     case "com.amazonaws.elasticloadbalancingv2#TooManyTagsException":
       response = {
         ...(await deserializeAws_queryTooManyTagsExceptionResponse(parsedOutput, context)),
@@ -1093,7 +1093,7 @@ const deserializeAws_queryCreateListenerCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "TooManyTargets":
+    case "TooManyTargetsException":
     case "com.amazonaws.elasticloadbalancingv2#TooManyTargetsException":
       response = {
         ...(await deserializeAws_queryTooManyTargetsExceptionResponse(parsedOutput, context)),
@@ -1101,7 +1101,7 @@ const deserializeAws_queryCreateListenerCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "TooManyUniqueTargetGroupsPerLoadBalancer":
+    case "TooManyUniqueTargetGroupsPerLoadBalancerException":
     case "com.amazonaws.elasticloadbalancingv2#TooManyUniqueTargetGroupsPerLoadBalancerException":
       response = {
         ...(await deserializeAws_queryTooManyUniqueTargetGroupsPerLoadBalancerExceptionResponse(parsedOutput, context)),
@@ -1109,7 +1109,7 @@ const deserializeAws_queryCreateListenerCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "UnsupportedProtocol":
+    case "UnsupportedProtocolException":
     case "com.amazonaws.elasticloadbalancingv2#UnsupportedProtocolException":
       response = {
         ...(await deserializeAws_queryUnsupportedProtocolExceptionResponse(parsedOutput, context)),
@@ -1163,7 +1163,7 @@ const deserializeAws_queryCreateLoadBalancerCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "AllocationIdNotFound":
+    case "AllocationIdNotFoundException":
     case "com.amazonaws.elasticloadbalancingv2#AllocationIdNotFoundException":
       response = {
         ...(await deserializeAws_queryAllocationIdNotFoundExceptionResponse(parsedOutput, context)),
@@ -1171,7 +1171,7 @@ const deserializeAws_queryCreateLoadBalancerCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "AvailabilityZoneNotSupported":
+    case "AvailabilityZoneNotSupportedException":
     case "com.amazonaws.elasticloadbalancingv2#AvailabilityZoneNotSupportedException":
       response = {
         ...(await deserializeAws_queryAvailabilityZoneNotSupportedExceptionResponse(parsedOutput, context)),
@@ -1179,7 +1179,7 @@ const deserializeAws_queryCreateLoadBalancerCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "DuplicateLoadBalancerName":
+    case "DuplicateLoadBalancerNameException":
     case "com.amazonaws.elasticloadbalancingv2#DuplicateLoadBalancerNameException":
       response = {
         ...(await deserializeAws_queryDuplicateLoadBalancerNameExceptionResponse(parsedOutput, context)),
@@ -1187,7 +1187,7 @@ const deserializeAws_queryCreateLoadBalancerCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "DuplicateTagKeys":
+    case "DuplicateTagKeysException":
     case "com.amazonaws.elasticloadbalancingv2#DuplicateTagKeysException":
       response = {
         ...(await deserializeAws_queryDuplicateTagKeysExceptionResponse(parsedOutput, context)),
@@ -1195,7 +1195,7 @@ const deserializeAws_queryCreateLoadBalancerCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidConfigurationRequest":
+    case "InvalidConfigurationRequestException":
     case "com.amazonaws.elasticloadbalancingv2#InvalidConfigurationRequestException":
       response = {
         ...(await deserializeAws_queryInvalidConfigurationRequestExceptionResponse(parsedOutput, context)),
@@ -1203,7 +1203,7 @@ const deserializeAws_queryCreateLoadBalancerCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidScheme":
+    case "InvalidSchemeException":
     case "com.amazonaws.elasticloadbalancingv2#InvalidSchemeException":
       response = {
         ...(await deserializeAws_queryInvalidSchemeExceptionResponse(parsedOutput, context)),
@@ -1211,7 +1211,7 @@ const deserializeAws_queryCreateLoadBalancerCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidSecurityGroup":
+    case "InvalidSecurityGroupException":
     case "com.amazonaws.elasticloadbalancingv2#InvalidSecurityGroupException":
       response = {
         ...(await deserializeAws_queryInvalidSecurityGroupExceptionResponse(parsedOutput, context)),
@@ -1219,7 +1219,7 @@ const deserializeAws_queryCreateLoadBalancerCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidSubnet":
+    case "InvalidSubnetException":
     case "com.amazonaws.elasticloadbalancingv2#InvalidSubnetException":
       response = {
         ...(await deserializeAws_queryInvalidSubnetExceptionResponse(parsedOutput, context)),
@@ -1227,7 +1227,7 @@ const deserializeAws_queryCreateLoadBalancerCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "OperationNotPermitted":
+    case "OperationNotPermittedException":
     case "com.amazonaws.elasticloadbalancingv2#OperationNotPermittedException":
       response = {
         ...(await deserializeAws_queryOperationNotPermittedExceptionResponse(parsedOutput, context)),
@@ -1235,7 +1235,7 @@ const deserializeAws_queryCreateLoadBalancerCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ResourceInUse":
+    case "ResourceInUseException":
     case "com.amazonaws.elasticloadbalancingv2#ResourceInUseException":
       response = {
         ...(await deserializeAws_queryResourceInUseExceptionResponse(parsedOutput, context)),
@@ -1243,7 +1243,7 @@ const deserializeAws_queryCreateLoadBalancerCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "SubnetNotFound":
+    case "SubnetNotFoundException":
     case "com.amazonaws.elasticloadbalancingv2#SubnetNotFoundException":
       response = {
         ...(await deserializeAws_querySubnetNotFoundExceptionResponse(parsedOutput, context)),
@@ -1251,7 +1251,7 @@ const deserializeAws_queryCreateLoadBalancerCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "TooManyLoadBalancers":
+    case "TooManyLoadBalancersException":
     case "com.amazonaws.elasticloadbalancingv2#TooManyLoadBalancersException":
       response = {
         ...(await deserializeAws_queryTooManyLoadBalancersExceptionResponse(parsedOutput, context)),
@@ -1259,7 +1259,7 @@ const deserializeAws_queryCreateLoadBalancerCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "TooManyTags":
+    case "TooManyTagsException":
     case "com.amazonaws.elasticloadbalancingv2#TooManyTagsException":
       response = {
         ...(await deserializeAws_queryTooManyTagsExceptionResponse(parsedOutput, context)),
@@ -1313,7 +1313,7 @@ const deserializeAws_queryCreateRuleCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "IncompatibleProtocols":
+    case "IncompatibleProtocolsException":
     case "com.amazonaws.elasticloadbalancingv2#IncompatibleProtocolsException":
       response = {
         ...(await deserializeAws_queryIncompatibleProtocolsExceptionResponse(parsedOutput, context)),
@@ -1321,7 +1321,7 @@ const deserializeAws_queryCreateRuleCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidConfigurationRequest":
+    case "InvalidConfigurationRequestException":
     case "com.amazonaws.elasticloadbalancingv2#InvalidConfigurationRequestException":
       response = {
         ...(await deserializeAws_queryInvalidConfigurationRequestExceptionResponse(parsedOutput, context)),
@@ -1329,7 +1329,7 @@ const deserializeAws_queryCreateRuleCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidLoadBalancerAction":
+    case "InvalidLoadBalancerActionException":
     case "com.amazonaws.elasticloadbalancingv2#InvalidLoadBalancerActionException":
       response = {
         ...(await deserializeAws_queryInvalidLoadBalancerActionExceptionResponse(parsedOutput, context)),
@@ -1337,7 +1337,7 @@ const deserializeAws_queryCreateRuleCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ListenerNotFound":
+    case "ListenerNotFoundException":
     case "com.amazonaws.elasticloadbalancingv2#ListenerNotFoundException":
       response = {
         ...(await deserializeAws_queryListenerNotFoundExceptionResponse(parsedOutput, context)),
@@ -1345,7 +1345,7 @@ const deserializeAws_queryCreateRuleCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "PriorityInUse":
+    case "PriorityInUseException":
     case "com.amazonaws.elasticloadbalancingv2#PriorityInUseException":
       response = {
         ...(await deserializeAws_queryPriorityInUseExceptionResponse(parsedOutput, context)),
@@ -1353,7 +1353,7 @@ const deserializeAws_queryCreateRuleCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "TargetGroupAssociationLimit":
+    case "TargetGroupAssociationLimitException":
     case "com.amazonaws.elasticloadbalancingv2#TargetGroupAssociationLimitException":
       response = {
         ...(await deserializeAws_queryTargetGroupAssociationLimitExceptionResponse(parsedOutput, context)),
@@ -1361,7 +1361,7 @@ const deserializeAws_queryCreateRuleCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "TargetGroupNotFound":
+    case "TargetGroupNotFoundException":
     case "com.amazonaws.elasticloadbalancingv2#TargetGroupNotFoundException":
       response = {
         ...(await deserializeAws_queryTargetGroupNotFoundExceptionResponse(parsedOutput, context)),
@@ -1369,7 +1369,7 @@ const deserializeAws_queryCreateRuleCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "TooManyActions":
+    case "TooManyActionsException":
     case "com.amazonaws.elasticloadbalancingv2#TooManyActionsException":
       response = {
         ...(await deserializeAws_queryTooManyActionsExceptionResponse(parsedOutput, context)),
@@ -1377,7 +1377,7 @@ const deserializeAws_queryCreateRuleCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "TooManyRegistrationsForTargetId":
+    case "TooManyRegistrationsForTargetIdException":
     case "com.amazonaws.elasticloadbalancingv2#TooManyRegistrationsForTargetIdException":
       response = {
         ...(await deserializeAws_queryTooManyRegistrationsForTargetIdExceptionResponse(parsedOutput, context)),
@@ -1385,7 +1385,7 @@ const deserializeAws_queryCreateRuleCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "TooManyRules":
+    case "TooManyRulesException":
     case "com.amazonaws.elasticloadbalancingv2#TooManyRulesException":
       response = {
         ...(await deserializeAws_queryTooManyRulesExceptionResponse(parsedOutput, context)),
@@ -1393,7 +1393,7 @@ const deserializeAws_queryCreateRuleCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "TooManyTags":
+    case "TooManyTagsException":
     case "com.amazonaws.elasticloadbalancingv2#TooManyTagsException":
       response = {
         ...(await deserializeAws_queryTooManyTagsExceptionResponse(parsedOutput, context)),
@@ -1401,7 +1401,7 @@ const deserializeAws_queryCreateRuleCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "TooManyTargetGroups":
+    case "TooManyTargetGroupsException":
     case "com.amazonaws.elasticloadbalancingv2#TooManyTargetGroupsException":
       response = {
         ...(await deserializeAws_queryTooManyTargetGroupsExceptionResponse(parsedOutput, context)),
@@ -1409,7 +1409,7 @@ const deserializeAws_queryCreateRuleCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "TooManyTargets":
+    case "TooManyTargetsException":
     case "com.amazonaws.elasticloadbalancingv2#TooManyTargetsException":
       response = {
         ...(await deserializeAws_queryTooManyTargetsExceptionResponse(parsedOutput, context)),
@@ -1417,7 +1417,7 @@ const deserializeAws_queryCreateRuleCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "TooManyUniqueTargetGroupsPerLoadBalancer":
+    case "TooManyUniqueTargetGroupsPerLoadBalancerException":
     case "com.amazonaws.elasticloadbalancingv2#TooManyUniqueTargetGroupsPerLoadBalancerException":
       response = {
         ...(await deserializeAws_queryTooManyUniqueTargetGroupsPerLoadBalancerExceptionResponse(parsedOutput, context)),
@@ -1425,7 +1425,7 @@ const deserializeAws_queryCreateRuleCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "UnsupportedProtocol":
+    case "UnsupportedProtocolException":
     case "com.amazonaws.elasticloadbalancingv2#UnsupportedProtocolException":
       response = {
         ...(await deserializeAws_queryUnsupportedProtocolExceptionResponse(parsedOutput, context)),
@@ -1479,7 +1479,7 @@ const deserializeAws_queryCreateTargetGroupCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "DuplicateTargetGroupName":
+    case "DuplicateTargetGroupNameException":
     case "com.amazonaws.elasticloadbalancingv2#DuplicateTargetGroupNameException":
       response = {
         ...(await deserializeAws_queryDuplicateTargetGroupNameExceptionResponse(parsedOutput, context)),
@@ -1487,7 +1487,7 @@ const deserializeAws_queryCreateTargetGroupCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidConfigurationRequest":
+    case "InvalidConfigurationRequestException":
     case "com.amazonaws.elasticloadbalancingv2#InvalidConfigurationRequestException":
       response = {
         ...(await deserializeAws_queryInvalidConfigurationRequestExceptionResponse(parsedOutput, context)),
@@ -1495,7 +1495,7 @@ const deserializeAws_queryCreateTargetGroupCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "TooManyTags":
+    case "TooManyTagsException":
     case "com.amazonaws.elasticloadbalancingv2#TooManyTagsException":
       response = {
         ...(await deserializeAws_queryTooManyTagsExceptionResponse(parsedOutput, context)),
@@ -1503,7 +1503,7 @@ const deserializeAws_queryCreateTargetGroupCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "TooManyTargetGroups":
+    case "TooManyTargetGroupsException":
     case "com.amazonaws.elasticloadbalancingv2#TooManyTargetGroupsException":
       response = {
         ...(await deserializeAws_queryTooManyTargetGroupsExceptionResponse(parsedOutput, context)),
@@ -1557,7 +1557,7 @@ const deserializeAws_queryDeleteListenerCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "ListenerNotFound":
+    case "ListenerNotFoundException":
     case "com.amazonaws.elasticloadbalancingv2#ListenerNotFoundException":
       response = {
         ...(await deserializeAws_queryListenerNotFoundExceptionResponse(parsedOutput, context)),
@@ -1565,7 +1565,7 @@ const deserializeAws_queryDeleteListenerCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ResourceInUse":
+    case "ResourceInUseException":
     case "com.amazonaws.elasticloadbalancingv2#ResourceInUseException":
       response = {
         ...(await deserializeAws_queryResourceInUseExceptionResponse(parsedOutput, context)),
@@ -1619,7 +1619,7 @@ const deserializeAws_queryDeleteLoadBalancerCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "LoadBalancerNotFound":
+    case "LoadBalancerNotFoundException":
     case "com.amazonaws.elasticloadbalancingv2#LoadBalancerNotFoundException":
       response = {
         ...(await deserializeAws_queryLoadBalancerNotFoundExceptionResponse(parsedOutput, context)),
@@ -1627,7 +1627,7 @@ const deserializeAws_queryDeleteLoadBalancerCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "OperationNotPermitted":
+    case "OperationNotPermittedException":
     case "com.amazonaws.elasticloadbalancingv2#OperationNotPermittedException":
       response = {
         ...(await deserializeAws_queryOperationNotPermittedExceptionResponse(parsedOutput, context)),
@@ -1635,7 +1635,7 @@ const deserializeAws_queryDeleteLoadBalancerCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ResourceInUse":
+    case "ResourceInUseException":
     case "com.amazonaws.elasticloadbalancingv2#ResourceInUseException":
       response = {
         ...(await deserializeAws_queryResourceInUseExceptionResponse(parsedOutput, context)),
@@ -1689,7 +1689,7 @@ const deserializeAws_queryDeleteRuleCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "OperationNotPermitted":
+    case "OperationNotPermittedException":
     case "com.amazonaws.elasticloadbalancingv2#OperationNotPermittedException":
       response = {
         ...(await deserializeAws_queryOperationNotPermittedExceptionResponse(parsedOutput, context)),
@@ -1697,7 +1697,7 @@ const deserializeAws_queryDeleteRuleCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "RuleNotFound":
+    case "RuleNotFoundException":
     case "com.amazonaws.elasticloadbalancingv2#RuleNotFoundException":
       response = {
         ...(await deserializeAws_queryRuleNotFoundExceptionResponse(parsedOutput, context)),
@@ -1751,7 +1751,7 @@ const deserializeAws_queryDeleteTargetGroupCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "ResourceInUse":
+    case "ResourceInUseException":
     case "com.amazonaws.elasticloadbalancingv2#ResourceInUseException":
       response = {
         ...(await deserializeAws_queryResourceInUseExceptionResponse(parsedOutput, context)),
@@ -1805,7 +1805,7 @@ const deserializeAws_queryDeregisterTargetsCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "InvalidTarget":
+    case "InvalidTargetException":
     case "com.amazonaws.elasticloadbalancingv2#InvalidTargetException":
       response = {
         ...(await deserializeAws_queryInvalidTargetExceptionResponse(parsedOutput, context)),
@@ -1813,7 +1813,7 @@ const deserializeAws_queryDeregisterTargetsCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "TargetGroupNotFound":
+    case "TargetGroupNotFoundException":
     case "com.amazonaws.elasticloadbalancingv2#TargetGroupNotFoundException":
       response = {
         ...(await deserializeAws_queryTargetGroupNotFoundExceptionResponse(parsedOutput, context)),
@@ -1913,7 +1913,7 @@ const deserializeAws_queryDescribeListenerCertificatesCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "ListenerNotFound":
+    case "ListenerNotFoundException":
     case "com.amazonaws.elasticloadbalancingv2#ListenerNotFoundException":
       response = {
         ...(await deserializeAws_queryListenerNotFoundExceptionResponse(parsedOutput, context)),
@@ -1967,7 +1967,7 @@ const deserializeAws_queryDescribeListenersCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "ListenerNotFound":
+    case "ListenerNotFoundException":
     case "com.amazonaws.elasticloadbalancingv2#ListenerNotFoundException":
       response = {
         ...(await deserializeAws_queryListenerNotFoundExceptionResponse(parsedOutput, context)),
@@ -1975,7 +1975,7 @@ const deserializeAws_queryDescribeListenersCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "LoadBalancerNotFound":
+    case "LoadBalancerNotFoundException":
     case "com.amazonaws.elasticloadbalancingv2#LoadBalancerNotFoundException":
       response = {
         ...(await deserializeAws_queryLoadBalancerNotFoundExceptionResponse(parsedOutput, context)),
@@ -1983,7 +1983,7 @@ const deserializeAws_queryDescribeListenersCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "UnsupportedProtocol":
+    case "UnsupportedProtocolException":
     case "com.amazonaws.elasticloadbalancingv2#UnsupportedProtocolException":
       response = {
         ...(await deserializeAws_queryUnsupportedProtocolExceptionResponse(parsedOutput, context)),
@@ -2040,7 +2040,7 @@ const deserializeAws_queryDescribeLoadBalancerAttributesCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "LoadBalancerNotFound":
+    case "LoadBalancerNotFoundException":
     case "com.amazonaws.elasticloadbalancingv2#LoadBalancerNotFoundException":
       response = {
         ...(await deserializeAws_queryLoadBalancerNotFoundExceptionResponse(parsedOutput, context)),
@@ -2094,7 +2094,7 @@ const deserializeAws_queryDescribeLoadBalancersCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "LoadBalancerNotFound":
+    case "LoadBalancerNotFoundException":
     case "com.amazonaws.elasticloadbalancingv2#LoadBalancerNotFoundException":
       response = {
         ...(await deserializeAws_queryLoadBalancerNotFoundExceptionResponse(parsedOutput, context)),
@@ -2148,7 +2148,7 @@ const deserializeAws_queryDescribeRulesCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "ListenerNotFound":
+    case "ListenerNotFoundException":
     case "com.amazonaws.elasticloadbalancingv2#ListenerNotFoundException":
       response = {
         ...(await deserializeAws_queryListenerNotFoundExceptionResponse(parsedOutput, context)),
@@ -2156,7 +2156,7 @@ const deserializeAws_queryDescribeRulesCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "RuleNotFound":
+    case "RuleNotFoundException":
     case "com.amazonaws.elasticloadbalancingv2#RuleNotFoundException":
       response = {
         ...(await deserializeAws_queryRuleNotFoundExceptionResponse(parsedOutput, context)),
@@ -2164,7 +2164,7 @@ const deserializeAws_queryDescribeRulesCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "UnsupportedProtocol":
+    case "UnsupportedProtocolException":
     case "com.amazonaws.elasticloadbalancingv2#UnsupportedProtocolException":
       response = {
         ...(await deserializeAws_queryUnsupportedProtocolExceptionResponse(parsedOutput, context)),
@@ -2218,7 +2218,7 @@ const deserializeAws_queryDescribeSSLPoliciesCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "SSLPolicyNotFound":
+    case "SSLPolicyNotFoundException":
     case "com.amazonaws.elasticloadbalancingv2#SSLPolicyNotFoundException":
       response = {
         ...(await deserializeAws_querySSLPolicyNotFoundExceptionResponse(parsedOutput, context)),
@@ -2272,7 +2272,7 @@ const deserializeAws_queryDescribeTagsCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "ListenerNotFound":
+    case "ListenerNotFoundException":
     case "com.amazonaws.elasticloadbalancingv2#ListenerNotFoundException":
       response = {
         ...(await deserializeAws_queryListenerNotFoundExceptionResponse(parsedOutput, context)),
@@ -2280,7 +2280,7 @@ const deserializeAws_queryDescribeTagsCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "LoadBalancerNotFound":
+    case "LoadBalancerNotFoundException":
     case "com.amazonaws.elasticloadbalancingv2#LoadBalancerNotFoundException":
       response = {
         ...(await deserializeAws_queryLoadBalancerNotFoundExceptionResponse(parsedOutput, context)),
@@ -2288,7 +2288,7 @@ const deserializeAws_queryDescribeTagsCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "RuleNotFound":
+    case "RuleNotFoundException":
     case "com.amazonaws.elasticloadbalancingv2#RuleNotFoundException":
       response = {
         ...(await deserializeAws_queryRuleNotFoundExceptionResponse(parsedOutput, context)),
@@ -2296,7 +2296,7 @@ const deserializeAws_queryDescribeTagsCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "TargetGroupNotFound":
+    case "TargetGroupNotFoundException":
     case "com.amazonaws.elasticloadbalancingv2#TargetGroupNotFoundException":
       response = {
         ...(await deserializeAws_queryTargetGroupNotFoundExceptionResponse(parsedOutput, context)),
@@ -2350,7 +2350,7 @@ const deserializeAws_queryDescribeTargetGroupAttributesCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "TargetGroupNotFound":
+    case "TargetGroupNotFoundException":
     case "com.amazonaws.elasticloadbalancingv2#TargetGroupNotFoundException":
       response = {
         ...(await deserializeAws_queryTargetGroupNotFoundExceptionResponse(parsedOutput, context)),
@@ -2404,7 +2404,7 @@ const deserializeAws_queryDescribeTargetGroupsCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "LoadBalancerNotFound":
+    case "LoadBalancerNotFoundException":
     case "com.amazonaws.elasticloadbalancingv2#LoadBalancerNotFoundException":
       response = {
         ...(await deserializeAws_queryLoadBalancerNotFoundExceptionResponse(parsedOutput, context)),
@@ -2412,7 +2412,7 @@ const deserializeAws_queryDescribeTargetGroupsCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "TargetGroupNotFound":
+    case "TargetGroupNotFoundException":
     case "com.amazonaws.elasticloadbalancingv2#TargetGroupNotFoundException":
       response = {
         ...(await deserializeAws_queryTargetGroupNotFoundExceptionResponse(parsedOutput, context)),
@@ -2466,7 +2466,7 @@ const deserializeAws_queryDescribeTargetHealthCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "HealthUnavailable":
+    case "HealthUnavailableException":
     case "com.amazonaws.elasticloadbalancingv2#HealthUnavailableException":
       response = {
         ...(await deserializeAws_queryHealthUnavailableExceptionResponse(parsedOutput, context)),
@@ -2474,7 +2474,7 @@ const deserializeAws_queryDescribeTargetHealthCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidTarget":
+    case "InvalidTargetException":
     case "com.amazonaws.elasticloadbalancingv2#InvalidTargetException":
       response = {
         ...(await deserializeAws_queryInvalidTargetExceptionResponse(parsedOutput, context)),
@@ -2482,7 +2482,7 @@ const deserializeAws_queryDescribeTargetHealthCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "TargetGroupNotFound":
+    case "TargetGroupNotFoundException":
     case "com.amazonaws.elasticloadbalancingv2#TargetGroupNotFoundException":
       response = {
         ...(await deserializeAws_queryTargetGroupNotFoundExceptionResponse(parsedOutput, context)),
@@ -2536,7 +2536,7 @@ const deserializeAws_queryModifyListenerCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "ALPNPolicyNotFound":
+    case "ALPNPolicyNotSupportedException":
     case "com.amazonaws.elasticloadbalancingv2#ALPNPolicyNotSupportedException":
       response = {
         ...(await deserializeAws_queryALPNPolicyNotSupportedExceptionResponse(parsedOutput, context)),
@@ -2544,7 +2544,7 @@ const deserializeAws_queryModifyListenerCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "CertificateNotFound":
+    case "CertificateNotFoundException":
     case "com.amazonaws.elasticloadbalancingv2#CertificateNotFoundException":
       response = {
         ...(await deserializeAws_queryCertificateNotFoundExceptionResponse(parsedOutput, context)),
@@ -2552,7 +2552,7 @@ const deserializeAws_queryModifyListenerCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "DuplicateListener":
+    case "DuplicateListenerException":
     case "com.amazonaws.elasticloadbalancingv2#DuplicateListenerException":
       response = {
         ...(await deserializeAws_queryDuplicateListenerExceptionResponse(parsedOutput, context)),
@@ -2560,7 +2560,7 @@ const deserializeAws_queryModifyListenerCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "IncompatibleProtocols":
+    case "IncompatibleProtocolsException":
     case "com.amazonaws.elasticloadbalancingv2#IncompatibleProtocolsException":
       response = {
         ...(await deserializeAws_queryIncompatibleProtocolsExceptionResponse(parsedOutput, context)),
@@ -2568,7 +2568,7 @@ const deserializeAws_queryModifyListenerCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidConfigurationRequest":
+    case "InvalidConfigurationRequestException":
     case "com.amazonaws.elasticloadbalancingv2#InvalidConfigurationRequestException":
       response = {
         ...(await deserializeAws_queryInvalidConfigurationRequestExceptionResponse(parsedOutput, context)),
@@ -2576,7 +2576,7 @@ const deserializeAws_queryModifyListenerCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidLoadBalancerAction":
+    case "InvalidLoadBalancerActionException":
     case "com.amazonaws.elasticloadbalancingv2#InvalidLoadBalancerActionException":
       response = {
         ...(await deserializeAws_queryInvalidLoadBalancerActionExceptionResponse(parsedOutput, context)),
@@ -2584,7 +2584,7 @@ const deserializeAws_queryModifyListenerCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ListenerNotFound":
+    case "ListenerNotFoundException":
     case "com.amazonaws.elasticloadbalancingv2#ListenerNotFoundException":
       response = {
         ...(await deserializeAws_queryListenerNotFoundExceptionResponse(parsedOutput, context)),
@@ -2592,7 +2592,7 @@ const deserializeAws_queryModifyListenerCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "SSLPolicyNotFound":
+    case "SSLPolicyNotFoundException":
     case "com.amazonaws.elasticloadbalancingv2#SSLPolicyNotFoundException":
       response = {
         ...(await deserializeAws_querySSLPolicyNotFoundExceptionResponse(parsedOutput, context)),
@@ -2600,7 +2600,7 @@ const deserializeAws_queryModifyListenerCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "TargetGroupAssociationLimit":
+    case "TargetGroupAssociationLimitException":
     case "com.amazonaws.elasticloadbalancingv2#TargetGroupAssociationLimitException":
       response = {
         ...(await deserializeAws_queryTargetGroupAssociationLimitExceptionResponse(parsedOutput, context)),
@@ -2608,7 +2608,7 @@ const deserializeAws_queryModifyListenerCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "TargetGroupNotFound":
+    case "TargetGroupNotFoundException":
     case "com.amazonaws.elasticloadbalancingv2#TargetGroupNotFoundException":
       response = {
         ...(await deserializeAws_queryTargetGroupNotFoundExceptionResponse(parsedOutput, context)),
@@ -2616,7 +2616,7 @@ const deserializeAws_queryModifyListenerCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "TooManyActions":
+    case "TooManyActionsException":
     case "com.amazonaws.elasticloadbalancingv2#TooManyActionsException":
       response = {
         ...(await deserializeAws_queryTooManyActionsExceptionResponse(parsedOutput, context)),
@@ -2624,7 +2624,7 @@ const deserializeAws_queryModifyListenerCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "TooManyCertificates":
+    case "TooManyCertificatesException":
     case "com.amazonaws.elasticloadbalancingv2#TooManyCertificatesException":
       response = {
         ...(await deserializeAws_queryTooManyCertificatesExceptionResponse(parsedOutput, context)),
@@ -2632,7 +2632,7 @@ const deserializeAws_queryModifyListenerCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "TooManyListeners":
+    case "TooManyListenersException":
     case "com.amazonaws.elasticloadbalancingv2#TooManyListenersException":
       response = {
         ...(await deserializeAws_queryTooManyListenersExceptionResponse(parsedOutput, context)),
@@ -2640,7 +2640,7 @@ const deserializeAws_queryModifyListenerCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "TooManyRegistrationsForTargetId":
+    case "TooManyRegistrationsForTargetIdException":
     case "com.amazonaws.elasticloadbalancingv2#TooManyRegistrationsForTargetIdException":
       response = {
         ...(await deserializeAws_queryTooManyRegistrationsForTargetIdExceptionResponse(parsedOutput, context)),
@@ -2648,7 +2648,7 @@ const deserializeAws_queryModifyListenerCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "TooManyTargets":
+    case "TooManyTargetsException":
     case "com.amazonaws.elasticloadbalancingv2#TooManyTargetsException":
       response = {
         ...(await deserializeAws_queryTooManyTargetsExceptionResponse(parsedOutput, context)),
@@ -2656,7 +2656,7 @@ const deserializeAws_queryModifyListenerCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "TooManyUniqueTargetGroupsPerLoadBalancer":
+    case "TooManyUniqueTargetGroupsPerLoadBalancerException":
     case "com.amazonaws.elasticloadbalancingv2#TooManyUniqueTargetGroupsPerLoadBalancerException":
       response = {
         ...(await deserializeAws_queryTooManyUniqueTargetGroupsPerLoadBalancerExceptionResponse(parsedOutput, context)),
@@ -2664,7 +2664,7 @@ const deserializeAws_queryModifyListenerCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "UnsupportedProtocol":
+    case "UnsupportedProtocolException":
     case "com.amazonaws.elasticloadbalancingv2#UnsupportedProtocolException":
       response = {
         ...(await deserializeAws_queryUnsupportedProtocolExceptionResponse(parsedOutput, context)),
@@ -2718,7 +2718,7 @@ const deserializeAws_queryModifyLoadBalancerAttributesCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "InvalidConfigurationRequest":
+    case "InvalidConfigurationRequestException":
     case "com.amazonaws.elasticloadbalancingv2#InvalidConfigurationRequestException":
       response = {
         ...(await deserializeAws_queryInvalidConfigurationRequestExceptionResponse(parsedOutput, context)),
@@ -2726,7 +2726,7 @@ const deserializeAws_queryModifyLoadBalancerAttributesCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "LoadBalancerNotFound":
+    case "LoadBalancerNotFoundException":
     case "com.amazonaws.elasticloadbalancingv2#LoadBalancerNotFoundException":
       response = {
         ...(await deserializeAws_queryLoadBalancerNotFoundExceptionResponse(parsedOutput, context)),
@@ -2780,7 +2780,7 @@ const deserializeAws_queryModifyRuleCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "IncompatibleProtocols":
+    case "IncompatibleProtocolsException":
     case "com.amazonaws.elasticloadbalancingv2#IncompatibleProtocolsException":
       response = {
         ...(await deserializeAws_queryIncompatibleProtocolsExceptionResponse(parsedOutput, context)),
@@ -2788,7 +2788,7 @@ const deserializeAws_queryModifyRuleCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidLoadBalancerAction":
+    case "InvalidLoadBalancerActionException":
     case "com.amazonaws.elasticloadbalancingv2#InvalidLoadBalancerActionException":
       response = {
         ...(await deserializeAws_queryInvalidLoadBalancerActionExceptionResponse(parsedOutput, context)),
@@ -2796,7 +2796,7 @@ const deserializeAws_queryModifyRuleCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "OperationNotPermitted":
+    case "OperationNotPermittedException":
     case "com.amazonaws.elasticloadbalancingv2#OperationNotPermittedException":
       response = {
         ...(await deserializeAws_queryOperationNotPermittedExceptionResponse(parsedOutput, context)),
@@ -2804,7 +2804,7 @@ const deserializeAws_queryModifyRuleCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "RuleNotFound":
+    case "RuleNotFoundException":
     case "com.amazonaws.elasticloadbalancingv2#RuleNotFoundException":
       response = {
         ...(await deserializeAws_queryRuleNotFoundExceptionResponse(parsedOutput, context)),
@@ -2812,7 +2812,7 @@ const deserializeAws_queryModifyRuleCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "TargetGroupAssociationLimit":
+    case "TargetGroupAssociationLimitException":
     case "com.amazonaws.elasticloadbalancingv2#TargetGroupAssociationLimitException":
       response = {
         ...(await deserializeAws_queryTargetGroupAssociationLimitExceptionResponse(parsedOutput, context)),
@@ -2820,7 +2820,7 @@ const deserializeAws_queryModifyRuleCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "TargetGroupNotFound":
+    case "TargetGroupNotFoundException":
     case "com.amazonaws.elasticloadbalancingv2#TargetGroupNotFoundException":
       response = {
         ...(await deserializeAws_queryTargetGroupNotFoundExceptionResponse(parsedOutput, context)),
@@ -2828,7 +2828,7 @@ const deserializeAws_queryModifyRuleCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "TooManyActions":
+    case "TooManyActionsException":
     case "com.amazonaws.elasticloadbalancingv2#TooManyActionsException":
       response = {
         ...(await deserializeAws_queryTooManyActionsExceptionResponse(parsedOutput, context)),
@@ -2836,7 +2836,7 @@ const deserializeAws_queryModifyRuleCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "TooManyRegistrationsForTargetId":
+    case "TooManyRegistrationsForTargetIdException":
     case "com.amazonaws.elasticloadbalancingv2#TooManyRegistrationsForTargetIdException":
       response = {
         ...(await deserializeAws_queryTooManyRegistrationsForTargetIdExceptionResponse(parsedOutput, context)),
@@ -2844,7 +2844,7 @@ const deserializeAws_queryModifyRuleCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "TooManyTargets":
+    case "TooManyTargetsException":
     case "com.amazonaws.elasticloadbalancingv2#TooManyTargetsException":
       response = {
         ...(await deserializeAws_queryTooManyTargetsExceptionResponse(parsedOutput, context)),
@@ -2852,7 +2852,7 @@ const deserializeAws_queryModifyRuleCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "TooManyUniqueTargetGroupsPerLoadBalancer":
+    case "TooManyUniqueTargetGroupsPerLoadBalancerException":
     case "com.amazonaws.elasticloadbalancingv2#TooManyUniqueTargetGroupsPerLoadBalancerException":
       response = {
         ...(await deserializeAws_queryTooManyUniqueTargetGroupsPerLoadBalancerExceptionResponse(parsedOutput, context)),
@@ -2860,7 +2860,7 @@ const deserializeAws_queryModifyRuleCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "UnsupportedProtocol":
+    case "UnsupportedProtocolException":
     case "com.amazonaws.elasticloadbalancingv2#UnsupportedProtocolException":
       response = {
         ...(await deserializeAws_queryUnsupportedProtocolExceptionResponse(parsedOutput, context)),
@@ -2914,7 +2914,7 @@ const deserializeAws_queryModifyTargetGroupCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "InvalidConfigurationRequest":
+    case "InvalidConfigurationRequestException":
     case "com.amazonaws.elasticloadbalancingv2#InvalidConfigurationRequestException":
       response = {
         ...(await deserializeAws_queryInvalidConfigurationRequestExceptionResponse(parsedOutput, context)),
@@ -2922,7 +2922,7 @@ const deserializeAws_queryModifyTargetGroupCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "TargetGroupNotFound":
+    case "TargetGroupNotFoundException":
     case "com.amazonaws.elasticloadbalancingv2#TargetGroupNotFoundException":
       response = {
         ...(await deserializeAws_queryTargetGroupNotFoundExceptionResponse(parsedOutput, context)),
@@ -2976,7 +2976,7 @@ const deserializeAws_queryModifyTargetGroupAttributesCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "InvalidConfigurationRequest":
+    case "InvalidConfigurationRequestException":
     case "com.amazonaws.elasticloadbalancingv2#InvalidConfigurationRequestException":
       response = {
         ...(await deserializeAws_queryInvalidConfigurationRequestExceptionResponse(parsedOutput, context)),
@@ -2984,7 +2984,7 @@ const deserializeAws_queryModifyTargetGroupAttributesCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "TargetGroupNotFound":
+    case "TargetGroupNotFoundException":
     case "com.amazonaws.elasticloadbalancingv2#TargetGroupNotFoundException":
       response = {
         ...(await deserializeAws_queryTargetGroupNotFoundExceptionResponse(parsedOutput, context)),
@@ -3038,7 +3038,7 @@ const deserializeAws_queryRegisterTargetsCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "InvalidTarget":
+    case "InvalidTargetException":
     case "com.amazonaws.elasticloadbalancingv2#InvalidTargetException":
       response = {
         ...(await deserializeAws_queryInvalidTargetExceptionResponse(parsedOutput, context)),
@@ -3046,7 +3046,7 @@ const deserializeAws_queryRegisterTargetsCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "TargetGroupNotFound":
+    case "TargetGroupNotFoundException":
     case "com.amazonaws.elasticloadbalancingv2#TargetGroupNotFoundException":
       response = {
         ...(await deserializeAws_queryTargetGroupNotFoundExceptionResponse(parsedOutput, context)),
@@ -3054,7 +3054,7 @@ const deserializeAws_queryRegisterTargetsCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "TooManyRegistrationsForTargetId":
+    case "TooManyRegistrationsForTargetIdException":
     case "com.amazonaws.elasticloadbalancingv2#TooManyRegistrationsForTargetIdException":
       response = {
         ...(await deserializeAws_queryTooManyRegistrationsForTargetIdExceptionResponse(parsedOutput, context)),
@@ -3062,7 +3062,7 @@ const deserializeAws_queryRegisterTargetsCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "TooManyTargets":
+    case "TooManyTargetsException":
     case "com.amazonaws.elasticloadbalancingv2#TooManyTargetsException":
       response = {
         ...(await deserializeAws_queryTooManyTargetsExceptionResponse(parsedOutput, context)),
@@ -3116,7 +3116,7 @@ const deserializeAws_queryRemoveListenerCertificatesCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "ListenerNotFound":
+    case "ListenerNotFoundException":
     case "com.amazonaws.elasticloadbalancingv2#ListenerNotFoundException":
       response = {
         ...(await deserializeAws_queryListenerNotFoundExceptionResponse(parsedOutput, context)),
@@ -3124,7 +3124,7 @@ const deserializeAws_queryRemoveListenerCertificatesCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "OperationNotPermitted":
+    case "OperationNotPermittedException":
     case "com.amazonaws.elasticloadbalancingv2#OperationNotPermittedException":
       response = {
         ...(await deserializeAws_queryOperationNotPermittedExceptionResponse(parsedOutput, context)),
@@ -3178,7 +3178,7 @@ const deserializeAws_queryRemoveTagsCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "ListenerNotFound":
+    case "ListenerNotFoundException":
     case "com.amazonaws.elasticloadbalancingv2#ListenerNotFoundException":
       response = {
         ...(await deserializeAws_queryListenerNotFoundExceptionResponse(parsedOutput, context)),
@@ -3186,7 +3186,7 @@ const deserializeAws_queryRemoveTagsCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "LoadBalancerNotFound":
+    case "LoadBalancerNotFoundException":
     case "com.amazonaws.elasticloadbalancingv2#LoadBalancerNotFoundException":
       response = {
         ...(await deserializeAws_queryLoadBalancerNotFoundExceptionResponse(parsedOutput, context)),
@@ -3194,7 +3194,7 @@ const deserializeAws_queryRemoveTagsCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "RuleNotFound":
+    case "RuleNotFoundException":
     case "com.amazonaws.elasticloadbalancingv2#RuleNotFoundException":
       response = {
         ...(await deserializeAws_queryRuleNotFoundExceptionResponse(parsedOutput, context)),
@@ -3202,7 +3202,7 @@ const deserializeAws_queryRemoveTagsCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "TargetGroupNotFound":
+    case "TargetGroupNotFoundException":
     case "com.amazonaws.elasticloadbalancingv2#TargetGroupNotFoundException":
       response = {
         ...(await deserializeAws_queryTargetGroupNotFoundExceptionResponse(parsedOutput, context)),
@@ -3210,7 +3210,7 @@ const deserializeAws_queryRemoveTagsCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "TooManyTags":
+    case "TooManyTagsException":
     case "com.amazonaws.elasticloadbalancingv2#TooManyTagsException":
       response = {
         ...(await deserializeAws_queryTooManyTagsExceptionResponse(parsedOutput, context)),
@@ -3264,7 +3264,7 @@ const deserializeAws_querySetIpAddressTypeCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "InvalidConfigurationRequest":
+    case "InvalidConfigurationRequestException":
     case "com.amazonaws.elasticloadbalancingv2#InvalidConfigurationRequestException":
       response = {
         ...(await deserializeAws_queryInvalidConfigurationRequestExceptionResponse(parsedOutput, context)),
@@ -3272,7 +3272,7 @@ const deserializeAws_querySetIpAddressTypeCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidSubnet":
+    case "InvalidSubnetException":
     case "com.amazonaws.elasticloadbalancingv2#InvalidSubnetException":
       response = {
         ...(await deserializeAws_queryInvalidSubnetExceptionResponse(parsedOutput, context)),
@@ -3280,7 +3280,7 @@ const deserializeAws_querySetIpAddressTypeCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "LoadBalancerNotFound":
+    case "LoadBalancerNotFoundException":
     case "com.amazonaws.elasticloadbalancingv2#LoadBalancerNotFoundException":
       response = {
         ...(await deserializeAws_queryLoadBalancerNotFoundExceptionResponse(parsedOutput, context)),
@@ -3334,7 +3334,7 @@ const deserializeAws_querySetRulePrioritiesCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "OperationNotPermitted":
+    case "OperationNotPermittedException":
     case "com.amazonaws.elasticloadbalancingv2#OperationNotPermittedException":
       response = {
         ...(await deserializeAws_queryOperationNotPermittedExceptionResponse(parsedOutput, context)),
@@ -3342,7 +3342,7 @@ const deserializeAws_querySetRulePrioritiesCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "PriorityInUse":
+    case "PriorityInUseException":
     case "com.amazonaws.elasticloadbalancingv2#PriorityInUseException":
       response = {
         ...(await deserializeAws_queryPriorityInUseExceptionResponse(parsedOutput, context)),
@@ -3350,7 +3350,7 @@ const deserializeAws_querySetRulePrioritiesCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "RuleNotFound":
+    case "RuleNotFoundException":
     case "com.amazonaws.elasticloadbalancingv2#RuleNotFoundException":
       response = {
         ...(await deserializeAws_queryRuleNotFoundExceptionResponse(parsedOutput, context)),
@@ -3404,7 +3404,7 @@ const deserializeAws_querySetSecurityGroupsCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "InvalidConfigurationRequest":
+    case "InvalidConfigurationRequestException":
     case "com.amazonaws.elasticloadbalancingv2#InvalidConfigurationRequestException":
       response = {
         ...(await deserializeAws_queryInvalidConfigurationRequestExceptionResponse(parsedOutput, context)),
@@ -3412,7 +3412,7 @@ const deserializeAws_querySetSecurityGroupsCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidSecurityGroup":
+    case "InvalidSecurityGroupException":
     case "com.amazonaws.elasticloadbalancingv2#InvalidSecurityGroupException":
       response = {
         ...(await deserializeAws_queryInvalidSecurityGroupExceptionResponse(parsedOutput, context)),
@@ -3420,7 +3420,7 @@ const deserializeAws_querySetSecurityGroupsCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "LoadBalancerNotFound":
+    case "LoadBalancerNotFoundException":
     case "com.amazonaws.elasticloadbalancingv2#LoadBalancerNotFoundException":
       response = {
         ...(await deserializeAws_queryLoadBalancerNotFoundExceptionResponse(parsedOutput, context)),
@@ -3474,7 +3474,7 @@ const deserializeAws_querySetSubnetsCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "AllocationIdNotFound":
+    case "AllocationIdNotFoundException":
     case "com.amazonaws.elasticloadbalancingv2#AllocationIdNotFoundException":
       response = {
         ...(await deserializeAws_queryAllocationIdNotFoundExceptionResponse(parsedOutput, context)),
@@ -3482,7 +3482,7 @@ const deserializeAws_querySetSubnetsCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "AvailabilityZoneNotSupported":
+    case "AvailabilityZoneNotSupportedException":
     case "com.amazonaws.elasticloadbalancingv2#AvailabilityZoneNotSupportedException":
       response = {
         ...(await deserializeAws_queryAvailabilityZoneNotSupportedExceptionResponse(parsedOutput, context)),
@@ -3490,7 +3490,7 @@ const deserializeAws_querySetSubnetsCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidConfigurationRequest":
+    case "InvalidConfigurationRequestException":
     case "com.amazonaws.elasticloadbalancingv2#InvalidConfigurationRequestException":
       response = {
         ...(await deserializeAws_queryInvalidConfigurationRequestExceptionResponse(parsedOutput, context)),
@@ -3498,7 +3498,7 @@ const deserializeAws_querySetSubnetsCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidSubnet":
+    case "InvalidSubnetException":
     case "com.amazonaws.elasticloadbalancingv2#InvalidSubnetException":
       response = {
         ...(await deserializeAws_queryInvalidSubnetExceptionResponse(parsedOutput, context)),
@@ -3506,7 +3506,7 @@ const deserializeAws_querySetSubnetsCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "LoadBalancerNotFound":
+    case "LoadBalancerNotFoundException":
     case "com.amazonaws.elasticloadbalancingv2#LoadBalancerNotFoundException":
       response = {
         ...(await deserializeAws_queryLoadBalancerNotFoundExceptionResponse(parsedOutput, context)),
@@ -3514,7 +3514,7 @@ const deserializeAws_querySetSubnetsCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "SubnetNotFound":
+    case "SubnetNotFoundException":
     case "com.amazonaws.elasticloadbalancingv2#SubnetNotFoundException":
       response = {
         ...(await deserializeAws_querySubnetNotFoundExceptionResponse(parsedOutput, context)),

--- a/clients/client-elastic-load-balancing/src/protocols/Aws_query.ts
+++ b/clients/client-elastic-load-balancing/src/protocols/Aws_query.ts
@@ -724,15 +724,7 @@ const deserializeAws_queryAddTagsCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "DuplicateTagKeys":
-    case "com.amazonaws.elasticloadbalancing#DuplicateTagKeysException":
-      response = {
-        ...(await deserializeAws_queryDuplicateTagKeysExceptionResponse(parsedOutput, context)),
-        name: errorCode,
-        $metadata: deserializeMetadata(output),
-      };
-      break;
-    case "LoadBalancerNotFound":
+    case "AccessPointNotFoundException":
     case "com.amazonaws.elasticloadbalancing#AccessPointNotFoundException":
       response = {
         ...(await deserializeAws_queryAccessPointNotFoundExceptionResponse(parsedOutput, context)),
@@ -740,7 +732,15 @@ const deserializeAws_queryAddTagsCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "TooManyTags":
+    case "DuplicateTagKeysException":
+    case "com.amazonaws.elasticloadbalancing#DuplicateTagKeysException":
+      response = {
+        ...(await deserializeAws_queryDuplicateTagKeysExceptionResponse(parsedOutput, context)),
+        name: errorCode,
+        $metadata: deserializeMetadata(output),
+      };
+      break;
+    case "TooManyTagsException":
     case "com.amazonaws.elasticloadbalancing#TooManyTagsException":
       response = {
         ...(await deserializeAws_queryTooManyTagsExceptionResponse(parsedOutput, context)),
@@ -797,7 +797,15 @@ const deserializeAws_queryApplySecurityGroupsToLoadBalancerCommandError = async 
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "InvalidConfigurationRequest":
+    case "AccessPointNotFoundException":
+    case "com.amazonaws.elasticloadbalancing#AccessPointNotFoundException":
+      response = {
+        ...(await deserializeAws_queryAccessPointNotFoundExceptionResponse(parsedOutput, context)),
+        name: errorCode,
+        $metadata: deserializeMetadata(output),
+      };
+      break;
+    case "InvalidConfigurationRequestException":
     case "com.amazonaws.elasticloadbalancing#InvalidConfigurationRequestException":
       response = {
         ...(await deserializeAws_queryInvalidConfigurationRequestExceptionResponse(parsedOutput, context)),
@@ -805,18 +813,10 @@ const deserializeAws_queryApplySecurityGroupsToLoadBalancerCommandError = async 
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidSecurityGroup":
+    case "InvalidSecurityGroupException":
     case "com.amazonaws.elasticloadbalancing#InvalidSecurityGroupException":
       response = {
         ...(await deserializeAws_queryInvalidSecurityGroupExceptionResponse(parsedOutput, context)),
-        name: errorCode,
-        $metadata: deserializeMetadata(output),
-      };
-      break;
-    case "LoadBalancerNotFound":
-    case "com.amazonaws.elasticloadbalancing#AccessPointNotFoundException":
-      response = {
-        ...(await deserializeAws_queryAccessPointNotFoundExceptionResponse(parsedOutput, context)),
         name: errorCode,
         $metadata: deserializeMetadata(output),
       };
@@ -867,23 +867,7 @@ const deserializeAws_queryAttachLoadBalancerToSubnetsCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "InvalidConfigurationRequest":
-    case "com.amazonaws.elasticloadbalancing#InvalidConfigurationRequestException":
-      response = {
-        ...(await deserializeAws_queryInvalidConfigurationRequestExceptionResponse(parsedOutput, context)),
-        name: errorCode,
-        $metadata: deserializeMetadata(output),
-      };
-      break;
-    case "InvalidSubnet":
-    case "com.amazonaws.elasticloadbalancing#InvalidSubnetException":
-      response = {
-        ...(await deserializeAws_queryInvalidSubnetExceptionResponse(parsedOutput, context)),
-        name: errorCode,
-        $metadata: deserializeMetadata(output),
-      };
-      break;
-    case "LoadBalancerNotFound":
+    case "AccessPointNotFoundException":
     case "com.amazonaws.elasticloadbalancing#AccessPointNotFoundException":
       response = {
         ...(await deserializeAws_queryAccessPointNotFoundExceptionResponse(parsedOutput, context)),
@@ -891,7 +875,23 @@ const deserializeAws_queryAttachLoadBalancerToSubnetsCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "SubnetNotFound":
+    case "InvalidConfigurationRequestException":
+    case "com.amazonaws.elasticloadbalancing#InvalidConfigurationRequestException":
+      response = {
+        ...(await deserializeAws_queryInvalidConfigurationRequestExceptionResponse(parsedOutput, context)),
+        name: errorCode,
+        $metadata: deserializeMetadata(output),
+      };
+      break;
+    case "InvalidSubnetException":
+    case "com.amazonaws.elasticloadbalancing#InvalidSubnetException":
+      response = {
+        ...(await deserializeAws_queryInvalidSubnetExceptionResponse(parsedOutput, context)),
+        name: errorCode,
+        $metadata: deserializeMetadata(output),
+      };
+      break;
+    case "SubnetNotFoundException":
     case "com.amazonaws.elasticloadbalancing#SubnetNotFoundException":
       response = {
         ...(await deserializeAws_querySubnetNotFoundExceptionResponse(parsedOutput, context)),
@@ -945,7 +945,7 @@ const deserializeAws_queryConfigureHealthCheckCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "LoadBalancerNotFound":
+    case "AccessPointNotFoundException":
     case "com.amazonaws.elasticloadbalancing#AccessPointNotFoundException":
       response = {
         ...(await deserializeAws_queryAccessPointNotFoundExceptionResponse(parsedOutput, context)),
@@ -1002,23 +1002,7 @@ const deserializeAws_queryCreateAppCookieStickinessPolicyCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "DuplicatePolicyName":
-    case "com.amazonaws.elasticloadbalancing#DuplicatePolicyNameException":
-      response = {
-        ...(await deserializeAws_queryDuplicatePolicyNameExceptionResponse(parsedOutput, context)),
-        name: errorCode,
-        $metadata: deserializeMetadata(output),
-      };
-      break;
-    case "InvalidConfigurationRequest":
-    case "com.amazonaws.elasticloadbalancing#InvalidConfigurationRequestException":
-      response = {
-        ...(await deserializeAws_queryInvalidConfigurationRequestExceptionResponse(parsedOutput, context)),
-        name: errorCode,
-        $metadata: deserializeMetadata(output),
-      };
-      break;
-    case "LoadBalancerNotFound":
+    case "AccessPointNotFoundException":
     case "com.amazonaws.elasticloadbalancing#AccessPointNotFoundException":
       response = {
         ...(await deserializeAws_queryAccessPointNotFoundExceptionResponse(parsedOutput, context)),
@@ -1026,7 +1010,23 @@ const deserializeAws_queryCreateAppCookieStickinessPolicyCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "TooManyPolicies":
+    case "DuplicatePolicyNameException":
+    case "com.amazonaws.elasticloadbalancing#DuplicatePolicyNameException":
+      response = {
+        ...(await deserializeAws_queryDuplicatePolicyNameExceptionResponse(parsedOutput, context)),
+        name: errorCode,
+        $metadata: deserializeMetadata(output),
+      };
+      break;
+    case "InvalidConfigurationRequestException":
+    case "com.amazonaws.elasticloadbalancing#InvalidConfigurationRequestException":
+      response = {
+        ...(await deserializeAws_queryInvalidConfigurationRequestExceptionResponse(parsedOutput, context)),
+        name: errorCode,
+        $metadata: deserializeMetadata(output),
+      };
+      break;
+    case "TooManyPoliciesException":
     case "com.amazonaws.elasticloadbalancing#TooManyPoliciesException":
       response = {
         ...(await deserializeAws_queryTooManyPoliciesExceptionResponse(parsedOutput, context)),
@@ -1083,23 +1083,7 @@ const deserializeAws_queryCreateLBCookieStickinessPolicyCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "DuplicatePolicyName":
-    case "com.amazonaws.elasticloadbalancing#DuplicatePolicyNameException":
-      response = {
-        ...(await deserializeAws_queryDuplicatePolicyNameExceptionResponse(parsedOutput, context)),
-        name: errorCode,
-        $metadata: deserializeMetadata(output),
-      };
-      break;
-    case "InvalidConfigurationRequest":
-    case "com.amazonaws.elasticloadbalancing#InvalidConfigurationRequestException":
-      response = {
-        ...(await deserializeAws_queryInvalidConfigurationRequestExceptionResponse(parsedOutput, context)),
-        name: errorCode,
-        $metadata: deserializeMetadata(output),
-      };
-      break;
-    case "LoadBalancerNotFound":
+    case "AccessPointNotFoundException":
     case "com.amazonaws.elasticloadbalancing#AccessPointNotFoundException":
       response = {
         ...(await deserializeAws_queryAccessPointNotFoundExceptionResponse(parsedOutput, context)),
@@ -1107,7 +1091,23 @@ const deserializeAws_queryCreateLBCookieStickinessPolicyCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "TooManyPolicies":
+    case "DuplicatePolicyNameException":
+    case "com.amazonaws.elasticloadbalancing#DuplicatePolicyNameException":
+      response = {
+        ...(await deserializeAws_queryDuplicatePolicyNameExceptionResponse(parsedOutput, context)),
+        name: errorCode,
+        $metadata: deserializeMetadata(output),
+      };
+      break;
+    case "InvalidConfigurationRequestException":
+    case "com.amazonaws.elasticloadbalancing#InvalidConfigurationRequestException":
+      response = {
+        ...(await deserializeAws_queryInvalidConfigurationRequestExceptionResponse(parsedOutput, context)),
+        name: errorCode,
+        $metadata: deserializeMetadata(output),
+      };
+      break;
+    case "TooManyPoliciesException":
     case "com.amazonaws.elasticloadbalancing#TooManyPoliciesException":
       response = {
         ...(await deserializeAws_queryTooManyPoliciesExceptionResponse(parsedOutput, context)),
@@ -1161,7 +1161,7 @@ const deserializeAws_queryCreateLoadBalancerCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "CertificateNotFound":
+    case "CertificateNotFoundException":
     case "com.amazonaws.elasticloadbalancing#CertificateNotFoundException":
       response = {
         ...(await deserializeAws_queryCertificateNotFoundExceptionResponse(parsedOutput, context)),
@@ -1169,7 +1169,7 @@ const deserializeAws_queryCreateLoadBalancerCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "DuplicateLoadBalancerName":
+    case "DuplicateAccessPointNameException":
     case "com.amazonaws.elasticloadbalancing#DuplicateAccessPointNameException":
       response = {
         ...(await deserializeAws_queryDuplicateAccessPointNameExceptionResponse(parsedOutput, context)),
@@ -1177,7 +1177,7 @@ const deserializeAws_queryCreateLoadBalancerCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "DuplicateTagKeys":
+    case "DuplicateTagKeysException":
     case "com.amazonaws.elasticloadbalancing#DuplicateTagKeysException":
       response = {
         ...(await deserializeAws_queryDuplicateTagKeysExceptionResponse(parsedOutput, context)),
@@ -1185,7 +1185,7 @@ const deserializeAws_queryCreateLoadBalancerCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidConfigurationRequest":
+    case "InvalidConfigurationRequestException":
     case "com.amazonaws.elasticloadbalancing#InvalidConfigurationRequestException":
       response = {
         ...(await deserializeAws_queryInvalidConfigurationRequestExceptionResponse(parsedOutput, context)),
@@ -1193,7 +1193,7 @@ const deserializeAws_queryCreateLoadBalancerCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidScheme":
+    case "InvalidSchemeException":
     case "com.amazonaws.elasticloadbalancing#InvalidSchemeException":
       response = {
         ...(await deserializeAws_queryInvalidSchemeExceptionResponse(parsedOutput, context)),
@@ -1201,7 +1201,7 @@ const deserializeAws_queryCreateLoadBalancerCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidSecurityGroup":
+    case "InvalidSecurityGroupException":
     case "com.amazonaws.elasticloadbalancing#InvalidSecurityGroupException":
       response = {
         ...(await deserializeAws_queryInvalidSecurityGroupExceptionResponse(parsedOutput, context)),
@@ -1209,7 +1209,7 @@ const deserializeAws_queryCreateLoadBalancerCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidSubnet":
+    case "InvalidSubnetException":
     case "com.amazonaws.elasticloadbalancing#InvalidSubnetException":
       response = {
         ...(await deserializeAws_queryInvalidSubnetExceptionResponse(parsedOutput, context)),
@@ -1217,7 +1217,7 @@ const deserializeAws_queryCreateLoadBalancerCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "OperationNotPermitted":
+    case "OperationNotPermittedException":
     case "com.amazonaws.elasticloadbalancing#OperationNotPermittedException":
       response = {
         ...(await deserializeAws_queryOperationNotPermittedExceptionResponse(parsedOutput, context)),
@@ -1225,7 +1225,7 @@ const deserializeAws_queryCreateLoadBalancerCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "SubnetNotFound":
+    case "SubnetNotFoundException":
     case "com.amazonaws.elasticloadbalancing#SubnetNotFoundException":
       response = {
         ...(await deserializeAws_querySubnetNotFoundExceptionResponse(parsedOutput, context)),
@@ -1233,7 +1233,7 @@ const deserializeAws_queryCreateLoadBalancerCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "TooManyLoadBalancers":
+    case "TooManyAccessPointsException":
     case "com.amazonaws.elasticloadbalancing#TooManyAccessPointsException":
       response = {
         ...(await deserializeAws_queryTooManyAccessPointsExceptionResponse(parsedOutput, context)),
@@ -1241,7 +1241,7 @@ const deserializeAws_queryCreateLoadBalancerCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "TooManyTags":
+    case "TooManyTagsException":
     case "com.amazonaws.elasticloadbalancing#TooManyTagsException":
       response = {
         ...(await deserializeAws_queryTooManyTagsExceptionResponse(parsedOutput, context)),
@@ -1249,7 +1249,7 @@ const deserializeAws_queryCreateLoadBalancerCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "UnsupportedProtocol":
+    case "UnsupportedProtocolException":
     case "com.amazonaws.elasticloadbalancing#UnsupportedProtocolException":
       response = {
         ...(await deserializeAws_queryUnsupportedProtocolExceptionResponse(parsedOutput, context)),
@@ -1303,31 +1303,7 @@ const deserializeAws_queryCreateLoadBalancerListenersCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "CertificateNotFound":
-    case "com.amazonaws.elasticloadbalancing#CertificateNotFoundException":
-      response = {
-        ...(await deserializeAws_queryCertificateNotFoundExceptionResponse(parsedOutput, context)),
-        name: errorCode,
-        $metadata: deserializeMetadata(output),
-      };
-      break;
-    case "DuplicateListener":
-    case "com.amazonaws.elasticloadbalancing#DuplicateListenerException":
-      response = {
-        ...(await deserializeAws_queryDuplicateListenerExceptionResponse(parsedOutput, context)),
-        name: errorCode,
-        $metadata: deserializeMetadata(output),
-      };
-      break;
-    case "InvalidConfigurationRequest":
-    case "com.amazonaws.elasticloadbalancing#InvalidConfigurationRequestException":
-      response = {
-        ...(await deserializeAws_queryInvalidConfigurationRequestExceptionResponse(parsedOutput, context)),
-        name: errorCode,
-        $metadata: deserializeMetadata(output),
-      };
-      break;
-    case "LoadBalancerNotFound":
+    case "AccessPointNotFoundException":
     case "com.amazonaws.elasticloadbalancing#AccessPointNotFoundException":
       response = {
         ...(await deserializeAws_queryAccessPointNotFoundExceptionResponse(parsedOutput, context)),
@@ -1335,7 +1311,31 @@ const deserializeAws_queryCreateLoadBalancerListenersCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "UnsupportedProtocol":
+    case "CertificateNotFoundException":
+    case "com.amazonaws.elasticloadbalancing#CertificateNotFoundException":
+      response = {
+        ...(await deserializeAws_queryCertificateNotFoundExceptionResponse(parsedOutput, context)),
+        name: errorCode,
+        $metadata: deserializeMetadata(output),
+      };
+      break;
+    case "DuplicateListenerException":
+    case "com.amazonaws.elasticloadbalancing#DuplicateListenerException":
+      response = {
+        ...(await deserializeAws_queryDuplicateListenerExceptionResponse(parsedOutput, context)),
+        name: errorCode,
+        $metadata: deserializeMetadata(output),
+      };
+      break;
+    case "InvalidConfigurationRequestException":
+    case "com.amazonaws.elasticloadbalancing#InvalidConfigurationRequestException":
+      response = {
+        ...(await deserializeAws_queryInvalidConfigurationRequestExceptionResponse(parsedOutput, context)),
+        name: errorCode,
+        $metadata: deserializeMetadata(output),
+      };
+      break;
+    case "UnsupportedProtocolException":
     case "com.amazonaws.elasticloadbalancing#UnsupportedProtocolException":
       response = {
         ...(await deserializeAws_queryUnsupportedProtocolExceptionResponse(parsedOutput, context)),
@@ -1389,23 +1389,7 @@ const deserializeAws_queryCreateLoadBalancerPolicyCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "DuplicatePolicyName":
-    case "com.amazonaws.elasticloadbalancing#DuplicatePolicyNameException":
-      response = {
-        ...(await deserializeAws_queryDuplicatePolicyNameExceptionResponse(parsedOutput, context)),
-        name: errorCode,
-        $metadata: deserializeMetadata(output),
-      };
-      break;
-    case "InvalidConfigurationRequest":
-    case "com.amazonaws.elasticloadbalancing#InvalidConfigurationRequestException":
-      response = {
-        ...(await deserializeAws_queryInvalidConfigurationRequestExceptionResponse(parsedOutput, context)),
-        name: errorCode,
-        $metadata: deserializeMetadata(output),
-      };
-      break;
-    case "LoadBalancerNotFound":
+    case "AccessPointNotFoundException":
     case "com.amazonaws.elasticloadbalancing#AccessPointNotFoundException":
       response = {
         ...(await deserializeAws_queryAccessPointNotFoundExceptionResponse(parsedOutput, context)),
@@ -1413,7 +1397,23 @@ const deserializeAws_queryCreateLoadBalancerPolicyCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "PolicyTypeNotFound":
+    case "DuplicatePolicyNameException":
+    case "com.amazonaws.elasticloadbalancing#DuplicatePolicyNameException":
+      response = {
+        ...(await deserializeAws_queryDuplicatePolicyNameExceptionResponse(parsedOutput, context)),
+        name: errorCode,
+        $metadata: deserializeMetadata(output),
+      };
+      break;
+    case "InvalidConfigurationRequestException":
+    case "com.amazonaws.elasticloadbalancing#InvalidConfigurationRequestException":
+      response = {
+        ...(await deserializeAws_queryInvalidConfigurationRequestExceptionResponse(parsedOutput, context)),
+        name: errorCode,
+        $metadata: deserializeMetadata(output),
+      };
+      break;
+    case "PolicyTypeNotFoundException":
     case "com.amazonaws.elasticloadbalancing#PolicyTypeNotFoundException":
       response = {
         ...(await deserializeAws_queryPolicyTypeNotFoundExceptionResponse(parsedOutput, context)),
@@ -1421,7 +1421,7 @@ const deserializeAws_queryCreateLoadBalancerPolicyCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "TooManyPolicies":
+    case "TooManyPoliciesException":
     case "com.amazonaws.elasticloadbalancing#TooManyPoliciesException":
       response = {
         ...(await deserializeAws_queryTooManyPoliciesExceptionResponse(parsedOutput, context)),
@@ -1521,7 +1521,7 @@ const deserializeAws_queryDeleteLoadBalancerListenersCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "LoadBalancerNotFound":
+    case "AccessPointNotFoundException":
     case "com.amazonaws.elasticloadbalancing#AccessPointNotFoundException":
       response = {
         ...(await deserializeAws_queryAccessPointNotFoundExceptionResponse(parsedOutput, context)),
@@ -1575,18 +1575,18 @@ const deserializeAws_queryDeleteLoadBalancerPolicyCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "InvalidConfigurationRequest":
-    case "com.amazonaws.elasticloadbalancing#InvalidConfigurationRequestException":
+    case "AccessPointNotFoundException":
+    case "com.amazonaws.elasticloadbalancing#AccessPointNotFoundException":
       response = {
-        ...(await deserializeAws_queryInvalidConfigurationRequestExceptionResponse(parsedOutput, context)),
+        ...(await deserializeAws_queryAccessPointNotFoundExceptionResponse(parsedOutput, context)),
         name: errorCode,
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "LoadBalancerNotFound":
-    case "com.amazonaws.elasticloadbalancing#AccessPointNotFoundException":
+    case "InvalidConfigurationRequestException":
+    case "com.amazonaws.elasticloadbalancing#InvalidConfigurationRequestException":
       response = {
-        ...(await deserializeAws_queryAccessPointNotFoundExceptionResponse(parsedOutput, context)),
+        ...(await deserializeAws_queryInvalidConfigurationRequestExceptionResponse(parsedOutput, context)),
         name: errorCode,
         $metadata: deserializeMetadata(output),
       };
@@ -1637,18 +1637,18 @@ const deserializeAws_queryDeregisterInstancesFromLoadBalancerCommandError = asyn
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "InvalidInstance":
-    case "com.amazonaws.elasticloadbalancing#InvalidEndPointException":
+    case "AccessPointNotFoundException":
+    case "com.amazonaws.elasticloadbalancing#AccessPointNotFoundException":
       response = {
-        ...(await deserializeAws_queryInvalidEndPointExceptionResponse(parsedOutput, context)),
+        ...(await deserializeAws_queryAccessPointNotFoundExceptionResponse(parsedOutput, context)),
         name: errorCode,
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "LoadBalancerNotFound":
-    case "com.amazonaws.elasticloadbalancing#AccessPointNotFoundException":
+    case "InvalidEndPointException":
+    case "com.amazonaws.elasticloadbalancing#InvalidEndPointException":
       response = {
-        ...(await deserializeAws_queryAccessPointNotFoundExceptionResponse(parsedOutput, context)),
+        ...(await deserializeAws_queryInvalidEndPointExceptionResponse(parsedOutput, context)),
         name: errorCode,
         $metadata: deserializeMetadata(output),
       };
@@ -1745,18 +1745,18 @@ const deserializeAws_queryDescribeInstanceHealthCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "InvalidInstance":
-    case "com.amazonaws.elasticloadbalancing#InvalidEndPointException":
+    case "AccessPointNotFoundException":
+    case "com.amazonaws.elasticloadbalancing#AccessPointNotFoundException":
       response = {
-        ...(await deserializeAws_queryInvalidEndPointExceptionResponse(parsedOutput, context)),
+        ...(await deserializeAws_queryAccessPointNotFoundExceptionResponse(parsedOutput, context)),
         name: errorCode,
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "LoadBalancerNotFound":
-    case "com.amazonaws.elasticloadbalancing#AccessPointNotFoundException":
+    case "InvalidEndPointException":
+    case "com.amazonaws.elasticloadbalancing#InvalidEndPointException":
       response = {
-        ...(await deserializeAws_queryAccessPointNotFoundExceptionResponse(parsedOutput, context)),
+        ...(await deserializeAws_queryInvalidEndPointExceptionResponse(parsedOutput, context)),
         name: errorCode,
         $metadata: deserializeMetadata(output),
       };
@@ -1810,18 +1810,18 @@ const deserializeAws_queryDescribeLoadBalancerAttributesCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "LoadBalancerAttributeNotFound":
-    case "com.amazonaws.elasticloadbalancing#LoadBalancerAttributeNotFoundException":
+    case "AccessPointNotFoundException":
+    case "com.amazonaws.elasticloadbalancing#AccessPointNotFoundException":
       response = {
-        ...(await deserializeAws_queryLoadBalancerAttributeNotFoundExceptionResponse(parsedOutput, context)),
+        ...(await deserializeAws_queryAccessPointNotFoundExceptionResponse(parsedOutput, context)),
         name: errorCode,
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "LoadBalancerNotFound":
-    case "com.amazonaws.elasticloadbalancing#AccessPointNotFoundException":
+    case "LoadBalancerAttributeNotFoundException":
+    case "com.amazonaws.elasticloadbalancing#LoadBalancerAttributeNotFoundException":
       response = {
-        ...(await deserializeAws_queryAccessPointNotFoundExceptionResponse(parsedOutput, context)),
+        ...(await deserializeAws_queryLoadBalancerAttributeNotFoundExceptionResponse(parsedOutput, context)),
         name: errorCode,
         $metadata: deserializeMetadata(output),
       };
@@ -1872,7 +1872,7 @@ const deserializeAws_queryDescribeLoadBalancerPoliciesCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "LoadBalancerNotFound":
+    case "AccessPointNotFoundException":
     case "com.amazonaws.elasticloadbalancing#AccessPointNotFoundException":
       response = {
         ...(await deserializeAws_queryAccessPointNotFoundExceptionResponse(parsedOutput, context)),
@@ -1880,7 +1880,7 @@ const deserializeAws_queryDescribeLoadBalancerPoliciesCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "PolicyNotFound":
+    case "PolicyNotFoundException":
     case "com.amazonaws.elasticloadbalancing#PolicyNotFoundException":
       response = {
         ...(await deserializeAws_queryPolicyNotFoundExceptionResponse(parsedOutput, context)),
@@ -1937,7 +1937,7 @@ const deserializeAws_queryDescribeLoadBalancerPolicyTypesCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "PolicyTypeNotFound":
+    case "PolicyTypeNotFoundException":
     case "com.amazonaws.elasticloadbalancing#PolicyTypeNotFoundException":
       response = {
         ...(await deserializeAws_queryPolicyTypeNotFoundExceptionResponse(parsedOutput, context)),
@@ -1991,18 +1991,18 @@ const deserializeAws_queryDescribeLoadBalancersCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "DependencyThrottle":
-    case "com.amazonaws.elasticloadbalancing#DependencyThrottleException":
+    case "AccessPointNotFoundException":
+    case "com.amazonaws.elasticloadbalancing#AccessPointNotFoundException":
       response = {
-        ...(await deserializeAws_queryDependencyThrottleExceptionResponse(parsedOutput, context)),
+        ...(await deserializeAws_queryAccessPointNotFoundExceptionResponse(parsedOutput, context)),
         name: errorCode,
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "LoadBalancerNotFound":
-    case "com.amazonaws.elasticloadbalancing#AccessPointNotFoundException":
+    case "DependencyThrottleException":
+    case "com.amazonaws.elasticloadbalancing#DependencyThrottleException":
       response = {
-        ...(await deserializeAws_queryAccessPointNotFoundExceptionResponse(parsedOutput, context)),
+        ...(await deserializeAws_queryDependencyThrottleExceptionResponse(parsedOutput, context)),
         name: errorCode,
         $metadata: deserializeMetadata(output),
       };
@@ -2053,7 +2053,7 @@ const deserializeAws_queryDescribeTagsCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "LoadBalancerNotFound":
+    case "AccessPointNotFoundException":
     case "com.amazonaws.elasticloadbalancing#AccessPointNotFoundException":
       response = {
         ...(await deserializeAws_queryAccessPointNotFoundExceptionResponse(parsedOutput, context)),
@@ -2107,18 +2107,18 @@ const deserializeAws_queryDetachLoadBalancerFromSubnetsCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "InvalidConfigurationRequest":
-    case "com.amazonaws.elasticloadbalancing#InvalidConfigurationRequestException":
+    case "AccessPointNotFoundException":
+    case "com.amazonaws.elasticloadbalancing#AccessPointNotFoundException":
       response = {
-        ...(await deserializeAws_queryInvalidConfigurationRequestExceptionResponse(parsedOutput, context)),
+        ...(await deserializeAws_queryAccessPointNotFoundExceptionResponse(parsedOutput, context)),
         name: errorCode,
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "LoadBalancerNotFound":
-    case "com.amazonaws.elasticloadbalancing#AccessPointNotFoundException":
+    case "InvalidConfigurationRequestException":
+    case "com.amazonaws.elasticloadbalancing#InvalidConfigurationRequestException":
       response = {
-        ...(await deserializeAws_queryAccessPointNotFoundExceptionResponse(parsedOutput, context)),
+        ...(await deserializeAws_queryInvalidConfigurationRequestExceptionResponse(parsedOutput, context)),
         name: errorCode,
         $metadata: deserializeMetadata(output),
       };
@@ -2172,18 +2172,18 @@ const deserializeAws_queryDisableAvailabilityZonesForLoadBalancerCommandError = 
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "InvalidConfigurationRequest":
-    case "com.amazonaws.elasticloadbalancing#InvalidConfigurationRequestException":
+    case "AccessPointNotFoundException":
+    case "com.amazonaws.elasticloadbalancing#AccessPointNotFoundException":
       response = {
-        ...(await deserializeAws_queryInvalidConfigurationRequestExceptionResponse(parsedOutput, context)),
+        ...(await deserializeAws_queryAccessPointNotFoundExceptionResponse(parsedOutput, context)),
         name: errorCode,
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "LoadBalancerNotFound":
-    case "com.amazonaws.elasticloadbalancing#AccessPointNotFoundException":
+    case "InvalidConfigurationRequestException":
+    case "com.amazonaws.elasticloadbalancing#InvalidConfigurationRequestException":
       response = {
-        ...(await deserializeAws_queryAccessPointNotFoundExceptionResponse(parsedOutput, context)),
+        ...(await deserializeAws_queryInvalidConfigurationRequestExceptionResponse(parsedOutput, context)),
         name: errorCode,
         $metadata: deserializeMetadata(output),
       };
@@ -2234,7 +2234,7 @@ const deserializeAws_queryEnableAvailabilityZonesForLoadBalancerCommandError = a
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "LoadBalancerNotFound":
+    case "AccessPointNotFoundException":
     case "com.amazonaws.elasticloadbalancing#AccessPointNotFoundException":
       response = {
         ...(await deserializeAws_queryAccessPointNotFoundExceptionResponse(parsedOutput, context)),
@@ -2288,7 +2288,15 @@ const deserializeAws_queryModifyLoadBalancerAttributesCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "InvalidConfigurationRequest":
+    case "AccessPointNotFoundException":
+    case "com.amazonaws.elasticloadbalancing#AccessPointNotFoundException":
+      response = {
+        ...(await deserializeAws_queryAccessPointNotFoundExceptionResponse(parsedOutput, context)),
+        name: errorCode,
+        $metadata: deserializeMetadata(output),
+      };
+      break;
+    case "InvalidConfigurationRequestException":
     case "com.amazonaws.elasticloadbalancing#InvalidConfigurationRequestException":
       response = {
         ...(await deserializeAws_queryInvalidConfigurationRequestExceptionResponse(parsedOutput, context)),
@@ -2296,18 +2304,10 @@ const deserializeAws_queryModifyLoadBalancerAttributesCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "LoadBalancerAttributeNotFound":
+    case "LoadBalancerAttributeNotFoundException":
     case "com.amazonaws.elasticloadbalancing#LoadBalancerAttributeNotFoundException":
       response = {
         ...(await deserializeAws_queryLoadBalancerAttributeNotFoundExceptionResponse(parsedOutput, context)),
-        name: errorCode,
-        $metadata: deserializeMetadata(output),
-      };
-      break;
-    case "LoadBalancerNotFound":
-    case "com.amazonaws.elasticloadbalancing#AccessPointNotFoundException":
-      response = {
-        ...(await deserializeAws_queryAccessPointNotFoundExceptionResponse(parsedOutput, context)),
         name: errorCode,
         $metadata: deserializeMetadata(output),
       };
@@ -2358,18 +2358,18 @@ const deserializeAws_queryRegisterInstancesWithLoadBalancerCommandError = async 
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "InvalidInstance":
-    case "com.amazonaws.elasticloadbalancing#InvalidEndPointException":
+    case "AccessPointNotFoundException":
+    case "com.amazonaws.elasticloadbalancing#AccessPointNotFoundException":
       response = {
-        ...(await deserializeAws_queryInvalidEndPointExceptionResponse(parsedOutput, context)),
+        ...(await deserializeAws_queryAccessPointNotFoundExceptionResponse(parsedOutput, context)),
         name: errorCode,
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "LoadBalancerNotFound":
-    case "com.amazonaws.elasticloadbalancing#AccessPointNotFoundException":
+    case "InvalidEndPointException":
+    case "com.amazonaws.elasticloadbalancing#InvalidEndPointException":
       response = {
-        ...(await deserializeAws_queryAccessPointNotFoundExceptionResponse(parsedOutput, context)),
+        ...(await deserializeAws_queryInvalidEndPointExceptionResponse(parsedOutput, context)),
         name: errorCode,
         $metadata: deserializeMetadata(output),
       };
@@ -2420,7 +2420,7 @@ const deserializeAws_queryRemoveTagsCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "LoadBalancerNotFound":
+    case "AccessPointNotFoundException":
     case "com.amazonaws.elasticloadbalancing#AccessPointNotFoundException":
       response = {
         ...(await deserializeAws_queryAccessPointNotFoundExceptionResponse(parsedOutput, context)),
@@ -2477,31 +2477,7 @@ const deserializeAws_querySetLoadBalancerListenerSSLCertificateCommandError = as
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "CertificateNotFound":
-    case "com.amazonaws.elasticloadbalancing#CertificateNotFoundException":
-      response = {
-        ...(await deserializeAws_queryCertificateNotFoundExceptionResponse(parsedOutput, context)),
-        name: errorCode,
-        $metadata: deserializeMetadata(output),
-      };
-      break;
-    case "InvalidConfigurationRequest":
-    case "com.amazonaws.elasticloadbalancing#InvalidConfigurationRequestException":
-      response = {
-        ...(await deserializeAws_queryInvalidConfigurationRequestExceptionResponse(parsedOutput, context)),
-        name: errorCode,
-        $metadata: deserializeMetadata(output),
-      };
-      break;
-    case "ListenerNotFound":
-    case "com.amazonaws.elasticloadbalancing#ListenerNotFoundException":
-      response = {
-        ...(await deserializeAws_queryListenerNotFoundExceptionResponse(parsedOutput, context)),
-        name: errorCode,
-        $metadata: deserializeMetadata(output),
-      };
-      break;
-    case "LoadBalancerNotFound":
+    case "AccessPointNotFoundException":
     case "com.amazonaws.elasticloadbalancing#AccessPointNotFoundException":
       response = {
         ...(await deserializeAws_queryAccessPointNotFoundExceptionResponse(parsedOutput, context)),
@@ -2509,7 +2485,31 @@ const deserializeAws_querySetLoadBalancerListenerSSLCertificateCommandError = as
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "UnsupportedProtocol":
+    case "CertificateNotFoundException":
+    case "com.amazonaws.elasticloadbalancing#CertificateNotFoundException":
+      response = {
+        ...(await deserializeAws_queryCertificateNotFoundExceptionResponse(parsedOutput, context)),
+        name: errorCode,
+        $metadata: deserializeMetadata(output),
+      };
+      break;
+    case "InvalidConfigurationRequestException":
+    case "com.amazonaws.elasticloadbalancing#InvalidConfigurationRequestException":
+      response = {
+        ...(await deserializeAws_queryInvalidConfigurationRequestExceptionResponse(parsedOutput, context)),
+        name: errorCode,
+        $metadata: deserializeMetadata(output),
+      };
+      break;
+    case "ListenerNotFoundException":
+    case "com.amazonaws.elasticloadbalancing#ListenerNotFoundException":
+      response = {
+        ...(await deserializeAws_queryListenerNotFoundExceptionResponse(parsedOutput, context)),
+        name: errorCode,
+        $metadata: deserializeMetadata(output),
+      };
+      break;
+    case "UnsupportedProtocolException":
     case "com.amazonaws.elasticloadbalancing#UnsupportedProtocolException":
       response = {
         ...(await deserializeAws_queryUnsupportedProtocolExceptionResponse(parsedOutput, context)),
@@ -2566,15 +2566,7 @@ const deserializeAws_querySetLoadBalancerPoliciesForBackendServerCommandError = 
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "InvalidConfigurationRequest":
-    case "com.amazonaws.elasticloadbalancing#InvalidConfigurationRequestException":
-      response = {
-        ...(await deserializeAws_queryInvalidConfigurationRequestExceptionResponse(parsedOutput, context)),
-        name: errorCode,
-        $metadata: deserializeMetadata(output),
-      };
-      break;
-    case "LoadBalancerNotFound":
+    case "AccessPointNotFoundException":
     case "com.amazonaws.elasticloadbalancing#AccessPointNotFoundException":
       response = {
         ...(await deserializeAws_queryAccessPointNotFoundExceptionResponse(parsedOutput, context)),
@@ -2582,7 +2574,15 @@ const deserializeAws_querySetLoadBalancerPoliciesForBackendServerCommandError = 
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "PolicyNotFound":
+    case "InvalidConfigurationRequestException":
+    case "com.amazonaws.elasticloadbalancing#InvalidConfigurationRequestException":
+      response = {
+        ...(await deserializeAws_queryInvalidConfigurationRequestExceptionResponse(parsedOutput, context)),
+        name: errorCode,
+        $metadata: deserializeMetadata(output),
+      };
+      break;
+    case "PolicyNotFoundException":
     case "com.amazonaws.elasticloadbalancing#PolicyNotFoundException":
       response = {
         ...(await deserializeAws_queryPolicyNotFoundExceptionResponse(parsedOutput, context)),
@@ -2639,23 +2639,7 @@ const deserializeAws_querySetLoadBalancerPoliciesOfListenerCommandError = async 
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "InvalidConfigurationRequest":
-    case "com.amazonaws.elasticloadbalancing#InvalidConfigurationRequestException":
-      response = {
-        ...(await deserializeAws_queryInvalidConfigurationRequestExceptionResponse(parsedOutput, context)),
-        name: errorCode,
-        $metadata: deserializeMetadata(output),
-      };
-      break;
-    case "ListenerNotFound":
-    case "com.amazonaws.elasticloadbalancing#ListenerNotFoundException":
-      response = {
-        ...(await deserializeAws_queryListenerNotFoundExceptionResponse(parsedOutput, context)),
-        name: errorCode,
-        $metadata: deserializeMetadata(output),
-      };
-      break;
-    case "LoadBalancerNotFound":
+    case "AccessPointNotFoundException":
     case "com.amazonaws.elasticloadbalancing#AccessPointNotFoundException":
       response = {
         ...(await deserializeAws_queryAccessPointNotFoundExceptionResponse(parsedOutput, context)),
@@ -2663,7 +2647,23 @@ const deserializeAws_querySetLoadBalancerPoliciesOfListenerCommandError = async 
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "PolicyNotFound":
+    case "InvalidConfigurationRequestException":
+    case "com.amazonaws.elasticloadbalancing#InvalidConfigurationRequestException":
+      response = {
+        ...(await deserializeAws_queryInvalidConfigurationRequestExceptionResponse(parsedOutput, context)),
+        name: errorCode,
+        $metadata: deserializeMetadata(output),
+      };
+      break;
+    case "ListenerNotFoundException":
+    case "com.amazonaws.elasticloadbalancing#ListenerNotFoundException":
+      response = {
+        ...(await deserializeAws_queryListenerNotFoundExceptionResponse(parsedOutput, context)),
+        name: errorCode,
+        $metadata: deserializeMetadata(output),
+      };
+      break;
+    case "PolicyNotFoundException":
     case "com.amazonaws.elasticloadbalancing#PolicyNotFoundException":
       response = {
         ...(await deserializeAws_queryPolicyNotFoundExceptionResponse(parsedOutput, context)),

--- a/clients/client-elasticache/src/protocols/Aws_query.ts
+++ b/clients/client-elasticache/src/protocols/Aws_query.ts
@@ -1539,7 +1539,7 @@ const deserializeAws_queryAddTagsToResourceCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "CacheClusterNotFound":
+    case "CacheClusterNotFoundFault":
     case "com.amazonaws.elasticache#CacheClusterNotFoundFault":
       response = {
         ...(await deserializeAws_queryCacheClusterNotFoundFaultResponse(parsedOutput, context)),
@@ -1547,7 +1547,7 @@ const deserializeAws_queryAddTagsToResourceCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "CacheParameterGroupNotFound":
+    case "CacheParameterGroupNotFoundFault":
     case "com.amazonaws.elasticache#CacheParameterGroupNotFoundFault":
       response = {
         ...(await deserializeAws_queryCacheParameterGroupNotFoundFaultResponse(parsedOutput, context)),
@@ -1555,7 +1555,7 @@ const deserializeAws_queryAddTagsToResourceCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "CacheSecurityGroupNotFound":
+    case "CacheSecurityGroupNotFoundFault":
     case "com.amazonaws.elasticache#CacheSecurityGroupNotFoundFault":
       response = {
         ...(await deserializeAws_queryCacheSecurityGroupNotFoundFaultResponse(parsedOutput, context)),
@@ -1571,7 +1571,7 @@ const deserializeAws_queryAddTagsToResourceCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidARN":
+    case "InvalidARNFault":
     case "com.amazonaws.elasticache#InvalidARNFault":
       response = {
         ...(await deserializeAws_queryInvalidARNFaultResponse(parsedOutput, context)),
@@ -1579,7 +1579,7 @@ const deserializeAws_queryAddTagsToResourceCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidReplicationGroupState":
+    case "InvalidReplicationGroupStateFault":
     case "com.amazonaws.elasticache#InvalidReplicationGroupStateFault":
       response = {
         ...(await deserializeAws_queryInvalidReplicationGroupStateFaultResponse(parsedOutput, context)),
@@ -1595,7 +1595,7 @@ const deserializeAws_queryAddTagsToResourceCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ReservedCacheNodeNotFound":
+    case "ReservedCacheNodeNotFoundFault":
     case "com.amazonaws.elasticache#ReservedCacheNodeNotFoundFault":
       response = {
         ...(await deserializeAws_queryReservedCacheNodeNotFoundFaultResponse(parsedOutput, context)),
@@ -1619,7 +1619,7 @@ const deserializeAws_queryAddTagsToResourceCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "UserGroupNotFound":
+    case "UserGroupNotFoundFault":
     case "com.amazonaws.elasticache#UserGroupNotFoundFault":
       response = {
         ...(await deserializeAws_queryUserGroupNotFoundFaultResponse(parsedOutput, context)),
@@ -1627,7 +1627,7 @@ const deserializeAws_queryAddTagsToResourceCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "UserNotFound":
+    case "UserNotFoundFault":
     case "com.amazonaws.elasticache#UserNotFoundFault":
       response = {
         ...(await deserializeAws_queryUserNotFoundFaultResponse(parsedOutput, context)),
@@ -1684,7 +1684,7 @@ const deserializeAws_queryAuthorizeCacheSecurityGroupIngressCommandError = async
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "AuthorizationAlreadyExists":
+    case "AuthorizationAlreadyExistsFault":
     case "com.amazonaws.elasticache#AuthorizationAlreadyExistsFault":
       response = {
         ...(await deserializeAws_queryAuthorizationAlreadyExistsFaultResponse(parsedOutput, context)),
@@ -1692,7 +1692,7 @@ const deserializeAws_queryAuthorizeCacheSecurityGroupIngressCommandError = async
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "CacheSecurityGroupNotFound":
+    case "CacheSecurityGroupNotFoundFault":
     case "com.amazonaws.elasticache#CacheSecurityGroupNotFoundFault":
       response = {
         ...(await deserializeAws_queryCacheSecurityGroupNotFoundFaultResponse(parsedOutput, context)),
@@ -1700,7 +1700,7 @@ const deserializeAws_queryAuthorizeCacheSecurityGroupIngressCommandError = async
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidCacheSecurityGroupState":
+    case "InvalidCacheSecurityGroupStateFault":
     case "com.amazonaws.elasticache#InvalidCacheSecurityGroupStateFault":
       response = {
         ...(await deserializeAws_queryInvalidCacheSecurityGroupStateFaultResponse(parsedOutput, context)),
@@ -1708,7 +1708,7 @@ const deserializeAws_queryAuthorizeCacheSecurityGroupIngressCommandError = async
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidParameterCombination":
+    case "InvalidParameterCombinationException":
     case "com.amazonaws.elasticache#InvalidParameterCombinationException":
       response = {
         ...(await deserializeAws_queryInvalidParameterCombinationExceptionResponse(parsedOutput, context)),
@@ -1716,7 +1716,7 @@ const deserializeAws_queryAuthorizeCacheSecurityGroupIngressCommandError = async
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidParameterValue":
+    case "InvalidParameterValueException":
     case "com.amazonaws.elasticache#InvalidParameterValueException":
       response = {
         ...(await deserializeAws_queryInvalidParameterValueExceptionResponse(parsedOutput, context)),
@@ -1770,7 +1770,7 @@ const deserializeAws_queryBatchApplyUpdateActionCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "InvalidParameterValue":
+    case "InvalidParameterValueException":
     case "com.amazonaws.elasticache#InvalidParameterValueException":
       response = {
         ...(await deserializeAws_queryInvalidParameterValueExceptionResponse(parsedOutput, context)),
@@ -1832,7 +1832,7 @@ const deserializeAws_queryBatchStopUpdateActionCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "InvalidParameterValue":
+    case "InvalidParameterValueException":
     case "com.amazonaws.elasticache#InvalidParameterValueException":
       response = {
         ...(await deserializeAws_queryInvalidParameterValueExceptionResponse(parsedOutput, context)),
@@ -1894,7 +1894,7 @@ const deserializeAws_queryCompleteMigrationCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "InvalidReplicationGroupState":
+    case "InvalidReplicationGroupStateFault":
     case "com.amazonaws.elasticache#InvalidReplicationGroupStateFault":
       response = {
         ...(await deserializeAws_queryInvalidReplicationGroupStateFaultResponse(parsedOutput, context)),
@@ -1964,7 +1964,7 @@ const deserializeAws_queryCopySnapshotCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "InvalidParameterCombination":
+    case "InvalidParameterCombinationException":
     case "com.amazonaws.elasticache#InvalidParameterCombinationException":
       response = {
         ...(await deserializeAws_queryInvalidParameterCombinationExceptionResponse(parsedOutput, context)),
@@ -1972,7 +1972,7 @@ const deserializeAws_queryCopySnapshotCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidParameterValue":
+    case "InvalidParameterValueException":
     case "com.amazonaws.elasticache#InvalidParameterValueException":
       response = {
         ...(await deserializeAws_queryInvalidParameterValueExceptionResponse(parsedOutput, context)),
@@ -1980,7 +1980,7 @@ const deserializeAws_queryCopySnapshotCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidSnapshotState":
+    case "InvalidSnapshotStateFault":
     case "com.amazonaws.elasticache#InvalidSnapshotStateFault":
       response = {
         ...(await deserializeAws_queryInvalidSnapshotStateFaultResponse(parsedOutput, context)),
@@ -2066,7 +2066,7 @@ const deserializeAws_queryCreateCacheClusterCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "CacheClusterAlreadyExists":
+    case "CacheClusterAlreadyExistsFault":
     case "com.amazonaws.elasticache#CacheClusterAlreadyExistsFault":
       response = {
         ...(await deserializeAws_queryCacheClusterAlreadyExistsFaultResponse(parsedOutput, context)),
@@ -2074,7 +2074,7 @@ const deserializeAws_queryCreateCacheClusterCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "CacheParameterGroupNotFound":
+    case "CacheParameterGroupNotFoundFault":
     case "com.amazonaws.elasticache#CacheParameterGroupNotFoundFault":
       response = {
         ...(await deserializeAws_queryCacheParameterGroupNotFoundFaultResponse(parsedOutput, context)),
@@ -2082,7 +2082,7 @@ const deserializeAws_queryCreateCacheClusterCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "CacheSecurityGroupNotFound":
+    case "CacheSecurityGroupNotFoundFault":
     case "com.amazonaws.elasticache#CacheSecurityGroupNotFoundFault":
       response = {
         ...(await deserializeAws_queryCacheSecurityGroupNotFoundFaultResponse(parsedOutput, context)),
@@ -2098,7 +2098,7 @@ const deserializeAws_queryCreateCacheClusterCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ClusterQuotaForCustomerExceeded":
+    case "ClusterQuotaForCustomerExceededFault":
     case "com.amazonaws.elasticache#ClusterQuotaForCustomerExceededFault":
       response = {
         ...(await deserializeAws_queryClusterQuotaForCustomerExceededFaultResponse(parsedOutput, context)),
@@ -2106,7 +2106,7 @@ const deserializeAws_queryCreateCacheClusterCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InsufficientCacheClusterCapacity":
+    case "InsufficientCacheClusterCapacityFault":
     case "com.amazonaws.elasticache#InsufficientCacheClusterCapacityFault":
       response = {
         ...(await deserializeAws_queryInsufficientCacheClusterCapacityFaultResponse(parsedOutput, context)),
@@ -2114,7 +2114,7 @@ const deserializeAws_queryCreateCacheClusterCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidParameterCombination":
+    case "InvalidParameterCombinationException":
     case "com.amazonaws.elasticache#InvalidParameterCombinationException":
       response = {
         ...(await deserializeAws_queryInvalidParameterCombinationExceptionResponse(parsedOutput, context)),
@@ -2122,7 +2122,7 @@ const deserializeAws_queryCreateCacheClusterCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidParameterValue":
+    case "InvalidParameterValueException":
     case "com.amazonaws.elasticache#InvalidParameterValueException":
       response = {
         ...(await deserializeAws_queryInvalidParameterValueExceptionResponse(parsedOutput, context)),
@@ -2130,7 +2130,7 @@ const deserializeAws_queryCreateCacheClusterCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidReplicationGroupState":
+    case "InvalidReplicationGroupStateFault":
     case "com.amazonaws.elasticache#InvalidReplicationGroupStateFault":
       response = {
         ...(await deserializeAws_queryInvalidReplicationGroupStateFaultResponse(parsedOutput, context)),
@@ -2146,7 +2146,7 @@ const deserializeAws_queryCreateCacheClusterCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "NodeQuotaForClusterExceeded":
+    case "NodeQuotaForClusterExceededFault":
     case "com.amazonaws.elasticache#NodeQuotaForClusterExceededFault":
       response = {
         ...(await deserializeAws_queryNodeQuotaForClusterExceededFaultResponse(parsedOutput, context)),
@@ -2154,7 +2154,7 @@ const deserializeAws_queryCreateCacheClusterCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "NodeQuotaForCustomerExceeded":
+    case "NodeQuotaForCustomerExceededFault":
     case "com.amazonaws.elasticache#NodeQuotaForCustomerExceededFault":
       response = {
         ...(await deserializeAws_queryNodeQuotaForCustomerExceededFaultResponse(parsedOutput, context)),
@@ -2224,7 +2224,7 @@ const deserializeAws_queryCreateCacheParameterGroupCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "CacheParameterGroupAlreadyExists":
+    case "CacheParameterGroupAlreadyExistsFault":
     case "com.amazonaws.elasticache#CacheParameterGroupAlreadyExistsFault":
       response = {
         ...(await deserializeAws_queryCacheParameterGroupAlreadyExistsFaultResponse(parsedOutput, context)),
@@ -2232,7 +2232,7 @@ const deserializeAws_queryCreateCacheParameterGroupCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "CacheParameterGroupQuotaExceeded":
+    case "CacheParameterGroupQuotaExceededFault":
     case "com.amazonaws.elasticache#CacheParameterGroupQuotaExceededFault":
       response = {
         ...(await deserializeAws_queryCacheParameterGroupQuotaExceededFaultResponse(parsedOutput, context)),
@@ -2240,7 +2240,7 @@ const deserializeAws_queryCreateCacheParameterGroupCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidCacheParameterGroupState":
+    case "InvalidCacheParameterGroupStateFault":
     case "com.amazonaws.elasticache#InvalidCacheParameterGroupStateFault":
       response = {
         ...(await deserializeAws_queryInvalidCacheParameterGroupStateFaultResponse(parsedOutput, context)),
@@ -2248,7 +2248,7 @@ const deserializeAws_queryCreateCacheParameterGroupCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidParameterCombination":
+    case "InvalidParameterCombinationException":
     case "com.amazonaws.elasticache#InvalidParameterCombinationException":
       response = {
         ...(await deserializeAws_queryInvalidParameterCombinationExceptionResponse(parsedOutput, context)),
@@ -2256,7 +2256,7 @@ const deserializeAws_queryCreateCacheParameterGroupCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidParameterValue":
+    case "InvalidParameterValueException":
     case "com.amazonaws.elasticache#InvalidParameterValueException":
       response = {
         ...(await deserializeAws_queryInvalidParameterValueExceptionResponse(parsedOutput, context)),
@@ -2318,7 +2318,7 @@ const deserializeAws_queryCreateCacheSecurityGroupCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "CacheSecurityGroupAlreadyExists":
+    case "CacheSecurityGroupAlreadyExistsFault":
     case "com.amazonaws.elasticache#CacheSecurityGroupAlreadyExistsFault":
       response = {
         ...(await deserializeAws_queryCacheSecurityGroupAlreadyExistsFaultResponse(parsedOutput, context)),
@@ -2326,7 +2326,15 @@ const deserializeAws_queryCreateCacheSecurityGroupCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidParameterCombination":
+    case "CacheSecurityGroupQuotaExceededFault":
+    case "com.amazonaws.elasticache#CacheSecurityGroupQuotaExceededFault":
+      response = {
+        ...(await deserializeAws_queryCacheSecurityGroupQuotaExceededFaultResponse(parsedOutput, context)),
+        name: errorCode,
+        $metadata: deserializeMetadata(output),
+      };
+      break;
+    case "InvalidParameterCombinationException":
     case "com.amazonaws.elasticache#InvalidParameterCombinationException":
       response = {
         ...(await deserializeAws_queryInvalidParameterCombinationExceptionResponse(parsedOutput, context)),
@@ -2334,18 +2342,10 @@ const deserializeAws_queryCreateCacheSecurityGroupCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidParameterValue":
+    case "InvalidParameterValueException":
     case "com.amazonaws.elasticache#InvalidParameterValueException":
       response = {
         ...(await deserializeAws_queryInvalidParameterValueExceptionResponse(parsedOutput, context)),
-        name: errorCode,
-        $metadata: deserializeMetadata(output),
-      };
-      break;
-    case "QuotaExceeded.CacheSecurityGroup":
-    case "com.amazonaws.elasticache#CacheSecurityGroupQuotaExceededFault":
-      response = {
-        ...(await deserializeAws_queryCacheSecurityGroupQuotaExceededFaultResponse(parsedOutput, context)),
         name: errorCode,
         $metadata: deserializeMetadata(output),
       };
@@ -2404,7 +2404,7 @@ const deserializeAws_queryCreateCacheSubnetGroupCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "CacheSubnetGroupAlreadyExists":
+    case "CacheSubnetGroupAlreadyExistsFault":
     case "com.amazonaws.elasticache#CacheSubnetGroupAlreadyExistsFault":
       response = {
         ...(await deserializeAws_queryCacheSubnetGroupAlreadyExistsFaultResponse(parsedOutput, context)),
@@ -2412,7 +2412,7 @@ const deserializeAws_queryCreateCacheSubnetGroupCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "CacheSubnetGroupQuotaExceeded":
+    case "CacheSubnetGroupQuotaExceededFault":
     case "com.amazonaws.elasticache#CacheSubnetGroupQuotaExceededFault":
       response = {
         ...(await deserializeAws_queryCacheSubnetGroupQuotaExceededFaultResponse(parsedOutput, context)),
@@ -2506,7 +2506,7 @@ const deserializeAws_queryCreateGlobalReplicationGroupCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidParameterValue":
+    case "InvalidParameterValueException":
     case "com.amazonaws.elasticache#InvalidParameterValueException":
       response = {
         ...(await deserializeAws_queryInvalidParameterValueExceptionResponse(parsedOutput, context)),
@@ -2514,7 +2514,7 @@ const deserializeAws_queryCreateGlobalReplicationGroupCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidReplicationGroupState":
+    case "InvalidReplicationGroupStateFault":
     case "com.amazonaws.elasticache#InvalidReplicationGroupStateFault":
       response = {
         ...(await deserializeAws_queryInvalidReplicationGroupStateFaultResponse(parsedOutput, context)),
@@ -2584,7 +2584,7 @@ const deserializeAws_queryCreateReplicationGroupCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "CacheClusterNotFound":
+    case "CacheClusterNotFoundFault":
     case "com.amazonaws.elasticache#CacheClusterNotFoundFault":
       response = {
         ...(await deserializeAws_queryCacheClusterNotFoundFaultResponse(parsedOutput, context)),
@@ -2592,7 +2592,7 @@ const deserializeAws_queryCreateReplicationGroupCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "CacheParameterGroupNotFound":
+    case "CacheParameterGroupNotFoundFault":
     case "com.amazonaws.elasticache#CacheParameterGroupNotFoundFault":
       response = {
         ...(await deserializeAws_queryCacheParameterGroupNotFoundFaultResponse(parsedOutput, context)),
@@ -2600,7 +2600,7 @@ const deserializeAws_queryCreateReplicationGroupCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "CacheSecurityGroupNotFound":
+    case "CacheSecurityGroupNotFoundFault":
     case "com.amazonaws.elasticache#CacheSecurityGroupNotFoundFault":
       response = {
         ...(await deserializeAws_queryCacheSecurityGroupNotFoundFaultResponse(parsedOutput, context)),
@@ -2616,7 +2616,7 @@ const deserializeAws_queryCreateReplicationGroupCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ClusterQuotaForCustomerExceeded":
+    case "ClusterQuotaForCustomerExceededFault":
     case "com.amazonaws.elasticache#ClusterQuotaForCustomerExceededFault":
       response = {
         ...(await deserializeAws_queryClusterQuotaForCustomerExceededFaultResponse(parsedOutput, context)),
@@ -2632,7 +2632,7 @@ const deserializeAws_queryCreateReplicationGroupCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InsufficientCacheClusterCapacity":
+    case "InsufficientCacheClusterCapacityFault":
     case "com.amazonaws.elasticache#InsufficientCacheClusterCapacityFault":
       response = {
         ...(await deserializeAws_queryInsufficientCacheClusterCapacityFaultResponse(parsedOutput, context)),
@@ -2640,7 +2640,7 @@ const deserializeAws_queryCreateReplicationGroupCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidCacheClusterState":
+    case "InvalidCacheClusterStateFault":
     case "com.amazonaws.elasticache#InvalidCacheClusterStateFault":
       response = {
         ...(await deserializeAws_queryInvalidCacheClusterStateFaultResponse(parsedOutput, context)),
@@ -2648,7 +2648,7 @@ const deserializeAws_queryCreateReplicationGroupCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidGlobalReplicationGroupState":
+    case "InvalidGlobalReplicationGroupStateFault":
     case "com.amazonaws.elasticache#InvalidGlobalReplicationGroupStateFault":
       response = {
         ...(await deserializeAws_queryInvalidGlobalReplicationGroupStateFaultResponse(parsedOutput, context)),
@@ -2656,7 +2656,7 @@ const deserializeAws_queryCreateReplicationGroupCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidParameterCombination":
+    case "InvalidParameterCombinationException":
     case "com.amazonaws.elasticache#InvalidParameterCombinationException":
       response = {
         ...(await deserializeAws_queryInvalidParameterCombinationExceptionResponse(parsedOutput, context)),
@@ -2664,7 +2664,7 @@ const deserializeAws_queryCreateReplicationGroupCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidParameterValue":
+    case "InvalidParameterValueException":
     case "com.amazonaws.elasticache#InvalidParameterValueException":
       response = {
         ...(await deserializeAws_queryInvalidParameterValueExceptionResponse(parsedOutput, context)),
@@ -2672,7 +2672,7 @@ const deserializeAws_queryCreateReplicationGroupCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidUserGroupState":
+    case "InvalidUserGroupStateFault":
     case "com.amazonaws.elasticache#InvalidUserGroupStateFault":
       response = {
         ...(await deserializeAws_queryInvalidUserGroupStateFaultResponse(parsedOutput, context)),
@@ -2688,7 +2688,7 @@ const deserializeAws_queryCreateReplicationGroupCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "NodeGroupsPerReplicationGroupQuotaExceeded":
+    case "NodeGroupsPerReplicationGroupQuotaExceededFault":
     case "com.amazonaws.elasticache#NodeGroupsPerReplicationGroupQuotaExceededFault":
       response = {
         ...(await deserializeAws_queryNodeGroupsPerReplicationGroupQuotaExceededFaultResponse(parsedOutput, context)),
@@ -2696,7 +2696,7 @@ const deserializeAws_queryCreateReplicationGroupCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "NodeQuotaForClusterExceeded":
+    case "NodeQuotaForClusterExceededFault":
     case "com.amazonaws.elasticache#NodeQuotaForClusterExceededFault":
       response = {
         ...(await deserializeAws_queryNodeQuotaForClusterExceededFaultResponse(parsedOutput, context)),
@@ -2704,7 +2704,7 @@ const deserializeAws_queryCreateReplicationGroupCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "NodeQuotaForCustomerExceeded":
+    case "NodeQuotaForCustomerExceededFault":
     case "com.amazonaws.elasticache#NodeQuotaForCustomerExceededFault":
       response = {
         ...(await deserializeAws_queryNodeQuotaForCustomerExceededFaultResponse(parsedOutput, context)),
@@ -2712,7 +2712,7 @@ const deserializeAws_queryCreateReplicationGroupCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ReplicationGroupAlreadyExists":
+    case "ReplicationGroupAlreadyExistsFault":
     case "com.amazonaws.elasticache#ReplicationGroupAlreadyExistsFault":
       response = {
         ...(await deserializeAws_queryReplicationGroupAlreadyExistsFaultResponse(parsedOutput, context)),
@@ -2728,7 +2728,7 @@ const deserializeAws_queryCreateReplicationGroupCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "UserGroupNotFound":
+    case "UserGroupNotFoundFault":
     case "com.amazonaws.elasticache#UserGroupNotFoundFault":
       response = {
         ...(await deserializeAws_queryUserGroupNotFoundFaultResponse(parsedOutput, context)),
@@ -2782,7 +2782,7 @@ const deserializeAws_queryCreateSnapshotCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "CacheClusterNotFound":
+    case "CacheClusterNotFoundFault":
     case "com.amazonaws.elasticache#CacheClusterNotFoundFault":
       response = {
         ...(await deserializeAws_queryCacheClusterNotFoundFaultResponse(parsedOutput, context)),
@@ -2790,7 +2790,7 @@ const deserializeAws_queryCreateSnapshotCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidCacheClusterState":
+    case "InvalidCacheClusterStateFault":
     case "com.amazonaws.elasticache#InvalidCacheClusterStateFault":
       response = {
         ...(await deserializeAws_queryInvalidCacheClusterStateFaultResponse(parsedOutput, context)),
@@ -2798,7 +2798,7 @@ const deserializeAws_queryCreateSnapshotCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidParameterCombination":
+    case "InvalidParameterCombinationException":
     case "com.amazonaws.elasticache#InvalidParameterCombinationException":
       response = {
         ...(await deserializeAws_queryInvalidParameterCombinationExceptionResponse(parsedOutput, context)),
@@ -2806,7 +2806,7 @@ const deserializeAws_queryCreateSnapshotCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidParameterValue":
+    case "InvalidParameterValueException":
     case "com.amazonaws.elasticache#InvalidParameterValueException":
       response = {
         ...(await deserializeAws_queryInvalidParameterValueExceptionResponse(parsedOutput, context)),
@@ -2814,7 +2814,7 @@ const deserializeAws_queryCreateSnapshotCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidReplicationGroupState":
+    case "InvalidReplicationGroupStateFault":
     case "com.amazonaws.elasticache#InvalidReplicationGroupStateFault":
       response = {
         ...(await deserializeAws_queryInvalidReplicationGroupStateFaultResponse(parsedOutput, context)),
@@ -2908,7 +2908,7 @@ const deserializeAws_queryCreateUserCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "DuplicateUserName":
+    case "DuplicateUserNameFault":
     case "com.amazonaws.elasticache#DuplicateUserNameFault":
       response = {
         ...(await deserializeAws_queryDuplicateUserNameFaultResponse(parsedOutput, context)),
@@ -2916,7 +2916,7 @@ const deserializeAws_queryCreateUserCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidParameterCombination":
+    case "InvalidParameterCombinationException":
     case "com.amazonaws.elasticache#InvalidParameterCombinationException":
       response = {
         ...(await deserializeAws_queryInvalidParameterCombinationExceptionResponse(parsedOutput, context)),
@@ -2924,7 +2924,7 @@ const deserializeAws_queryCreateUserCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidParameterValue":
+    case "InvalidParameterValueException":
     case "com.amazonaws.elasticache#InvalidParameterValueException":
       response = {
         ...(await deserializeAws_queryInvalidParameterValueExceptionResponse(parsedOutput, context)),
@@ -2948,7 +2948,7 @@ const deserializeAws_queryCreateUserCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "UserAlreadyExists":
+    case "UserAlreadyExistsFault":
     case "com.amazonaws.elasticache#UserAlreadyExistsFault":
       response = {
         ...(await deserializeAws_queryUserAlreadyExistsFaultResponse(parsedOutput, context)),
@@ -2956,7 +2956,7 @@ const deserializeAws_queryCreateUserCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "UserQuotaExceeded":
+    case "UserQuotaExceededFault":
     case "com.amazonaws.elasticache#UserQuotaExceededFault":
       response = {
         ...(await deserializeAws_queryUserQuotaExceededFaultResponse(parsedOutput, context)),
@@ -3018,7 +3018,7 @@ const deserializeAws_queryCreateUserGroupCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "DuplicateUserName":
+    case "DuplicateUserNameFault":
     case "com.amazonaws.elasticache#DuplicateUserNameFault":
       response = {
         ...(await deserializeAws_queryDuplicateUserNameFaultResponse(parsedOutput, context)),
@@ -3026,7 +3026,7 @@ const deserializeAws_queryCreateUserGroupCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidParameterValue":
+    case "InvalidParameterValueException":
     case "com.amazonaws.elasticache#InvalidParameterValueException":
       response = {
         ...(await deserializeAws_queryInvalidParameterValueExceptionResponse(parsedOutput, context)),
@@ -3050,7 +3050,7 @@ const deserializeAws_queryCreateUserGroupCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "UserGroupAlreadyExists":
+    case "UserGroupAlreadyExistsFault":
     case "com.amazonaws.elasticache#UserGroupAlreadyExistsFault":
       response = {
         ...(await deserializeAws_queryUserGroupAlreadyExistsFaultResponse(parsedOutput, context)),
@@ -3058,7 +3058,7 @@ const deserializeAws_queryCreateUserGroupCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "UserGroupQuotaExceeded":
+    case "UserGroupQuotaExceededFault":
     case "com.amazonaws.elasticache#UserGroupQuotaExceededFault":
       response = {
         ...(await deserializeAws_queryUserGroupQuotaExceededFaultResponse(parsedOutput, context)),
@@ -3066,7 +3066,7 @@ const deserializeAws_queryCreateUserGroupCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "UserNotFound":
+    case "UserNotFoundFault":
     case "com.amazonaws.elasticache#UserNotFoundFault":
       response = {
         ...(await deserializeAws_queryUserNotFoundFaultResponse(parsedOutput, context)),
@@ -3131,7 +3131,7 @@ const deserializeAws_queryDecreaseNodeGroupsInGlobalReplicationGroupCommandError
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidGlobalReplicationGroupState":
+    case "InvalidGlobalReplicationGroupStateFault":
     case "com.amazonaws.elasticache#InvalidGlobalReplicationGroupStateFault":
       response = {
         ...(await deserializeAws_queryInvalidGlobalReplicationGroupStateFaultResponse(parsedOutput, context)),
@@ -3139,7 +3139,7 @@ const deserializeAws_queryDecreaseNodeGroupsInGlobalReplicationGroupCommandError
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidParameterCombination":
+    case "InvalidParameterCombinationException":
     case "com.amazonaws.elasticache#InvalidParameterCombinationException":
       response = {
         ...(await deserializeAws_queryInvalidParameterCombinationExceptionResponse(parsedOutput, context)),
@@ -3147,7 +3147,7 @@ const deserializeAws_queryDecreaseNodeGroupsInGlobalReplicationGroupCommandError
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidParameterValue":
+    case "InvalidParameterValueException":
     case "com.amazonaws.elasticache#InvalidParameterValueException":
       response = {
         ...(await deserializeAws_queryInvalidParameterValueExceptionResponse(parsedOutput, context)),
@@ -3201,7 +3201,7 @@ const deserializeAws_queryDecreaseReplicaCountCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "ClusterQuotaForCustomerExceeded":
+    case "ClusterQuotaForCustomerExceededFault":
     case "com.amazonaws.elasticache#ClusterQuotaForCustomerExceededFault":
       response = {
         ...(await deserializeAws_queryClusterQuotaForCustomerExceededFaultResponse(parsedOutput, context)),
@@ -3209,7 +3209,7 @@ const deserializeAws_queryDecreaseReplicaCountCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InsufficientCacheClusterCapacity":
+    case "InsufficientCacheClusterCapacityFault":
     case "com.amazonaws.elasticache#InsufficientCacheClusterCapacityFault":
       response = {
         ...(await deserializeAws_queryInsufficientCacheClusterCapacityFaultResponse(parsedOutput, context)),
@@ -3217,7 +3217,7 @@ const deserializeAws_queryDecreaseReplicaCountCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidCacheClusterState":
+    case "InvalidCacheClusterStateFault":
     case "com.amazonaws.elasticache#InvalidCacheClusterStateFault":
       response = {
         ...(await deserializeAws_queryInvalidCacheClusterStateFaultResponse(parsedOutput, context)),
@@ -3225,7 +3225,7 @@ const deserializeAws_queryDecreaseReplicaCountCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidParameterCombination":
+    case "InvalidParameterCombinationException":
     case "com.amazonaws.elasticache#InvalidParameterCombinationException":
       response = {
         ...(await deserializeAws_queryInvalidParameterCombinationExceptionResponse(parsedOutput, context)),
@@ -3233,7 +3233,7 @@ const deserializeAws_queryDecreaseReplicaCountCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidParameterValue":
+    case "InvalidParameterValueException":
     case "com.amazonaws.elasticache#InvalidParameterValueException":
       response = {
         ...(await deserializeAws_queryInvalidParameterValueExceptionResponse(parsedOutput, context)),
@@ -3241,7 +3241,7 @@ const deserializeAws_queryDecreaseReplicaCountCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidReplicationGroupState":
+    case "InvalidReplicationGroupStateFault":
     case "com.amazonaws.elasticache#InvalidReplicationGroupStateFault":
       response = {
         ...(await deserializeAws_queryInvalidReplicationGroupStateFaultResponse(parsedOutput, context)),
@@ -3257,15 +3257,7 @@ const deserializeAws_queryDecreaseReplicaCountCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "NoOperationFault":
-    case "com.amazonaws.elasticache#NoOperationFault":
-      response = {
-        ...(await deserializeAws_queryNoOperationFaultResponse(parsedOutput, context)),
-        name: errorCode,
-        $metadata: deserializeMetadata(output),
-      };
-      break;
-    case "NodeGroupsPerReplicationGroupQuotaExceeded":
+    case "NodeGroupsPerReplicationGroupQuotaExceededFault":
     case "com.amazonaws.elasticache#NodeGroupsPerReplicationGroupQuotaExceededFault":
       response = {
         ...(await deserializeAws_queryNodeGroupsPerReplicationGroupQuotaExceededFaultResponse(parsedOutput, context)),
@@ -3273,10 +3265,18 @@ const deserializeAws_queryDecreaseReplicaCountCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "NodeQuotaForCustomerExceeded":
+    case "NodeQuotaForCustomerExceededFault":
     case "com.amazonaws.elasticache#NodeQuotaForCustomerExceededFault":
       response = {
         ...(await deserializeAws_queryNodeQuotaForCustomerExceededFaultResponse(parsedOutput, context)),
+        name: errorCode,
+        $metadata: deserializeMetadata(output),
+      };
+      break;
+    case "NoOperationFault":
+    case "com.amazonaws.elasticache#NoOperationFault":
+      response = {
+        ...(await deserializeAws_queryNoOperationFaultResponse(parsedOutput, context)),
         name: errorCode,
         $metadata: deserializeMetadata(output),
       };
@@ -3343,7 +3343,7 @@ const deserializeAws_queryDeleteCacheClusterCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "CacheClusterNotFound":
+    case "CacheClusterNotFoundFault":
     case "com.amazonaws.elasticache#CacheClusterNotFoundFault":
       response = {
         ...(await deserializeAws_queryCacheClusterNotFoundFaultResponse(parsedOutput, context)),
@@ -3351,7 +3351,7 @@ const deserializeAws_queryDeleteCacheClusterCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidCacheClusterState":
+    case "InvalidCacheClusterStateFault":
     case "com.amazonaws.elasticache#InvalidCacheClusterStateFault":
       response = {
         ...(await deserializeAws_queryInvalidCacheClusterStateFaultResponse(parsedOutput, context)),
@@ -3359,7 +3359,7 @@ const deserializeAws_queryDeleteCacheClusterCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidParameterCombination":
+    case "InvalidParameterCombinationException":
     case "com.amazonaws.elasticache#InvalidParameterCombinationException":
       response = {
         ...(await deserializeAws_queryInvalidParameterCombinationExceptionResponse(parsedOutput, context)),
@@ -3367,7 +3367,7 @@ const deserializeAws_queryDeleteCacheClusterCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidParameterValue":
+    case "InvalidParameterValueException":
     case "com.amazonaws.elasticache#InvalidParameterValueException":
       response = {
         ...(await deserializeAws_queryInvalidParameterValueExceptionResponse(parsedOutput, context)),
@@ -3442,7 +3442,7 @@ const deserializeAws_queryDeleteCacheParameterGroupCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "CacheParameterGroupNotFound":
+    case "CacheParameterGroupNotFoundFault":
     case "com.amazonaws.elasticache#CacheParameterGroupNotFoundFault":
       response = {
         ...(await deserializeAws_queryCacheParameterGroupNotFoundFaultResponse(parsedOutput, context)),
@@ -3450,7 +3450,7 @@ const deserializeAws_queryDeleteCacheParameterGroupCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidCacheParameterGroupState":
+    case "InvalidCacheParameterGroupStateFault":
     case "com.amazonaws.elasticache#InvalidCacheParameterGroupStateFault":
       response = {
         ...(await deserializeAws_queryInvalidCacheParameterGroupStateFaultResponse(parsedOutput, context)),
@@ -3458,7 +3458,7 @@ const deserializeAws_queryDeleteCacheParameterGroupCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidParameterCombination":
+    case "InvalidParameterCombinationException":
     case "com.amazonaws.elasticache#InvalidParameterCombinationException":
       response = {
         ...(await deserializeAws_queryInvalidParameterCombinationExceptionResponse(parsedOutput, context)),
@@ -3466,7 +3466,7 @@ const deserializeAws_queryDeleteCacheParameterGroupCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidParameterValue":
+    case "InvalidParameterValueException":
     case "com.amazonaws.elasticache#InvalidParameterValueException":
       response = {
         ...(await deserializeAws_queryInvalidParameterValueExceptionResponse(parsedOutput, context)),
@@ -3517,7 +3517,7 @@ const deserializeAws_queryDeleteCacheSecurityGroupCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "CacheSecurityGroupNotFound":
+    case "CacheSecurityGroupNotFoundFault":
     case "com.amazonaws.elasticache#CacheSecurityGroupNotFoundFault":
       response = {
         ...(await deserializeAws_queryCacheSecurityGroupNotFoundFaultResponse(parsedOutput, context)),
@@ -3525,7 +3525,7 @@ const deserializeAws_queryDeleteCacheSecurityGroupCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidCacheSecurityGroupState":
+    case "InvalidCacheSecurityGroupStateFault":
     case "com.amazonaws.elasticache#InvalidCacheSecurityGroupStateFault":
       response = {
         ...(await deserializeAws_queryInvalidCacheSecurityGroupStateFaultResponse(parsedOutput, context)),
@@ -3533,7 +3533,7 @@ const deserializeAws_queryDeleteCacheSecurityGroupCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidParameterCombination":
+    case "InvalidParameterCombinationException":
     case "com.amazonaws.elasticache#InvalidParameterCombinationException":
       response = {
         ...(await deserializeAws_queryInvalidParameterCombinationExceptionResponse(parsedOutput, context)),
@@ -3541,7 +3541,7 @@ const deserializeAws_queryDeleteCacheSecurityGroupCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidParameterValue":
+    case "InvalidParameterValueException":
     case "com.amazonaws.elasticache#InvalidParameterValueException":
       response = {
         ...(await deserializeAws_queryInvalidParameterValueExceptionResponse(parsedOutput, context)),
@@ -3662,7 +3662,7 @@ const deserializeAws_queryDeleteGlobalReplicationGroupCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidGlobalReplicationGroupState":
+    case "InvalidGlobalReplicationGroupStateFault":
     case "com.amazonaws.elasticache#InvalidGlobalReplicationGroupStateFault":
       response = {
         ...(await deserializeAws_queryInvalidGlobalReplicationGroupStateFaultResponse(parsedOutput, context)),
@@ -3670,7 +3670,7 @@ const deserializeAws_queryDeleteGlobalReplicationGroupCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidParameterValue":
+    case "InvalidParameterValueException":
     case "com.amazonaws.elasticache#InvalidParameterValueException":
       response = {
         ...(await deserializeAws_queryInvalidParameterValueExceptionResponse(parsedOutput, context)),
@@ -3724,7 +3724,7 @@ const deserializeAws_queryDeleteReplicationGroupCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "InvalidParameterCombination":
+    case "InvalidParameterCombinationException":
     case "com.amazonaws.elasticache#InvalidParameterCombinationException":
       response = {
         ...(await deserializeAws_queryInvalidParameterCombinationExceptionResponse(parsedOutput, context)),
@@ -3732,7 +3732,7 @@ const deserializeAws_queryDeleteReplicationGroupCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidParameterValue":
+    case "InvalidParameterValueException":
     case "com.amazonaws.elasticache#InvalidParameterValueException":
       response = {
         ...(await deserializeAws_queryInvalidParameterValueExceptionResponse(parsedOutput, context)),
@@ -3740,7 +3740,7 @@ const deserializeAws_queryDeleteReplicationGroupCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidReplicationGroupState":
+    case "InvalidReplicationGroupStateFault":
     case "com.amazonaws.elasticache#InvalidReplicationGroupStateFault":
       response = {
         ...(await deserializeAws_queryInvalidReplicationGroupStateFaultResponse(parsedOutput, context)),
@@ -3826,7 +3826,7 @@ const deserializeAws_queryDeleteSnapshotCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "InvalidParameterCombination":
+    case "InvalidParameterCombinationException":
     case "com.amazonaws.elasticache#InvalidParameterCombinationException":
       response = {
         ...(await deserializeAws_queryInvalidParameterCombinationExceptionResponse(parsedOutput, context)),
@@ -3834,7 +3834,7 @@ const deserializeAws_queryDeleteSnapshotCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidParameterValue":
+    case "InvalidParameterValueException":
     case "com.amazonaws.elasticache#InvalidParameterValueException":
       response = {
         ...(await deserializeAws_queryInvalidParameterValueExceptionResponse(parsedOutput, context)),
@@ -3842,7 +3842,7 @@ const deserializeAws_queryDeleteSnapshotCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidSnapshotState":
+    case "InvalidSnapshotStateFault":
     case "com.amazonaws.elasticache#InvalidSnapshotStateFault":
       response = {
         ...(await deserializeAws_queryInvalidSnapshotStateFaultResponse(parsedOutput, context)),
@@ -3904,7 +3904,7 @@ const deserializeAws_queryDeleteUserCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "DefaultUserAssociatedToUserGroup":
+    case "DefaultUserAssociatedToUserGroupFault":
     case "com.amazonaws.elasticache#DefaultUserAssociatedToUserGroupFault":
       response = {
         ...(await deserializeAws_queryDefaultUserAssociatedToUserGroupFaultResponse(parsedOutput, context)),
@@ -3912,7 +3912,7 @@ const deserializeAws_queryDeleteUserCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidParameterValue":
+    case "InvalidParameterValueException":
     case "com.amazonaws.elasticache#InvalidParameterValueException":
       response = {
         ...(await deserializeAws_queryInvalidParameterValueExceptionResponse(parsedOutput, context)),
@@ -3920,7 +3920,7 @@ const deserializeAws_queryDeleteUserCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidUserState":
+    case "InvalidUserStateFault":
     case "com.amazonaws.elasticache#InvalidUserStateFault":
       response = {
         ...(await deserializeAws_queryInvalidUserStateFaultResponse(parsedOutput, context)),
@@ -3936,7 +3936,7 @@ const deserializeAws_queryDeleteUserCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "UserNotFound":
+    case "UserNotFoundFault":
     case "com.amazonaws.elasticache#UserNotFoundFault":
       response = {
         ...(await deserializeAws_queryUserNotFoundFaultResponse(parsedOutput, context)),
@@ -3990,7 +3990,7 @@ const deserializeAws_queryDeleteUserGroupCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "InvalidParameterValue":
+    case "InvalidParameterValueException":
     case "com.amazonaws.elasticache#InvalidParameterValueException":
       response = {
         ...(await deserializeAws_queryInvalidParameterValueExceptionResponse(parsedOutput, context)),
@@ -3998,7 +3998,7 @@ const deserializeAws_queryDeleteUserGroupCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidUserGroupState":
+    case "InvalidUserGroupStateFault":
     case "com.amazonaws.elasticache#InvalidUserGroupStateFault":
       response = {
         ...(await deserializeAws_queryInvalidUserGroupStateFaultResponse(parsedOutput, context)),
@@ -4014,7 +4014,7 @@ const deserializeAws_queryDeleteUserGroupCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "UserGroupNotFound":
+    case "UserGroupNotFoundFault":
     case "com.amazonaws.elasticache#UserGroupNotFoundFault":
       response = {
         ...(await deserializeAws_queryUserGroupNotFoundFaultResponse(parsedOutput, context)),
@@ -4068,7 +4068,7 @@ const deserializeAws_queryDescribeCacheClustersCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "CacheClusterNotFound":
+    case "CacheClusterNotFoundFault":
     case "com.amazonaws.elasticache#CacheClusterNotFoundFault":
       response = {
         ...(await deserializeAws_queryCacheClusterNotFoundFaultResponse(parsedOutput, context)),
@@ -4076,7 +4076,7 @@ const deserializeAws_queryDescribeCacheClustersCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidParameterCombination":
+    case "InvalidParameterCombinationException":
     case "com.amazonaws.elasticache#InvalidParameterCombinationException":
       response = {
         ...(await deserializeAws_queryInvalidParameterCombinationExceptionResponse(parsedOutput, context)),
@@ -4084,7 +4084,7 @@ const deserializeAws_queryDescribeCacheClustersCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidParameterValue":
+    case "InvalidParameterValueException":
     case "com.amazonaws.elasticache#InvalidParameterValueException":
       response = {
         ...(await deserializeAws_queryInvalidParameterValueExceptionResponse(parsedOutput, context)),
@@ -4184,7 +4184,7 @@ const deserializeAws_queryDescribeCacheParameterGroupsCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "CacheParameterGroupNotFound":
+    case "CacheParameterGroupNotFoundFault":
     case "com.amazonaws.elasticache#CacheParameterGroupNotFoundFault":
       response = {
         ...(await deserializeAws_queryCacheParameterGroupNotFoundFaultResponse(parsedOutput, context)),
@@ -4192,7 +4192,7 @@ const deserializeAws_queryDescribeCacheParameterGroupsCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidParameterCombination":
+    case "InvalidParameterCombinationException":
     case "com.amazonaws.elasticache#InvalidParameterCombinationException":
       response = {
         ...(await deserializeAws_queryInvalidParameterCombinationExceptionResponse(parsedOutput, context)),
@@ -4200,7 +4200,7 @@ const deserializeAws_queryDescribeCacheParameterGroupsCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidParameterValue":
+    case "InvalidParameterValueException":
     case "com.amazonaws.elasticache#InvalidParameterValueException":
       response = {
         ...(await deserializeAws_queryInvalidParameterValueExceptionResponse(parsedOutput, context)),
@@ -4254,7 +4254,7 @@ const deserializeAws_queryDescribeCacheParametersCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "CacheParameterGroupNotFound":
+    case "CacheParameterGroupNotFoundFault":
     case "com.amazonaws.elasticache#CacheParameterGroupNotFoundFault":
       response = {
         ...(await deserializeAws_queryCacheParameterGroupNotFoundFaultResponse(parsedOutput, context)),
@@ -4262,7 +4262,7 @@ const deserializeAws_queryDescribeCacheParametersCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidParameterCombination":
+    case "InvalidParameterCombinationException":
     case "com.amazonaws.elasticache#InvalidParameterCombinationException":
       response = {
         ...(await deserializeAws_queryInvalidParameterCombinationExceptionResponse(parsedOutput, context)),
@@ -4270,7 +4270,7 @@ const deserializeAws_queryDescribeCacheParametersCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidParameterValue":
+    case "InvalidParameterValueException":
     case "com.amazonaws.elasticache#InvalidParameterValueException":
       response = {
         ...(await deserializeAws_queryInvalidParameterValueExceptionResponse(parsedOutput, context)),
@@ -4324,7 +4324,7 @@ const deserializeAws_queryDescribeCacheSecurityGroupsCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "CacheSecurityGroupNotFound":
+    case "CacheSecurityGroupNotFoundFault":
     case "com.amazonaws.elasticache#CacheSecurityGroupNotFoundFault":
       response = {
         ...(await deserializeAws_queryCacheSecurityGroupNotFoundFaultResponse(parsedOutput, context)),
@@ -4332,7 +4332,7 @@ const deserializeAws_queryDescribeCacheSecurityGroupsCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidParameterCombination":
+    case "InvalidParameterCombinationException":
     case "com.amazonaws.elasticache#InvalidParameterCombinationException":
       response = {
         ...(await deserializeAws_queryInvalidParameterCombinationExceptionResponse(parsedOutput, context)),
@@ -4340,7 +4340,7 @@ const deserializeAws_queryDescribeCacheSecurityGroupsCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidParameterValue":
+    case "InvalidParameterValueException":
     case "com.amazonaws.elasticache#InvalidParameterValueException":
       response = {
         ...(await deserializeAws_queryInvalidParameterValueExceptionResponse(parsedOutput, context)),
@@ -4451,7 +4451,7 @@ const deserializeAws_queryDescribeEngineDefaultParametersCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "InvalidParameterCombination":
+    case "InvalidParameterCombinationException":
     case "com.amazonaws.elasticache#InvalidParameterCombinationException":
       response = {
         ...(await deserializeAws_queryInvalidParameterCombinationExceptionResponse(parsedOutput, context)),
@@ -4459,7 +4459,7 @@ const deserializeAws_queryDescribeEngineDefaultParametersCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidParameterValue":
+    case "InvalidParameterValueException":
     case "com.amazonaws.elasticache#InvalidParameterValueException":
       response = {
         ...(await deserializeAws_queryInvalidParameterValueExceptionResponse(parsedOutput, context)),
@@ -4513,7 +4513,7 @@ const deserializeAws_queryDescribeEventsCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "InvalidParameterCombination":
+    case "InvalidParameterCombinationException":
     case "com.amazonaws.elasticache#InvalidParameterCombinationException":
       response = {
         ...(await deserializeAws_queryInvalidParameterCombinationExceptionResponse(parsedOutput, context)),
@@ -4521,7 +4521,7 @@ const deserializeAws_queryDescribeEventsCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidParameterValue":
+    case "InvalidParameterValueException":
     case "com.amazonaws.elasticache#InvalidParameterValueException":
       response = {
         ...(await deserializeAws_queryInvalidParameterValueExceptionResponse(parsedOutput, context)),
@@ -4586,7 +4586,7 @@ const deserializeAws_queryDescribeGlobalReplicationGroupsCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidParameterCombination":
+    case "InvalidParameterCombinationException":
     case "com.amazonaws.elasticache#InvalidParameterCombinationException":
       response = {
         ...(await deserializeAws_queryInvalidParameterCombinationExceptionResponse(parsedOutput, context)),
@@ -4594,7 +4594,7 @@ const deserializeAws_queryDescribeGlobalReplicationGroupsCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidParameterValue":
+    case "InvalidParameterValueException":
     case "com.amazonaws.elasticache#InvalidParameterValueException":
       response = {
         ...(await deserializeAws_queryInvalidParameterValueExceptionResponse(parsedOutput, context)),
@@ -4648,7 +4648,7 @@ const deserializeAws_queryDescribeReplicationGroupsCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "InvalidParameterCombination":
+    case "InvalidParameterCombinationException":
     case "com.amazonaws.elasticache#InvalidParameterCombinationException":
       response = {
         ...(await deserializeAws_queryInvalidParameterCombinationExceptionResponse(parsedOutput, context)),
@@ -4656,7 +4656,7 @@ const deserializeAws_queryDescribeReplicationGroupsCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidParameterValue":
+    case "InvalidParameterValueException":
     case "com.amazonaws.elasticache#InvalidParameterValueException":
       response = {
         ...(await deserializeAws_queryInvalidParameterValueExceptionResponse(parsedOutput, context)),
@@ -4718,7 +4718,7 @@ const deserializeAws_queryDescribeReservedCacheNodesCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "InvalidParameterCombination":
+    case "InvalidParameterCombinationException":
     case "com.amazonaws.elasticache#InvalidParameterCombinationException":
       response = {
         ...(await deserializeAws_queryInvalidParameterCombinationExceptionResponse(parsedOutput, context)),
@@ -4726,7 +4726,7 @@ const deserializeAws_queryDescribeReservedCacheNodesCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidParameterValue":
+    case "InvalidParameterValueException":
     case "com.amazonaws.elasticache#InvalidParameterValueException":
       response = {
         ...(await deserializeAws_queryInvalidParameterValueExceptionResponse(parsedOutput, context)),
@@ -4734,7 +4734,7 @@ const deserializeAws_queryDescribeReservedCacheNodesCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ReservedCacheNodeNotFound":
+    case "ReservedCacheNodeNotFoundFault":
     case "com.amazonaws.elasticache#ReservedCacheNodeNotFoundFault":
       response = {
         ...(await deserializeAws_queryReservedCacheNodeNotFoundFaultResponse(parsedOutput, context)),
@@ -4791,7 +4791,7 @@ const deserializeAws_queryDescribeReservedCacheNodesOfferingsCommandError = asyn
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "InvalidParameterCombination":
+    case "InvalidParameterCombinationException":
     case "com.amazonaws.elasticache#InvalidParameterCombinationException":
       response = {
         ...(await deserializeAws_queryInvalidParameterCombinationExceptionResponse(parsedOutput, context)),
@@ -4799,7 +4799,7 @@ const deserializeAws_queryDescribeReservedCacheNodesOfferingsCommandError = asyn
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidParameterValue":
+    case "InvalidParameterValueException":
     case "com.amazonaws.elasticache#InvalidParameterValueException":
       response = {
         ...(await deserializeAws_queryInvalidParameterValueExceptionResponse(parsedOutput, context)),
@@ -4807,7 +4807,7 @@ const deserializeAws_queryDescribeReservedCacheNodesOfferingsCommandError = asyn
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ReservedCacheNodesOfferingNotFound":
+    case "ReservedCacheNodesOfferingNotFoundFault":
     case "com.amazonaws.elasticache#ReservedCacheNodesOfferingNotFoundFault":
       response = {
         ...(await deserializeAws_queryReservedCacheNodesOfferingNotFoundFaultResponse(parsedOutput, context)),
@@ -4861,7 +4861,7 @@ const deserializeAws_queryDescribeServiceUpdatesCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "InvalidParameterCombination":
+    case "InvalidParameterCombinationException":
     case "com.amazonaws.elasticache#InvalidParameterCombinationException":
       response = {
         ...(await deserializeAws_queryInvalidParameterCombinationExceptionResponse(parsedOutput, context)),
@@ -4869,7 +4869,7 @@ const deserializeAws_queryDescribeServiceUpdatesCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidParameterValue":
+    case "InvalidParameterValueException":
     case "com.amazonaws.elasticache#InvalidParameterValueException":
       response = {
         ...(await deserializeAws_queryInvalidParameterValueExceptionResponse(parsedOutput, context)),
@@ -4931,7 +4931,7 @@ const deserializeAws_queryDescribeSnapshotsCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "CacheClusterNotFound":
+    case "CacheClusterNotFoundFault":
     case "com.amazonaws.elasticache#CacheClusterNotFoundFault":
       response = {
         ...(await deserializeAws_queryCacheClusterNotFoundFaultResponse(parsedOutput, context)),
@@ -4939,7 +4939,7 @@ const deserializeAws_queryDescribeSnapshotsCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidParameterCombination":
+    case "InvalidParameterCombinationException":
     case "com.amazonaws.elasticache#InvalidParameterCombinationException":
       response = {
         ...(await deserializeAws_queryInvalidParameterCombinationExceptionResponse(parsedOutput, context)),
@@ -4947,7 +4947,7 @@ const deserializeAws_queryDescribeSnapshotsCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidParameterValue":
+    case "InvalidParameterValueException":
     case "com.amazonaws.elasticache#InvalidParameterValueException":
       response = {
         ...(await deserializeAws_queryInvalidParameterValueExceptionResponse(parsedOutput, context)),
@@ -5009,7 +5009,7 @@ const deserializeAws_queryDescribeUpdateActionsCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "InvalidParameterCombination":
+    case "InvalidParameterCombinationException":
     case "com.amazonaws.elasticache#InvalidParameterCombinationException":
       response = {
         ...(await deserializeAws_queryInvalidParameterCombinationExceptionResponse(parsedOutput, context)),
@@ -5017,7 +5017,7 @@ const deserializeAws_queryDescribeUpdateActionsCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidParameterValue":
+    case "InvalidParameterValueException":
     case "com.amazonaws.elasticache#InvalidParameterValueException":
       response = {
         ...(await deserializeAws_queryInvalidParameterValueExceptionResponse(parsedOutput, context)),
@@ -5071,7 +5071,7 @@ const deserializeAws_queryDescribeUserGroupsCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "InvalidParameterCombination":
+    case "InvalidParameterCombinationException":
     case "com.amazonaws.elasticache#InvalidParameterCombinationException":
       response = {
         ...(await deserializeAws_queryInvalidParameterCombinationExceptionResponse(parsedOutput, context)),
@@ -5087,7 +5087,7 @@ const deserializeAws_queryDescribeUserGroupsCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "UserGroupNotFound":
+    case "UserGroupNotFoundFault":
     case "com.amazonaws.elasticache#UserGroupNotFoundFault":
       response = {
         ...(await deserializeAws_queryUserGroupNotFoundFaultResponse(parsedOutput, context)),
@@ -5141,7 +5141,7 @@ const deserializeAws_queryDescribeUsersCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "InvalidParameterCombination":
+    case "InvalidParameterCombinationException":
     case "com.amazonaws.elasticache#InvalidParameterCombinationException":
       response = {
         ...(await deserializeAws_queryInvalidParameterCombinationExceptionResponse(parsedOutput, context)),
@@ -5157,7 +5157,7 @@ const deserializeAws_queryDescribeUsersCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "UserNotFound":
+    case "UserNotFoundFault":
     case "com.amazonaws.elasticache#UserNotFoundFault":
       response = {
         ...(await deserializeAws_queryUserNotFoundFaultResponse(parsedOutput, context)),
@@ -5222,7 +5222,7 @@ const deserializeAws_queryDisassociateGlobalReplicationGroupCommandError = async
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidGlobalReplicationGroupState":
+    case "InvalidGlobalReplicationGroupStateFault":
     case "com.amazonaws.elasticache#InvalidGlobalReplicationGroupStateFault":
       response = {
         ...(await deserializeAws_queryInvalidGlobalReplicationGroupStateFaultResponse(parsedOutput, context)),
@@ -5230,7 +5230,7 @@ const deserializeAws_queryDisassociateGlobalReplicationGroupCommandError = async
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidParameterCombination":
+    case "InvalidParameterCombinationException":
     case "com.amazonaws.elasticache#InvalidParameterCombinationException":
       response = {
         ...(await deserializeAws_queryInvalidParameterCombinationExceptionResponse(parsedOutput, context)),
@@ -5238,7 +5238,7 @@ const deserializeAws_queryDisassociateGlobalReplicationGroupCommandError = async
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidParameterValue":
+    case "InvalidParameterValueException":
     case "com.amazonaws.elasticache#InvalidParameterValueException":
       response = {
         ...(await deserializeAws_queryInvalidParameterValueExceptionResponse(parsedOutput, context)),
@@ -5303,7 +5303,7 @@ const deserializeAws_queryFailoverGlobalReplicationGroupCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidGlobalReplicationGroupState":
+    case "InvalidGlobalReplicationGroupStateFault":
     case "com.amazonaws.elasticache#InvalidGlobalReplicationGroupStateFault":
       response = {
         ...(await deserializeAws_queryInvalidGlobalReplicationGroupStateFaultResponse(parsedOutput, context)),
@@ -5311,7 +5311,7 @@ const deserializeAws_queryFailoverGlobalReplicationGroupCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidParameterCombination":
+    case "InvalidParameterCombinationException":
     case "com.amazonaws.elasticache#InvalidParameterCombinationException":
       response = {
         ...(await deserializeAws_queryInvalidParameterCombinationExceptionResponse(parsedOutput, context)),
@@ -5319,7 +5319,7 @@ const deserializeAws_queryFailoverGlobalReplicationGroupCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidParameterValue":
+    case "InvalidParameterValueException":
     case "com.amazonaws.elasticache#InvalidParameterValueException":
       response = {
         ...(await deserializeAws_queryInvalidParameterValueExceptionResponse(parsedOutput, context)),
@@ -5384,7 +5384,7 @@ const deserializeAws_queryIncreaseNodeGroupsInGlobalReplicationGroupCommandError
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidGlobalReplicationGroupState":
+    case "InvalidGlobalReplicationGroupStateFault":
     case "com.amazonaws.elasticache#InvalidGlobalReplicationGroupStateFault":
       response = {
         ...(await deserializeAws_queryInvalidGlobalReplicationGroupStateFaultResponse(parsedOutput, context)),
@@ -5392,7 +5392,7 @@ const deserializeAws_queryIncreaseNodeGroupsInGlobalReplicationGroupCommandError
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidParameterValue":
+    case "InvalidParameterValueException":
     case "com.amazonaws.elasticache#InvalidParameterValueException":
       response = {
         ...(await deserializeAws_queryInvalidParameterValueExceptionResponse(parsedOutput, context)),
@@ -5446,7 +5446,7 @@ const deserializeAws_queryIncreaseReplicaCountCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "ClusterQuotaForCustomerExceeded":
+    case "ClusterQuotaForCustomerExceededFault":
     case "com.amazonaws.elasticache#ClusterQuotaForCustomerExceededFault":
       response = {
         ...(await deserializeAws_queryClusterQuotaForCustomerExceededFaultResponse(parsedOutput, context)),
@@ -5454,7 +5454,7 @@ const deserializeAws_queryIncreaseReplicaCountCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InsufficientCacheClusterCapacity":
+    case "InsufficientCacheClusterCapacityFault":
     case "com.amazonaws.elasticache#InsufficientCacheClusterCapacityFault":
       response = {
         ...(await deserializeAws_queryInsufficientCacheClusterCapacityFaultResponse(parsedOutput, context)),
@@ -5462,7 +5462,7 @@ const deserializeAws_queryIncreaseReplicaCountCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidCacheClusterState":
+    case "InvalidCacheClusterStateFault":
     case "com.amazonaws.elasticache#InvalidCacheClusterStateFault":
       response = {
         ...(await deserializeAws_queryInvalidCacheClusterStateFaultResponse(parsedOutput, context)),
@@ -5478,7 +5478,7 @@ const deserializeAws_queryIncreaseReplicaCountCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidParameterCombination":
+    case "InvalidParameterCombinationException":
     case "com.amazonaws.elasticache#InvalidParameterCombinationException":
       response = {
         ...(await deserializeAws_queryInvalidParameterCombinationExceptionResponse(parsedOutput, context)),
@@ -5486,7 +5486,7 @@ const deserializeAws_queryIncreaseReplicaCountCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidParameterValue":
+    case "InvalidParameterValueException":
     case "com.amazonaws.elasticache#InvalidParameterValueException":
       response = {
         ...(await deserializeAws_queryInvalidParameterValueExceptionResponse(parsedOutput, context)),
@@ -5494,7 +5494,7 @@ const deserializeAws_queryIncreaseReplicaCountCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidReplicationGroupState":
+    case "InvalidReplicationGroupStateFault":
     case "com.amazonaws.elasticache#InvalidReplicationGroupStateFault":
       response = {
         ...(await deserializeAws_queryInvalidReplicationGroupStateFaultResponse(parsedOutput, context)),
@@ -5510,15 +5510,7 @@ const deserializeAws_queryIncreaseReplicaCountCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "NoOperationFault":
-    case "com.amazonaws.elasticache#NoOperationFault":
-      response = {
-        ...(await deserializeAws_queryNoOperationFaultResponse(parsedOutput, context)),
-        name: errorCode,
-        $metadata: deserializeMetadata(output),
-      };
-      break;
-    case "NodeGroupsPerReplicationGroupQuotaExceeded":
+    case "NodeGroupsPerReplicationGroupQuotaExceededFault":
     case "com.amazonaws.elasticache#NodeGroupsPerReplicationGroupQuotaExceededFault":
       response = {
         ...(await deserializeAws_queryNodeGroupsPerReplicationGroupQuotaExceededFaultResponse(parsedOutput, context)),
@@ -5526,10 +5518,18 @@ const deserializeAws_queryIncreaseReplicaCountCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "NodeQuotaForCustomerExceeded":
+    case "NodeQuotaForCustomerExceededFault":
     case "com.amazonaws.elasticache#NodeQuotaForCustomerExceededFault":
       response = {
         ...(await deserializeAws_queryNodeQuotaForCustomerExceededFaultResponse(parsedOutput, context)),
+        name: errorCode,
+        $metadata: deserializeMetadata(output),
+      };
+      break;
+    case "NoOperationFault":
+    case "com.amazonaws.elasticache#NoOperationFault":
+      response = {
+        ...(await deserializeAws_queryNoOperationFaultResponse(parsedOutput, context)),
         name: errorCode,
         $metadata: deserializeMetadata(output),
       };
@@ -5591,7 +5591,7 @@ const deserializeAws_queryListAllowedNodeTypeModificationsCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "CacheClusterNotFound":
+    case "CacheClusterNotFoundFault":
     case "com.amazonaws.elasticache#CacheClusterNotFoundFault":
       response = {
         ...(await deserializeAws_queryCacheClusterNotFoundFaultResponse(parsedOutput, context)),
@@ -5599,7 +5599,7 @@ const deserializeAws_queryListAllowedNodeTypeModificationsCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidParameterCombination":
+    case "InvalidParameterCombinationException":
     case "com.amazonaws.elasticache#InvalidParameterCombinationException":
       response = {
         ...(await deserializeAws_queryInvalidParameterCombinationExceptionResponse(parsedOutput, context)),
@@ -5607,7 +5607,7 @@ const deserializeAws_queryListAllowedNodeTypeModificationsCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidParameterValue":
+    case "InvalidParameterValueException":
     case "com.amazonaws.elasticache#InvalidParameterValueException":
       response = {
         ...(await deserializeAws_queryInvalidParameterValueExceptionResponse(parsedOutput, context)),
@@ -5669,7 +5669,7 @@ const deserializeAws_queryListTagsForResourceCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "CacheClusterNotFound":
+    case "CacheClusterNotFoundFault":
     case "com.amazonaws.elasticache#CacheClusterNotFoundFault":
       response = {
         ...(await deserializeAws_queryCacheClusterNotFoundFaultResponse(parsedOutput, context)),
@@ -5677,7 +5677,7 @@ const deserializeAws_queryListTagsForResourceCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "CacheParameterGroupNotFound":
+    case "CacheParameterGroupNotFoundFault":
     case "com.amazonaws.elasticache#CacheParameterGroupNotFoundFault":
       response = {
         ...(await deserializeAws_queryCacheParameterGroupNotFoundFaultResponse(parsedOutput, context)),
@@ -5685,7 +5685,7 @@ const deserializeAws_queryListTagsForResourceCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "CacheSecurityGroupNotFound":
+    case "CacheSecurityGroupNotFoundFault":
     case "com.amazonaws.elasticache#CacheSecurityGroupNotFoundFault":
       response = {
         ...(await deserializeAws_queryCacheSecurityGroupNotFoundFaultResponse(parsedOutput, context)),
@@ -5701,7 +5701,7 @@ const deserializeAws_queryListTagsForResourceCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidARN":
+    case "InvalidARNFault":
     case "com.amazonaws.elasticache#InvalidARNFault":
       response = {
         ...(await deserializeAws_queryInvalidARNFaultResponse(parsedOutput, context)),
@@ -5709,7 +5709,7 @@ const deserializeAws_queryListTagsForResourceCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidReplicationGroupState":
+    case "InvalidReplicationGroupStateFault":
     case "com.amazonaws.elasticache#InvalidReplicationGroupStateFault":
       response = {
         ...(await deserializeAws_queryInvalidReplicationGroupStateFaultResponse(parsedOutput, context)),
@@ -5725,7 +5725,7 @@ const deserializeAws_queryListTagsForResourceCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ReservedCacheNodeNotFound":
+    case "ReservedCacheNodeNotFoundFault":
     case "com.amazonaws.elasticache#ReservedCacheNodeNotFoundFault":
       response = {
         ...(await deserializeAws_queryReservedCacheNodeNotFoundFaultResponse(parsedOutput, context)),
@@ -5741,7 +5741,7 @@ const deserializeAws_queryListTagsForResourceCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "UserGroupNotFound":
+    case "UserGroupNotFoundFault":
     case "com.amazonaws.elasticache#UserGroupNotFoundFault":
       response = {
         ...(await deserializeAws_queryUserGroupNotFoundFaultResponse(parsedOutput, context)),
@@ -5749,7 +5749,7 @@ const deserializeAws_queryListTagsForResourceCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "UserNotFound":
+    case "UserNotFoundFault":
     case "com.amazonaws.elasticache#UserNotFoundFault":
       response = {
         ...(await deserializeAws_queryUserNotFoundFaultResponse(parsedOutput, context)),
@@ -5803,7 +5803,7 @@ const deserializeAws_queryModifyCacheClusterCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "CacheClusterNotFound":
+    case "CacheClusterNotFoundFault":
     case "com.amazonaws.elasticache#CacheClusterNotFoundFault":
       response = {
         ...(await deserializeAws_queryCacheClusterNotFoundFaultResponse(parsedOutput, context)),
@@ -5811,7 +5811,7 @@ const deserializeAws_queryModifyCacheClusterCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "CacheParameterGroupNotFound":
+    case "CacheParameterGroupNotFoundFault":
     case "com.amazonaws.elasticache#CacheParameterGroupNotFoundFault":
       response = {
         ...(await deserializeAws_queryCacheParameterGroupNotFoundFaultResponse(parsedOutput, context)),
@@ -5819,7 +5819,7 @@ const deserializeAws_queryModifyCacheClusterCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "CacheSecurityGroupNotFound":
+    case "CacheSecurityGroupNotFoundFault":
     case "com.amazonaws.elasticache#CacheSecurityGroupNotFoundFault":
       response = {
         ...(await deserializeAws_queryCacheSecurityGroupNotFoundFaultResponse(parsedOutput, context)),
@@ -5827,7 +5827,7 @@ const deserializeAws_queryModifyCacheClusterCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InsufficientCacheClusterCapacity":
+    case "InsufficientCacheClusterCapacityFault":
     case "com.amazonaws.elasticache#InsufficientCacheClusterCapacityFault":
       response = {
         ...(await deserializeAws_queryInsufficientCacheClusterCapacityFaultResponse(parsedOutput, context)),
@@ -5835,7 +5835,7 @@ const deserializeAws_queryModifyCacheClusterCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidCacheClusterState":
+    case "InvalidCacheClusterStateFault":
     case "com.amazonaws.elasticache#InvalidCacheClusterStateFault":
       response = {
         ...(await deserializeAws_queryInvalidCacheClusterStateFaultResponse(parsedOutput, context)),
@@ -5843,7 +5843,7 @@ const deserializeAws_queryModifyCacheClusterCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidCacheSecurityGroupState":
+    case "InvalidCacheSecurityGroupStateFault":
     case "com.amazonaws.elasticache#InvalidCacheSecurityGroupStateFault":
       response = {
         ...(await deserializeAws_queryInvalidCacheSecurityGroupStateFaultResponse(parsedOutput, context)),
@@ -5851,7 +5851,7 @@ const deserializeAws_queryModifyCacheClusterCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidParameterCombination":
+    case "InvalidParameterCombinationException":
     case "com.amazonaws.elasticache#InvalidParameterCombinationException":
       response = {
         ...(await deserializeAws_queryInvalidParameterCombinationExceptionResponse(parsedOutput, context)),
@@ -5859,7 +5859,7 @@ const deserializeAws_queryModifyCacheClusterCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidParameterValue":
+    case "InvalidParameterValueException":
     case "com.amazonaws.elasticache#InvalidParameterValueException":
       response = {
         ...(await deserializeAws_queryInvalidParameterValueExceptionResponse(parsedOutput, context)),
@@ -5875,7 +5875,7 @@ const deserializeAws_queryModifyCacheClusterCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "NodeQuotaForClusterExceeded":
+    case "NodeQuotaForClusterExceededFault":
     case "com.amazonaws.elasticache#NodeQuotaForClusterExceededFault":
       response = {
         ...(await deserializeAws_queryNodeQuotaForClusterExceededFaultResponse(parsedOutput, context)),
@@ -5883,7 +5883,7 @@ const deserializeAws_queryModifyCacheClusterCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "NodeQuotaForCustomerExceeded":
+    case "NodeQuotaForCustomerExceededFault":
     case "com.amazonaws.elasticache#NodeQuotaForCustomerExceededFault":
       response = {
         ...(await deserializeAws_queryNodeQuotaForCustomerExceededFaultResponse(parsedOutput, context)),
@@ -5937,7 +5937,7 @@ const deserializeAws_queryModifyCacheParameterGroupCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "CacheParameterGroupNotFound":
+    case "CacheParameterGroupNotFoundFault":
     case "com.amazonaws.elasticache#CacheParameterGroupNotFoundFault":
       response = {
         ...(await deserializeAws_queryCacheParameterGroupNotFoundFaultResponse(parsedOutput, context)),
@@ -5945,7 +5945,7 @@ const deserializeAws_queryModifyCacheParameterGroupCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidCacheParameterGroupState":
+    case "InvalidCacheParameterGroupStateFault":
     case "com.amazonaws.elasticache#InvalidCacheParameterGroupStateFault":
       response = {
         ...(await deserializeAws_queryInvalidCacheParameterGroupStateFaultResponse(parsedOutput, context)),
@@ -5953,7 +5953,7 @@ const deserializeAws_queryModifyCacheParameterGroupCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidGlobalReplicationGroupState":
+    case "InvalidGlobalReplicationGroupStateFault":
     case "com.amazonaws.elasticache#InvalidGlobalReplicationGroupStateFault":
       response = {
         ...(await deserializeAws_queryInvalidGlobalReplicationGroupStateFaultResponse(parsedOutput, context)),
@@ -5961,7 +5961,7 @@ const deserializeAws_queryModifyCacheParameterGroupCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidParameterCombination":
+    case "InvalidParameterCombinationException":
     case "com.amazonaws.elasticache#InvalidParameterCombinationException":
       response = {
         ...(await deserializeAws_queryInvalidParameterCombinationExceptionResponse(parsedOutput, context)),
@@ -5969,7 +5969,7 @@ const deserializeAws_queryModifyCacheParameterGroupCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidParameterValue":
+    case "InvalidParameterValueException":
     case "com.amazonaws.elasticache#InvalidParameterValueException":
       response = {
         ...(await deserializeAws_queryInvalidParameterValueExceptionResponse(parsedOutput, context)),
@@ -6117,7 +6117,7 @@ const deserializeAws_queryModifyGlobalReplicationGroupCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidGlobalReplicationGroupState":
+    case "InvalidGlobalReplicationGroupStateFault":
     case "com.amazonaws.elasticache#InvalidGlobalReplicationGroupStateFault":
       response = {
         ...(await deserializeAws_queryInvalidGlobalReplicationGroupStateFaultResponse(parsedOutput, context)),
@@ -6125,7 +6125,7 @@ const deserializeAws_queryModifyGlobalReplicationGroupCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidParameterValue":
+    case "InvalidParameterValueException":
     case "com.amazonaws.elasticache#InvalidParameterValueException":
       response = {
         ...(await deserializeAws_queryInvalidParameterValueExceptionResponse(parsedOutput, context)),
@@ -6179,7 +6179,7 @@ const deserializeAws_queryModifyReplicationGroupCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "CacheClusterNotFound":
+    case "CacheClusterNotFoundFault":
     case "com.amazonaws.elasticache#CacheClusterNotFoundFault":
       response = {
         ...(await deserializeAws_queryCacheClusterNotFoundFaultResponse(parsedOutput, context)),
@@ -6187,7 +6187,7 @@ const deserializeAws_queryModifyReplicationGroupCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "CacheParameterGroupNotFound":
+    case "CacheParameterGroupNotFoundFault":
     case "com.amazonaws.elasticache#CacheParameterGroupNotFoundFault":
       response = {
         ...(await deserializeAws_queryCacheParameterGroupNotFoundFaultResponse(parsedOutput, context)),
@@ -6195,7 +6195,7 @@ const deserializeAws_queryModifyReplicationGroupCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "CacheSecurityGroupNotFound":
+    case "CacheSecurityGroupNotFoundFault":
     case "com.amazonaws.elasticache#CacheSecurityGroupNotFoundFault":
       response = {
         ...(await deserializeAws_queryCacheSecurityGroupNotFoundFaultResponse(parsedOutput, context)),
@@ -6203,7 +6203,7 @@ const deserializeAws_queryModifyReplicationGroupCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InsufficientCacheClusterCapacity":
+    case "InsufficientCacheClusterCapacityFault":
     case "com.amazonaws.elasticache#InsufficientCacheClusterCapacityFault":
       response = {
         ...(await deserializeAws_queryInsufficientCacheClusterCapacityFaultResponse(parsedOutput, context)),
@@ -6211,7 +6211,7 @@ const deserializeAws_queryModifyReplicationGroupCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidCacheClusterState":
+    case "InvalidCacheClusterStateFault":
     case "com.amazonaws.elasticache#InvalidCacheClusterStateFault":
       response = {
         ...(await deserializeAws_queryInvalidCacheClusterStateFaultResponse(parsedOutput, context)),
@@ -6219,7 +6219,7 @@ const deserializeAws_queryModifyReplicationGroupCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidCacheSecurityGroupState":
+    case "InvalidCacheSecurityGroupStateFault":
     case "com.amazonaws.elasticache#InvalidCacheSecurityGroupStateFault":
       response = {
         ...(await deserializeAws_queryInvalidCacheSecurityGroupStateFaultResponse(parsedOutput, context)),
@@ -6235,7 +6235,7 @@ const deserializeAws_queryModifyReplicationGroupCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidParameterCombination":
+    case "InvalidParameterCombinationException":
     case "com.amazonaws.elasticache#InvalidParameterCombinationException":
       response = {
         ...(await deserializeAws_queryInvalidParameterCombinationExceptionResponse(parsedOutput, context)),
@@ -6243,7 +6243,7 @@ const deserializeAws_queryModifyReplicationGroupCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidParameterValue":
+    case "InvalidParameterValueException":
     case "com.amazonaws.elasticache#InvalidParameterValueException":
       response = {
         ...(await deserializeAws_queryInvalidParameterValueExceptionResponse(parsedOutput, context)),
@@ -6251,7 +6251,7 @@ const deserializeAws_queryModifyReplicationGroupCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidReplicationGroupState":
+    case "InvalidReplicationGroupStateFault":
     case "com.amazonaws.elasticache#InvalidReplicationGroupStateFault":
       response = {
         ...(await deserializeAws_queryInvalidReplicationGroupStateFaultResponse(parsedOutput, context)),
@@ -6259,7 +6259,7 @@ const deserializeAws_queryModifyReplicationGroupCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidUserGroupState":
+    case "InvalidUserGroupStateFault":
     case "com.amazonaws.elasticache#InvalidUserGroupStateFault":
       response = {
         ...(await deserializeAws_queryInvalidUserGroupStateFaultResponse(parsedOutput, context)),
@@ -6275,7 +6275,7 @@ const deserializeAws_queryModifyReplicationGroupCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "NodeQuotaForClusterExceeded":
+    case "NodeQuotaForClusterExceededFault":
     case "com.amazonaws.elasticache#NodeQuotaForClusterExceededFault":
       response = {
         ...(await deserializeAws_queryNodeQuotaForClusterExceededFaultResponse(parsedOutput, context)),
@@ -6283,7 +6283,7 @@ const deserializeAws_queryModifyReplicationGroupCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "NodeQuotaForCustomerExceeded":
+    case "NodeQuotaForCustomerExceededFault":
     case "com.amazonaws.elasticache#NodeQuotaForCustomerExceededFault":
       response = {
         ...(await deserializeAws_queryNodeQuotaForCustomerExceededFaultResponse(parsedOutput, context)),
@@ -6299,7 +6299,7 @@ const deserializeAws_queryModifyReplicationGroupCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "UserGroupNotFound":
+    case "UserGroupNotFoundFault":
     case "com.amazonaws.elasticache#UserGroupNotFoundFault":
       response = {
         ...(await deserializeAws_queryUserGroupNotFoundFaultResponse(parsedOutput, context)),
@@ -6356,7 +6356,7 @@ const deserializeAws_queryModifyReplicationGroupShardConfigurationCommandError =
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "InsufficientCacheClusterCapacity":
+    case "InsufficientCacheClusterCapacityFault":
     case "com.amazonaws.elasticache#InsufficientCacheClusterCapacityFault":
       response = {
         ...(await deserializeAws_queryInsufficientCacheClusterCapacityFaultResponse(parsedOutput, context)),
@@ -6364,7 +6364,7 @@ const deserializeAws_queryModifyReplicationGroupShardConfigurationCommandError =
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidCacheClusterState":
+    case "InvalidCacheClusterStateFault":
     case "com.amazonaws.elasticache#InvalidCacheClusterStateFault":
       response = {
         ...(await deserializeAws_queryInvalidCacheClusterStateFaultResponse(parsedOutput, context)),
@@ -6380,7 +6380,7 @@ const deserializeAws_queryModifyReplicationGroupShardConfigurationCommandError =
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidParameterCombination":
+    case "InvalidParameterCombinationException":
     case "com.amazonaws.elasticache#InvalidParameterCombinationException":
       response = {
         ...(await deserializeAws_queryInvalidParameterCombinationExceptionResponse(parsedOutput, context)),
@@ -6388,7 +6388,7 @@ const deserializeAws_queryModifyReplicationGroupShardConfigurationCommandError =
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidParameterValue":
+    case "InvalidParameterValueException":
     case "com.amazonaws.elasticache#InvalidParameterValueException":
       response = {
         ...(await deserializeAws_queryInvalidParameterValueExceptionResponse(parsedOutput, context)),
@@ -6396,7 +6396,7 @@ const deserializeAws_queryModifyReplicationGroupShardConfigurationCommandError =
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidReplicationGroupState":
+    case "InvalidReplicationGroupStateFault":
     case "com.amazonaws.elasticache#InvalidReplicationGroupStateFault":
       response = {
         ...(await deserializeAws_queryInvalidReplicationGroupStateFaultResponse(parsedOutput, context)),
@@ -6412,7 +6412,7 @@ const deserializeAws_queryModifyReplicationGroupShardConfigurationCommandError =
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "NodeGroupsPerReplicationGroupQuotaExceeded":
+    case "NodeGroupsPerReplicationGroupQuotaExceededFault":
     case "com.amazonaws.elasticache#NodeGroupsPerReplicationGroupQuotaExceededFault":
       response = {
         ...(await deserializeAws_queryNodeGroupsPerReplicationGroupQuotaExceededFaultResponse(parsedOutput, context)),
@@ -6420,7 +6420,7 @@ const deserializeAws_queryModifyReplicationGroupShardConfigurationCommandError =
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "NodeQuotaForCustomerExceeded":
+    case "NodeQuotaForCustomerExceededFault":
     case "com.amazonaws.elasticache#NodeQuotaForCustomerExceededFault":
       response = {
         ...(await deserializeAws_queryNodeQuotaForCustomerExceededFaultResponse(parsedOutput, context)),
@@ -6482,7 +6482,7 @@ const deserializeAws_queryModifyUserCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "InvalidParameterCombination":
+    case "InvalidParameterCombinationException":
     case "com.amazonaws.elasticache#InvalidParameterCombinationException":
       response = {
         ...(await deserializeAws_queryInvalidParameterCombinationExceptionResponse(parsedOutput, context)),
@@ -6490,7 +6490,7 @@ const deserializeAws_queryModifyUserCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidParameterValue":
+    case "InvalidParameterValueException":
     case "com.amazonaws.elasticache#InvalidParameterValueException":
       response = {
         ...(await deserializeAws_queryInvalidParameterValueExceptionResponse(parsedOutput, context)),
@@ -6498,7 +6498,7 @@ const deserializeAws_queryModifyUserCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidUserState":
+    case "InvalidUserStateFault":
     case "com.amazonaws.elasticache#InvalidUserStateFault":
       response = {
         ...(await deserializeAws_queryInvalidUserStateFaultResponse(parsedOutput, context)),
@@ -6514,7 +6514,7 @@ const deserializeAws_queryModifyUserCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "UserNotFound":
+    case "UserNotFoundFault":
     case "com.amazonaws.elasticache#UserNotFoundFault":
       response = {
         ...(await deserializeAws_queryUserNotFoundFaultResponse(parsedOutput, context)),
@@ -6576,7 +6576,7 @@ const deserializeAws_queryModifyUserGroupCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "DuplicateUserName":
+    case "DuplicateUserNameFault":
     case "com.amazonaws.elasticache#DuplicateUserNameFault":
       response = {
         ...(await deserializeAws_queryDuplicateUserNameFaultResponse(parsedOutput, context)),
@@ -6584,7 +6584,7 @@ const deserializeAws_queryModifyUserGroupCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidParameterCombination":
+    case "InvalidParameterCombinationException":
     case "com.amazonaws.elasticache#InvalidParameterCombinationException":
       response = {
         ...(await deserializeAws_queryInvalidParameterCombinationExceptionResponse(parsedOutput, context)),
@@ -6592,7 +6592,7 @@ const deserializeAws_queryModifyUserGroupCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidParameterValue":
+    case "InvalidParameterValueException":
     case "com.amazonaws.elasticache#InvalidParameterValueException":
       response = {
         ...(await deserializeAws_queryInvalidParameterValueExceptionResponse(parsedOutput, context)),
@@ -6600,7 +6600,7 @@ const deserializeAws_queryModifyUserGroupCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidUserGroupState":
+    case "InvalidUserGroupStateFault":
     case "com.amazonaws.elasticache#InvalidUserGroupStateFault":
       response = {
         ...(await deserializeAws_queryInvalidUserGroupStateFaultResponse(parsedOutput, context)),
@@ -6616,7 +6616,7 @@ const deserializeAws_queryModifyUserGroupCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "UserGroupNotFound":
+    case "UserGroupNotFoundFault":
     case "com.amazonaws.elasticache#UserGroupNotFoundFault":
       response = {
         ...(await deserializeAws_queryUserGroupNotFoundFaultResponse(parsedOutput, context)),
@@ -6624,7 +6624,7 @@ const deserializeAws_queryModifyUserGroupCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "UserNotFound":
+    case "UserNotFoundFault":
     case "com.amazonaws.elasticache#UserNotFoundFault":
       response = {
         ...(await deserializeAws_queryUserNotFoundFaultResponse(parsedOutput, context)),
@@ -6681,7 +6681,7 @@ const deserializeAws_queryPurchaseReservedCacheNodesOfferingCommandError = async
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "InvalidParameterCombination":
+    case "InvalidParameterCombinationException":
     case "com.amazonaws.elasticache#InvalidParameterCombinationException":
       response = {
         ...(await deserializeAws_queryInvalidParameterCombinationExceptionResponse(parsedOutput, context)),
@@ -6689,7 +6689,7 @@ const deserializeAws_queryPurchaseReservedCacheNodesOfferingCommandError = async
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidParameterValue":
+    case "InvalidParameterValueException":
     case "com.amazonaws.elasticache#InvalidParameterValueException":
       response = {
         ...(await deserializeAws_queryInvalidParameterValueExceptionResponse(parsedOutput, context)),
@@ -6697,7 +6697,7 @@ const deserializeAws_queryPurchaseReservedCacheNodesOfferingCommandError = async
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ReservedCacheNodeAlreadyExists":
+    case "ReservedCacheNodeAlreadyExistsFault":
     case "com.amazonaws.elasticache#ReservedCacheNodeAlreadyExistsFault":
       response = {
         ...(await deserializeAws_queryReservedCacheNodeAlreadyExistsFaultResponse(parsedOutput, context)),
@@ -6705,7 +6705,7 @@ const deserializeAws_queryPurchaseReservedCacheNodesOfferingCommandError = async
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ReservedCacheNodeQuotaExceeded":
+    case "ReservedCacheNodeQuotaExceededFault":
     case "com.amazonaws.elasticache#ReservedCacheNodeQuotaExceededFault":
       response = {
         ...(await deserializeAws_queryReservedCacheNodeQuotaExceededFaultResponse(parsedOutput, context)),
@@ -6713,7 +6713,7 @@ const deserializeAws_queryPurchaseReservedCacheNodesOfferingCommandError = async
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ReservedCacheNodesOfferingNotFound":
+    case "ReservedCacheNodesOfferingNotFoundFault":
     case "com.amazonaws.elasticache#ReservedCacheNodesOfferingNotFoundFault":
       response = {
         ...(await deserializeAws_queryReservedCacheNodesOfferingNotFoundFaultResponse(parsedOutput, context)),
@@ -6786,7 +6786,7 @@ const deserializeAws_queryRebalanceSlotsInGlobalReplicationGroupCommandError = a
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidGlobalReplicationGroupState":
+    case "InvalidGlobalReplicationGroupStateFault":
     case "com.amazonaws.elasticache#InvalidGlobalReplicationGroupStateFault":
       response = {
         ...(await deserializeAws_queryInvalidGlobalReplicationGroupStateFaultResponse(parsedOutput, context)),
@@ -6794,7 +6794,7 @@ const deserializeAws_queryRebalanceSlotsInGlobalReplicationGroupCommandError = a
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidParameterValue":
+    case "InvalidParameterValueException":
     case "com.amazonaws.elasticache#InvalidParameterValueException":
       response = {
         ...(await deserializeAws_queryInvalidParameterValueExceptionResponse(parsedOutput, context)),
@@ -6848,7 +6848,7 @@ const deserializeAws_queryRebootCacheClusterCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "CacheClusterNotFound":
+    case "CacheClusterNotFoundFault":
     case "com.amazonaws.elasticache#CacheClusterNotFoundFault":
       response = {
         ...(await deserializeAws_queryCacheClusterNotFoundFaultResponse(parsedOutput, context)),
@@ -6856,7 +6856,7 @@ const deserializeAws_queryRebootCacheClusterCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidCacheClusterState":
+    case "InvalidCacheClusterStateFault":
     case "com.amazonaws.elasticache#InvalidCacheClusterStateFault":
       response = {
         ...(await deserializeAws_queryInvalidCacheClusterStateFaultResponse(parsedOutput, context)),
@@ -6910,7 +6910,7 @@ const deserializeAws_queryRemoveTagsFromResourceCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "CacheClusterNotFound":
+    case "CacheClusterNotFoundFault":
     case "com.amazonaws.elasticache#CacheClusterNotFoundFault":
       response = {
         ...(await deserializeAws_queryCacheClusterNotFoundFaultResponse(parsedOutput, context)),
@@ -6918,7 +6918,7 @@ const deserializeAws_queryRemoveTagsFromResourceCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "CacheParameterGroupNotFound":
+    case "CacheParameterGroupNotFoundFault":
     case "com.amazonaws.elasticache#CacheParameterGroupNotFoundFault":
       response = {
         ...(await deserializeAws_queryCacheParameterGroupNotFoundFaultResponse(parsedOutput, context)),
@@ -6926,7 +6926,7 @@ const deserializeAws_queryRemoveTagsFromResourceCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "CacheSecurityGroupNotFound":
+    case "CacheSecurityGroupNotFoundFault":
     case "com.amazonaws.elasticache#CacheSecurityGroupNotFoundFault":
       response = {
         ...(await deserializeAws_queryCacheSecurityGroupNotFoundFaultResponse(parsedOutput, context)),
@@ -6942,7 +6942,7 @@ const deserializeAws_queryRemoveTagsFromResourceCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidARN":
+    case "InvalidARNFault":
     case "com.amazonaws.elasticache#InvalidARNFault":
       response = {
         ...(await deserializeAws_queryInvalidARNFaultResponse(parsedOutput, context)),
@@ -6950,7 +6950,7 @@ const deserializeAws_queryRemoveTagsFromResourceCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidReplicationGroupState":
+    case "InvalidReplicationGroupStateFault":
     case "com.amazonaws.elasticache#InvalidReplicationGroupStateFault":
       response = {
         ...(await deserializeAws_queryInvalidReplicationGroupStateFaultResponse(parsedOutput, context)),
@@ -6966,7 +6966,7 @@ const deserializeAws_queryRemoveTagsFromResourceCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ReservedCacheNodeNotFound":
+    case "ReservedCacheNodeNotFoundFault":
     case "com.amazonaws.elasticache#ReservedCacheNodeNotFoundFault":
       response = {
         ...(await deserializeAws_queryReservedCacheNodeNotFoundFaultResponse(parsedOutput, context)),
@@ -6982,7 +6982,7 @@ const deserializeAws_queryRemoveTagsFromResourceCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "TagNotFound":
+    case "TagNotFoundFault":
     case "com.amazonaws.elasticache#TagNotFoundFault":
       response = {
         ...(await deserializeAws_queryTagNotFoundFaultResponse(parsedOutput, context)),
@@ -6990,7 +6990,7 @@ const deserializeAws_queryRemoveTagsFromResourceCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "UserGroupNotFound":
+    case "UserGroupNotFoundFault":
     case "com.amazonaws.elasticache#UserGroupNotFoundFault":
       response = {
         ...(await deserializeAws_queryUserGroupNotFoundFaultResponse(parsedOutput, context)),
@@ -6998,7 +6998,7 @@ const deserializeAws_queryRemoveTagsFromResourceCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "UserNotFound":
+    case "UserNotFoundFault":
     case "com.amazonaws.elasticache#UserNotFoundFault":
       response = {
         ...(await deserializeAws_queryUserNotFoundFaultResponse(parsedOutput, context)),
@@ -7052,7 +7052,7 @@ const deserializeAws_queryResetCacheParameterGroupCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "CacheParameterGroupNotFound":
+    case "CacheParameterGroupNotFoundFault":
     case "com.amazonaws.elasticache#CacheParameterGroupNotFoundFault":
       response = {
         ...(await deserializeAws_queryCacheParameterGroupNotFoundFaultResponse(parsedOutput, context)),
@@ -7060,7 +7060,7 @@ const deserializeAws_queryResetCacheParameterGroupCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidCacheParameterGroupState":
+    case "InvalidCacheParameterGroupStateFault":
     case "com.amazonaws.elasticache#InvalidCacheParameterGroupStateFault":
       response = {
         ...(await deserializeAws_queryInvalidCacheParameterGroupStateFaultResponse(parsedOutput, context)),
@@ -7068,7 +7068,7 @@ const deserializeAws_queryResetCacheParameterGroupCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidGlobalReplicationGroupState":
+    case "InvalidGlobalReplicationGroupStateFault":
     case "com.amazonaws.elasticache#InvalidGlobalReplicationGroupStateFault":
       response = {
         ...(await deserializeAws_queryInvalidGlobalReplicationGroupStateFaultResponse(parsedOutput, context)),
@@ -7076,7 +7076,7 @@ const deserializeAws_queryResetCacheParameterGroupCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidParameterCombination":
+    case "InvalidParameterCombinationException":
     case "com.amazonaws.elasticache#InvalidParameterCombinationException":
       response = {
         ...(await deserializeAws_queryInvalidParameterCombinationExceptionResponse(parsedOutput, context)),
@@ -7084,7 +7084,7 @@ const deserializeAws_queryResetCacheParameterGroupCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidParameterValue":
+    case "InvalidParameterValueException":
     case "com.amazonaws.elasticache#InvalidParameterValueException":
       response = {
         ...(await deserializeAws_queryInvalidParameterValueExceptionResponse(parsedOutput, context)),
@@ -7141,7 +7141,7 @@ const deserializeAws_queryRevokeCacheSecurityGroupIngressCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "AuthorizationNotFound":
+    case "AuthorizationNotFoundFault":
     case "com.amazonaws.elasticache#AuthorizationNotFoundFault":
       response = {
         ...(await deserializeAws_queryAuthorizationNotFoundFaultResponse(parsedOutput, context)),
@@ -7149,7 +7149,7 @@ const deserializeAws_queryRevokeCacheSecurityGroupIngressCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "CacheSecurityGroupNotFound":
+    case "CacheSecurityGroupNotFoundFault":
     case "com.amazonaws.elasticache#CacheSecurityGroupNotFoundFault":
       response = {
         ...(await deserializeAws_queryCacheSecurityGroupNotFoundFaultResponse(parsedOutput, context)),
@@ -7157,7 +7157,7 @@ const deserializeAws_queryRevokeCacheSecurityGroupIngressCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidCacheSecurityGroupState":
+    case "InvalidCacheSecurityGroupStateFault":
     case "com.amazonaws.elasticache#InvalidCacheSecurityGroupStateFault":
       response = {
         ...(await deserializeAws_queryInvalidCacheSecurityGroupStateFaultResponse(parsedOutput, context)),
@@ -7165,7 +7165,7 @@ const deserializeAws_queryRevokeCacheSecurityGroupIngressCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidParameterCombination":
+    case "InvalidParameterCombinationException":
     case "com.amazonaws.elasticache#InvalidParameterCombinationException":
       response = {
         ...(await deserializeAws_queryInvalidParameterCombinationExceptionResponse(parsedOutput, context)),
@@ -7173,7 +7173,7 @@ const deserializeAws_queryRevokeCacheSecurityGroupIngressCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidParameterValue":
+    case "InvalidParameterValueException":
     case "com.amazonaws.elasticache#InvalidParameterValueException":
       response = {
         ...(await deserializeAws_queryInvalidParameterValueExceptionResponse(parsedOutput, context)),
@@ -7227,7 +7227,7 @@ const deserializeAws_queryStartMigrationCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "InvalidParameterValue":
+    case "InvalidParameterValueException":
     case "com.amazonaws.elasticache#InvalidParameterValueException":
       response = {
         ...(await deserializeAws_queryInvalidParameterValueExceptionResponse(parsedOutput, context)),
@@ -7235,7 +7235,7 @@ const deserializeAws_queryStartMigrationCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidReplicationGroupState":
+    case "InvalidReplicationGroupStateFault":
     case "com.amazonaws.elasticache#InvalidReplicationGroupStateFault":
       response = {
         ...(await deserializeAws_queryInvalidReplicationGroupStateFaultResponse(parsedOutput, context)),
@@ -7305,7 +7305,7 @@ const deserializeAws_queryTestFailoverCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "APICallRateForCustomerExceeded":
+    case "APICallRateForCustomerExceededFault":
     case "com.amazonaws.elasticache#APICallRateForCustomerExceededFault":
       response = {
         ...(await deserializeAws_queryAPICallRateForCustomerExceededFaultResponse(parsedOutput, context)),
@@ -7313,7 +7313,7 @@ const deserializeAws_queryTestFailoverCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidCacheClusterState":
+    case "InvalidCacheClusterStateFault":
     case "com.amazonaws.elasticache#InvalidCacheClusterStateFault":
       response = {
         ...(await deserializeAws_queryInvalidCacheClusterStateFaultResponse(parsedOutput, context)),
@@ -7329,7 +7329,7 @@ const deserializeAws_queryTestFailoverCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidParameterCombination":
+    case "InvalidParameterCombinationException":
     case "com.amazonaws.elasticache#InvalidParameterCombinationException":
       response = {
         ...(await deserializeAws_queryInvalidParameterCombinationExceptionResponse(parsedOutput, context)),
@@ -7337,7 +7337,7 @@ const deserializeAws_queryTestFailoverCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidParameterValue":
+    case "InvalidParameterValueException":
     case "com.amazonaws.elasticache#InvalidParameterValueException":
       response = {
         ...(await deserializeAws_queryInvalidParameterValueExceptionResponse(parsedOutput, context)),
@@ -7345,7 +7345,7 @@ const deserializeAws_queryTestFailoverCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidReplicationGroupState":
+    case "InvalidReplicationGroupStateFault":
     case "com.amazonaws.elasticache#InvalidReplicationGroupStateFault":
       response = {
         ...(await deserializeAws_queryInvalidReplicationGroupStateFaultResponse(parsedOutput, context)),

--- a/clients/client-iam/src/protocols/Aws_query.ts
+++ b/clients/client-iam/src/protocols/Aws_query.ts
@@ -3268,7 +3268,7 @@ const deserializeAws_queryAddClientIDToOpenIDConnectProviderCommandError = async
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "InvalidInput":
+    case "InvalidInputException":
     case "com.amazonaws.iam#InvalidInputException":
       response = {
         ...(await deserializeAws_queryInvalidInputExceptionResponse(parsedOutput, context)),
@@ -3276,7 +3276,7 @@ const deserializeAws_queryAddClientIDToOpenIDConnectProviderCommandError = async
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "LimitExceeded":
+    case "LimitExceededException":
     case "com.amazonaws.iam#LimitExceededException":
       response = {
         ...(await deserializeAws_queryLimitExceededExceptionResponse(parsedOutput, context)),
@@ -3284,7 +3284,7 @@ const deserializeAws_queryAddClientIDToOpenIDConnectProviderCommandError = async
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "NoSuchEntity":
+    case "NoSuchEntityException":
     case "com.amazonaws.iam#NoSuchEntityException":
       response = {
         ...(await deserializeAws_queryNoSuchEntityExceptionResponse(parsedOutput, context)),
@@ -3292,7 +3292,7 @@ const deserializeAws_queryAddClientIDToOpenIDConnectProviderCommandError = async
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ServiceFailure":
+    case "ServiceFailureException":
     case "com.amazonaws.iam#ServiceFailureException":
       response = {
         ...(await deserializeAws_queryServiceFailureExceptionResponse(parsedOutput, context)),
@@ -3343,7 +3343,7 @@ const deserializeAws_queryAddRoleToInstanceProfileCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "EntityAlreadyExists":
+    case "EntityAlreadyExistsException":
     case "com.amazonaws.iam#EntityAlreadyExistsException":
       response = {
         ...(await deserializeAws_queryEntityAlreadyExistsExceptionResponse(parsedOutput, context)),
@@ -3351,7 +3351,7 @@ const deserializeAws_queryAddRoleToInstanceProfileCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "LimitExceeded":
+    case "LimitExceededException":
     case "com.amazonaws.iam#LimitExceededException":
       response = {
         ...(await deserializeAws_queryLimitExceededExceptionResponse(parsedOutput, context)),
@@ -3359,7 +3359,7 @@ const deserializeAws_queryAddRoleToInstanceProfileCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "NoSuchEntity":
+    case "NoSuchEntityException":
     case "com.amazonaws.iam#NoSuchEntityException":
       response = {
         ...(await deserializeAws_queryNoSuchEntityExceptionResponse(parsedOutput, context)),
@@ -3367,7 +3367,7 @@ const deserializeAws_queryAddRoleToInstanceProfileCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ServiceFailure":
+    case "ServiceFailureException":
     case "com.amazonaws.iam#ServiceFailureException":
       response = {
         ...(await deserializeAws_queryServiceFailureExceptionResponse(parsedOutput, context)),
@@ -3375,7 +3375,7 @@ const deserializeAws_queryAddRoleToInstanceProfileCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "UnmodifiableEntity":
+    case "UnmodifiableEntityException":
     case "com.amazonaws.iam#UnmodifiableEntityException":
       response = {
         ...(await deserializeAws_queryUnmodifiableEntityExceptionResponse(parsedOutput, context)),
@@ -3426,7 +3426,7 @@ const deserializeAws_queryAddUserToGroupCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "LimitExceeded":
+    case "LimitExceededException":
     case "com.amazonaws.iam#LimitExceededException":
       response = {
         ...(await deserializeAws_queryLimitExceededExceptionResponse(parsedOutput, context)),
@@ -3434,7 +3434,7 @@ const deserializeAws_queryAddUserToGroupCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "NoSuchEntity":
+    case "NoSuchEntityException":
     case "com.amazonaws.iam#NoSuchEntityException":
       response = {
         ...(await deserializeAws_queryNoSuchEntityExceptionResponse(parsedOutput, context)),
@@ -3442,7 +3442,7 @@ const deserializeAws_queryAddUserToGroupCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ServiceFailure":
+    case "ServiceFailureException":
     case "com.amazonaws.iam#ServiceFailureException":
       response = {
         ...(await deserializeAws_queryServiceFailureExceptionResponse(parsedOutput, context)),
@@ -3493,7 +3493,7 @@ const deserializeAws_queryAttachGroupPolicyCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "InvalidInput":
+    case "InvalidInputException":
     case "com.amazonaws.iam#InvalidInputException":
       response = {
         ...(await deserializeAws_queryInvalidInputExceptionResponse(parsedOutput, context)),
@@ -3501,7 +3501,7 @@ const deserializeAws_queryAttachGroupPolicyCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "LimitExceeded":
+    case "LimitExceededException":
     case "com.amazonaws.iam#LimitExceededException":
       response = {
         ...(await deserializeAws_queryLimitExceededExceptionResponse(parsedOutput, context)),
@@ -3509,7 +3509,7 @@ const deserializeAws_queryAttachGroupPolicyCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "NoSuchEntity":
+    case "NoSuchEntityException":
     case "com.amazonaws.iam#NoSuchEntityException":
       response = {
         ...(await deserializeAws_queryNoSuchEntityExceptionResponse(parsedOutput, context)),
@@ -3517,7 +3517,7 @@ const deserializeAws_queryAttachGroupPolicyCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "PolicyNotAttachable":
+    case "PolicyNotAttachableException":
     case "com.amazonaws.iam#PolicyNotAttachableException":
       response = {
         ...(await deserializeAws_queryPolicyNotAttachableExceptionResponse(parsedOutput, context)),
@@ -3525,7 +3525,7 @@ const deserializeAws_queryAttachGroupPolicyCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ServiceFailure":
+    case "ServiceFailureException":
     case "com.amazonaws.iam#ServiceFailureException":
       response = {
         ...(await deserializeAws_queryServiceFailureExceptionResponse(parsedOutput, context)),
@@ -3576,7 +3576,7 @@ const deserializeAws_queryAttachRolePolicyCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "InvalidInput":
+    case "InvalidInputException":
     case "com.amazonaws.iam#InvalidInputException":
       response = {
         ...(await deserializeAws_queryInvalidInputExceptionResponse(parsedOutput, context)),
@@ -3584,7 +3584,7 @@ const deserializeAws_queryAttachRolePolicyCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "LimitExceeded":
+    case "LimitExceededException":
     case "com.amazonaws.iam#LimitExceededException":
       response = {
         ...(await deserializeAws_queryLimitExceededExceptionResponse(parsedOutput, context)),
@@ -3592,7 +3592,7 @@ const deserializeAws_queryAttachRolePolicyCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "NoSuchEntity":
+    case "NoSuchEntityException":
     case "com.amazonaws.iam#NoSuchEntityException":
       response = {
         ...(await deserializeAws_queryNoSuchEntityExceptionResponse(parsedOutput, context)),
@@ -3600,7 +3600,7 @@ const deserializeAws_queryAttachRolePolicyCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "PolicyNotAttachable":
+    case "PolicyNotAttachableException":
     case "com.amazonaws.iam#PolicyNotAttachableException":
       response = {
         ...(await deserializeAws_queryPolicyNotAttachableExceptionResponse(parsedOutput, context)),
@@ -3608,7 +3608,7 @@ const deserializeAws_queryAttachRolePolicyCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ServiceFailure":
+    case "ServiceFailureException":
     case "com.amazonaws.iam#ServiceFailureException":
       response = {
         ...(await deserializeAws_queryServiceFailureExceptionResponse(parsedOutput, context)),
@@ -3616,7 +3616,7 @@ const deserializeAws_queryAttachRolePolicyCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "UnmodifiableEntity":
+    case "UnmodifiableEntityException":
     case "com.amazonaws.iam#UnmodifiableEntityException":
       response = {
         ...(await deserializeAws_queryUnmodifiableEntityExceptionResponse(parsedOutput, context)),
@@ -3667,7 +3667,7 @@ const deserializeAws_queryAttachUserPolicyCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "InvalidInput":
+    case "InvalidInputException":
     case "com.amazonaws.iam#InvalidInputException":
       response = {
         ...(await deserializeAws_queryInvalidInputExceptionResponse(parsedOutput, context)),
@@ -3675,7 +3675,7 @@ const deserializeAws_queryAttachUserPolicyCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "LimitExceeded":
+    case "LimitExceededException":
     case "com.amazonaws.iam#LimitExceededException":
       response = {
         ...(await deserializeAws_queryLimitExceededExceptionResponse(parsedOutput, context)),
@@ -3683,7 +3683,7 @@ const deserializeAws_queryAttachUserPolicyCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "NoSuchEntity":
+    case "NoSuchEntityException":
     case "com.amazonaws.iam#NoSuchEntityException":
       response = {
         ...(await deserializeAws_queryNoSuchEntityExceptionResponse(parsedOutput, context)),
@@ -3691,7 +3691,7 @@ const deserializeAws_queryAttachUserPolicyCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "PolicyNotAttachable":
+    case "PolicyNotAttachableException":
     case "com.amazonaws.iam#PolicyNotAttachableException":
       response = {
         ...(await deserializeAws_queryPolicyNotAttachableExceptionResponse(parsedOutput, context)),
@@ -3699,7 +3699,7 @@ const deserializeAws_queryAttachUserPolicyCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ServiceFailure":
+    case "ServiceFailureException":
     case "com.amazonaws.iam#ServiceFailureException":
       response = {
         ...(await deserializeAws_queryServiceFailureExceptionResponse(parsedOutput, context)),
@@ -3750,7 +3750,7 @@ const deserializeAws_queryChangePasswordCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "EntityTemporarilyUnmodifiable":
+    case "EntityTemporarilyUnmodifiableException":
     case "com.amazonaws.iam#EntityTemporarilyUnmodifiableException":
       response = {
         ...(await deserializeAws_queryEntityTemporarilyUnmodifiableExceptionResponse(parsedOutput, context)),
@@ -3758,7 +3758,7 @@ const deserializeAws_queryChangePasswordCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidUserType":
+    case "InvalidUserTypeException":
     case "com.amazonaws.iam#InvalidUserTypeException":
       response = {
         ...(await deserializeAws_queryInvalidUserTypeExceptionResponse(parsedOutput, context)),
@@ -3766,7 +3766,7 @@ const deserializeAws_queryChangePasswordCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "LimitExceeded":
+    case "LimitExceededException":
     case "com.amazonaws.iam#LimitExceededException":
       response = {
         ...(await deserializeAws_queryLimitExceededExceptionResponse(parsedOutput, context)),
@@ -3774,7 +3774,7 @@ const deserializeAws_queryChangePasswordCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "NoSuchEntity":
+    case "NoSuchEntityException":
     case "com.amazonaws.iam#NoSuchEntityException":
       response = {
         ...(await deserializeAws_queryNoSuchEntityExceptionResponse(parsedOutput, context)),
@@ -3782,7 +3782,7 @@ const deserializeAws_queryChangePasswordCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "PasswordPolicyViolation":
+    case "PasswordPolicyViolationException":
     case "com.amazonaws.iam#PasswordPolicyViolationException":
       response = {
         ...(await deserializeAws_queryPasswordPolicyViolationExceptionResponse(parsedOutput, context)),
@@ -3790,7 +3790,7 @@ const deserializeAws_queryChangePasswordCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ServiceFailure":
+    case "ServiceFailureException":
     case "com.amazonaws.iam#ServiceFailureException":
       response = {
         ...(await deserializeAws_queryServiceFailureExceptionResponse(parsedOutput, context)),
@@ -3844,7 +3844,7 @@ const deserializeAws_queryCreateAccessKeyCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "LimitExceeded":
+    case "LimitExceededException":
     case "com.amazonaws.iam#LimitExceededException":
       response = {
         ...(await deserializeAws_queryLimitExceededExceptionResponse(parsedOutput, context)),
@@ -3852,7 +3852,7 @@ const deserializeAws_queryCreateAccessKeyCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "NoSuchEntity":
+    case "NoSuchEntityException":
     case "com.amazonaws.iam#NoSuchEntityException":
       response = {
         ...(await deserializeAws_queryNoSuchEntityExceptionResponse(parsedOutput, context)),
@@ -3860,7 +3860,7 @@ const deserializeAws_queryCreateAccessKeyCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ServiceFailure":
+    case "ServiceFailureException":
     case "com.amazonaws.iam#ServiceFailureException":
       response = {
         ...(await deserializeAws_queryServiceFailureExceptionResponse(parsedOutput, context)),
@@ -3911,7 +3911,7 @@ const deserializeAws_queryCreateAccountAliasCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "EntityAlreadyExists":
+    case "EntityAlreadyExistsException":
     case "com.amazonaws.iam#EntityAlreadyExistsException":
       response = {
         ...(await deserializeAws_queryEntityAlreadyExistsExceptionResponse(parsedOutput, context)),
@@ -3919,7 +3919,7 @@ const deserializeAws_queryCreateAccountAliasCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "LimitExceeded":
+    case "LimitExceededException":
     case "com.amazonaws.iam#LimitExceededException":
       response = {
         ...(await deserializeAws_queryLimitExceededExceptionResponse(parsedOutput, context)),
@@ -3927,7 +3927,7 @@ const deserializeAws_queryCreateAccountAliasCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ServiceFailure":
+    case "ServiceFailureException":
     case "com.amazonaws.iam#ServiceFailureException":
       response = {
         ...(await deserializeAws_queryServiceFailureExceptionResponse(parsedOutput, context)),
@@ -3981,7 +3981,7 @@ const deserializeAws_queryCreateGroupCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "EntityAlreadyExists":
+    case "EntityAlreadyExistsException":
     case "com.amazonaws.iam#EntityAlreadyExistsException":
       response = {
         ...(await deserializeAws_queryEntityAlreadyExistsExceptionResponse(parsedOutput, context)),
@@ -3989,7 +3989,7 @@ const deserializeAws_queryCreateGroupCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "LimitExceeded":
+    case "LimitExceededException":
     case "com.amazonaws.iam#LimitExceededException":
       response = {
         ...(await deserializeAws_queryLimitExceededExceptionResponse(parsedOutput, context)),
@@ -3997,7 +3997,7 @@ const deserializeAws_queryCreateGroupCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "NoSuchEntity":
+    case "NoSuchEntityException":
     case "com.amazonaws.iam#NoSuchEntityException":
       response = {
         ...(await deserializeAws_queryNoSuchEntityExceptionResponse(parsedOutput, context)),
@@ -4005,7 +4005,7 @@ const deserializeAws_queryCreateGroupCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ServiceFailure":
+    case "ServiceFailureException":
     case "com.amazonaws.iam#ServiceFailureException":
       response = {
         ...(await deserializeAws_queryServiceFailureExceptionResponse(parsedOutput, context)),
@@ -4059,7 +4059,7 @@ const deserializeAws_queryCreateInstanceProfileCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "ConcurrentModification":
+    case "ConcurrentModificationException":
     case "com.amazonaws.iam#ConcurrentModificationException":
       response = {
         ...(await deserializeAws_queryConcurrentModificationExceptionResponse(parsedOutput, context)),
@@ -4067,7 +4067,7 @@ const deserializeAws_queryCreateInstanceProfileCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "EntityAlreadyExists":
+    case "EntityAlreadyExistsException":
     case "com.amazonaws.iam#EntityAlreadyExistsException":
       response = {
         ...(await deserializeAws_queryEntityAlreadyExistsExceptionResponse(parsedOutput, context)),
@@ -4075,7 +4075,7 @@ const deserializeAws_queryCreateInstanceProfileCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidInput":
+    case "InvalidInputException":
     case "com.amazonaws.iam#InvalidInputException":
       response = {
         ...(await deserializeAws_queryInvalidInputExceptionResponse(parsedOutput, context)),
@@ -4083,7 +4083,7 @@ const deserializeAws_queryCreateInstanceProfileCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "LimitExceeded":
+    case "LimitExceededException":
     case "com.amazonaws.iam#LimitExceededException":
       response = {
         ...(await deserializeAws_queryLimitExceededExceptionResponse(parsedOutput, context)),
@@ -4091,7 +4091,7 @@ const deserializeAws_queryCreateInstanceProfileCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ServiceFailure":
+    case "ServiceFailureException":
     case "com.amazonaws.iam#ServiceFailureException":
       response = {
         ...(await deserializeAws_queryServiceFailureExceptionResponse(parsedOutput, context)),
@@ -4145,7 +4145,7 @@ const deserializeAws_queryCreateLoginProfileCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "EntityAlreadyExists":
+    case "EntityAlreadyExistsException":
     case "com.amazonaws.iam#EntityAlreadyExistsException":
       response = {
         ...(await deserializeAws_queryEntityAlreadyExistsExceptionResponse(parsedOutput, context)),
@@ -4153,7 +4153,7 @@ const deserializeAws_queryCreateLoginProfileCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "LimitExceeded":
+    case "LimitExceededException":
     case "com.amazonaws.iam#LimitExceededException":
       response = {
         ...(await deserializeAws_queryLimitExceededExceptionResponse(parsedOutput, context)),
@@ -4161,7 +4161,7 @@ const deserializeAws_queryCreateLoginProfileCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "NoSuchEntity":
+    case "NoSuchEntityException":
     case "com.amazonaws.iam#NoSuchEntityException":
       response = {
         ...(await deserializeAws_queryNoSuchEntityExceptionResponse(parsedOutput, context)),
@@ -4169,7 +4169,7 @@ const deserializeAws_queryCreateLoginProfileCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "PasswordPolicyViolation":
+    case "PasswordPolicyViolationException":
     case "com.amazonaws.iam#PasswordPolicyViolationException":
       response = {
         ...(await deserializeAws_queryPasswordPolicyViolationExceptionResponse(parsedOutput, context)),
@@ -4177,7 +4177,7 @@ const deserializeAws_queryCreateLoginProfileCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ServiceFailure":
+    case "ServiceFailureException":
     case "com.amazonaws.iam#ServiceFailureException":
       response = {
         ...(await deserializeAws_queryServiceFailureExceptionResponse(parsedOutput, context)),
@@ -4231,7 +4231,7 @@ const deserializeAws_queryCreateOpenIDConnectProviderCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "ConcurrentModification":
+    case "ConcurrentModificationException":
     case "com.amazonaws.iam#ConcurrentModificationException":
       response = {
         ...(await deserializeAws_queryConcurrentModificationExceptionResponse(parsedOutput, context)),
@@ -4239,7 +4239,7 @@ const deserializeAws_queryCreateOpenIDConnectProviderCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "EntityAlreadyExists":
+    case "EntityAlreadyExistsException":
     case "com.amazonaws.iam#EntityAlreadyExistsException":
       response = {
         ...(await deserializeAws_queryEntityAlreadyExistsExceptionResponse(parsedOutput, context)),
@@ -4247,7 +4247,7 @@ const deserializeAws_queryCreateOpenIDConnectProviderCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidInput":
+    case "InvalidInputException":
     case "com.amazonaws.iam#InvalidInputException":
       response = {
         ...(await deserializeAws_queryInvalidInputExceptionResponse(parsedOutput, context)),
@@ -4255,7 +4255,7 @@ const deserializeAws_queryCreateOpenIDConnectProviderCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "LimitExceeded":
+    case "LimitExceededException":
     case "com.amazonaws.iam#LimitExceededException":
       response = {
         ...(await deserializeAws_queryLimitExceededExceptionResponse(parsedOutput, context)),
@@ -4263,7 +4263,7 @@ const deserializeAws_queryCreateOpenIDConnectProviderCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ServiceFailure":
+    case "ServiceFailureException":
     case "com.amazonaws.iam#ServiceFailureException":
       response = {
         ...(await deserializeAws_queryServiceFailureExceptionResponse(parsedOutput, context)),
@@ -4317,7 +4317,7 @@ const deserializeAws_queryCreatePolicyCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "ConcurrentModification":
+    case "ConcurrentModificationException":
     case "com.amazonaws.iam#ConcurrentModificationException":
       response = {
         ...(await deserializeAws_queryConcurrentModificationExceptionResponse(parsedOutput, context)),
@@ -4325,7 +4325,7 @@ const deserializeAws_queryCreatePolicyCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "EntityAlreadyExists":
+    case "EntityAlreadyExistsException":
     case "com.amazonaws.iam#EntityAlreadyExistsException":
       response = {
         ...(await deserializeAws_queryEntityAlreadyExistsExceptionResponse(parsedOutput, context)),
@@ -4333,7 +4333,7 @@ const deserializeAws_queryCreatePolicyCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidInput":
+    case "InvalidInputException":
     case "com.amazonaws.iam#InvalidInputException":
       response = {
         ...(await deserializeAws_queryInvalidInputExceptionResponse(parsedOutput, context)),
@@ -4341,7 +4341,7 @@ const deserializeAws_queryCreatePolicyCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "LimitExceeded":
+    case "LimitExceededException":
     case "com.amazonaws.iam#LimitExceededException":
       response = {
         ...(await deserializeAws_queryLimitExceededExceptionResponse(parsedOutput, context)),
@@ -4349,7 +4349,7 @@ const deserializeAws_queryCreatePolicyCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "MalformedPolicyDocument":
+    case "MalformedPolicyDocumentException":
     case "com.amazonaws.iam#MalformedPolicyDocumentException":
       response = {
         ...(await deserializeAws_queryMalformedPolicyDocumentExceptionResponse(parsedOutput, context)),
@@ -4357,7 +4357,7 @@ const deserializeAws_queryCreatePolicyCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ServiceFailure":
+    case "ServiceFailureException":
     case "com.amazonaws.iam#ServiceFailureException":
       response = {
         ...(await deserializeAws_queryServiceFailureExceptionResponse(parsedOutput, context)),
@@ -4411,7 +4411,7 @@ const deserializeAws_queryCreatePolicyVersionCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "InvalidInput":
+    case "InvalidInputException":
     case "com.amazonaws.iam#InvalidInputException":
       response = {
         ...(await deserializeAws_queryInvalidInputExceptionResponse(parsedOutput, context)),
@@ -4419,7 +4419,7 @@ const deserializeAws_queryCreatePolicyVersionCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "LimitExceeded":
+    case "LimitExceededException":
     case "com.amazonaws.iam#LimitExceededException":
       response = {
         ...(await deserializeAws_queryLimitExceededExceptionResponse(parsedOutput, context)),
@@ -4427,7 +4427,7 @@ const deserializeAws_queryCreatePolicyVersionCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "MalformedPolicyDocument":
+    case "MalformedPolicyDocumentException":
     case "com.amazonaws.iam#MalformedPolicyDocumentException":
       response = {
         ...(await deserializeAws_queryMalformedPolicyDocumentExceptionResponse(parsedOutput, context)),
@@ -4435,7 +4435,7 @@ const deserializeAws_queryCreatePolicyVersionCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "NoSuchEntity":
+    case "NoSuchEntityException":
     case "com.amazonaws.iam#NoSuchEntityException":
       response = {
         ...(await deserializeAws_queryNoSuchEntityExceptionResponse(parsedOutput, context)),
@@ -4443,7 +4443,7 @@ const deserializeAws_queryCreatePolicyVersionCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ServiceFailure":
+    case "ServiceFailureException":
     case "com.amazonaws.iam#ServiceFailureException":
       response = {
         ...(await deserializeAws_queryServiceFailureExceptionResponse(parsedOutput, context)),
@@ -4497,7 +4497,7 @@ const deserializeAws_queryCreateRoleCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "ConcurrentModification":
+    case "ConcurrentModificationException":
     case "com.amazonaws.iam#ConcurrentModificationException":
       response = {
         ...(await deserializeAws_queryConcurrentModificationExceptionResponse(parsedOutput, context)),
@@ -4505,7 +4505,7 @@ const deserializeAws_queryCreateRoleCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "EntityAlreadyExists":
+    case "EntityAlreadyExistsException":
     case "com.amazonaws.iam#EntityAlreadyExistsException":
       response = {
         ...(await deserializeAws_queryEntityAlreadyExistsExceptionResponse(parsedOutput, context)),
@@ -4513,7 +4513,7 @@ const deserializeAws_queryCreateRoleCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidInput":
+    case "InvalidInputException":
     case "com.amazonaws.iam#InvalidInputException":
       response = {
         ...(await deserializeAws_queryInvalidInputExceptionResponse(parsedOutput, context)),
@@ -4521,7 +4521,7 @@ const deserializeAws_queryCreateRoleCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "LimitExceeded":
+    case "LimitExceededException":
     case "com.amazonaws.iam#LimitExceededException":
       response = {
         ...(await deserializeAws_queryLimitExceededExceptionResponse(parsedOutput, context)),
@@ -4529,7 +4529,7 @@ const deserializeAws_queryCreateRoleCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "MalformedPolicyDocument":
+    case "MalformedPolicyDocumentException":
     case "com.amazonaws.iam#MalformedPolicyDocumentException":
       response = {
         ...(await deserializeAws_queryMalformedPolicyDocumentExceptionResponse(parsedOutput, context)),
@@ -4537,7 +4537,7 @@ const deserializeAws_queryCreateRoleCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ServiceFailure":
+    case "ServiceFailureException":
     case "com.amazonaws.iam#ServiceFailureException":
       response = {
         ...(await deserializeAws_queryServiceFailureExceptionResponse(parsedOutput, context)),
@@ -4591,7 +4591,7 @@ const deserializeAws_queryCreateSAMLProviderCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "ConcurrentModification":
+    case "ConcurrentModificationException":
     case "com.amazonaws.iam#ConcurrentModificationException":
       response = {
         ...(await deserializeAws_queryConcurrentModificationExceptionResponse(parsedOutput, context)),
@@ -4599,7 +4599,7 @@ const deserializeAws_queryCreateSAMLProviderCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "EntityAlreadyExists":
+    case "EntityAlreadyExistsException":
     case "com.amazonaws.iam#EntityAlreadyExistsException":
       response = {
         ...(await deserializeAws_queryEntityAlreadyExistsExceptionResponse(parsedOutput, context)),
@@ -4607,7 +4607,7 @@ const deserializeAws_queryCreateSAMLProviderCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidInput":
+    case "InvalidInputException":
     case "com.amazonaws.iam#InvalidInputException":
       response = {
         ...(await deserializeAws_queryInvalidInputExceptionResponse(parsedOutput, context)),
@@ -4615,7 +4615,7 @@ const deserializeAws_queryCreateSAMLProviderCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "LimitExceeded":
+    case "LimitExceededException":
     case "com.amazonaws.iam#LimitExceededException":
       response = {
         ...(await deserializeAws_queryLimitExceededExceptionResponse(parsedOutput, context)),
@@ -4623,7 +4623,7 @@ const deserializeAws_queryCreateSAMLProviderCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ServiceFailure":
+    case "ServiceFailureException":
     case "com.amazonaws.iam#ServiceFailureException":
       response = {
         ...(await deserializeAws_queryServiceFailureExceptionResponse(parsedOutput, context)),
@@ -4677,7 +4677,7 @@ const deserializeAws_queryCreateServiceLinkedRoleCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "InvalidInput":
+    case "InvalidInputException":
     case "com.amazonaws.iam#InvalidInputException":
       response = {
         ...(await deserializeAws_queryInvalidInputExceptionResponse(parsedOutput, context)),
@@ -4685,7 +4685,7 @@ const deserializeAws_queryCreateServiceLinkedRoleCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "LimitExceeded":
+    case "LimitExceededException":
     case "com.amazonaws.iam#LimitExceededException":
       response = {
         ...(await deserializeAws_queryLimitExceededExceptionResponse(parsedOutput, context)),
@@ -4693,7 +4693,7 @@ const deserializeAws_queryCreateServiceLinkedRoleCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "NoSuchEntity":
+    case "NoSuchEntityException":
     case "com.amazonaws.iam#NoSuchEntityException":
       response = {
         ...(await deserializeAws_queryNoSuchEntityExceptionResponse(parsedOutput, context)),
@@ -4701,7 +4701,7 @@ const deserializeAws_queryCreateServiceLinkedRoleCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ServiceFailure":
+    case "ServiceFailureException":
     case "com.amazonaws.iam#ServiceFailureException":
       response = {
         ...(await deserializeAws_queryServiceFailureExceptionResponse(parsedOutput, context)),
@@ -4758,7 +4758,7 @@ const deserializeAws_queryCreateServiceSpecificCredentialCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "LimitExceeded":
+    case "LimitExceededException":
     case "com.amazonaws.iam#LimitExceededException":
       response = {
         ...(await deserializeAws_queryLimitExceededExceptionResponse(parsedOutput, context)),
@@ -4766,7 +4766,7 @@ const deserializeAws_queryCreateServiceSpecificCredentialCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "NoSuchEntity":
+    case "NoSuchEntityException":
     case "com.amazonaws.iam#NoSuchEntityException":
       response = {
         ...(await deserializeAws_queryNoSuchEntityExceptionResponse(parsedOutput, context)),
@@ -4774,7 +4774,7 @@ const deserializeAws_queryCreateServiceSpecificCredentialCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "NotSupportedService":
+    case "ServiceNotSupportedException":
     case "com.amazonaws.iam#ServiceNotSupportedException":
       response = {
         ...(await deserializeAws_queryServiceNotSupportedExceptionResponse(parsedOutput, context)),
@@ -4828,7 +4828,7 @@ const deserializeAws_queryCreateUserCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "ConcurrentModification":
+    case "ConcurrentModificationException":
     case "com.amazonaws.iam#ConcurrentModificationException":
       response = {
         ...(await deserializeAws_queryConcurrentModificationExceptionResponse(parsedOutput, context)),
@@ -4836,7 +4836,7 @@ const deserializeAws_queryCreateUserCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "EntityAlreadyExists":
+    case "EntityAlreadyExistsException":
     case "com.amazonaws.iam#EntityAlreadyExistsException":
       response = {
         ...(await deserializeAws_queryEntityAlreadyExistsExceptionResponse(parsedOutput, context)),
@@ -4844,7 +4844,7 @@ const deserializeAws_queryCreateUserCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidInput":
+    case "InvalidInputException":
     case "com.amazonaws.iam#InvalidInputException":
       response = {
         ...(await deserializeAws_queryInvalidInputExceptionResponse(parsedOutput, context)),
@@ -4852,7 +4852,7 @@ const deserializeAws_queryCreateUserCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "LimitExceeded":
+    case "LimitExceededException":
     case "com.amazonaws.iam#LimitExceededException":
       response = {
         ...(await deserializeAws_queryLimitExceededExceptionResponse(parsedOutput, context)),
@@ -4860,7 +4860,7 @@ const deserializeAws_queryCreateUserCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "NoSuchEntity":
+    case "NoSuchEntityException":
     case "com.amazonaws.iam#NoSuchEntityException":
       response = {
         ...(await deserializeAws_queryNoSuchEntityExceptionResponse(parsedOutput, context)),
@@ -4868,7 +4868,7 @@ const deserializeAws_queryCreateUserCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ServiceFailure":
+    case "ServiceFailureException":
     case "com.amazonaws.iam#ServiceFailureException":
       response = {
         ...(await deserializeAws_queryServiceFailureExceptionResponse(parsedOutput, context)),
@@ -4922,7 +4922,7 @@ const deserializeAws_queryCreateVirtualMFADeviceCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "ConcurrentModification":
+    case "ConcurrentModificationException":
     case "com.amazonaws.iam#ConcurrentModificationException":
       response = {
         ...(await deserializeAws_queryConcurrentModificationExceptionResponse(parsedOutput, context)),
@@ -4930,7 +4930,7 @@ const deserializeAws_queryCreateVirtualMFADeviceCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "EntityAlreadyExists":
+    case "EntityAlreadyExistsException":
     case "com.amazonaws.iam#EntityAlreadyExistsException":
       response = {
         ...(await deserializeAws_queryEntityAlreadyExistsExceptionResponse(parsedOutput, context)),
@@ -4938,7 +4938,7 @@ const deserializeAws_queryCreateVirtualMFADeviceCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidInput":
+    case "InvalidInputException":
     case "com.amazonaws.iam#InvalidInputException":
       response = {
         ...(await deserializeAws_queryInvalidInputExceptionResponse(parsedOutput, context)),
@@ -4946,7 +4946,7 @@ const deserializeAws_queryCreateVirtualMFADeviceCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "LimitExceeded":
+    case "LimitExceededException":
     case "com.amazonaws.iam#LimitExceededException":
       response = {
         ...(await deserializeAws_queryLimitExceededExceptionResponse(parsedOutput, context)),
@@ -4954,7 +4954,7 @@ const deserializeAws_queryCreateVirtualMFADeviceCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ServiceFailure":
+    case "ServiceFailureException":
     case "com.amazonaws.iam#ServiceFailureException":
       response = {
         ...(await deserializeAws_queryServiceFailureExceptionResponse(parsedOutput, context)),
@@ -5005,7 +5005,7 @@ const deserializeAws_queryDeactivateMFADeviceCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "EntityTemporarilyUnmodifiable":
+    case "EntityTemporarilyUnmodifiableException":
     case "com.amazonaws.iam#EntityTemporarilyUnmodifiableException":
       response = {
         ...(await deserializeAws_queryEntityTemporarilyUnmodifiableExceptionResponse(parsedOutput, context)),
@@ -5013,7 +5013,7 @@ const deserializeAws_queryDeactivateMFADeviceCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "LimitExceeded":
+    case "LimitExceededException":
     case "com.amazonaws.iam#LimitExceededException":
       response = {
         ...(await deserializeAws_queryLimitExceededExceptionResponse(parsedOutput, context)),
@@ -5021,7 +5021,7 @@ const deserializeAws_queryDeactivateMFADeviceCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "NoSuchEntity":
+    case "NoSuchEntityException":
     case "com.amazonaws.iam#NoSuchEntityException":
       response = {
         ...(await deserializeAws_queryNoSuchEntityExceptionResponse(parsedOutput, context)),
@@ -5029,7 +5029,7 @@ const deserializeAws_queryDeactivateMFADeviceCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ServiceFailure":
+    case "ServiceFailureException":
     case "com.amazonaws.iam#ServiceFailureException":
       response = {
         ...(await deserializeAws_queryServiceFailureExceptionResponse(parsedOutput, context)),
@@ -5080,7 +5080,7 @@ const deserializeAws_queryDeleteAccessKeyCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "LimitExceeded":
+    case "LimitExceededException":
     case "com.amazonaws.iam#LimitExceededException":
       response = {
         ...(await deserializeAws_queryLimitExceededExceptionResponse(parsedOutput, context)),
@@ -5088,7 +5088,7 @@ const deserializeAws_queryDeleteAccessKeyCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "NoSuchEntity":
+    case "NoSuchEntityException":
     case "com.amazonaws.iam#NoSuchEntityException":
       response = {
         ...(await deserializeAws_queryNoSuchEntityExceptionResponse(parsedOutput, context)),
@@ -5096,7 +5096,7 @@ const deserializeAws_queryDeleteAccessKeyCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ServiceFailure":
+    case "ServiceFailureException":
     case "com.amazonaws.iam#ServiceFailureException":
       response = {
         ...(await deserializeAws_queryServiceFailureExceptionResponse(parsedOutput, context)),
@@ -5147,7 +5147,7 @@ const deserializeAws_queryDeleteAccountAliasCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "LimitExceeded":
+    case "LimitExceededException":
     case "com.amazonaws.iam#LimitExceededException":
       response = {
         ...(await deserializeAws_queryLimitExceededExceptionResponse(parsedOutput, context)),
@@ -5155,7 +5155,7 @@ const deserializeAws_queryDeleteAccountAliasCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "NoSuchEntity":
+    case "NoSuchEntityException":
     case "com.amazonaws.iam#NoSuchEntityException":
       response = {
         ...(await deserializeAws_queryNoSuchEntityExceptionResponse(parsedOutput, context)),
@@ -5163,7 +5163,7 @@ const deserializeAws_queryDeleteAccountAliasCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ServiceFailure":
+    case "ServiceFailureException":
     case "com.amazonaws.iam#ServiceFailureException":
       response = {
         ...(await deserializeAws_queryServiceFailureExceptionResponse(parsedOutput, context)),
@@ -5214,7 +5214,7 @@ const deserializeAws_queryDeleteAccountPasswordPolicyCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "LimitExceeded":
+    case "LimitExceededException":
     case "com.amazonaws.iam#LimitExceededException":
       response = {
         ...(await deserializeAws_queryLimitExceededExceptionResponse(parsedOutput, context)),
@@ -5222,7 +5222,7 @@ const deserializeAws_queryDeleteAccountPasswordPolicyCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "NoSuchEntity":
+    case "NoSuchEntityException":
     case "com.amazonaws.iam#NoSuchEntityException":
       response = {
         ...(await deserializeAws_queryNoSuchEntityExceptionResponse(parsedOutput, context)),
@@ -5230,7 +5230,7 @@ const deserializeAws_queryDeleteAccountPasswordPolicyCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ServiceFailure":
+    case "ServiceFailureException":
     case "com.amazonaws.iam#ServiceFailureException":
       response = {
         ...(await deserializeAws_queryServiceFailureExceptionResponse(parsedOutput, context)),
@@ -5281,7 +5281,7 @@ const deserializeAws_queryDeleteGroupCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "DeleteConflict":
+    case "DeleteConflictException":
     case "com.amazonaws.iam#DeleteConflictException":
       response = {
         ...(await deserializeAws_queryDeleteConflictExceptionResponse(parsedOutput, context)),
@@ -5289,7 +5289,7 @@ const deserializeAws_queryDeleteGroupCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "LimitExceeded":
+    case "LimitExceededException":
     case "com.amazonaws.iam#LimitExceededException":
       response = {
         ...(await deserializeAws_queryLimitExceededExceptionResponse(parsedOutput, context)),
@@ -5297,7 +5297,7 @@ const deserializeAws_queryDeleteGroupCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "NoSuchEntity":
+    case "NoSuchEntityException":
     case "com.amazonaws.iam#NoSuchEntityException":
       response = {
         ...(await deserializeAws_queryNoSuchEntityExceptionResponse(parsedOutput, context)),
@@ -5305,7 +5305,7 @@ const deserializeAws_queryDeleteGroupCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ServiceFailure":
+    case "ServiceFailureException":
     case "com.amazonaws.iam#ServiceFailureException":
       response = {
         ...(await deserializeAws_queryServiceFailureExceptionResponse(parsedOutput, context)),
@@ -5356,7 +5356,7 @@ const deserializeAws_queryDeleteGroupPolicyCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "LimitExceeded":
+    case "LimitExceededException":
     case "com.amazonaws.iam#LimitExceededException":
       response = {
         ...(await deserializeAws_queryLimitExceededExceptionResponse(parsedOutput, context)),
@@ -5364,7 +5364,7 @@ const deserializeAws_queryDeleteGroupPolicyCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "NoSuchEntity":
+    case "NoSuchEntityException":
     case "com.amazonaws.iam#NoSuchEntityException":
       response = {
         ...(await deserializeAws_queryNoSuchEntityExceptionResponse(parsedOutput, context)),
@@ -5372,7 +5372,7 @@ const deserializeAws_queryDeleteGroupPolicyCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ServiceFailure":
+    case "ServiceFailureException":
     case "com.amazonaws.iam#ServiceFailureException":
       response = {
         ...(await deserializeAws_queryServiceFailureExceptionResponse(parsedOutput, context)),
@@ -5423,7 +5423,7 @@ const deserializeAws_queryDeleteInstanceProfileCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "DeleteConflict":
+    case "DeleteConflictException":
     case "com.amazonaws.iam#DeleteConflictException":
       response = {
         ...(await deserializeAws_queryDeleteConflictExceptionResponse(parsedOutput, context)),
@@ -5431,7 +5431,7 @@ const deserializeAws_queryDeleteInstanceProfileCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "LimitExceeded":
+    case "LimitExceededException":
     case "com.amazonaws.iam#LimitExceededException":
       response = {
         ...(await deserializeAws_queryLimitExceededExceptionResponse(parsedOutput, context)),
@@ -5439,7 +5439,7 @@ const deserializeAws_queryDeleteInstanceProfileCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "NoSuchEntity":
+    case "NoSuchEntityException":
     case "com.amazonaws.iam#NoSuchEntityException":
       response = {
         ...(await deserializeAws_queryNoSuchEntityExceptionResponse(parsedOutput, context)),
@@ -5447,7 +5447,7 @@ const deserializeAws_queryDeleteInstanceProfileCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ServiceFailure":
+    case "ServiceFailureException":
     case "com.amazonaws.iam#ServiceFailureException":
       response = {
         ...(await deserializeAws_queryServiceFailureExceptionResponse(parsedOutput, context)),
@@ -5498,7 +5498,7 @@ const deserializeAws_queryDeleteLoginProfileCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "EntityTemporarilyUnmodifiable":
+    case "EntityTemporarilyUnmodifiableException":
     case "com.amazonaws.iam#EntityTemporarilyUnmodifiableException":
       response = {
         ...(await deserializeAws_queryEntityTemporarilyUnmodifiableExceptionResponse(parsedOutput, context)),
@@ -5506,7 +5506,7 @@ const deserializeAws_queryDeleteLoginProfileCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "LimitExceeded":
+    case "LimitExceededException":
     case "com.amazonaws.iam#LimitExceededException":
       response = {
         ...(await deserializeAws_queryLimitExceededExceptionResponse(parsedOutput, context)),
@@ -5514,7 +5514,7 @@ const deserializeAws_queryDeleteLoginProfileCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "NoSuchEntity":
+    case "NoSuchEntityException":
     case "com.amazonaws.iam#NoSuchEntityException":
       response = {
         ...(await deserializeAws_queryNoSuchEntityExceptionResponse(parsedOutput, context)),
@@ -5522,7 +5522,7 @@ const deserializeAws_queryDeleteLoginProfileCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ServiceFailure":
+    case "ServiceFailureException":
     case "com.amazonaws.iam#ServiceFailureException":
       response = {
         ...(await deserializeAws_queryServiceFailureExceptionResponse(parsedOutput, context)),
@@ -5573,7 +5573,7 @@ const deserializeAws_queryDeleteOpenIDConnectProviderCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "InvalidInput":
+    case "InvalidInputException":
     case "com.amazonaws.iam#InvalidInputException":
       response = {
         ...(await deserializeAws_queryInvalidInputExceptionResponse(parsedOutput, context)),
@@ -5581,7 +5581,7 @@ const deserializeAws_queryDeleteOpenIDConnectProviderCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "NoSuchEntity":
+    case "NoSuchEntityException":
     case "com.amazonaws.iam#NoSuchEntityException":
       response = {
         ...(await deserializeAws_queryNoSuchEntityExceptionResponse(parsedOutput, context)),
@@ -5589,7 +5589,7 @@ const deserializeAws_queryDeleteOpenIDConnectProviderCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ServiceFailure":
+    case "ServiceFailureException":
     case "com.amazonaws.iam#ServiceFailureException":
       response = {
         ...(await deserializeAws_queryServiceFailureExceptionResponse(parsedOutput, context)),
@@ -5640,7 +5640,7 @@ const deserializeAws_queryDeletePolicyCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "DeleteConflict":
+    case "DeleteConflictException":
     case "com.amazonaws.iam#DeleteConflictException":
       response = {
         ...(await deserializeAws_queryDeleteConflictExceptionResponse(parsedOutput, context)),
@@ -5648,7 +5648,7 @@ const deserializeAws_queryDeletePolicyCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidInput":
+    case "InvalidInputException":
     case "com.amazonaws.iam#InvalidInputException":
       response = {
         ...(await deserializeAws_queryInvalidInputExceptionResponse(parsedOutput, context)),
@@ -5656,7 +5656,7 @@ const deserializeAws_queryDeletePolicyCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "LimitExceeded":
+    case "LimitExceededException":
     case "com.amazonaws.iam#LimitExceededException":
       response = {
         ...(await deserializeAws_queryLimitExceededExceptionResponse(parsedOutput, context)),
@@ -5664,7 +5664,7 @@ const deserializeAws_queryDeletePolicyCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "NoSuchEntity":
+    case "NoSuchEntityException":
     case "com.amazonaws.iam#NoSuchEntityException":
       response = {
         ...(await deserializeAws_queryNoSuchEntityExceptionResponse(parsedOutput, context)),
@@ -5672,7 +5672,7 @@ const deserializeAws_queryDeletePolicyCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ServiceFailure":
+    case "ServiceFailureException":
     case "com.amazonaws.iam#ServiceFailureException":
       response = {
         ...(await deserializeAws_queryServiceFailureExceptionResponse(parsedOutput, context)),
@@ -5723,7 +5723,7 @@ const deserializeAws_queryDeletePolicyVersionCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "DeleteConflict":
+    case "DeleteConflictException":
     case "com.amazonaws.iam#DeleteConflictException":
       response = {
         ...(await deserializeAws_queryDeleteConflictExceptionResponse(parsedOutput, context)),
@@ -5731,7 +5731,7 @@ const deserializeAws_queryDeletePolicyVersionCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidInput":
+    case "InvalidInputException":
     case "com.amazonaws.iam#InvalidInputException":
       response = {
         ...(await deserializeAws_queryInvalidInputExceptionResponse(parsedOutput, context)),
@@ -5739,7 +5739,7 @@ const deserializeAws_queryDeletePolicyVersionCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "LimitExceeded":
+    case "LimitExceededException":
     case "com.amazonaws.iam#LimitExceededException":
       response = {
         ...(await deserializeAws_queryLimitExceededExceptionResponse(parsedOutput, context)),
@@ -5747,7 +5747,7 @@ const deserializeAws_queryDeletePolicyVersionCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "NoSuchEntity":
+    case "NoSuchEntityException":
     case "com.amazonaws.iam#NoSuchEntityException":
       response = {
         ...(await deserializeAws_queryNoSuchEntityExceptionResponse(parsedOutput, context)),
@@ -5755,7 +5755,7 @@ const deserializeAws_queryDeletePolicyVersionCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ServiceFailure":
+    case "ServiceFailureException":
     case "com.amazonaws.iam#ServiceFailureException":
       response = {
         ...(await deserializeAws_queryServiceFailureExceptionResponse(parsedOutput, context)),
@@ -5806,7 +5806,7 @@ const deserializeAws_queryDeleteRoleCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "ConcurrentModification":
+    case "ConcurrentModificationException":
     case "com.amazonaws.iam#ConcurrentModificationException":
       response = {
         ...(await deserializeAws_queryConcurrentModificationExceptionResponse(parsedOutput, context)),
@@ -5814,7 +5814,7 @@ const deserializeAws_queryDeleteRoleCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "DeleteConflict":
+    case "DeleteConflictException":
     case "com.amazonaws.iam#DeleteConflictException":
       response = {
         ...(await deserializeAws_queryDeleteConflictExceptionResponse(parsedOutput, context)),
@@ -5822,7 +5822,7 @@ const deserializeAws_queryDeleteRoleCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "LimitExceeded":
+    case "LimitExceededException":
     case "com.amazonaws.iam#LimitExceededException":
       response = {
         ...(await deserializeAws_queryLimitExceededExceptionResponse(parsedOutput, context)),
@@ -5830,7 +5830,7 @@ const deserializeAws_queryDeleteRoleCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "NoSuchEntity":
+    case "NoSuchEntityException":
     case "com.amazonaws.iam#NoSuchEntityException":
       response = {
         ...(await deserializeAws_queryNoSuchEntityExceptionResponse(parsedOutput, context)),
@@ -5838,7 +5838,7 @@ const deserializeAws_queryDeleteRoleCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ServiceFailure":
+    case "ServiceFailureException":
     case "com.amazonaws.iam#ServiceFailureException":
       response = {
         ...(await deserializeAws_queryServiceFailureExceptionResponse(parsedOutput, context)),
@@ -5846,7 +5846,7 @@ const deserializeAws_queryDeleteRoleCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "UnmodifiableEntity":
+    case "UnmodifiableEntityException":
     case "com.amazonaws.iam#UnmodifiableEntityException":
       response = {
         ...(await deserializeAws_queryUnmodifiableEntityExceptionResponse(parsedOutput, context)),
@@ -5897,7 +5897,7 @@ const deserializeAws_queryDeleteRolePermissionsBoundaryCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "NoSuchEntity":
+    case "NoSuchEntityException":
     case "com.amazonaws.iam#NoSuchEntityException":
       response = {
         ...(await deserializeAws_queryNoSuchEntityExceptionResponse(parsedOutput, context)),
@@ -5905,7 +5905,7 @@ const deserializeAws_queryDeleteRolePermissionsBoundaryCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ServiceFailure":
+    case "ServiceFailureException":
     case "com.amazonaws.iam#ServiceFailureException":
       response = {
         ...(await deserializeAws_queryServiceFailureExceptionResponse(parsedOutput, context)),
@@ -5913,7 +5913,7 @@ const deserializeAws_queryDeleteRolePermissionsBoundaryCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "UnmodifiableEntity":
+    case "UnmodifiableEntityException":
     case "com.amazonaws.iam#UnmodifiableEntityException":
       response = {
         ...(await deserializeAws_queryUnmodifiableEntityExceptionResponse(parsedOutput, context)),
@@ -5964,7 +5964,7 @@ const deserializeAws_queryDeleteRolePolicyCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "LimitExceeded":
+    case "LimitExceededException":
     case "com.amazonaws.iam#LimitExceededException":
       response = {
         ...(await deserializeAws_queryLimitExceededExceptionResponse(parsedOutput, context)),
@@ -5972,7 +5972,7 @@ const deserializeAws_queryDeleteRolePolicyCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "NoSuchEntity":
+    case "NoSuchEntityException":
     case "com.amazonaws.iam#NoSuchEntityException":
       response = {
         ...(await deserializeAws_queryNoSuchEntityExceptionResponse(parsedOutput, context)),
@@ -5980,7 +5980,7 @@ const deserializeAws_queryDeleteRolePolicyCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ServiceFailure":
+    case "ServiceFailureException":
     case "com.amazonaws.iam#ServiceFailureException":
       response = {
         ...(await deserializeAws_queryServiceFailureExceptionResponse(parsedOutput, context)),
@@ -5988,7 +5988,7 @@ const deserializeAws_queryDeleteRolePolicyCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "UnmodifiableEntity":
+    case "UnmodifiableEntityException":
     case "com.amazonaws.iam#UnmodifiableEntityException":
       response = {
         ...(await deserializeAws_queryUnmodifiableEntityExceptionResponse(parsedOutput, context)),
@@ -6039,7 +6039,7 @@ const deserializeAws_queryDeleteSAMLProviderCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "InvalidInput":
+    case "InvalidInputException":
     case "com.amazonaws.iam#InvalidInputException":
       response = {
         ...(await deserializeAws_queryInvalidInputExceptionResponse(parsedOutput, context)),
@@ -6047,7 +6047,7 @@ const deserializeAws_queryDeleteSAMLProviderCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "LimitExceeded":
+    case "LimitExceededException":
     case "com.amazonaws.iam#LimitExceededException":
       response = {
         ...(await deserializeAws_queryLimitExceededExceptionResponse(parsedOutput, context)),
@@ -6055,7 +6055,7 @@ const deserializeAws_queryDeleteSAMLProviderCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "NoSuchEntity":
+    case "NoSuchEntityException":
     case "com.amazonaws.iam#NoSuchEntityException":
       response = {
         ...(await deserializeAws_queryNoSuchEntityExceptionResponse(parsedOutput, context)),
@@ -6063,7 +6063,7 @@ const deserializeAws_queryDeleteSAMLProviderCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ServiceFailure":
+    case "ServiceFailureException":
     case "com.amazonaws.iam#ServiceFailureException":
       response = {
         ...(await deserializeAws_queryServiceFailureExceptionResponse(parsedOutput, context)),
@@ -6114,7 +6114,7 @@ const deserializeAws_queryDeleteServerCertificateCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "DeleteConflict":
+    case "DeleteConflictException":
     case "com.amazonaws.iam#DeleteConflictException":
       response = {
         ...(await deserializeAws_queryDeleteConflictExceptionResponse(parsedOutput, context)),
@@ -6122,7 +6122,7 @@ const deserializeAws_queryDeleteServerCertificateCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "LimitExceeded":
+    case "LimitExceededException":
     case "com.amazonaws.iam#LimitExceededException":
       response = {
         ...(await deserializeAws_queryLimitExceededExceptionResponse(parsedOutput, context)),
@@ -6130,7 +6130,7 @@ const deserializeAws_queryDeleteServerCertificateCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "NoSuchEntity":
+    case "NoSuchEntityException":
     case "com.amazonaws.iam#NoSuchEntityException":
       response = {
         ...(await deserializeAws_queryNoSuchEntityExceptionResponse(parsedOutput, context)),
@@ -6138,7 +6138,7 @@ const deserializeAws_queryDeleteServerCertificateCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ServiceFailure":
+    case "ServiceFailureException":
     case "com.amazonaws.iam#ServiceFailureException":
       response = {
         ...(await deserializeAws_queryServiceFailureExceptionResponse(parsedOutput, context)),
@@ -6192,7 +6192,7 @@ const deserializeAws_queryDeleteServiceLinkedRoleCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "LimitExceeded":
+    case "LimitExceededException":
     case "com.amazonaws.iam#LimitExceededException":
       response = {
         ...(await deserializeAws_queryLimitExceededExceptionResponse(parsedOutput, context)),
@@ -6200,7 +6200,7 @@ const deserializeAws_queryDeleteServiceLinkedRoleCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "NoSuchEntity":
+    case "NoSuchEntityException":
     case "com.amazonaws.iam#NoSuchEntityException":
       response = {
         ...(await deserializeAws_queryNoSuchEntityExceptionResponse(parsedOutput, context)),
@@ -6208,7 +6208,7 @@ const deserializeAws_queryDeleteServiceLinkedRoleCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ServiceFailure":
+    case "ServiceFailureException":
     case "com.amazonaws.iam#ServiceFailureException":
       response = {
         ...(await deserializeAws_queryServiceFailureExceptionResponse(parsedOutput, context)),
@@ -6259,7 +6259,7 @@ const deserializeAws_queryDeleteServiceSpecificCredentialCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "NoSuchEntity":
+    case "NoSuchEntityException":
     case "com.amazonaws.iam#NoSuchEntityException":
       response = {
         ...(await deserializeAws_queryNoSuchEntityExceptionResponse(parsedOutput, context)),
@@ -6310,7 +6310,7 @@ const deserializeAws_queryDeleteSigningCertificateCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "LimitExceeded":
+    case "LimitExceededException":
     case "com.amazonaws.iam#LimitExceededException":
       response = {
         ...(await deserializeAws_queryLimitExceededExceptionResponse(parsedOutput, context)),
@@ -6318,7 +6318,7 @@ const deserializeAws_queryDeleteSigningCertificateCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "NoSuchEntity":
+    case "NoSuchEntityException":
     case "com.amazonaws.iam#NoSuchEntityException":
       response = {
         ...(await deserializeAws_queryNoSuchEntityExceptionResponse(parsedOutput, context)),
@@ -6326,7 +6326,7 @@ const deserializeAws_queryDeleteSigningCertificateCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ServiceFailure":
+    case "ServiceFailureException":
     case "com.amazonaws.iam#ServiceFailureException":
       response = {
         ...(await deserializeAws_queryServiceFailureExceptionResponse(parsedOutput, context)),
@@ -6377,7 +6377,7 @@ const deserializeAws_queryDeleteSSHPublicKeyCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "NoSuchEntity":
+    case "NoSuchEntityException":
     case "com.amazonaws.iam#NoSuchEntityException":
       response = {
         ...(await deserializeAws_queryNoSuchEntityExceptionResponse(parsedOutput, context)),
@@ -6428,7 +6428,7 @@ const deserializeAws_queryDeleteUserCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "ConcurrentModification":
+    case "ConcurrentModificationException":
     case "com.amazonaws.iam#ConcurrentModificationException":
       response = {
         ...(await deserializeAws_queryConcurrentModificationExceptionResponse(parsedOutput, context)),
@@ -6436,7 +6436,7 @@ const deserializeAws_queryDeleteUserCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "DeleteConflict":
+    case "DeleteConflictException":
     case "com.amazonaws.iam#DeleteConflictException":
       response = {
         ...(await deserializeAws_queryDeleteConflictExceptionResponse(parsedOutput, context)),
@@ -6444,7 +6444,7 @@ const deserializeAws_queryDeleteUserCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "LimitExceeded":
+    case "LimitExceededException":
     case "com.amazonaws.iam#LimitExceededException":
       response = {
         ...(await deserializeAws_queryLimitExceededExceptionResponse(parsedOutput, context)),
@@ -6452,7 +6452,7 @@ const deserializeAws_queryDeleteUserCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "NoSuchEntity":
+    case "NoSuchEntityException":
     case "com.amazonaws.iam#NoSuchEntityException":
       response = {
         ...(await deserializeAws_queryNoSuchEntityExceptionResponse(parsedOutput, context)),
@@ -6460,7 +6460,7 @@ const deserializeAws_queryDeleteUserCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ServiceFailure":
+    case "ServiceFailureException":
     case "com.amazonaws.iam#ServiceFailureException":
       response = {
         ...(await deserializeAws_queryServiceFailureExceptionResponse(parsedOutput, context)),
@@ -6511,7 +6511,7 @@ const deserializeAws_queryDeleteUserPermissionsBoundaryCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "NoSuchEntity":
+    case "NoSuchEntityException":
     case "com.amazonaws.iam#NoSuchEntityException":
       response = {
         ...(await deserializeAws_queryNoSuchEntityExceptionResponse(parsedOutput, context)),
@@ -6519,7 +6519,7 @@ const deserializeAws_queryDeleteUserPermissionsBoundaryCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ServiceFailure":
+    case "ServiceFailureException":
     case "com.amazonaws.iam#ServiceFailureException":
       response = {
         ...(await deserializeAws_queryServiceFailureExceptionResponse(parsedOutput, context)),
@@ -6570,7 +6570,7 @@ const deserializeAws_queryDeleteUserPolicyCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "LimitExceeded":
+    case "LimitExceededException":
     case "com.amazonaws.iam#LimitExceededException":
       response = {
         ...(await deserializeAws_queryLimitExceededExceptionResponse(parsedOutput, context)),
@@ -6578,7 +6578,7 @@ const deserializeAws_queryDeleteUserPolicyCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "NoSuchEntity":
+    case "NoSuchEntityException":
     case "com.amazonaws.iam#NoSuchEntityException":
       response = {
         ...(await deserializeAws_queryNoSuchEntityExceptionResponse(parsedOutput, context)),
@@ -6586,7 +6586,7 @@ const deserializeAws_queryDeleteUserPolicyCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ServiceFailure":
+    case "ServiceFailureException":
     case "com.amazonaws.iam#ServiceFailureException":
       response = {
         ...(await deserializeAws_queryServiceFailureExceptionResponse(parsedOutput, context)),
@@ -6637,7 +6637,7 @@ const deserializeAws_queryDeleteVirtualMFADeviceCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "DeleteConflict":
+    case "DeleteConflictException":
     case "com.amazonaws.iam#DeleteConflictException":
       response = {
         ...(await deserializeAws_queryDeleteConflictExceptionResponse(parsedOutput, context)),
@@ -6645,7 +6645,7 @@ const deserializeAws_queryDeleteVirtualMFADeviceCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "LimitExceeded":
+    case "LimitExceededException":
     case "com.amazonaws.iam#LimitExceededException":
       response = {
         ...(await deserializeAws_queryLimitExceededExceptionResponse(parsedOutput, context)),
@@ -6653,7 +6653,7 @@ const deserializeAws_queryDeleteVirtualMFADeviceCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "NoSuchEntity":
+    case "NoSuchEntityException":
     case "com.amazonaws.iam#NoSuchEntityException":
       response = {
         ...(await deserializeAws_queryNoSuchEntityExceptionResponse(parsedOutput, context)),
@@ -6661,7 +6661,7 @@ const deserializeAws_queryDeleteVirtualMFADeviceCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ServiceFailure":
+    case "ServiceFailureException":
     case "com.amazonaws.iam#ServiceFailureException":
       response = {
         ...(await deserializeAws_queryServiceFailureExceptionResponse(parsedOutput, context)),
@@ -6712,7 +6712,7 @@ const deserializeAws_queryDetachGroupPolicyCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "InvalidInput":
+    case "InvalidInputException":
     case "com.amazonaws.iam#InvalidInputException":
       response = {
         ...(await deserializeAws_queryInvalidInputExceptionResponse(parsedOutput, context)),
@@ -6720,7 +6720,7 @@ const deserializeAws_queryDetachGroupPolicyCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "LimitExceeded":
+    case "LimitExceededException":
     case "com.amazonaws.iam#LimitExceededException":
       response = {
         ...(await deserializeAws_queryLimitExceededExceptionResponse(parsedOutput, context)),
@@ -6728,7 +6728,7 @@ const deserializeAws_queryDetachGroupPolicyCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "NoSuchEntity":
+    case "NoSuchEntityException":
     case "com.amazonaws.iam#NoSuchEntityException":
       response = {
         ...(await deserializeAws_queryNoSuchEntityExceptionResponse(parsedOutput, context)),
@@ -6736,7 +6736,7 @@ const deserializeAws_queryDetachGroupPolicyCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ServiceFailure":
+    case "ServiceFailureException":
     case "com.amazonaws.iam#ServiceFailureException":
       response = {
         ...(await deserializeAws_queryServiceFailureExceptionResponse(parsedOutput, context)),
@@ -6787,7 +6787,7 @@ const deserializeAws_queryDetachRolePolicyCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "InvalidInput":
+    case "InvalidInputException":
     case "com.amazonaws.iam#InvalidInputException":
       response = {
         ...(await deserializeAws_queryInvalidInputExceptionResponse(parsedOutput, context)),
@@ -6795,7 +6795,7 @@ const deserializeAws_queryDetachRolePolicyCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "LimitExceeded":
+    case "LimitExceededException":
     case "com.amazonaws.iam#LimitExceededException":
       response = {
         ...(await deserializeAws_queryLimitExceededExceptionResponse(parsedOutput, context)),
@@ -6803,7 +6803,7 @@ const deserializeAws_queryDetachRolePolicyCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "NoSuchEntity":
+    case "NoSuchEntityException":
     case "com.amazonaws.iam#NoSuchEntityException":
       response = {
         ...(await deserializeAws_queryNoSuchEntityExceptionResponse(parsedOutput, context)),
@@ -6811,7 +6811,7 @@ const deserializeAws_queryDetachRolePolicyCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ServiceFailure":
+    case "ServiceFailureException":
     case "com.amazonaws.iam#ServiceFailureException":
       response = {
         ...(await deserializeAws_queryServiceFailureExceptionResponse(parsedOutput, context)),
@@ -6819,7 +6819,7 @@ const deserializeAws_queryDetachRolePolicyCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "UnmodifiableEntity":
+    case "UnmodifiableEntityException":
     case "com.amazonaws.iam#UnmodifiableEntityException":
       response = {
         ...(await deserializeAws_queryUnmodifiableEntityExceptionResponse(parsedOutput, context)),
@@ -6870,7 +6870,7 @@ const deserializeAws_queryDetachUserPolicyCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "InvalidInput":
+    case "InvalidInputException":
     case "com.amazonaws.iam#InvalidInputException":
       response = {
         ...(await deserializeAws_queryInvalidInputExceptionResponse(parsedOutput, context)),
@@ -6878,7 +6878,7 @@ const deserializeAws_queryDetachUserPolicyCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "LimitExceeded":
+    case "LimitExceededException":
     case "com.amazonaws.iam#LimitExceededException":
       response = {
         ...(await deserializeAws_queryLimitExceededExceptionResponse(parsedOutput, context)),
@@ -6886,7 +6886,7 @@ const deserializeAws_queryDetachUserPolicyCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "NoSuchEntity":
+    case "NoSuchEntityException":
     case "com.amazonaws.iam#NoSuchEntityException":
       response = {
         ...(await deserializeAws_queryNoSuchEntityExceptionResponse(parsedOutput, context)),
@@ -6894,7 +6894,7 @@ const deserializeAws_queryDetachUserPolicyCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ServiceFailure":
+    case "ServiceFailureException":
     case "com.amazonaws.iam#ServiceFailureException":
       response = {
         ...(await deserializeAws_queryServiceFailureExceptionResponse(parsedOutput, context)),
@@ -6945,7 +6945,7 @@ const deserializeAws_queryEnableMFADeviceCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "EntityAlreadyExists":
+    case "EntityAlreadyExistsException":
     case "com.amazonaws.iam#EntityAlreadyExistsException":
       response = {
         ...(await deserializeAws_queryEntityAlreadyExistsExceptionResponse(parsedOutput, context)),
@@ -6953,7 +6953,7 @@ const deserializeAws_queryEnableMFADeviceCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "EntityTemporarilyUnmodifiable":
+    case "EntityTemporarilyUnmodifiableException":
     case "com.amazonaws.iam#EntityTemporarilyUnmodifiableException":
       response = {
         ...(await deserializeAws_queryEntityTemporarilyUnmodifiableExceptionResponse(parsedOutput, context)),
@@ -6961,7 +6961,7 @@ const deserializeAws_queryEnableMFADeviceCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidAuthenticationCode":
+    case "InvalidAuthenticationCodeException":
     case "com.amazonaws.iam#InvalidAuthenticationCodeException":
       response = {
         ...(await deserializeAws_queryInvalidAuthenticationCodeExceptionResponse(parsedOutput, context)),
@@ -6969,7 +6969,7 @@ const deserializeAws_queryEnableMFADeviceCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "LimitExceeded":
+    case "LimitExceededException":
     case "com.amazonaws.iam#LimitExceededException":
       response = {
         ...(await deserializeAws_queryLimitExceededExceptionResponse(parsedOutput, context)),
@@ -6977,7 +6977,7 @@ const deserializeAws_queryEnableMFADeviceCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "NoSuchEntity":
+    case "NoSuchEntityException":
     case "com.amazonaws.iam#NoSuchEntityException":
       response = {
         ...(await deserializeAws_queryNoSuchEntityExceptionResponse(parsedOutput, context)),
@@ -6985,7 +6985,7 @@ const deserializeAws_queryEnableMFADeviceCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ServiceFailure":
+    case "ServiceFailureException":
     case "com.amazonaws.iam#ServiceFailureException":
       response = {
         ...(await deserializeAws_queryServiceFailureExceptionResponse(parsedOutput, context)),
@@ -7039,7 +7039,7 @@ const deserializeAws_queryGenerateCredentialReportCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "LimitExceeded":
+    case "LimitExceededException":
     case "com.amazonaws.iam#LimitExceededException":
       response = {
         ...(await deserializeAws_queryLimitExceededExceptionResponse(parsedOutput, context)),
@@ -7047,7 +7047,7 @@ const deserializeAws_queryGenerateCredentialReportCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ServiceFailure":
+    case "ServiceFailureException":
     case "com.amazonaws.iam#ServiceFailureException":
       response = {
         ...(await deserializeAws_queryServiceFailureExceptionResponse(parsedOutput, context)),
@@ -7104,7 +7104,7 @@ const deserializeAws_queryGenerateOrganizationsAccessReportCommandError = async 
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "ReportGenerationLimitExceeded":
+    case "ReportGenerationLimitExceededException":
     case "com.amazonaws.iam#ReportGenerationLimitExceededException":
       response = {
         ...(await deserializeAws_queryReportGenerationLimitExceededExceptionResponse(parsedOutput, context)),
@@ -7161,7 +7161,7 @@ const deserializeAws_queryGenerateServiceLastAccessedDetailsCommandError = async
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "InvalidInput":
+    case "InvalidInputException":
     case "com.amazonaws.iam#InvalidInputException":
       response = {
         ...(await deserializeAws_queryInvalidInputExceptionResponse(parsedOutput, context)),
@@ -7169,7 +7169,7 @@ const deserializeAws_queryGenerateServiceLastAccessedDetailsCommandError = async
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "NoSuchEntity":
+    case "NoSuchEntityException":
     case "com.amazonaws.iam#NoSuchEntityException":
       response = {
         ...(await deserializeAws_queryNoSuchEntityExceptionResponse(parsedOutput, context)),
@@ -7223,7 +7223,7 @@ const deserializeAws_queryGetAccessKeyLastUsedCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "NoSuchEntity":
+    case "NoSuchEntityException":
     case "com.amazonaws.iam#NoSuchEntityException":
       response = {
         ...(await deserializeAws_queryNoSuchEntityExceptionResponse(parsedOutput, context)),
@@ -7280,7 +7280,7 @@ const deserializeAws_queryGetAccountAuthorizationDetailsCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "ServiceFailure":
+    case "ServiceFailureException":
     case "com.amazonaws.iam#ServiceFailureException":
       response = {
         ...(await deserializeAws_queryServiceFailureExceptionResponse(parsedOutput, context)),
@@ -7334,7 +7334,7 @@ const deserializeAws_queryGetAccountPasswordPolicyCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "NoSuchEntity":
+    case "NoSuchEntityException":
     case "com.amazonaws.iam#NoSuchEntityException":
       response = {
         ...(await deserializeAws_queryNoSuchEntityExceptionResponse(parsedOutput, context)),
@@ -7342,7 +7342,7 @@ const deserializeAws_queryGetAccountPasswordPolicyCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ServiceFailure":
+    case "ServiceFailureException":
     case "com.amazonaws.iam#ServiceFailureException":
       response = {
         ...(await deserializeAws_queryServiceFailureExceptionResponse(parsedOutput, context)),
@@ -7396,7 +7396,7 @@ const deserializeAws_queryGetAccountSummaryCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "ServiceFailure":
+    case "ServiceFailureException":
     case "com.amazonaws.iam#ServiceFailureException":
       response = {
         ...(await deserializeAws_queryServiceFailureExceptionResponse(parsedOutput, context)),
@@ -7450,7 +7450,7 @@ const deserializeAws_queryGetContextKeysForCustomPolicyCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "InvalidInput":
+    case "InvalidInputException":
     case "com.amazonaws.iam#InvalidInputException":
       response = {
         ...(await deserializeAws_queryInvalidInputExceptionResponse(parsedOutput, context)),
@@ -7504,7 +7504,7 @@ const deserializeAws_queryGetContextKeysForPrincipalPolicyCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "InvalidInput":
+    case "InvalidInputException":
     case "com.amazonaws.iam#InvalidInputException":
       response = {
         ...(await deserializeAws_queryInvalidInputExceptionResponse(parsedOutput, context)),
@@ -7512,7 +7512,7 @@ const deserializeAws_queryGetContextKeysForPrincipalPolicyCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "NoSuchEntity":
+    case "NoSuchEntityException":
     case "com.amazonaws.iam#NoSuchEntityException":
       response = {
         ...(await deserializeAws_queryNoSuchEntityExceptionResponse(parsedOutput, context)),
@@ -7566,7 +7566,7 @@ const deserializeAws_queryGetCredentialReportCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "ReportExpired":
+    case "CredentialReportExpiredException":
     case "com.amazonaws.iam#CredentialReportExpiredException":
       response = {
         ...(await deserializeAws_queryCredentialReportExpiredExceptionResponse(parsedOutput, context)),
@@ -7574,15 +7574,7 @@ const deserializeAws_queryGetCredentialReportCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ReportInProgress":
-    case "com.amazonaws.iam#CredentialReportNotReadyException":
-      response = {
-        ...(await deserializeAws_queryCredentialReportNotReadyExceptionResponse(parsedOutput, context)),
-        name: errorCode,
-        $metadata: deserializeMetadata(output),
-      };
-      break;
-    case "ReportNotPresent":
+    case "CredentialReportNotPresentException":
     case "com.amazonaws.iam#CredentialReportNotPresentException":
       response = {
         ...(await deserializeAws_queryCredentialReportNotPresentExceptionResponse(parsedOutput, context)),
@@ -7590,7 +7582,15 @@ const deserializeAws_queryGetCredentialReportCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ServiceFailure":
+    case "CredentialReportNotReadyException":
+    case "com.amazonaws.iam#CredentialReportNotReadyException":
+      response = {
+        ...(await deserializeAws_queryCredentialReportNotReadyExceptionResponse(parsedOutput, context)),
+        name: errorCode,
+        $metadata: deserializeMetadata(output),
+      };
+      break;
+    case "ServiceFailureException":
     case "com.amazonaws.iam#ServiceFailureException":
       response = {
         ...(await deserializeAws_queryServiceFailureExceptionResponse(parsedOutput, context)),
@@ -7644,7 +7644,7 @@ const deserializeAws_queryGetGroupCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "NoSuchEntity":
+    case "NoSuchEntityException":
     case "com.amazonaws.iam#NoSuchEntityException":
       response = {
         ...(await deserializeAws_queryNoSuchEntityExceptionResponse(parsedOutput, context)),
@@ -7652,7 +7652,7 @@ const deserializeAws_queryGetGroupCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ServiceFailure":
+    case "ServiceFailureException":
     case "com.amazonaws.iam#ServiceFailureException":
       response = {
         ...(await deserializeAws_queryServiceFailureExceptionResponse(parsedOutput, context)),
@@ -7706,7 +7706,7 @@ const deserializeAws_queryGetGroupPolicyCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "NoSuchEntity":
+    case "NoSuchEntityException":
     case "com.amazonaws.iam#NoSuchEntityException":
       response = {
         ...(await deserializeAws_queryNoSuchEntityExceptionResponse(parsedOutput, context)),
@@ -7714,7 +7714,7 @@ const deserializeAws_queryGetGroupPolicyCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ServiceFailure":
+    case "ServiceFailureException":
     case "com.amazonaws.iam#ServiceFailureException":
       response = {
         ...(await deserializeAws_queryServiceFailureExceptionResponse(parsedOutput, context)),
@@ -7768,7 +7768,7 @@ const deserializeAws_queryGetInstanceProfileCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "NoSuchEntity":
+    case "NoSuchEntityException":
     case "com.amazonaws.iam#NoSuchEntityException":
       response = {
         ...(await deserializeAws_queryNoSuchEntityExceptionResponse(parsedOutput, context)),
@@ -7776,7 +7776,7 @@ const deserializeAws_queryGetInstanceProfileCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ServiceFailure":
+    case "ServiceFailureException":
     case "com.amazonaws.iam#ServiceFailureException":
       response = {
         ...(await deserializeAws_queryServiceFailureExceptionResponse(parsedOutput, context)),
@@ -7830,7 +7830,7 @@ const deserializeAws_queryGetLoginProfileCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "NoSuchEntity":
+    case "NoSuchEntityException":
     case "com.amazonaws.iam#NoSuchEntityException":
       response = {
         ...(await deserializeAws_queryNoSuchEntityExceptionResponse(parsedOutput, context)),
@@ -7838,7 +7838,7 @@ const deserializeAws_queryGetLoginProfileCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ServiceFailure":
+    case "ServiceFailureException":
     case "com.amazonaws.iam#ServiceFailureException":
       response = {
         ...(await deserializeAws_queryServiceFailureExceptionResponse(parsedOutput, context)),
@@ -7892,7 +7892,7 @@ const deserializeAws_queryGetOpenIDConnectProviderCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "InvalidInput":
+    case "InvalidInputException":
     case "com.amazonaws.iam#InvalidInputException":
       response = {
         ...(await deserializeAws_queryInvalidInputExceptionResponse(parsedOutput, context)),
@@ -7900,7 +7900,7 @@ const deserializeAws_queryGetOpenIDConnectProviderCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "NoSuchEntity":
+    case "NoSuchEntityException":
     case "com.amazonaws.iam#NoSuchEntityException":
       response = {
         ...(await deserializeAws_queryNoSuchEntityExceptionResponse(parsedOutput, context)),
@@ -7908,7 +7908,7 @@ const deserializeAws_queryGetOpenIDConnectProviderCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ServiceFailure":
+    case "ServiceFailureException":
     case "com.amazonaws.iam#ServiceFailureException":
       response = {
         ...(await deserializeAws_queryServiceFailureExceptionResponse(parsedOutput, context)),
@@ -7962,7 +7962,7 @@ const deserializeAws_queryGetOrganizationsAccessReportCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "NoSuchEntity":
+    case "NoSuchEntityException":
     case "com.amazonaws.iam#NoSuchEntityException":
       response = {
         ...(await deserializeAws_queryNoSuchEntityExceptionResponse(parsedOutput, context)),
@@ -8016,7 +8016,7 @@ const deserializeAws_queryGetPolicyCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "InvalidInput":
+    case "InvalidInputException":
     case "com.amazonaws.iam#InvalidInputException":
       response = {
         ...(await deserializeAws_queryInvalidInputExceptionResponse(parsedOutput, context)),
@@ -8024,7 +8024,7 @@ const deserializeAws_queryGetPolicyCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "NoSuchEntity":
+    case "NoSuchEntityException":
     case "com.amazonaws.iam#NoSuchEntityException":
       response = {
         ...(await deserializeAws_queryNoSuchEntityExceptionResponse(parsedOutput, context)),
@@ -8032,7 +8032,7 @@ const deserializeAws_queryGetPolicyCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ServiceFailure":
+    case "ServiceFailureException":
     case "com.amazonaws.iam#ServiceFailureException":
       response = {
         ...(await deserializeAws_queryServiceFailureExceptionResponse(parsedOutput, context)),
@@ -8086,7 +8086,7 @@ const deserializeAws_queryGetPolicyVersionCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "InvalidInput":
+    case "InvalidInputException":
     case "com.amazonaws.iam#InvalidInputException":
       response = {
         ...(await deserializeAws_queryInvalidInputExceptionResponse(parsedOutput, context)),
@@ -8094,7 +8094,7 @@ const deserializeAws_queryGetPolicyVersionCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "NoSuchEntity":
+    case "NoSuchEntityException":
     case "com.amazonaws.iam#NoSuchEntityException":
       response = {
         ...(await deserializeAws_queryNoSuchEntityExceptionResponse(parsedOutput, context)),
@@ -8102,7 +8102,7 @@ const deserializeAws_queryGetPolicyVersionCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ServiceFailure":
+    case "ServiceFailureException":
     case "com.amazonaws.iam#ServiceFailureException":
       response = {
         ...(await deserializeAws_queryServiceFailureExceptionResponse(parsedOutput, context)),
@@ -8156,7 +8156,7 @@ const deserializeAws_queryGetRoleCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "NoSuchEntity":
+    case "NoSuchEntityException":
     case "com.amazonaws.iam#NoSuchEntityException":
       response = {
         ...(await deserializeAws_queryNoSuchEntityExceptionResponse(parsedOutput, context)),
@@ -8164,7 +8164,7 @@ const deserializeAws_queryGetRoleCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ServiceFailure":
+    case "ServiceFailureException":
     case "com.amazonaws.iam#ServiceFailureException":
       response = {
         ...(await deserializeAws_queryServiceFailureExceptionResponse(parsedOutput, context)),
@@ -8218,7 +8218,7 @@ const deserializeAws_queryGetRolePolicyCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "NoSuchEntity":
+    case "NoSuchEntityException":
     case "com.amazonaws.iam#NoSuchEntityException":
       response = {
         ...(await deserializeAws_queryNoSuchEntityExceptionResponse(parsedOutput, context)),
@@ -8226,7 +8226,7 @@ const deserializeAws_queryGetRolePolicyCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ServiceFailure":
+    case "ServiceFailureException":
     case "com.amazonaws.iam#ServiceFailureException":
       response = {
         ...(await deserializeAws_queryServiceFailureExceptionResponse(parsedOutput, context)),
@@ -8280,7 +8280,7 @@ const deserializeAws_queryGetSAMLProviderCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "InvalidInput":
+    case "InvalidInputException":
     case "com.amazonaws.iam#InvalidInputException":
       response = {
         ...(await deserializeAws_queryInvalidInputExceptionResponse(parsedOutput, context)),
@@ -8288,7 +8288,7 @@ const deserializeAws_queryGetSAMLProviderCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "NoSuchEntity":
+    case "NoSuchEntityException":
     case "com.amazonaws.iam#NoSuchEntityException":
       response = {
         ...(await deserializeAws_queryNoSuchEntityExceptionResponse(parsedOutput, context)),
@@ -8296,7 +8296,7 @@ const deserializeAws_queryGetSAMLProviderCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ServiceFailure":
+    case "ServiceFailureException":
     case "com.amazonaws.iam#ServiceFailureException":
       response = {
         ...(await deserializeAws_queryServiceFailureExceptionResponse(parsedOutput, context)),
@@ -8350,7 +8350,7 @@ const deserializeAws_queryGetServerCertificateCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "NoSuchEntity":
+    case "NoSuchEntityException":
     case "com.amazonaws.iam#NoSuchEntityException":
       response = {
         ...(await deserializeAws_queryNoSuchEntityExceptionResponse(parsedOutput, context)),
@@ -8358,7 +8358,7 @@ const deserializeAws_queryGetServerCertificateCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ServiceFailure":
+    case "ServiceFailureException":
     case "com.amazonaws.iam#ServiceFailureException":
       response = {
         ...(await deserializeAws_queryServiceFailureExceptionResponse(parsedOutput, context)),
@@ -8415,7 +8415,7 @@ const deserializeAws_queryGetServiceLastAccessedDetailsCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "InvalidInput":
+    case "InvalidInputException":
     case "com.amazonaws.iam#InvalidInputException":
       response = {
         ...(await deserializeAws_queryInvalidInputExceptionResponse(parsedOutput, context)),
@@ -8423,7 +8423,7 @@ const deserializeAws_queryGetServiceLastAccessedDetailsCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "NoSuchEntity":
+    case "NoSuchEntityException":
     case "com.amazonaws.iam#NoSuchEntityException":
       response = {
         ...(await deserializeAws_queryNoSuchEntityExceptionResponse(parsedOutput, context)),
@@ -8480,7 +8480,7 @@ const deserializeAws_queryGetServiceLastAccessedDetailsWithEntitiesCommandError 
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "InvalidInput":
+    case "InvalidInputException":
     case "com.amazonaws.iam#InvalidInputException":
       response = {
         ...(await deserializeAws_queryInvalidInputExceptionResponse(parsedOutput, context)),
@@ -8488,7 +8488,7 @@ const deserializeAws_queryGetServiceLastAccessedDetailsWithEntitiesCommandError 
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "NoSuchEntity":
+    case "NoSuchEntityException":
     case "com.amazonaws.iam#NoSuchEntityException":
       response = {
         ...(await deserializeAws_queryNoSuchEntityExceptionResponse(parsedOutput, context)),
@@ -8545,7 +8545,7 @@ const deserializeAws_queryGetServiceLinkedRoleDeletionStatusCommandError = async
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "InvalidInput":
+    case "InvalidInputException":
     case "com.amazonaws.iam#InvalidInputException":
       response = {
         ...(await deserializeAws_queryInvalidInputExceptionResponse(parsedOutput, context)),
@@ -8553,7 +8553,7 @@ const deserializeAws_queryGetServiceLinkedRoleDeletionStatusCommandError = async
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "NoSuchEntity":
+    case "NoSuchEntityException":
     case "com.amazonaws.iam#NoSuchEntityException":
       response = {
         ...(await deserializeAws_queryNoSuchEntityExceptionResponse(parsedOutput, context)),
@@ -8561,7 +8561,7 @@ const deserializeAws_queryGetServiceLinkedRoleDeletionStatusCommandError = async
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ServiceFailure":
+    case "ServiceFailureException":
     case "com.amazonaws.iam#ServiceFailureException":
       response = {
         ...(await deserializeAws_queryServiceFailureExceptionResponse(parsedOutput, context)),
@@ -8615,7 +8615,7 @@ const deserializeAws_queryGetSSHPublicKeyCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "NoSuchEntity":
+    case "NoSuchEntityException":
     case "com.amazonaws.iam#NoSuchEntityException":
       response = {
         ...(await deserializeAws_queryNoSuchEntityExceptionResponse(parsedOutput, context)),
@@ -8623,7 +8623,7 @@ const deserializeAws_queryGetSSHPublicKeyCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "UnrecognizedPublicKeyEncoding":
+    case "UnrecognizedPublicKeyEncodingException":
     case "com.amazonaws.iam#UnrecognizedPublicKeyEncodingException":
       response = {
         ...(await deserializeAws_queryUnrecognizedPublicKeyEncodingExceptionResponse(parsedOutput, context)),
@@ -8677,7 +8677,7 @@ const deserializeAws_queryGetUserCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "NoSuchEntity":
+    case "NoSuchEntityException":
     case "com.amazonaws.iam#NoSuchEntityException":
       response = {
         ...(await deserializeAws_queryNoSuchEntityExceptionResponse(parsedOutput, context)),
@@ -8685,7 +8685,7 @@ const deserializeAws_queryGetUserCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ServiceFailure":
+    case "ServiceFailureException":
     case "com.amazonaws.iam#ServiceFailureException":
       response = {
         ...(await deserializeAws_queryServiceFailureExceptionResponse(parsedOutput, context)),
@@ -8739,7 +8739,7 @@ const deserializeAws_queryGetUserPolicyCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "NoSuchEntity":
+    case "NoSuchEntityException":
     case "com.amazonaws.iam#NoSuchEntityException":
       response = {
         ...(await deserializeAws_queryNoSuchEntityExceptionResponse(parsedOutput, context)),
@@ -8747,7 +8747,7 @@ const deserializeAws_queryGetUserPolicyCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ServiceFailure":
+    case "ServiceFailureException":
     case "com.amazonaws.iam#ServiceFailureException":
       response = {
         ...(await deserializeAws_queryServiceFailureExceptionResponse(parsedOutput, context)),
@@ -8801,7 +8801,7 @@ const deserializeAws_queryListAccessKeysCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "NoSuchEntity":
+    case "NoSuchEntityException":
     case "com.amazonaws.iam#NoSuchEntityException":
       response = {
         ...(await deserializeAws_queryNoSuchEntityExceptionResponse(parsedOutput, context)),
@@ -8809,7 +8809,7 @@ const deserializeAws_queryListAccessKeysCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ServiceFailure":
+    case "ServiceFailureException":
     case "com.amazonaws.iam#ServiceFailureException":
       response = {
         ...(await deserializeAws_queryServiceFailureExceptionResponse(parsedOutput, context)),
@@ -8863,7 +8863,7 @@ const deserializeAws_queryListAccountAliasesCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "ServiceFailure":
+    case "ServiceFailureException":
     case "com.amazonaws.iam#ServiceFailureException":
       response = {
         ...(await deserializeAws_queryServiceFailureExceptionResponse(parsedOutput, context)),
@@ -8917,7 +8917,7 @@ const deserializeAws_queryListAttachedGroupPoliciesCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "InvalidInput":
+    case "InvalidInputException":
     case "com.amazonaws.iam#InvalidInputException":
       response = {
         ...(await deserializeAws_queryInvalidInputExceptionResponse(parsedOutput, context)),
@@ -8925,7 +8925,7 @@ const deserializeAws_queryListAttachedGroupPoliciesCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "NoSuchEntity":
+    case "NoSuchEntityException":
     case "com.amazonaws.iam#NoSuchEntityException":
       response = {
         ...(await deserializeAws_queryNoSuchEntityExceptionResponse(parsedOutput, context)),
@@ -8933,7 +8933,7 @@ const deserializeAws_queryListAttachedGroupPoliciesCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ServiceFailure":
+    case "ServiceFailureException":
     case "com.amazonaws.iam#ServiceFailureException":
       response = {
         ...(await deserializeAws_queryServiceFailureExceptionResponse(parsedOutput, context)),
@@ -8987,7 +8987,7 @@ const deserializeAws_queryListAttachedRolePoliciesCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "InvalidInput":
+    case "InvalidInputException":
     case "com.amazonaws.iam#InvalidInputException":
       response = {
         ...(await deserializeAws_queryInvalidInputExceptionResponse(parsedOutput, context)),
@@ -8995,7 +8995,7 @@ const deserializeAws_queryListAttachedRolePoliciesCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "NoSuchEntity":
+    case "NoSuchEntityException":
     case "com.amazonaws.iam#NoSuchEntityException":
       response = {
         ...(await deserializeAws_queryNoSuchEntityExceptionResponse(parsedOutput, context)),
@@ -9003,7 +9003,7 @@ const deserializeAws_queryListAttachedRolePoliciesCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ServiceFailure":
+    case "ServiceFailureException":
     case "com.amazonaws.iam#ServiceFailureException":
       response = {
         ...(await deserializeAws_queryServiceFailureExceptionResponse(parsedOutput, context)),
@@ -9057,7 +9057,7 @@ const deserializeAws_queryListAttachedUserPoliciesCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "InvalidInput":
+    case "InvalidInputException":
     case "com.amazonaws.iam#InvalidInputException":
       response = {
         ...(await deserializeAws_queryInvalidInputExceptionResponse(parsedOutput, context)),
@@ -9065,7 +9065,7 @@ const deserializeAws_queryListAttachedUserPoliciesCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "NoSuchEntity":
+    case "NoSuchEntityException":
     case "com.amazonaws.iam#NoSuchEntityException":
       response = {
         ...(await deserializeAws_queryNoSuchEntityExceptionResponse(parsedOutput, context)),
@@ -9073,7 +9073,7 @@ const deserializeAws_queryListAttachedUserPoliciesCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ServiceFailure":
+    case "ServiceFailureException":
     case "com.amazonaws.iam#ServiceFailureException":
       response = {
         ...(await deserializeAws_queryServiceFailureExceptionResponse(parsedOutput, context)),
@@ -9127,7 +9127,7 @@ const deserializeAws_queryListEntitiesForPolicyCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "InvalidInput":
+    case "InvalidInputException":
     case "com.amazonaws.iam#InvalidInputException":
       response = {
         ...(await deserializeAws_queryInvalidInputExceptionResponse(parsedOutput, context)),
@@ -9135,7 +9135,7 @@ const deserializeAws_queryListEntitiesForPolicyCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "NoSuchEntity":
+    case "NoSuchEntityException":
     case "com.amazonaws.iam#NoSuchEntityException":
       response = {
         ...(await deserializeAws_queryNoSuchEntityExceptionResponse(parsedOutput, context)),
@@ -9143,7 +9143,7 @@ const deserializeAws_queryListEntitiesForPolicyCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ServiceFailure":
+    case "ServiceFailureException":
     case "com.amazonaws.iam#ServiceFailureException":
       response = {
         ...(await deserializeAws_queryServiceFailureExceptionResponse(parsedOutput, context)),
@@ -9197,7 +9197,7 @@ const deserializeAws_queryListGroupPoliciesCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "NoSuchEntity":
+    case "NoSuchEntityException":
     case "com.amazonaws.iam#NoSuchEntityException":
       response = {
         ...(await deserializeAws_queryNoSuchEntityExceptionResponse(parsedOutput, context)),
@@ -9205,7 +9205,7 @@ const deserializeAws_queryListGroupPoliciesCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ServiceFailure":
+    case "ServiceFailureException":
     case "com.amazonaws.iam#ServiceFailureException":
       response = {
         ...(await deserializeAws_queryServiceFailureExceptionResponse(parsedOutput, context)),
@@ -9259,7 +9259,7 @@ const deserializeAws_queryListGroupsCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "ServiceFailure":
+    case "ServiceFailureException":
     case "com.amazonaws.iam#ServiceFailureException":
       response = {
         ...(await deserializeAws_queryServiceFailureExceptionResponse(parsedOutput, context)),
@@ -9313,7 +9313,7 @@ const deserializeAws_queryListGroupsForUserCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "NoSuchEntity":
+    case "NoSuchEntityException":
     case "com.amazonaws.iam#NoSuchEntityException":
       response = {
         ...(await deserializeAws_queryNoSuchEntityExceptionResponse(parsedOutput, context)),
@@ -9321,7 +9321,7 @@ const deserializeAws_queryListGroupsForUserCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ServiceFailure":
+    case "ServiceFailureException":
     case "com.amazonaws.iam#ServiceFailureException":
       response = {
         ...(await deserializeAws_queryServiceFailureExceptionResponse(parsedOutput, context)),
@@ -9375,7 +9375,7 @@ const deserializeAws_queryListInstanceProfilesCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "ServiceFailure":
+    case "ServiceFailureException":
     case "com.amazonaws.iam#ServiceFailureException":
       response = {
         ...(await deserializeAws_queryServiceFailureExceptionResponse(parsedOutput, context)),
@@ -9429,7 +9429,7 @@ const deserializeAws_queryListInstanceProfilesForRoleCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "NoSuchEntity":
+    case "NoSuchEntityException":
     case "com.amazonaws.iam#NoSuchEntityException":
       response = {
         ...(await deserializeAws_queryNoSuchEntityExceptionResponse(parsedOutput, context)),
@@ -9437,7 +9437,7 @@ const deserializeAws_queryListInstanceProfilesForRoleCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ServiceFailure":
+    case "ServiceFailureException":
     case "com.amazonaws.iam#ServiceFailureException":
       response = {
         ...(await deserializeAws_queryServiceFailureExceptionResponse(parsedOutput, context)),
@@ -9491,7 +9491,7 @@ const deserializeAws_queryListInstanceProfileTagsCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "NoSuchEntity":
+    case "NoSuchEntityException":
     case "com.amazonaws.iam#NoSuchEntityException":
       response = {
         ...(await deserializeAws_queryNoSuchEntityExceptionResponse(parsedOutput, context)),
@@ -9499,7 +9499,7 @@ const deserializeAws_queryListInstanceProfileTagsCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ServiceFailure":
+    case "ServiceFailureException":
     case "com.amazonaws.iam#ServiceFailureException":
       response = {
         ...(await deserializeAws_queryServiceFailureExceptionResponse(parsedOutput, context)),
@@ -9553,7 +9553,7 @@ const deserializeAws_queryListMFADevicesCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "NoSuchEntity":
+    case "NoSuchEntityException":
     case "com.amazonaws.iam#NoSuchEntityException":
       response = {
         ...(await deserializeAws_queryNoSuchEntityExceptionResponse(parsedOutput, context)),
@@ -9561,7 +9561,7 @@ const deserializeAws_queryListMFADevicesCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ServiceFailure":
+    case "ServiceFailureException":
     case "com.amazonaws.iam#ServiceFailureException":
       response = {
         ...(await deserializeAws_queryServiceFailureExceptionResponse(parsedOutput, context)),
@@ -9615,7 +9615,7 @@ const deserializeAws_queryListMFADeviceTagsCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "InvalidInput":
+    case "InvalidInputException":
     case "com.amazonaws.iam#InvalidInputException":
       response = {
         ...(await deserializeAws_queryInvalidInputExceptionResponse(parsedOutput, context)),
@@ -9623,7 +9623,7 @@ const deserializeAws_queryListMFADeviceTagsCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "NoSuchEntity":
+    case "NoSuchEntityException":
     case "com.amazonaws.iam#NoSuchEntityException":
       response = {
         ...(await deserializeAws_queryNoSuchEntityExceptionResponse(parsedOutput, context)),
@@ -9631,7 +9631,7 @@ const deserializeAws_queryListMFADeviceTagsCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ServiceFailure":
+    case "ServiceFailureException":
     case "com.amazonaws.iam#ServiceFailureException":
       response = {
         ...(await deserializeAws_queryServiceFailureExceptionResponse(parsedOutput, context)),
@@ -9685,7 +9685,7 @@ const deserializeAws_queryListOpenIDConnectProvidersCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "ServiceFailure":
+    case "ServiceFailureException":
     case "com.amazonaws.iam#ServiceFailureException":
       response = {
         ...(await deserializeAws_queryServiceFailureExceptionResponse(parsedOutput, context)),
@@ -9742,7 +9742,7 @@ const deserializeAws_queryListOpenIDConnectProviderTagsCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "InvalidInput":
+    case "InvalidInputException":
     case "com.amazonaws.iam#InvalidInputException":
       response = {
         ...(await deserializeAws_queryInvalidInputExceptionResponse(parsedOutput, context)),
@@ -9750,7 +9750,7 @@ const deserializeAws_queryListOpenIDConnectProviderTagsCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "NoSuchEntity":
+    case "NoSuchEntityException":
     case "com.amazonaws.iam#NoSuchEntityException":
       response = {
         ...(await deserializeAws_queryNoSuchEntityExceptionResponse(parsedOutput, context)),
@@ -9758,7 +9758,7 @@ const deserializeAws_queryListOpenIDConnectProviderTagsCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ServiceFailure":
+    case "ServiceFailureException":
     case "com.amazonaws.iam#ServiceFailureException":
       response = {
         ...(await deserializeAws_queryServiceFailureExceptionResponse(parsedOutput, context)),
@@ -9812,7 +9812,7 @@ const deserializeAws_queryListPoliciesCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "ServiceFailure":
+    case "ServiceFailureException":
     case "com.amazonaws.iam#ServiceFailureException":
       response = {
         ...(await deserializeAws_queryServiceFailureExceptionResponse(parsedOutput, context)),
@@ -9869,7 +9869,7 @@ const deserializeAws_queryListPoliciesGrantingServiceAccessCommandError = async 
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "InvalidInput":
+    case "InvalidInputException":
     case "com.amazonaws.iam#InvalidInputException":
       response = {
         ...(await deserializeAws_queryInvalidInputExceptionResponse(parsedOutput, context)),
@@ -9877,7 +9877,7 @@ const deserializeAws_queryListPoliciesGrantingServiceAccessCommandError = async 
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "NoSuchEntity":
+    case "NoSuchEntityException":
     case "com.amazonaws.iam#NoSuchEntityException":
       response = {
         ...(await deserializeAws_queryNoSuchEntityExceptionResponse(parsedOutput, context)),
@@ -9931,7 +9931,7 @@ const deserializeAws_queryListPolicyTagsCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "InvalidInput":
+    case "InvalidInputException":
     case "com.amazonaws.iam#InvalidInputException":
       response = {
         ...(await deserializeAws_queryInvalidInputExceptionResponse(parsedOutput, context)),
@@ -9939,7 +9939,7 @@ const deserializeAws_queryListPolicyTagsCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "NoSuchEntity":
+    case "NoSuchEntityException":
     case "com.amazonaws.iam#NoSuchEntityException":
       response = {
         ...(await deserializeAws_queryNoSuchEntityExceptionResponse(parsedOutput, context)),
@@ -9947,7 +9947,7 @@ const deserializeAws_queryListPolicyTagsCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ServiceFailure":
+    case "ServiceFailureException":
     case "com.amazonaws.iam#ServiceFailureException":
       response = {
         ...(await deserializeAws_queryServiceFailureExceptionResponse(parsedOutput, context)),
@@ -10001,7 +10001,7 @@ const deserializeAws_queryListPolicyVersionsCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "InvalidInput":
+    case "InvalidInputException":
     case "com.amazonaws.iam#InvalidInputException":
       response = {
         ...(await deserializeAws_queryInvalidInputExceptionResponse(parsedOutput, context)),
@@ -10009,7 +10009,7 @@ const deserializeAws_queryListPolicyVersionsCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "NoSuchEntity":
+    case "NoSuchEntityException":
     case "com.amazonaws.iam#NoSuchEntityException":
       response = {
         ...(await deserializeAws_queryNoSuchEntityExceptionResponse(parsedOutput, context)),
@@ -10017,7 +10017,7 @@ const deserializeAws_queryListPolicyVersionsCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ServiceFailure":
+    case "ServiceFailureException":
     case "com.amazonaws.iam#ServiceFailureException":
       response = {
         ...(await deserializeAws_queryServiceFailureExceptionResponse(parsedOutput, context)),
@@ -10071,7 +10071,7 @@ const deserializeAws_queryListRolePoliciesCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "NoSuchEntity":
+    case "NoSuchEntityException":
     case "com.amazonaws.iam#NoSuchEntityException":
       response = {
         ...(await deserializeAws_queryNoSuchEntityExceptionResponse(parsedOutput, context)),
@@ -10079,7 +10079,7 @@ const deserializeAws_queryListRolePoliciesCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ServiceFailure":
+    case "ServiceFailureException":
     case "com.amazonaws.iam#ServiceFailureException":
       response = {
         ...(await deserializeAws_queryServiceFailureExceptionResponse(parsedOutput, context)),
@@ -10133,7 +10133,7 @@ const deserializeAws_queryListRolesCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "ServiceFailure":
+    case "ServiceFailureException":
     case "com.amazonaws.iam#ServiceFailureException":
       response = {
         ...(await deserializeAws_queryServiceFailureExceptionResponse(parsedOutput, context)),
@@ -10187,7 +10187,7 @@ const deserializeAws_queryListRoleTagsCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "NoSuchEntity":
+    case "NoSuchEntityException":
     case "com.amazonaws.iam#NoSuchEntityException":
       response = {
         ...(await deserializeAws_queryNoSuchEntityExceptionResponse(parsedOutput, context)),
@@ -10195,7 +10195,7 @@ const deserializeAws_queryListRoleTagsCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ServiceFailure":
+    case "ServiceFailureException":
     case "com.amazonaws.iam#ServiceFailureException":
       response = {
         ...(await deserializeAws_queryServiceFailureExceptionResponse(parsedOutput, context)),
@@ -10249,7 +10249,7 @@ const deserializeAws_queryListSAMLProvidersCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "ServiceFailure":
+    case "ServiceFailureException":
     case "com.amazonaws.iam#ServiceFailureException":
       response = {
         ...(await deserializeAws_queryServiceFailureExceptionResponse(parsedOutput, context)),
@@ -10303,7 +10303,7 @@ const deserializeAws_queryListSAMLProviderTagsCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "InvalidInput":
+    case "InvalidInputException":
     case "com.amazonaws.iam#InvalidInputException":
       response = {
         ...(await deserializeAws_queryInvalidInputExceptionResponse(parsedOutput, context)),
@@ -10311,7 +10311,7 @@ const deserializeAws_queryListSAMLProviderTagsCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "NoSuchEntity":
+    case "NoSuchEntityException":
     case "com.amazonaws.iam#NoSuchEntityException":
       response = {
         ...(await deserializeAws_queryNoSuchEntityExceptionResponse(parsedOutput, context)),
@@ -10319,7 +10319,7 @@ const deserializeAws_queryListSAMLProviderTagsCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ServiceFailure":
+    case "ServiceFailureException":
     case "com.amazonaws.iam#ServiceFailureException":
       response = {
         ...(await deserializeAws_queryServiceFailureExceptionResponse(parsedOutput, context)),
@@ -10373,7 +10373,7 @@ const deserializeAws_queryListServerCertificatesCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "ServiceFailure":
+    case "ServiceFailureException":
     case "com.amazonaws.iam#ServiceFailureException":
       response = {
         ...(await deserializeAws_queryServiceFailureExceptionResponse(parsedOutput, context)),
@@ -10427,7 +10427,7 @@ const deserializeAws_queryListServerCertificateTagsCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "NoSuchEntity":
+    case "NoSuchEntityException":
     case "com.amazonaws.iam#NoSuchEntityException":
       response = {
         ...(await deserializeAws_queryNoSuchEntityExceptionResponse(parsedOutput, context)),
@@ -10435,7 +10435,7 @@ const deserializeAws_queryListServerCertificateTagsCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ServiceFailure":
+    case "ServiceFailureException":
     case "com.amazonaws.iam#ServiceFailureException":
       response = {
         ...(await deserializeAws_queryServiceFailureExceptionResponse(parsedOutput, context)),
@@ -10492,7 +10492,7 @@ const deserializeAws_queryListServiceSpecificCredentialsCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "NoSuchEntity":
+    case "NoSuchEntityException":
     case "com.amazonaws.iam#NoSuchEntityException":
       response = {
         ...(await deserializeAws_queryNoSuchEntityExceptionResponse(parsedOutput, context)),
@@ -10500,7 +10500,7 @@ const deserializeAws_queryListServiceSpecificCredentialsCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "NotSupportedService":
+    case "ServiceNotSupportedException":
     case "com.amazonaws.iam#ServiceNotSupportedException":
       response = {
         ...(await deserializeAws_queryServiceNotSupportedExceptionResponse(parsedOutput, context)),
@@ -10554,7 +10554,7 @@ const deserializeAws_queryListSigningCertificatesCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "NoSuchEntity":
+    case "NoSuchEntityException":
     case "com.amazonaws.iam#NoSuchEntityException":
       response = {
         ...(await deserializeAws_queryNoSuchEntityExceptionResponse(parsedOutput, context)),
@@ -10562,7 +10562,7 @@ const deserializeAws_queryListSigningCertificatesCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ServiceFailure":
+    case "ServiceFailureException":
     case "com.amazonaws.iam#ServiceFailureException":
       response = {
         ...(await deserializeAws_queryServiceFailureExceptionResponse(parsedOutput, context)),
@@ -10616,7 +10616,7 @@ const deserializeAws_queryListSSHPublicKeysCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "NoSuchEntity":
+    case "NoSuchEntityException":
     case "com.amazonaws.iam#NoSuchEntityException":
       response = {
         ...(await deserializeAws_queryNoSuchEntityExceptionResponse(parsedOutput, context)),
@@ -10670,7 +10670,7 @@ const deserializeAws_queryListUserPoliciesCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "NoSuchEntity":
+    case "NoSuchEntityException":
     case "com.amazonaws.iam#NoSuchEntityException":
       response = {
         ...(await deserializeAws_queryNoSuchEntityExceptionResponse(parsedOutput, context)),
@@ -10678,7 +10678,7 @@ const deserializeAws_queryListUserPoliciesCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ServiceFailure":
+    case "ServiceFailureException":
     case "com.amazonaws.iam#ServiceFailureException":
       response = {
         ...(await deserializeAws_queryServiceFailureExceptionResponse(parsedOutput, context)),
@@ -10732,7 +10732,7 @@ const deserializeAws_queryListUsersCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "ServiceFailure":
+    case "ServiceFailureException":
     case "com.amazonaws.iam#ServiceFailureException":
       response = {
         ...(await deserializeAws_queryServiceFailureExceptionResponse(parsedOutput, context)),
@@ -10786,7 +10786,7 @@ const deserializeAws_queryListUserTagsCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "NoSuchEntity":
+    case "NoSuchEntityException":
     case "com.amazonaws.iam#NoSuchEntityException":
       response = {
         ...(await deserializeAws_queryNoSuchEntityExceptionResponse(parsedOutput, context)),
@@ -10794,7 +10794,7 @@ const deserializeAws_queryListUserTagsCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ServiceFailure":
+    case "ServiceFailureException":
     case "com.amazonaws.iam#ServiceFailureException":
       response = {
         ...(await deserializeAws_queryServiceFailureExceptionResponse(parsedOutput, context)),
@@ -10891,7 +10891,7 @@ const deserializeAws_queryPutGroupPolicyCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "LimitExceeded":
+    case "LimitExceededException":
     case "com.amazonaws.iam#LimitExceededException":
       response = {
         ...(await deserializeAws_queryLimitExceededExceptionResponse(parsedOutput, context)),
@@ -10899,7 +10899,7 @@ const deserializeAws_queryPutGroupPolicyCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "MalformedPolicyDocument":
+    case "MalformedPolicyDocumentException":
     case "com.amazonaws.iam#MalformedPolicyDocumentException":
       response = {
         ...(await deserializeAws_queryMalformedPolicyDocumentExceptionResponse(parsedOutput, context)),
@@ -10907,7 +10907,7 @@ const deserializeAws_queryPutGroupPolicyCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "NoSuchEntity":
+    case "NoSuchEntityException":
     case "com.amazonaws.iam#NoSuchEntityException":
       response = {
         ...(await deserializeAws_queryNoSuchEntityExceptionResponse(parsedOutput, context)),
@@ -10915,7 +10915,7 @@ const deserializeAws_queryPutGroupPolicyCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ServiceFailure":
+    case "ServiceFailureException":
     case "com.amazonaws.iam#ServiceFailureException":
       response = {
         ...(await deserializeAws_queryServiceFailureExceptionResponse(parsedOutput, context)),
@@ -10966,7 +10966,7 @@ const deserializeAws_queryPutRolePermissionsBoundaryCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "InvalidInput":
+    case "InvalidInputException":
     case "com.amazonaws.iam#InvalidInputException":
       response = {
         ...(await deserializeAws_queryInvalidInputExceptionResponse(parsedOutput, context)),
@@ -10974,7 +10974,7 @@ const deserializeAws_queryPutRolePermissionsBoundaryCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "NoSuchEntity":
+    case "NoSuchEntityException":
     case "com.amazonaws.iam#NoSuchEntityException":
       response = {
         ...(await deserializeAws_queryNoSuchEntityExceptionResponse(parsedOutput, context)),
@@ -10982,7 +10982,7 @@ const deserializeAws_queryPutRolePermissionsBoundaryCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "PolicyNotAttachable":
+    case "PolicyNotAttachableException":
     case "com.amazonaws.iam#PolicyNotAttachableException":
       response = {
         ...(await deserializeAws_queryPolicyNotAttachableExceptionResponse(parsedOutput, context)),
@@ -10990,7 +10990,7 @@ const deserializeAws_queryPutRolePermissionsBoundaryCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ServiceFailure":
+    case "ServiceFailureException":
     case "com.amazonaws.iam#ServiceFailureException":
       response = {
         ...(await deserializeAws_queryServiceFailureExceptionResponse(parsedOutput, context)),
@@ -10998,7 +10998,7 @@ const deserializeAws_queryPutRolePermissionsBoundaryCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "UnmodifiableEntity":
+    case "UnmodifiableEntityException":
     case "com.amazonaws.iam#UnmodifiableEntityException":
       response = {
         ...(await deserializeAws_queryUnmodifiableEntityExceptionResponse(parsedOutput, context)),
@@ -11049,7 +11049,7 @@ const deserializeAws_queryPutRolePolicyCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "LimitExceeded":
+    case "LimitExceededException":
     case "com.amazonaws.iam#LimitExceededException":
       response = {
         ...(await deserializeAws_queryLimitExceededExceptionResponse(parsedOutput, context)),
@@ -11057,7 +11057,7 @@ const deserializeAws_queryPutRolePolicyCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "MalformedPolicyDocument":
+    case "MalformedPolicyDocumentException":
     case "com.amazonaws.iam#MalformedPolicyDocumentException":
       response = {
         ...(await deserializeAws_queryMalformedPolicyDocumentExceptionResponse(parsedOutput, context)),
@@ -11065,7 +11065,7 @@ const deserializeAws_queryPutRolePolicyCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "NoSuchEntity":
+    case "NoSuchEntityException":
     case "com.amazonaws.iam#NoSuchEntityException":
       response = {
         ...(await deserializeAws_queryNoSuchEntityExceptionResponse(parsedOutput, context)),
@@ -11073,7 +11073,7 @@ const deserializeAws_queryPutRolePolicyCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ServiceFailure":
+    case "ServiceFailureException":
     case "com.amazonaws.iam#ServiceFailureException":
       response = {
         ...(await deserializeAws_queryServiceFailureExceptionResponse(parsedOutput, context)),
@@ -11081,7 +11081,7 @@ const deserializeAws_queryPutRolePolicyCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "UnmodifiableEntity":
+    case "UnmodifiableEntityException":
     case "com.amazonaws.iam#UnmodifiableEntityException":
       response = {
         ...(await deserializeAws_queryUnmodifiableEntityExceptionResponse(parsedOutput, context)),
@@ -11132,7 +11132,7 @@ const deserializeAws_queryPutUserPermissionsBoundaryCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "InvalidInput":
+    case "InvalidInputException":
     case "com.amazonaws.iam#InvalidInputException":
       response = {
         ...(await deserializeAws_queryInvalidInputExceptionResponse(parsedOutput, context)),
@@ -11140,7 +11140,7 @@ const deserializeAws_queryPutUserPermissionsBoundaryCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "NoSuchEntity":
+    case "NoSuchEntityException":
     case "com.amazonaws.iam#NoSuchEntityException":
       response = {
         ...(await deserializeAws_queryNoSuchEntityExceptionResponse(parsedOutput, context)),
@@ -11148,7 +11148,7 @@ const deserializeAws_queryPutUserPermissionsBoundaryCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "PolicyNotAttachable":
+    case "PolicyNotAttachableException":
     case "com.amazonaws.iam#PolicyNotAttachableException":
       response = {
         ...(await deserializeAws_queryPolicyNotAttachableExceptionResponse(parsedOutput, context)),
@@ -11156,7 +11156,7 @@ const deserializeAws_queryPutUserPermissionsBoundaryCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ServiceFailure":
+    case "ServiceFailureException":
     case "com.amazonaws.iam#ServiceFailureException":
       response = {
         ...(await deserializeAws_queryServiceFailureExceptionResponse(parsedOutput, context)),
@@ -11207,7 +11207,7 @@ const deserializeAws_queryPutUserPolicyCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "LimitExceeded":
+    case "LimitExceededException":
     case "com.amazonaws.iam#LimitExceededException":
       response = {
         ...(await deserializeAws_queryLimitExceededExceptionResponse(parsedOutput, context)),
@@ -11215,7 +11215,7 @@ const deserializeAws_queryPutUserPolicyCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "MalformedPolicyDocument":
+    case "MalformedPolicyDocumentException":
     case "com.amazonaws.iam#MalformedPolicyDocumentException":
       response = {
         ...(await deserializeAws_queryMalformedPolicyDocumentExceptionResponse(parsedOutput, context)),
@@ -11223,7 +11223,7 @@ const deserializeAws_queryPutUserPolicyCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "NoSuchEntity":
+    case "NoSuchEntityException":
     case "com.amazonaws.iam#NoSuchEntityException":
       response = {
         ...(await deserializeAws_queryNoSuchEntityExceptionResponse(parsedOutput, context)),
@@ -11231,7 +11231,7 @@ const deserializeAws_queryPutUserPolicyCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ServiceFailure":
+    case "ServiceFailureException":
     case "com.amazonaws.iam#ServiceFailureException":
       response = {
         ...(await deserializeAws_queryServiceFailureExceptionResponse(parsedOutput, context)),
@@ -11282,7 +11282,7 @@ const deserializeAws_queryRemoveClientIDFromOpenIDConnectProviderCommandError = 
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "InvalidInput":
+    case "InvalidInputException":
     case "com.amazonaws.iam#InvalidInputException":
       response = {
         ...(await deserializeAws_queryInvalidInputExceptionResponse(parsedOutput, context)),
@@ -11290,7 +11290,7 @@ const deserializeAws_queryRemoveClientIDFromOpenIDConnectProviderCommandError = 
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "NoSuchEntity":
+    case "NoSuchEntityException":
     case "com.amazonaws.iam#NoSuchEntityException":
       response = {
         ...(await deserializeAws_queryNoSuchEntityExceptionResponse(parsedOutput, context)),
@@ -11298,7 +11298,7 @@ const deserializeAws_queryRemoveClientIDFromOpenIDConnectProviderCommandError = 
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ServiceFailure":
+    case "ServiceFailureException":
     case "com.amazonaws.iam#ServiceFailureException":
       response = {
         ...(await deserializeAws_queryServiceFailureExceptionResponse(parsedOutput, context)),
@@ -11349,7 +11349,7 @@ const deserializeAws_queryRemoveRoleFromInstanceProfileCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "LimitExceeded":
+    case "LimitExceededException":
     case "com.amazonaws.iam#LimitExceededException":
       response = {
         ...(await deserializeAws_queryLimitExceededExceptionResponse(parsedOutput, context)),
@@ -11357,7 +11357,7 @@ const deserializeAws_queryRemoveRoleFromInstanceProfileCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "NoSuchEntity":
+    case "NoSuchEntityException":
     case "com.amazonaws.iam#NoSuchEntityException":
       response = {
         ...(await deserializeAws_queryNoSuchEntityExceptionResponse(parsedOutput, context)),
@@ -11365,7 +11365,7 @@ const deserializeAws_queryRemoveRoleFromInstanceProfileCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ServiceFailure":
+    case "ServiceFailureException":
     case "com.amazonaws.iam#ServiceFailureException":
       response = {
         ...(await deserializeAws_queryServiceFailureExceptionResponse(parsedOutput, context)),
@@ -11373,7 +11373,7 @@ const deserializeAws_queryRemoveRoleFromInstanceProfileCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "UnmodifiableEntity":
+    case "UnmodifiableEntityException":
     case "com.amazonaws.iam#UnmodifiableEntityException":
       response = {
         ...(await deserializeAws_queryUnmodifiableEntityExceptionResponse(parsedOutput, context)),
@@ -11424,7 +11424,7 @@ const deserializeAws_queryRemoveUserFromGroupCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "LimitExceeded":
+    case "LimitExceededException":
     case "com.amazonaws.iam#LimitExceededException":
       response = {
         ...(await deserializeAws_queryLimitExceededExceptionResponse(parsedOutput, context)),
@@ -11432,7 +11432,7 @@ const deserializeAws_queryRemoveUserFromGroupCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "NoSuchEntity":
+    case "NoSuchEntityException":
     case "com.amazonaws.iam#NoSuchEntityException":
       response = {
         ...(await deserializeAws_queryNoSuchEntityExceptionResponse(parsedOutput, context)),
@@ -11440,7 +11440,7 @@ const deserializeAws_queryRemoveUserFromGroupCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ServiceFailure":
+    case "ServiceFailureException":
     case "com.amazonaws.iam#ServiceFailureException":
       response = {
         ...(await deserializeAws_queryServiceFailureExceptionResponse(parsedOutput, context)),
@@ -11497,7 +11497,7 @@ const deserializeAws_queryResetServiceSpecificCredentialCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "NoSuchEntity":
+    case "NoSuchEntityException":
     case "com.amazonaws.iam#NoSuchEntityException":
       response = {
         ...(await deserializeAws_queryNoSuchEntityExceptionResponse(parsedOutput, context)),
@@ -11548,7 +11548,7 @@ const deserializeAws_queryResyncMFADeviceCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "InvalidAuthenticationCode":
+    case "InvalidAuthenticationCodeException":
     case "com.amazonaws.iam#InvalidAuthenticationCodeException":
       response = {
         ...(await deserializeAws_queryInvalidAuthenticationCodeExceptionResponse(parsedOutput, context)),
@@ -11556,7 +11556,7 @@ const deserializeAws_queryResyncMFADeviceCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "LimitExceeded":
+    case "LimitExceededException":
     case "com.amazonaws.iam#LimitExceededException":
       response = {
         ...(await deserializeAws_queryLimitExceededExceptionResponse(parsedOutput, context)),
@@ -11564,7 +11564,7 @@ const deserializeAws_queryResyncMFADeviceCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "NoSuchEntity":
+    case "NoSuchEntityException":
     case "com.amazonaws.iam#NoSuchEntityException":
       response = {
         ...(await deserializeAws_queryNoSuchEntityExceptionResponse(parsedOutput, context)),
@@ -11572,7 +11572,7 @@ const deserializeAws_queryResyncMFADeviceCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ServiceFailure":
+    case "ServiceFailureException":
     case "com.amazonaws.iam#ServiceFailureException":
       response = {
         ...(await deserializeAws_queryServiceFailureExceptionResponse(parsedOutput, context)),
@@ -11623,7 +11623,7 @@ const deserializeAws_querySetDefaultPolicyVersionCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "InvalidInput":
+    case "InvalidInputException":
     case "com.amazonaws.iam#InvalidInputException":
       response = {
         ...(await deserializeAws_queryInvalidInputExceptionResponse(parsedOutput, context)),
@@ -11631,7 +11631,7 @@ const deserializeAws_querySetDefaultPolicyVersionCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "LimitExceeded":
+    case "LimitExceededException":
     case "com.amazonaws.iam#LimitExceededException":
       response = {
         ...(await deserializeAws_queryLimitExceededExceptionResponse(parsedOutput, context)),
@@ -11639,7 +11639,7 @@ const deserializeAws_querySetDefaultPolicyVersionCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "NoSuchEntity":
+    case "NoSuchEntityException":
     case "com.amazonaws.iam#NoSuchEntityException":
       response = {
         ...(await deserializeAws_queryNoSuchEntityExceptionResponse(parsedOutput, context)),
@@ -11647,7 +11647,7 @@ const deserializeAws_querySetDefaultPolicyVersionCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ServiceFailure":
+    case "ServiceFailureException":
     case "com.amazonaws.iam#ServiceFailureException":
       response = {
         ...(await deserializeAws_queryServiceFailureExceptionResponse(parsedOutput, context)),
@@ -11698,7 +11698,7 @@ const deserializeAws_querySetSecurityTokenServicePreferencesCommandError = async
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "ServiceFailure":
+    case "ServiceFailureException":
     case "com.amazonaws.iam#ServiceFailureException":
       response = {
         ...(await deserializeAws_queryServiceFailureExceptionResponse(parsedOutput, context)),
@@ -11752,7 +11752,7 @@ const deserializeAws_querySimulateCustomPolicyCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "InvalidInput":
+    case "InvalidInputException":
     case "com.amazonaws.iam#InvalidInputException":
       response = {
         ...(await deserializeAws_queryInvalidInputExceptionResponse(parsedOutput, context)),
@@ -11760,7 +11760,7 @@ const deserializeAws_querySimulateCustomPolicyCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "PolicyEvaluation":
+    case "PolicyEvaluationException":
     case "com.amazonaws.iam#PolicyEvaluationException":
       response = {
         ...(await deserializeAws_queryPolicyEvaluationExceptionResponse(parsedOutput, context)),
@@ -11814,7 +11814,7 @@ const deserializeAws_querySimulatePrincipalPolicyCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "InvalidInput":
+    case "InvalidInputException":
     case "com.amazonaws.iam#InvalidInputException":
       response = {
         ...(await deserializeAws_queryInvalidInputExceptionResponse(parsedOutput, context)),
@@ -11822,7 +11822,7 @@ const deserializeAws_querySimulatePrincipalPolicyCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "NoSuchEntity":
+    case "NoSuchEntityException":
     case "com.amazonaws.iam#NoSuchEntityException":
       response = {
         ...(await deserializeAws_queryNoSuchEntityExceptionResponse(parsedOutput, context)),
@@ -11830,7 +11830,7 @@ const deserializeAws_querySimulatePrincipalPolicyCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "PolicyEvaluation":
+    case "PolicyEvaluationException":
     case "com.amazonaws.iam#PolicyEvaluationException":
       response = {
         ...(await deserializeAws_queryPolicyEvaluationExceptionResponse(parsedOutput, context)),
@@ -11881,7 +11881,7 @@ const deserializeAws_queryTagInstanceProfileCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "ConcurrentModification":
+    case "ConcurrentModificationException":
     case "com.amazonaws.iam#ConcurrentModificationException":
       response = {
         ...(await deserializeAws_queryConcurrentModificationExceptionResponse(parsedOutput, context)),
@@ -11889,7 +11889,7 @@ const deserializeAws_queryTagInstanceProfileCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidInput":
+    case "InvalidInputException":
     case "com.amazonaws.iam#InvalidInputException":
       response = {
         ...(await deserializeAws_queryInvalidInputExceptionResponse(parsedOutput, context)),
@@ -11897,7 +11897,7 @@ const deserializeAws_queryTagInstanceProfileCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "LimitExceeded":
+    case "LimitExceededException":
     case "com.amazonaws.iam#LimitExceededException":
       response = {
         ...(await deserializeAws_queryLimitExceededExceptionResponse(parsedOutput, context)),
@@ -11905,7 +11905,7 @@ const deserializeAws_queryTagInstanceProfileCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "NoSuchEntity":
+    case "NoSuchEntityException":
     case "com.amazonaws.iam#NoSuchEntityException":
       response = {
         ...(await deserializeAws_queryNoSuchEntityExceptionResponse(parsedOutput, context)),
@@ -11913,7 +11913,7 @@ const deserializeAws_queryTagInstanceProfileCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ServiceFailure":
+    case "ServiceFailureException":
     case "com.amazonaws.iam#ServiceFailureException":
       response = {
         ...(await deserializeAws_queryServiceFailureExceptionResponse(parsedOutput, context)),
@@ -11964,7 +11964,7 @@ const deserializeAws_queryTagMFADeviceCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "ConcurrentModification":
+    case "ConcurrentModificationException":
     case "com.amazonaws.iam#ConcurrentModificationException":
       response = {
         ...(await deserializeAws_queryConcurrentModificationExceptionResponse(parsedOutput, context)),
@@ -11972,7 +11972,7 @@ const deserializeAws_queryTagMFADeviceCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidInput":
+    case "InvalidInputException":
     case "com.amazonaws.iam#InvalidInputException":
       response = {
         ...(await deserializeAws_queryInvalidInputExceptionResponse(parsedOutput, context)),
@@ -11980,7 +11980,7 @@ const deserializeAws_queryTagMFADeviceCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "LimitExceeded":
+    case "LimitExceededException":
     case "com.amazonaws.iam#LimitExceededException":
       response = {
         ...(await deserializeAws_queryLimitExceededExceptionResponse(parsedOutput, context)),
@@ -11988,7 +11988,7 @@ const deserializeAws_queryTagMFADeviceCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "NoSuchEntity":
+    case "NoSuchEntityException":
     case "com.amazonaws.iam#NoSuchEntityException":
       response = {
         ...(await deserializeAws_queryNoSuchEntityExceptionResponse(parsedOutput, context)),
@@ -11996,7 +11996,7 @@ const deserializeAws_queryTagMFADeviceCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ServiceFailure":
+    case "ServiceFailureException":
     case "com.amazonaws.iam#ServiceFailureException":
       response = {
         ...(await deserializeAws_queryServiceFailureExceptionResponse(parsedOutput, context)),
@@ -12047,7 +12047,7 @@ const deserializeAws_queryTagOpenIDConnectProviderCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "ConcurrentModification":
+    case "ConcurrentModificationException":
     case "com.amazonaws.iam#ConcurrentModificationException":
       response = {
         ...(await deserializeAws_queryConcurrentModificationExceptionResponse(parsedOutput, context)),
@@ -12055,7 +12055,7 @@ const deserializeAws_queryTagOpenIDConnectProviderCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidInput":
+    case "InvalidInputException":
     case "com.amazonaws.iam#InvalidInputException":
       response = {
         ...(await deserializeAws_queryInvalidInputExceptionResponse(parsedOutput, context)),
@@ -12063,7 +12063,7 @@ const deserializeAws_queryTagOpenIDConnectProviderCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "LimitExceeded":
+    case "LimitExceededException":
     case "com.amazonaws.iam#LimitExceededException":
       response = {
         ...(await deserializeAws_queryLimitExceededExceptionResponse(parsedOutput, context)),
@@ -12071,7 +12071,7 @@ const deserializeAws_queryTagOpenIDConnectProviderCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "NoSuchEntity":
+    case "NoSuchEntityException":
     case "com.amazonaws.iam#NoSuchEntityException":
       response = {
         ...(await deserializeAws_queryNoSuchEntityExceptionResponse(parsedOutput, context)),
@@ -12079,7 +12079,7 @@ const deserializeAws_queryTagOpenIDConnectProviderCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ServiceFailure":
+    case "ServiceFailureException":
     case "com.amazonaws.iam#ServiceFailureException":
       response = {
         ...(await deserializeAws_queryServiceFailureExceptionResponse(parsedOutput, context)),
@@ -12130,7 +12130,7 @@ const deserializeAws_queryTagPolicyCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "ConcurrentModification":
+    case "ConcurrentModificationException":
     case "com.amazonaws.iam#ConcurrentModificationException":
       response = {
         ...(await deserializeAws_queryConcurrentModificationExceptionResponse(parsedOutput, context)),
@@ -12138,7 +12138,7 @@ const deserializeAws_queryTagPolicyCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidInput":
+    case "InvalidInputException":
     case "com.amazonaws.iam#InvalidInputException":
       response = {
         ...(await deserializeAws_queryInvalidInputExceptionResponse(parsedOutput, context)),
@@ -12146,7 +12146,7 @@ const deserializeAws_queryTagPolicyCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "LimitExceeded":
+    case "LimitExceededException":
     case "com.amazonaws.iam#LimitExceededException":
       response = {
         ...(await deserializeAws_queryLimitExceededExceptionResponse(parsedOutput, context)),
@@ -12154,7 +12154,7 @@ const deserializeAws_queryTagPolicyCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "NoSuchEntity":
+    case "NoSuchEntityException":
     case "com.amazonaws.iam#NoSuchEntityException":
       response = {
         ...(await deserializeAws_queryNoSuchEntityExceptionResponse(parsedOutput, context)),
@@ -12162,7 +12162,7 @@ const deserializeAws_queryTagPolicyCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ServiceFailure":
+    case "ServiceFailureException":
     case "com.amazonaws.iam#ServiceFailureException":
       response = {
         ...(await deserializeAws_queryServiceFailureExceptionResponse(parsedOutput, context)),
@@ -12213,7 +12213,7 @@ const deserializeAws_queryTagRoleCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "ConcurrentModification":
+    case "ConcurrentModificationException":
     case "com.amazonaws.iam#ConcurrentModificationException":
       response = {
         ...(await deserializeAws_queryConcurrentModificationExceptionResponse(parsedOutput, context)),
@@ -12221,7 +12221,7 @@ const deserializeAws_queryTagRoleCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidInput":
+    case "InvalidInputException":
     case "com.amazonaws.iam#InvalidInputException":
       response = {
         ...(await deserializeAws_queryInvalidInputExceptionResponse(parsedOutput, context)),
@@ -12229,7 +12229,7 @@ const deserializeAws_queryTagRoleCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "LimitExceeded":
+    case "LimitExceededException":
     case "com.amazonaws.iam#LimitExceededException":
       response = {
         ...(await deserializeAws_queryLimitExceededExceptionResponse(parsedOutput, context)),
@@ -12237,7 +12237,7 @@ const deserializeAws_queryTagRoleCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "NoSuchEntity":
+    case "NoSuchEntityException":
     case "com.amazonaws.iam#NoSuchEntityException":
       response = {
         ...(await deserializeAws_queryNoSuchEntityExceptionResponse(parsedOutput, context)),
@@ -12245,7 +12245,7 @@ const deserializeAws_queryTagRoleCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ServiceFailure":
+    case "ServiceFailureException":
     case "com.amazonaws.iam#ServiceFailureException":
       response = {
         ...(await deserializeAws_queryServiceFailureExceptionResponse(parsedOutput, context)),
@@ -12296,7 +12296,7 @@ const deserializeAws_queryTagSAMLProviderCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "ConcurrentModification":
+    case "ConcurrentModificationException":
     case "com.amazonaws.iam#ConcurrentModificationException":
       response = {
         ...(await deserializeAws_queryConcurrentModificationExceptionResponse(parsedOutput, context)),
@@ -12304,7 +12304,7 @@ const deserializeAws_queryTagSAMLProviderCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidInput":
+    case "InvalidInputException":
     case "com.amazonaws.iam#InvalidInputException":
       response = {
         ...(await deserializeAws_queryInvalidInputExceptionResponse(parsedOutput, context)),
@@ -12312,7 +12312,7 @@ const deserializeAws_queryTagSAMLProviderCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "LimitExceeded":
+    case "LimitExceededException":
     case "com.amazonaws.iam#LimitExceededException":
       response = {
         ...(await deserializeAws_queryLimitExceededExceptionResponse(parsedOutput, context)),
@@ -12320,7 +12320,7 @@ const deserializeAws_queryTagSAMLProviderCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "NoSuchEntity":
+    case "NoSuchEntityException":
     case "com.amazonaws.iam#NoSuchEntityException":
       response = {
         ...(await deserializeAws_queryNoSuchEntityExceptionResponse(parsedOutput, context)),
@@ -12328,7 +12328,7 @@ const deserializeAws_queryTagSAMLProviderCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ServiceFailure":
+    case "ServiceFailureException":
     case "com.amazonaws.iam#ServiceFailureException":
       response = {
         ...(await deserializeAws_queryServiceFailureExceptionResponse(parsedOutput, context)),
@@ -12379,7 +12379,7 @@ const deserializeAws_queryTagServerCertificateCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "ConcurrentModification":
+    case "ConcurrentModificationException":
     case "com.amazonaws.iam#ConcurrentModificationException":
       response = {
         ...(await deserializeAws_queryConcurrentModificationExceptionResponse(parsedOutput, context)),
@@ -12387,7 +12387,7 @@ const deserializeAws_queryTagServerCertificateCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidInput":
+    case "InvalidInputException":
     case "com.amazonaws.iam#InvalidInputException":
       response = {
         ...(await deserializeAws_queryInvalidInputExceptionResponse(parsedOutput, context)),
@@ -12395,7 +12395,7 @@ const deserializeAws_queryTagServerCertificateCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "LimitExceeded":
+    case "LimitExceededException":
     case "com.amazonaws.iam#LimitExceededException":
       response = {
         ...(await deserializeAws_queryLimitExceededExceptionResponse(parsedOutput, context)),
@@ -12403,7 +12403,7 @@ const deserializeAws_queryTagServerCertificateCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "NoSuchEntity":
+    case "NoSuchEntityException":
     case "com.amazonaws.iam#NoSuchEntityException":
       response = {
         ...(await deserializeAws_queryNoSuchEntityExceptionResponse(parsedOutput, context)),
@@ -12411,7 +12411,7 @@ const deserializeAws_queryTagServerCertificateCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ServiceFailure":
+    case "ServiceFailureException":
     case "com.amazonaws.iam#ServiceFailureException":
       response = {
         ...(await deserializeAws_queryServiceFailureExceptionResponse(parsedOutput, context)),
@@ -12462,7 +12462,7 @@ const deserializeAws_queryTagUserCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "ConcurrentModification":
+    case "ConcurrentModificationException":
     case "com.amazonaws.iam#ConcurrentModificationException":
       response = {
         ...(await deserializeAws_queryConcurrentModificationExceptionResponse(parsedOutput, context)),
@@ -12470,7 +12470,7 @@ const deserializeAws_queryTagUserCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidInput":
+    case "InvalidInputException":
     case "com.amazonaws.iam#InvalidInputException":
       response = {
         ...(await deserializeAws_queryInvalidInputExceptionResponse(parsedOutput, context)),
@@ -12478,7 +12478,7 @@ const deserializeAws_queryTagUserCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "LimitExceeded":
+    case "LimitExceededException":
     case "com.amazonaws.iam#LimitExceededException":
       response = {
         ...(await deserializeAws_queryLimitExceededExceptionResponse(parsedOutput, context)),
@@ -12486,7 +12486,7 @@ const deserializeAws_queryTagUserCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "NoSuchEntity":
+    case "NoSuchEntityException":
     case "com.amazonaws.iam#NoSuchEntityException":
       response = {
         ...(await deserializeAws_queryNoSuchEntityExceptionResponse(parsedOutput, context)),
@@ -12494,7 +12494,7 @@ const deserializeAws_queryTagUserCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ServiceFailure":
+    case "ServiceFailureException":
     case "com.amazonaws.iam#ServiceFailureException":
       response = {
         ...(await deserializeAws_queryServiceFailureExceptionResponse(parsedOutput, context)),
@@ -12545,7 +12545,7 @@ const deserializeAws_queryUntagInstanceProfileCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "ConcurrentModification":
+    case "ConcurrentModificationException":
     case "com.amazonaws.iam#ConcurrentModificationException":
       response = {
         ...(await deserializeAws_queryConcurrentModificationExceptionResponse(parsedOutput, context)),
@@ -12553,7 +12553,7 @@ const deserializeAws_queryUntagInstanceProfileCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidInput":
+    case "InvalidInputException":
     case "com.amazonaws.iam#InvalidInputException":
       response = {
         ...(await deserializeAws_queryInvalidInputExceptionResponse(parsedOutput, context)),
@@ -12561,7 +12561,7 @@ const deserializeAws_queryUntagInstanceProfileCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "NoSuchEntity":
+    case "NoSuchEntityException":
     case "com.amazonaws.iam#NoSuchEntityException":
       response = {
         ...(await deserializeAws_queryNoSuchEntityExceptionResponse(parsedOutput, context)),
@@ -12569,7 +12569,7 @@ const deserializeAws_queryUntagInstanceProfileCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ServiceFailure":
+    case "ServiceFailureException":
     case "com.amazonaws.iam#ServiceFailureException":
       response = {
         ...(await deserializeAws_queryServiceFailureExceptionResponse(parsedOutput, context)),
@@ -12620,7 +12620,7 @@ const deserializeAws_queryUntagMFADeviceCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "ConcurrentModification":
+    case "ConcurrentModificationException":
     case "com.amazonaws.iam#ConcurrentModificationException":
       response = {
         ...(await deserializeAws_queryConcurrentModificationExceptionResponse(parsedOutput, context)),
@@ -12628,7 +12628,7 @@ const deserializeAws_queryUntagMFADeviceCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidInput":
+    case "InvalidInputException":
     case "com.amazonaws.iam#InvalidInputException":
       response = {
         ...(await deserializeAws_queryInvalidInputExceptionResponse(parsedOutput, context)),
@@ -12636,7 +12636,7 @@ const deserializeAws_queryUntagMFADeviceCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "NoSuchEntity":
+    case "NoSuchEntityException":
     case "com.amazonaws.iam#NoSuchEntityException":
       response = {
         ...(await deserializeAws_queryNoSuchEntityExceptionResponse(parsedOutput, context)),
@@ -12644,7 +12644,7 @@ const deserializeAws_queryUntagMFADeviceCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ServiceFailure":
+    case "ServiceFailureException":
     case "com.amazonaws.iam#ServiceFailureException":
       response = {
         ...(await deserializeAws_queryServiceFailureExceptionResponse(parsedOutput, context)),
@@ -12695,7 +12695,7 @@ const deserializeAws_queryUntagOpenIDConnectProviderCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "ConcurrentModification":
+    case "ConcurrentModificationException":
     case "com.amazonaws.iam#ConcurrentModificationException":
       response = {
         ...(await deserializeAws_queryConcurrentModificationExceptionResponse(parsedOutput, context)),
@@ -12703,7 +12703,7 @@ const deserializeAws_queryUntagOpenIDConnectProviderCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidInput":
+    case "InvalidInputException":
     case "com.amazonaws.iam#InvalidInputException":
       response = {
         ...(await deserializeAws_queryInvalidInputExceptionResponse(parsedOutput, context)),
@@ -12711,7 +12711,7 @@ const deserializeAws_queryUntagOpenIDConnectProviderCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "NoSuchEntity":
+    case "NoSuchEntityException":
     case "com.amazonaws.iam#NoSuchEntityException":
       response = {
         ...(await deserializeAws_queryNoSuchEntityExceptionResponse(parsedOutput, context)),
@@ -12719,7 +12719,7 @@ const deserializeAws_queryUntagOpenIDConnectProviderCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ServiceFailure":
+    case "ServiceFailureException":
     case "com.amazonaws.iam#ServiceFailureException":
       response = {
         ...(await deserializeAws_queryServiceFailureExceptionResponse(parsedOutput, context)),
@@ -12770,7 +12770,7 @@ const deserializeAws_queryUntagPolicyCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "ConcurrentModification":
+    case "ConcurrentModificationException":
     case "com.amazonaws.iam#ConcurrentModificationException":
       response = {
         ...(await deserializeAws_queryConcurrentModificationExceptionResponse(parsedOutput, context)),
@@ -12778,7 +12778,7 @@ const deserializeAws_queryUntagPolicyCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidInput":
+    case "InvalidInputException":
     case "com.amazonaws.iam#InvalidInputException":
       response = {
         ...(await deserializeAws_queryInvalidInputExceptionResponse(parsedOutput, context)),
@@ -12786,7 +12786,7 @@ const deserializeAws_queryUntagPolicyCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "NoSuchEntity":
+    case "NoSuchEntityException":
     case "com.amazonaws.iam#NoSuchEntityException":
       response = {
         ...(await deserializeAws_queryNoSuchEntityExceptionResponse(parsedOutput, context)),
@@ -12794,7 +12794,7 @@ const deserializeAws_queryUntagPolicyCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ServiceFailure":
+    case "ServiceFailureException":
     case "com.amazonaws.iam#ServiceFailureException":
       response = {
         ...(await deserializeAws_queryServiceFailureExceptionResponse(parsedOutput, context)),
@@ -12845,7 +12845,7 @@ const deserializeAws_queryUntagRoleCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "ConcurrentModification":
+    case "ConcurrentModificationException":
     case "com.amazonaws.iam#ConcurrentModificationException":
       response = {
         ...(await deserializeAws_queryConcurrentModificationExceptionResponse(parsedOutput, context)),
@@ -12853,7 +12853,7 @@ const deserializeAws_queryUntagRoleCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "NoSuchEntity":
+    case "NoSuchEntityException":
     case "com.amazonaws.iam#NoSuchEntityException":
       response = {
         ...(await deserializeAws_queryNoSuchEntityExceptionResponse(parsedOutput, context)),
@@ -12861,7 +12861,7 @@ const deserializeAws_queryUntagRoleCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ServiceFailure":
+    case "ServiceFailureException":
     case "com.amazonaws.iam#ServiceFailureException":
       response = {
         ...(await deserializeAws_queryServiceFailureExceptionResponse(parsedOutput, context)),
@@ -12912,7 +12912,7 @@ const deserializeAws_queryUntagSAMLProviderCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "ConcurrentModification":
+    case "ConcurrentModificationException":
     case "com.amazonaws.iam#ConcurrentModificationException":
       response = {
         ...(await deserializeAws_queryConcurrentModificationExceptionResponse(parsedOutput, context)),
@@ -12920,7 +12920,7 @@ const deserializeAws_queryUntagSAMLProviderCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidInput":
+    case "InvalidInputException":
     case "com.amazonaws.iam#InvalidInputException":
       response = {
         ...(await deserializeAws_queryInvalidInputExceptionResponse(parsedOutput, context)),
@@ -12928,7 +12928,7 @@ const deserializeAws_queryUntagSAMLProviderCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "NoSuchEntity":
+    case "NoSuchEntityException":
     case "com.amazonaws.iam#NoSuchEntityException":
       response = {
         ...(await deserializeAws_queryNoSuchEntityExceptionResponse(parsedOutput, context)),
@@ -12936,7 +12936,7 @@ const deserializeAws_queryUntagSAMLProviderCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ServiceFailure":
+    case "ServiceFailureException":
     case "com.amazonaws.iam#ServiceFailureException":
       response = {
         ...(await deserializeAws_queryServiceFailureExceptionResponse(parsedOutput, context)),
@@ -12987,7 +12987,7 @@ const deserializeAws_queryUntagServerCertificateCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "ConcurrentModification":
+    case "ConcurrentModificationException":
     case "com.amazonaws.iam#ConcurrentModificationException":
       response = {
         ...(await deserializeAws_queryConcurrentModificationExceptionResponse(parsedOutput, context)),
@@ -12995,7 +12995,7 @@ const deserializeAws_queryUntagServerCertificateCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidInput":
+    case "InvalidInputException":
     case "com.amazonaws.iam#InvalidInputException":
       response = {
         ...(await deserializeAws_queryInvalidInputExceptionResponse(parsedOutput, context)),
@@ -13003,7 +13003,7 @@ const deserializeAws_queryUntagServerCertificateCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "NoSuchEntity":
+    case "NoSuchEntityException":
     case "com.amazonaws.iam#NoSuchEntityException":
       response = {
         ...(await deserializeAws_queryNoSuchEntityExceptionResponse(parsedOutput, context)),
@@ -13011,7 +13011,7 @@ const deserializeAws_queryUntagServerCertificateCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ServiceFailure":
+    case "ServiceFailureException":
     case "com.amazonaws.iam#ServiceFailureException":
       response = {
         ...(await deserializeAws_queryServiceFailureExceptionResponse(parsedOutput, context)),
@@ -13062,7 +13062,7 @@ const deserializeAws_queryUntagUserCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "ConcurrentModification":
+    case "ConcurrentModificationException":
     case "com.amazonaws.iam#ConcurrentModificationException":
       response = {
         ...(await deserializeAws_queryConcurrentModificationExceptionResponse(parsedOutput, context)),
@@ -13070,7 +13070,7 @@ const deserializeAws_queryUntagUserCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "NoSuchEntity":
+    case "NoSuchEntityException":
     case "com.amazonaws.iam#NoSuchEntityException":
       response = {
         ...(await deserializeAws_queryNoSuchEntityExceptionResponse(parsedOutput, context)),
@@ -13078,7 +13078,7 @@ const deserializeAws_queryUntagUserCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ServiceFailure":
+    case "ServiceFailureException":
     case "com.amazonaws.iam#ServiceFailureException":
       response = {
         ...(await deserializeAws_queryServiceFailureExceptionResponse(parsedOutput, context)),
@@ -13129,7 +13129,7 @@ const deserializeAws_queryUpdateAccessKeyCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "LimitExceeded":
+    case "LimitExceededException":
     case "com.amazonaws.iam#LimitExceededException":
       response = {
         ...(await deserializeAws_queryLimitExceededExceptionResponse(parsedOutput, context)),
@@ -13137,7 +13137,7 @@ const deserializeAws_queryUpdateAccessKeyCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "NoSuchEntity":
+    case "NoSuchEntityException":
     case "com.amazonaws.iam#NoSuchEntityException":
       response = {
         ...(await deserializeAws_queryNoSuchEntityExceptionResponse(parsedOutput, context)),
@@ -13145,7 +13145,7 @@ const deserializeAws_queryUpdateAccessKeyCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ServiceFailure":
+    case "ServiceFailureException":
     case "com.amazonaws.iam#ServiceFailureException":
       response = {
         ...(await deserializeAws_queryServiceFailureExceptionResponse(parsedOutput, context)),
@@ -13196,7 +13196,7 @@ const deserializeAws_queryUpdateAccountPasswordPolicyCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "LimitExceeded":
+    case "LimitExceededException":
     case "com.amazonaws.iam#LimitExceededException":
       response = {
         ...(await deserializeAws_queryLimitExceededExceptionResponse(parsedOutput, context)),
@@ -13204,7 +13204,7 @@ const deserializeAws_queryUpdateAccountPasswordPolicyCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "MalformedPolicyDocument":
+    case "MalformedPolicyDocumentException":
     case "com.amazonaws.iam#MalformedPolicyDocumentException":
       response = {
         ...(await deserializeAws_queryMalformedPolicyDocumentExceptionResponse(parsedOutput, context)),
@@ -13212,7 +13212,7 @@ const deserializeAws_queryUpdateAccountPasswordPolicyCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "NoSuchEntity":
+    case "NoSuchEntityException":
     case "com.amazonaws.iam#NoSuchEntityException":
       response = {
         ...(await deserializeAws_queryNoSuchEntityExceptionResponse(parsedOutput, context)),
@@ -13220,7 +13220,7 @@ const deserializeAws_queryUpdateAccountPasswordPolicyCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ServiceFailure":
+    case "ServiceFailureException":
     case "com.amazonaws.iam#ServiceFailureException":
       response = {
         ...(await deserializeAws_queryServiceFailureExceptionResponse(parsedOutput, context)),
@@ -13271,7 +13271,7 @@ const deserializeAws_queryUpdateAssumeRolePolicyCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "LimitExceeded":
+    case "LimitExceededException":
     case "com.amazonaws.iam#LimitExceededException":
       response = {
         ...(await deserializeAws_queryLimitExceededExceptionResponse(parsedOutput, context)),
@@ -13279,7 +13279,7 @@ const deserializeAws_queryUpdateAssumeRolePolicyCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "MalformedPolicyDocument":
+    case "MalformedPolicyDocumentException":
     case "com.amazonaws.iam#MalformedPolicyDocumentException":
       response = {
         ...(await deserializeAws_queryMalformedPolicyDocumentExceptionResponse(parsedOutput, context)),
@@ -13287,7 +13287,7 @@ const deserializeAws_queryUpdateAssumeRolePolicyCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "NoSuchEntity":
+    case "NoSuchEntityException":
     case "com.amazonaws.iam#NoSuchEntityException":
       response = {
         ...(await deserializeAws_queryNoSuchEntityExceptionResponse(parsedOutput, context)),
@@ -13295,7 +13295,7 @@ const deserializeAws_queryUpdateAssumeRolePolicyCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ServiceFailure":
+    case "ServiceFailureException":
     case "com.amazonaws.iam#ServiceFailureException":
       response = {
         ...(await deserializeAws_queryServiceFailureExceptionResponse(parsedOutput, context)),
@@ -13303,7 +13303,7 @@ const deserializeAws_queryUpdateAssumeRolePolicyCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "UnmodifiableEntity":
+    case "UnmodifiableEntityException":
     case "com.amazonaws.iam#UnmodifiableEntityException":
       response = {
         ...(await deserializeAws_queryUnmodifiableEntityExceptionResponse(parsedOutput, context)),
@@ -13354,7 +13354,7 @@ const deserializeAws_queryUpdateGroupCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "EntityAlreadyExists":
+    case "EntityAlreadyExistsException":
     case "com.amazonaws.iam#EntityAlreadyExistsException":
       response = {
         ...(await deserializeAws_queryEntityAlreadyExistsExceptionResponse(parsedOutput, context)),
@@ -13362,7 +13362,7 @@ const deserializeAws_queryUpdateGroupCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "LimitExceeded":
+    case "LimitExceededException":
     case "com.amazonaws.iam#LimitExceededException":
       response = {
         ...(await deserializeAws_queryLimitExceededExceptionResponse(parsedOutput, context)),
@@ -13370,7 +13370,7 @@ const deserializeAws_queryUpdateGroupCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "NoSuchEntity":
+    case "NoSuchEntityException":
     case "com.amazonaws.iam#NoSuchEntityException":
       response = {
         ...(await deserializeAws_queryNoSuchEntityExceptionResponse(parsedOutput, context)),
@@ -13378,7 +13378,7 @@ const deserializeAws_queryUpdateGroupCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ServiceFailure":
+    case "ServiceFailureException":
     case "com.amazonaws.iam#ServiceFailureException":
       response = {
         ...(await deserializeAws_queryServiceFailureExceptionResponse(parsedOutput, context)),
@@ -13429,7 +13429,7 @@ const deserializeAws_queryUpdateLoginProfileCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "EntityTemporarilyUnmodifiable":
+    case "EntityTemporarilyUnmodifiableException":
     case "com.amazonaws.iam#EntityTemporarilyUnmodifiableException":
       response = {
         ...(await deserializeAws_queryEntityTemporarilyUnmodifiableExceptionResponse(parsedOutput, context)),
@@ -13437,7 +13437,7 @@ const deserializeAws_queryUpdateLoginProfileCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "LimitExceeded":
+    case "LimitExceededException":
     case "com.amazonaws.iam#LimitExceededException":
       response = {
         ...(await deserializeAws_queryLimitExceededExceptionResponse(parsedOutput, context)),
@@ -13445,7 +13445,7 @@ const deserializeAws_queryUpdateLoginProfileCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "NoSuchEntity":
+    case "NoSuchEntityException":
     case "com.amazonaws.iam#NoSuchEntityException":
       response = {
         ...(await deserializeAws_queryNoSuchEntityExceptionResponse(parsedOutput, context)),
@@ -13453,7 +13453,7 @@ const deserializeAws_queryUpdateLoginProfileCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "PasswordPolicyViolation":
+    case "PasswordPolicyViolationException":
     case "com.amazonaws.iam#PasswordPolicyViolationException":
       response = {
         ...(await deserializeAws_queryPasswordPolicyViolationExceptionResponse(parsedOutput, context)),
@@ -13461,7 +13461,7 @@ const deserializeAws_queryUpdateLoginProfileCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ServiceFailure":
+    case "ServiceFailureException":
     case "com.amazonaws.iam#ServiceFailureException":
       response = {
         ...(await deserializeAws_queryServiceFailureExceptionResponse(parsedOutput, context)),
@@ -13512,7 +13512,7 @@ const deserializeAws_queryUpdateOpenIDConnectProviderThumbprintCommandError = as
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "InvalidInput":
+    case "InvalidInputException":
     case "com.amazonaws.iam#InvalidInputException":
       response = {
         ...(await deserializeAws_queryInvalidInputExceptionResponse(parsedOutput, context)),
@@ -13520,7 +13520,7 @@ const deserializeAws_queryUpdateOpenIDConnectProviderThumbprintCommandError = as
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "NoSuchEntity":
+    case "NoSuchEntityException":
     case "com.amazonaws.iam#NoSuchEntityException":
       response = {
         ...(await deserializeAws_queryNoSuchEntityExceptionResponse(parsedOutput, context)),
@@ -13528,7 +13528,7 @@ const deserializeAws_queryUpdateOpenIDConnectProviderThumbprintCommandError = as
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ServiceFailure":
+    case "ServiceFailureException":
     case "com.amazonaws.iam#ServiceFailureException":
       response = {
         ...(await deserializeAws_queryServiceFailureExceptionResponse(parsedOutput, context)),
@@ -13582,7 +13582,7 @@ const deserializeAws_queryUpdateRoleCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "NoSuchEntity":
+    case "NoSuchEntityException":
     case "com.amazonaws.iam#NoSuchEntityException":
       response = {
         ...(await deserializeAws_queryNoSuchEntityExceptionResponse(parsedOutput, context)),
@@ -13590,7 +13590,7 @@ const deserializeAws_queryUpdateRoleCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ServiceFailure":
+    case "ServiceFailureException":
     case "com.amazonaws.iam#ServiceFailureException":
       response = {
         ...(await deserializeAws_queryServiceFailureExceptionResponse(parsedOutput, context)),
@@ -13598,7 +13598,7 @@ const deserializeAws_queryUpdateRoleCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "UnmodifiableEntity":
+    case "UnmodifiableEntityException":
     case "com.amazonaws.iam#UnmodifiableEntityException":
       response = {
         ...(await deserializeAws_queryUnmodifiableEntityExceptionResponse(parsedOutput, context)),
@@ -13652,7 +13652,7 @@ const deserializeAws_queryUpdateRoleDescriptionCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "NoSuchEntity":
+    case "NoSuchEntityException":
     case "com.amazonaws.iam#NoSuchEntityException":
       response = {
         ...(await deserializeAws_queryNoSuchEntityExceptionResponse(parsedOutput, context)),
@@ -13660,7 +13660,7 @@ const deserializeAws_queryUpdateRoleDescriptionCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ServiceFailure":
+    case "ServiceFailureException":
     case "com.amazonaws.iam#ServiceFailureException":
       response = {
         ...(await deserializeAws_queryServiceFailureExceptionResponse(parsedOutput, context)),
@@ -13668,7 +13668,7 @@ const deserializeAws_queryUpdateRoleDescriptionCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "UnmodifiableEntity":
+    case "UnmodifiableEntityException":
     case "com.amazonaws.iam#UnmodifiableEntityException":
       response = {
         ...(await deserializeAws_queryUnmodifiableEntityExceptionResponse(parsedOutput, context)),
@@ -13722,7 +13722,7 @@ const deserializeAws_queryUpdateSAMLProviderCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "InvalidInput":
+    case "InvalidInputException":
     case "com.amazonaws.iam#InvalidInputException":
       response = {
         ...(await deserializeAws_queryInvalidInputExceptionResponse(parsedOutput, context)),
@@ -13730,7 +13730,7 @@ const deserializeAws_queryUpdateSAMLProviderCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "LimitExceeded":
+    case "LimitExceededException":
     case "com.amazonaws.iam#LimitExceededException":
       response = {
         ...(await deserializeAws_queryLimitExceededExceptionResponse(parsedOutput, context)),
@@ -13738,7 +13738,7 @@ const deserializeAws_queryUpdateSAMLProviderCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "NoSuchEntity":
+    case "NoSuchEntityException":
     case "com.amazonaws.iam#NoSuchEntityException":
       response = {
         ...(await deserializeAws_queryNoSuchEntityExceptionResponse(parsedOutput, context)),
@@ -13746,7 +13746,7 @@ const deserializeAws_queryUpdateSAMLProviderCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ServiceFailure":
+    case "ServiceFailureException":
     case "com.amazonaws.iam#ServiceFailureException":
       response = {
         ...(await deserializeAws_queryServiceFailureExceptionResponse(parsedOutput, context)),
@@ -13797,7 +13797,7 @@ const deserializeAws_queryUpdateServerCertificateCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "EntityAlreadyExists":
+    case "EntityAlreadyExistsException":
     case "com.amazonaws.iam#EntityAlreadyExistsException":
       response = {
         ...(await deserializeAws_queryEntityAlreadyExistsExceptionResponse(parsedOutput, context)),
@@ -13805,7 +13805,7 @@ const deserializeAws_queryUpdateServerCertificateCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "LimitExceeded":
+    case "LimitExceededException":
     case "com.amazonaws.iam#LimitExceededException":
       response = {
         ...(await deserializeAws_queryLimitExceededExceptionResponse(parsedOutput, context)),
@@ -13813,7 +13813,7 @@ const deserializeAws_queryUpdateServerCertificateCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "NoSuchEntity":
+    case "NoSuchEntityException":
     case "com.amazonaws.iam#NoSuchEntityException":
       response = {
         ...(await deserializeAws_queryNoSuchEntityExceptionResponse(parsedOutput, context)),
@@ -13821,7 +13821,7 @@ const deserializeAws_queryUpdateServerCertificateCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ServiceFailure":
+    case "ServiceFailureException":
     case "com.amazonaws.iam#ServiceFailureException":
       response = {
         ...(await deserializeAws_queryServiceFailureExceptionResponse(parsedOutput, context)),
@@ -13872,7 +13872,7 @@ const deserializeAws_queryUpdateServiceSpecificCredentialCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "NoSuchEntity":
+    case "NoSuchEntityException":
     case "com.amazonaws.iam#NoSuchEntityException":
       response = {
         ...(await deserializeAws_queryNoSuchEntityExceptionResponse(parsedOutput, context)),
@@ -13923,7 +13923,7 @@ const deserializeAws_queryUpdateSigningCertificateCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "LimitExceeded":
+    case "LimitExceededException":
     case "com.amazonaws.iam#LimitExceededException":
       response = {
         ...(await deserializeAws_queryLimitExceededExceptionResponse(parsedOutput, context)),
@@ -13931,7 +13931,7 @@ const deserializeAws_queryUpdateSigningCertificateCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "NoSuchEntity":
+    case "NoSuchEntityException":
     case "com.amazonaws.iam#NoSuchEntityException":
       response = {
         ...(await deserializeAws_queryNoSuchEntityExceptionResponse(parsedOutput, context)),
@@ -13939,7 +13939,7 @@ const deserializeAws_queryUpdateSigningCertificateCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ServiceFailure":
+    case "ServiceFailureException":
     case "com.amazonaws.iam#ServiceFailureException":
       response = {
         ...(await deserializeAws_queryServiceFailureExceptionResponse(parsedOutput, context)),
@@ -13990,7 +13990,7 @@ const deserializeAws_queryUpdateSSHPublicKeyCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "NoSuchEntity":
+    case "NoSuchEntityException":
     case "com.amazonaws.iam#NoSuchEntityException":
       response = {
         ...(await deserializeAws_queryNoSuchEntityExceptionResponse(parsedOutput, context)),
@@ -14041,7 +14041,7 @@ const deserializeAws_queryUpdateUserCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "ConcurrentModification":
+    case "ConcurrentModificationException":
     case "com.amazonaws.iam#ConcurrentModificationException":
       response = {
         ...(await deserializeAws_queryConcurrentModificationExceptionResponse(parsedOutput, context)),
@@ -14049,7 +14049,7 @@ const deserializeAws_queryUpdateUserCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "EntityAlreadyExists":
+    case "EntityAlreadyExistsException":
     case "com.amazonaws.iam#EntityAlreadyExistsException":
       response = {
         ...(await deserializeAws_queryEntityAlreadyExistsExceptionResponse(parsedOutput, context)),
@@ -14057,7 +14057,7 @@ const deserializeAws_queryUpdateUserCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "EntityTemporarilyUnmodifiable":
+    case "EntityTemporarilyUnmodifiableException":
     case "com.amazonaws.iam#EntityTemporarilyUnmodifiableException":
       response = {
         ...(await deserializeAws_queryEntityTemporarilyUnmodifiableExceptionResponse(parsedOutput, context)),
@@ -14065,7 +14065,7 @@ const deserializeAws_queryUpdateUserCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "LimitExceeded":
+    case "LimitExceededException":
     case "com.amazonaws.iam#LimitExceededException":
       response = {
         ...(await deserializeAws_queryLimitExceededExceptionResponse(parsedOutput, context)),
@@ -14073,7 +14073,7 @@ const deserializeAws_queryUpdateUserCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "NoSuchEntity":
+    case "NoSuchEntityException":
     case "com.amazonaws.iam#NoSuchEntityException":
       response = {
         ...(await deserializeAws_queryNoSuchEntityExceptionResponse(parsedOutput, context)),
@@ -14081,7 +14081,7 @@ const deserializeAws_queryUpdateUserCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ServiceFailure":
+    case "ServiceFailureException":
     case "com.amazonaws.iam#ServiceFailureException":
       response = {
         ...(await deserializeAws_queryServiceFailureExceptionResponse(parsedOutput, context)),
@@ -14135,7 +14135,7 @@ const deserializeAws_queryUploadServerCertificateCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "ConcurrentModification":
+    case "ConcurrentModificationException":
     case "com.amazonaws.iam#ConcurrentModificationException":
       response = {
         ...(await deserializeAws_queryConcurrentModificationExceptionResponse(parsedOutput, context)),
@@ -14143,7 +14143,7 @@ const deserializeAws_queryUploadServerCertificateCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "EntityAlreadyExists":
+    case "EntityAlreadyExistsException":
     case "com.amazonaws.iam#EntityAlreadyExistsException":
       response = {
         ...(await deserializeAws_queryEntityAlreadyExistsExceptionResponse(parsedOutput, context)),
@@ -14151,7 +14151,7 @@ const deserializeAws_queryUploadServerCertificateCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidInput":
+    case "InvalidInputException":
     case "com.amazonaws.iam#InvalidInputException":
       response = {
         ...(await deserializeAws_queryInvalidInputExceptionResponse(parsedOutput, context)),
@@ -14159,7 +14159,7 @@ const deserializeAws_queryUploadServerCertificateCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "KeyPairMismatch":
+    case "KeyPairMismatchException":
     case "com.amazonaws.iam#KeyPairMismatchException":
       response = {
         ...(await deserializeAws_queryKeyPairMismatchExceptionResponse(parsedOutput, context)),
@@ -14167,7 +14167,7 @@ const deserializeAws_queryUploadServerCertificateCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "LimitExceeded":
+    case "LimitExceededException":
     case "com.amazonaws.iam#LimitExceededException":
       response = {
         ...(await deserializeAws_queryLimitExceededExceptionResponse(parsedOutput, context)),
@@ -14175,7 +14175,7 @@ const deserializeAws_queryUploadServerCertificateCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "MalformedCertificate":
+    case "MalformedCertificateException":
     case "com.amazonaws.iam#MalformedCertificateException":
       response = {
         ...(await deserializeAws_queryMalformedCertificateExceptionResponse(parsedOutput, context)),
@@ -14183,7 +14183,7 @@ const deserializeAws_queryUploadServerCertificateCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ServiceFailure":
+    case "ServiceFailureException":
     case "com.amazonaws.iam#ServiceFailureException":
       response = {
         ...(await deserializeAws_queryServiceFailureExceptionResponse(parsedOutput, context)),
@@ -14237,7 +14237,7 @@ const deserializeAws_queryUploadSigningCertificateCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "DuplicateCertificate":
+    case "DuplicateCertificateException":
     case "com.amazonaws.iam#DuplicateCertificateException":
       response = {
         ...(await deserializeAws_queryDuplicateCertificateExceptionResponse(parsedOutput, context)),
@@ -14245,7 +14245,7 @@ const deserializeAws_queryUploadSigningCertificateCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "EntityAlreadyExists":
+    case "EntityAlreadyExistsException":
     case "com.amazonaws.iam#EntityAlreadyExistsException":
       response = {
         ...(await deserializeAws_queryEntityAlreadyExistsExceptionResponse(parsedOutput, context)),
@@ -14253,7 +14253,7 @@ const deserializeAws_queryUploadSigningCertificateCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidCertificate":
+    case "InvalidCertificateException":
     case "com.amazonaws.iam#InvalidCertificateException":
       response = {
         ...(await deserializeAws_queryInvalidCertificateExceptionResponse(parsedOutput, context)),
@@ -14261,7 +14261,7 @@ const deserializeAws_queryUploadSigningCertificateCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "LimitExceeded":
+    case "LimitExceededException":
     case "com.amazonaws.iam#LimitExceededException":
       response = {
         ...(await deserializeAws_queryLimitExceededExceptionResponse(parsedOutput, context)),
@@ -14269,7 +14269,7 @@ const deserializeAws_queryUploadSigningCertificateCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "MalformedCertificate":
+    case "MalformedCertificateException":
     case "com.amazonaws.iam#MalformedCertificateException":
       response = {
         ...(await deserializeAws_queryMalformedCertificateExceptionResponse(parsedOutput, context)),
@@ -14277,7 +14277,7 @@ const deserializeAws_queryUploadSigningCertificateCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "NoSuchEntity":
+    case "NoSuchEntityException":
     case "com.amazonaws.iam#NoSuchEntityException":
       response = {
         ...(await deserializeAws_queryNoSuchEntityExceptionResponse(parsedOutput, context)),
@@ -14285,7 +14285,7 @@ const deserializeAws_queryUploadSigningCertificateCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ServiceFailure":
+    case "ServiceFailureException":
     case "com.amazonaws.iam#ServiceFailureException":
       response = {
         ...(await deserializeAws_queryServiceFailureExceptionResponse(parsedOutput, context)),
@@ -14339,7 +14339,7 @@ const deserializeAws_queryUploadSSHPublicKeyCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "DuplicateSSHPublicKey":
+    case "DuplicateSSHPublicKeyException":
     case "com.amazonaws.iam#DuplicateSSHPublicKeyException":
       response = {
         ...(await deserializeAws_queryDuplicateSSHPublicKeyExceptionResponse(parsedOutput, context)),
@@ -14347,7 +14347,7 @@ const deserializeAws_queryUploadSSHPublicKeyCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidPublicKey":
+    case "InvalidPublicKeyException":
     case "com.amazonaws.iam#InvalidPublicKeyException":
       response = {
         ...(await deserializeAws_queryInvalidPublicKeyExceptionResponse(parsedOutput, context)),
@@ -14355,7 +14355,7 @@ const deserializeAws_queryUploadSSHPublicKeyCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "LimitExceeded":
+    case "LimitExceededException":
     case "com.amazonaws.iam#LimitExceededException":
       response = {
         ...(await deserializeAws_queryLimitExceededExceptionResponse(parsedOutput, context)),
@@ -14363,7 +14363,7 @@ const deserializeAws_queryUploadSSHPublicKeyCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "NoSuchEntity":
+    case "NoSuchEntityException":
     case "com.amazonaws.iam#NoSuchEntityException":
       response = {
         ...(await deserializeAws_queryNoSuchEntityExceptionResponse(parsedOutput, context)),
@@ -14371,7 +14371,7 @@ const deserializeAws_queryUploadSSHPublicKeyCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "UnrecognizedPublicKeyEncoding":
+    case "UnrecognizedPublicKeyEncodingException":
     case "com.amazonaws.iam#UnrecognizedPublicKeyEncodingException":
       response = {
         ...(await deserializeAws_queryUnrecognizedPublicKeyEncodingExceptionResponse(parsedOutput, context)),

--- a/clients/client-kms/src/protocols/Aws_json1_1.ts
+++ b/clients/client-kms/src/protocols/Aws_json1_1.ts
@@ -1550,6 +1550,14 @@ const deserializeAws_json1_1DecryptCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
+    case "KeyUnavailableException":
+    case "com.amazonaws.kms#KeyUnavailableException":
+      response = {
+        ...(await deserializeAws_json1_1KeyUnavailableExceptionResponse(parsedOutput, context)),
+        name: errorCode,
+        $metadata: deserializeMetadata(output),
+      };
+      break;
     case "KMSInternalException":
     case "com.amazonaws.kms#KMSInternalException":
       response = {
@@ -1562,14 +1570,6 @@ const deserializeAws_json1_1DecryptCommandError = async (
     case "com.amazonaws.kms#KMSInvalidStateException":
       response = {
         ...(await deserializeAws_json1_1KMSInvalidStateExceptionResponse(parsedOutput, context)),
-        name: errorCode,
-        $metadata: deserializeMetadata(output),
-      };
-      break;
-    case "KeyUnavailableException":
-    case "com.amazonaws.kms#KeyUnavailableException":
-      response = {
-        ...(await deserializeAws_json1_1KeyUnavailableExceptionResponse(parsedOutput, context)),
         name: errorCode,
         $metadata: deserializeMetadata(output),
       };
@@ -2494,6 +2494,14 @@ const deserializeAws_json1_1EncryptCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
+    case "KeyUnavailableException":
+    case "com.amazonaws.kms#KeyUnavailableException":
+      response = {
+        ...(await deserializeAws_json1_1KeyUnavailableExceptionResponse(parsedOutput, context)),
+        name: errorCode,
+        $metadata: deserializeMetadata(output),
+      };
+      break;
     case "KMSInternalException":
     case "com.amazonaws.kms#KMSInternalException":
       response = {
@@ -2506,14 +2514,6 @@ const deserializeAws_json1_1EncryptCommandError = async (
     case "com.amazonaws.kms#KMSInvalidStateException":
       response = {
         ...(await deserializeAws_json1_1KMSInvalidStateExceptionResponse(parsedOutput, context)),
-        name: errorCode,
-        $metadata: deserializeMetadata(output),
-      };
-      break;
-    case "KeyUnavailableException":
-    case "com.amazonaws.kms#KeyUnavailableException":
-      response = {
-        ...(await deserializeAws_json1_1KeyUnavailableExceptionResponse(parsedOutput, context)),
         name: errorCode,
         $metadata: deserializeMetadata(output),
       };
@@ -2604,6 +2604,14 @@ const deserializeAws_json1_1GenerateDataKeyCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
+    case "KeyUnavailableException":
+    case "com.amazonaws.kms#KeyUnavailableException":
+      response = {
+        ...(await deserializeAws_json1_1KeyUnavailableExceptionResponse(parsedOutput, context)),
+        name: errorCode,
+        $metadata: deserializeMetadata(output),
+      };
+      break;
     case "KMSInternalException":
     case "com.amazonaws.kms#KMSInternalException":
       response = {
@@ -2616,14 +2624,6 @@ const deserializeAws_json1_1GenerateDataKeyCommandError = async (
     case "com.amazonaws.kms#KMSInvalidStateException":
       response = {
         ...(await deserializeAws_json1_1KMSInvalidStateExceptionResponse(parsedOutput, context)),
-        name: errorCode,
-        $metadata: deserializeMetadata(output),
-      };
-      break;
-    case "KeyUnavailableException":
-    case "com.amazonaws.kms#KeyUnavailableException":
-      response = {
-        ...(await deserializeAws_json1_1KeyUnavailableExceptionResponse(parsedOutput, context)),
         name: errorCode,
         $metadata: deserializeMetadata(output),
       };
@@ -2714,6 +2714,14 @@ const deserializeAws_json1_1GenerateDataKeyPairCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
+    case "KeyUnavailableException":
+    case "com.amazonaws.kms#KeyUnavailableException":
+      response = {
+        ...(await deserializeAws_json1_1KeyUnavailableExceptionResponse(parsedOutput, context)),
+        name: errorCode,
+        $metadata: deserializeMetadata(output),
+      };
+      break;
     case "KMSInternalException":
     case "com.amazonaws.kms#KMSInternalException":
       response = {
@@ -2726,14 +2734,6 @@ const deserializeAws_json1_1GenerateDataKeyPairCommandError = async (
     case "com.amazonaws.kms#KMSInvalidStateException":
       response = {
         ...(await deserializeAws_json1_1KMSInvalidStateExceptionResponse(parsedOutput, context)),
-        name: errorCode,
-        $metadata: deserializeMetadata(output),
-      };
-      break;
-    case "KeyUnavailableException":
-    case "com.amazonaws.kms#KeyUnavailableException":
-      response = {
-        ...(await deserializeAws_json1_1KeyUnavailableExceptionResponse(parsedOutput, context)),
         name: errorCode,
         $metadata: deserializeMetadata(output),
       };
@@ -2832,6 +2832,14 @@ const deserializeAws_json1_1GenerateDataKeyPairWithoutPlaintextCommandError = as
         $metadata: deserializeMetadata(output),
       };
       break;
+    case "KeyUnavailableException":
+    case "com.amazonaws.kms#KeyUnavailableException":
+      response = {
+        ...(await deserializeAws_json1_1KeyUnavailableExceptionResponse(parsedOutput, context)),
+        name: errorCode,
+        $metadata: deserializeMetadata(output),
+      };
+      break;
     case "KMSInternalException":
     case "com.amazonaws.kms#KMSInternalException":
       response = {
@@ -2844,14 +2852,6 @@ const deserializeAws_json1_1GenerateDataKeyPairWithoutPlaintextCommandError = as
     case "com.amazonaws.kms#KMSInvalidStateException":
       response = {
         ...(await deserializeAws_json1_1KMSInvalidStateExceptionResponse(parsedOutput, context)),
-        name: errorCode,
-        $metadata: deserializeMetadata(output),
-      };
-      break;
-    case "KeyUnavailableException":
-    case "com.amazonaws.kms#KeyUnavailableException":
-      response = {
-        ...(await deserializeAws_json1_1KeyUnavailableExceptionResponse(parsedOutput, context)),
         name: errorCode,
         $metadata: deserializeMetadata(output),
       };
@@ -2950,6 +2950,14 @@ const deserializeAws_json1_1GenerateDataKeyWithoutPlaintextCommandError = async 
         $metadata: deserializeMetadata(output),
       };
       break;
+    case "KeyUnavailableException":
+    case "com.amazonaws.kms#KeyUnavailableException":
+      response = {
+        ...(await deserializeAws_json1_1KeyUnavailableExceptionResponse(parsedOutput, context)),
+        name: errorCode,
+        $metadata: deserializeMetadata(output),
+      };
+      break;
     case "KMSInternalException":
     case "com.amazonaws.kms#KMSInternalException":
       response = {
@@ -2962,14 +2970,6 @@ const deserializeAws_json1_1GenerateDataKeyWithoutPlaintextCommandError = async 
     case "com.amazonaws.kms#KMSInvalidStateException":
       response = {
         ...(await deserializeAws_json1_1KMSInvalidStateExceptionResponse(parsedOutput, context)),
-        name: errorCode,
-        $metadata: deserializeMetadata(output),
-      };
-      break;
-    case "KeyUnavailableException":
-    case "com.amazonaws.kms#KeyUnavailableException":
-      response = {
-        ...(await deserializeAws_json1_1KeyUnavailableExceptionResponse(parsedOutput, context)),
         name: errorCode,
         $metadata: deserializeMetadata(output),
       };
@@ -3420,6 +3420,14 @@ const deserializeAws_json1_1GetPublicKeyCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
+    case "KeyUnavailableException":
+    case "com.amazonaws.kms#KeyUnavailableException":
+      response = {
+        ...(await deserializeAws_json1_1KeyUnavailableExceptionResponse(parsedOutput, context)),
+        name: errorCode,
+        $metadata: deserializeMetadata(output),
+      };
+      break;
     case "KMSInternalException":
     case "com.amazonaws.kms#KMSInternalException":
       response = {
@@ -3432,14 +3440,6 @@ const deserializeAws_json1_1GetPublicKeyCommandError = async (
     case "com.amazonaws.kms#KMSInvalidStateException":
       response = {
         ...(await deserializeAws_json1_1KMSInvalidStateExceptionResponse(parsedOutput, context)),
-        name: errorCode,
-        $metadata: deserializeMetadata(output),
-      };
-      break;
-    case "KeyUnavailableException":
-    case "com.amazonaws.kms#KeyUnavailableException":
-      response = {
-        ...(await deserializeAws_json1_1KeyUnavailableExceptionResponse(parsedOutput, context)),
         name: errorCode,
         $metadata: deserializeMetadata(output),
       };
@@ -4295,6 +4295,14 @@ const deserializeAws_json1_1ReEncryptCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
+    case "KeyUnavailableException":
+    case "com.amazonaws.kms#KeyUnavailableException":
+      response = {
+        ...(await deserializeAws_json1_1KeyUnavailableExceptionResponse(parsedOutput, context)),
+        name: errorCode,
+        $metadata: deserializeMetadata(output),
+      };
+      break;
     case "KMSInternalException":
     case "com.amazonaws.kms#KMSInternalException":
       response = {
@@ -4307,14 +4315,6 @@ const deserializeAws_json1_1ReEncryptCommandError = async (
     case "com.amazonaws.kms#KMSInvalidStateException":
       response = {
         ...(await deserializeAws_json1_1KMSInvalidStateExceptionResponse(parsedOutput, context)),
-        name: errorCode,
-        $metadata: deserializeMetadata(output),
-      };
-      break;
-    case "KeyUnavailableException":
-    case "com.amazonaws.kms#KeyUnavailableException":
-      response = {
-        ...(await deserializeAws_json1_1KeyUnavailableExceptionResponse(parsedOutput, context)),
         name: errorCode,
         $metadata: deserializeMetadata(output),
       };
@@ -4807,6 +4807,14 @@ const deserializeAws_json1_1SignCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
+    case "KeyUnavailableException":
+    case "com.amazonaws.kms#KeyUnavailableException":
+      response = {
+        ...(await deserializeAws_json1_1KeyUnavailableExceptionResponse(parsedOutput, context)),
+        name: errorCode,
+        $metadata: deserializeMetadata(output),
+      };
+      break;
     case "KMSInternalException":
     case "com.amazonaws.kms#KMSInternalException":
       response = {
@@ -4819,14 +4827,6 @@ const deserializeAws_json1_1SignCommandError = async (
     case "com.amazonaws.kms#KMSInvalidStateException":
       response = {
         ...(await deserializeAws_json1_1KMSInvalidStateExceptionResponse(parsedOutput, context)),
-        name: errorCode,
-        $metadata: deserializeMetadata(output),
-      };
-      break;
-    case "KeyUnavailableException":
-    case "com.amazonaws.kms#KeyUnavailableException":
-      response = {
-        ...(await deserializeAws_json1_1KeyUnavailableExceptionResponse(parsedOutput, context)),
         name: errorCode,
         $metadata: deserializeMetadata(output),
       };
@@ -5458,6 +5458,14 @@ const deserializeAws_json1_1VerifyCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
+    case "KeyUnavailableException":
+    case "com.amazonaws.kms#KeyUnavailableException":
+      response = {
+        ...(await deserializeAws_json1_1KeyUnavailableExceptionResponse(parsedOutput, context)),
+        name: errorCode,
+        $metadata: deserializeMetadata(output),
+      };
+      break;
     case "KMSInternalException":
     case "com.amazonaws.kms#KMSInternalException":
       response = {
@@ -5478,14 +5486,6 @@ const deserializeAws_json1_1VerifyCommandError = async (
     case "com.amazonaws.kms#KMSInvalidStateException":
       response = {
         ...(await deserializeAws_json1_1KMSInvalidStateExceptionResponse(parsedOutput, context)),
-        name: errorCode,
-        $metadata: deserializeMetadata(output),
-      };
-      break;
-    case "KeyUnavailableException":
-    case "com.amazonaws.kms#KeyUnavailableException":
-      response = {
-        ...(await deserializeAws_json1_1KeyUnavailableExceptionResponse(parsedOutput, context)),
         name: errorCode,
         $metadata: deserializeMetadata(output),
       };

--- a/clients/client-memorydb/src/protocols/Aws_json1_1.ts
+++ b/clients/client-memorydb/src/protocols/Aws_json1_1.ts
@@ -3578,14 +3578,6 @@ const deserializeAws_json1_1UpdateClusterCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "NoOperationFault":
-    case "com.amazonaws.memorydb#NoOperationFault":
-      response = {
-        ...(await deserializeAws_json1_1NoOperationFaultResponse(parsedOutput, context)),
-        name: errorCode,
-        $metadata: deserializeMetadata(output),
-      };
-      break;
     case "NodeQuotaForClusterExceededFault":
     case "com.amazonaws.memorydb#NodeQuotaForClusterExceededFault":
       response = {
@@ -3598,6 +3590,14 @@ const deserializeAws_json1_1UpdateClusterCommandError = async (
     case "com.amazonaws.memorydb#NodeQuotaForCustomerExceededFault":
       response = {
         ...(await deserializeAws_json1_1NodeQuotaForCustomerExceededFaultResponse(parsedOutput, context)),
+        name: errorCode,
+        $metadata: deserializeMetadata(output),
+      };
+      break;
+    case "NoOperationFault":
+    case "com.amazonaws.memorydb#NoOperationFault":
+      response = {
+        ...(await deserializeAws_json1_1NoOperationFaultResponse(parsedOutput, context)),
         name: errorCode,
         $metadata: deserializeMetadata(output),
       };

--- a/clients/client-neptune/src/protocols/Aws_query.ts
+++ b/clients/client-neptune/src/protocols/Aws_query.ts
@@ -1498,7 +1498,7 @@ const deserializeAws_queryAddRoleToDBClusterCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "DBClusterRoleAlreadyExists":
+    case "DBClusterRoleAlreadyExistsFault":
     case "com.amazonaws.neptune#DBClusterRoleAlreadyExistsFault":
       response = {
         ...(await deserializeAws_queryDBClusterRoleAlreadyExistsFaultResponse(parsedOutput, context)),
@@ -1506,7 +1506,7 @@ const deserializeAws_queryAddRoleToDBClusterCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "DBClusterRoleQuotaExceeded":
+    case "DBClusterRoleQuotaExceededFault":
     case "com.amazonaws.neptune#DBClusterRoleQuotaExceededFault":
       response = {
         ...(await deserializeAws_queryDBClusterRoleQuotaExceededFaultResponse(parsedOutput, context)),
@@ -1571,7 +1571,7 @@ const deserializeAws_queryAddSourceIdentifierToSubscriptionCommandError = async 
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "SourceNotFound":
+    case "SourceNotFoundFault":
     case "com.amazonaws.neptune#SourceNotFoundFault":
       response = {
         ...(await deserializeAws_querySourceNotFoundFaultResponse(parsedOutput, context)),
@@ -1579,7 +1579,7 @@ const deserializeAws_queryAddSourceIdentifierToSubscriptionCommandError = async 
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "SubscriptionNotFound":
+    case "SubscriptionNotFoundFault":
     case "com.amazonaws.neptune#SubscriptionNotFoundFault":
       response = {
         ...(await deserializeAws_querySubscriptionNotFoundFaultResponse(parsedOutput, context)),
@@ -1638,7 +1638,7 @@ const deserializeAws_queryAddTagsToResourceCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "DBInstanceNotFound":
+    case "DBInstanceNotFoundFault":
     case "com.amazonaws.neptune#DBInstanceNotFoundFault":
       response = {
         ...(await deserializeAws_queryDBInstanceNotFoundFaultResponse(parsedOutput, context)),
@@ -1646,7 +1646,7 @@ const deserializeAws_queryAddTagsToResourceCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "DBSnapshotNotFound":
+    case "DBSnapshotNotFoundFault":
     case "com.amazonaws.neptune#DBSnapshotNotFoundFault":
       response = {
         ...(await deserializeAws_queryDBSnapshotNotFoundFaultResponse(parsedOutput, context)),
@@ -1754,7 +1754,7 @@ const deserializeAws_queryCopyDBClusterParameterGroupCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "DBParameterGroupAlreadyExists":
+    case "DBParameterGroupAlreadyExistsFault":
     case "com.amazonaws.neptune#DBParameterGroupAlreadyExistsFault":
       response = {
         ...(await deserializeAws_queryDBParameterGroupAlreadyExistsFaultResponse(parsedOutput, context)),
@@ -1762,7 +1762,7 @@ const deserializeAws_queryCopyDBClusterParameterGroupCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "DBParameterGroupNotFound":
+    case "DBParameterGroupNotFoundFault":
     case "com.amazonaws.neptune#DBParameterGroupNotFoundFault":
       response = {
         ...(await deserializeAws_queryDBParameterGroupNotFoundFaultResponse(parsedOutput, context)),
@@ -1770,7 +1770,7 @@ const deserializeAws_queryCopyDBClusterParameterGroupCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "DBParameterGroupQuotaExceeded":
+    case "DBParameterGroupQuotaExceededFault":
     case "com.amazonaws.neptune#DBParameterGroupQuotaExceededFault":
       response = {
         ...(await deserializeAws_queryDBParameterGroupQuotaExceededFaultResponse(parsedOutput, context)),
@@ -1864,7 +1864,7 @@ const deserializeAws_queryCopyDBClusterSnapshotCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "SnapshotQuotaExceeded":
+    case "SnapshotQuotaExceededFault":
     case "com.amazonaws.neptune#SnapshotQuotaExceededFault":
       response = {
         ...(await deserializeAws_querySnapshotQuotaExceededFaultResponse(parsedOutput, context)),
@@ -1918,7 +1918,7 @@ const deserializeAws_queryCopyDBParameterGroupCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "DBParameterGroupAlreadyExists":
+    case "DBParameterGroupAlreadyExistsFault":
     case "com.amazonaws.neptune#DBParameterGroupAlreadyExistsFault":
       response = {
         ...(await deserializeAws_queryDBParameterGroupAlreadyExistsFaultResponse(parsedOutput, context)),
@@ -1926,7 +1926,7 @@ const deserializeAws_queryCopyDBParameterGroupCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "DBParameterGroupNotFound":
+    case "DBParameterGroupNotFoundFault":
     case "com.amazonaws.neptune#DBParameterGroupNotFoundFault":
       response = {
         ...(await deserializeAws_queryDBParameterGroupNotFoundFaultResponse(parsedOutput, context)),
@@ -1934,7 +1934,7 @@ const deserializeAws_queryCopyDBParameterGroupCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "DBParameterGroupQuotaExceeded":
+    case "DBParameterGroupQuotaExceededFault":
     case "com.amazonaws.neptune#DBParameterGroupQuotaExceededFault":
       response = {
         ...(await deserializeAws_queryDBParameterGroupQuotaExceededFaultResponse(parsedOutput, context)),
@@ -2004,7 +2004,7 @@ const deserializeAws_queryCreateDBClusterCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "DBClusterParameterGroupNotFound":
+    case "DBClusterParameterGroupNotFoundFault":
     case "com.amazonaws.neptune#DBClusterParameterGroupNotFoundFault":
       response = {
         ...(await deserializeAws_queryDBClusterParameterGroupNotFoundFaultResponse(parsedOutput, context)),
@@ -2020,7 +2020,7 @@ const deserializeAws_queryCreateDBClusterCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "DBInstanceNotFound":
+    case "DBInstanceNotFoundFault":
     case "com.amazonaws.neptune#DBInstanceNotFoundFault":
       response = {
         ...(await deserializeAws_queryDBInstanceNotFoundFaultResponse(parsedOutput, context)),
@@ -2044,7 +2044,7 @@ const deserializeAws_queryCreateDBClusterCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InsufficientStorageClusterCapacity":
+    case "InsufficientStorageClusterCapacityFault":
     case "com.amazonaws.neptune#InsufficientStorageClusterCapacityFault":
       response = {
         ...(await deserializeAws_queryInsufficientStorageClusterCapacityFaultResponse(parsedOutput, context)),
@@ -2060,7 +2060,7 @@ const deserializeAws_queryCreateDBClusterCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidDBInstanceState":
+    case "InvalidDBInstanceStateFault":
     case "com.amazonaws.neptune#InvalidDBInstanceStateFault":
       response = {
         ...(await deserializeAws_queryInvalidDBInstanceStateFaultResponse(parsedOutput, context)),
@@ -2100,7 +2100,7 @@ const deserializeAws_queryCreateDBClusterCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "StorageQuotaExceeded":
+    case "StorageQuotaExceededFault":
     case "com.amazonaws.neptune#StorageQuotaExceededFault":
       response = {
         ...(await deserializeAws_queryStorageQuotaExceededFaultResponse(parsedOutput, context)),
@@ -2178,7 +2178,7 @@ const deserializeAws_queryCreateDBClusterEndpointCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "DBInstanceNotFound":
+    case "DBInstanceNotFoundFault":
     case "com.amazonaws.neptune#DBInstanceNotFoundFault":
       response = {
         ...(await deserializeAws_queryDBInstanceNotFoundFaultResponse(parsedOutput, context)),
@@ -2194,7 +2194,7 @@ const deserializeAws_queryCreateDBClusterEndpointCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidDBInstanceState":
+    case "InvalidDBInstanceStateFault":
     case "com.amazonaws.neptune#InvalidDBInstanceStateFault":
       response = {
         ...(await deserializeAws_queryInvalidDBInstanceStateFaultResponse(parsedOutput, context)),
@@ -2248,7 +2248,7 @@ const deserializeAws_queryCreateDBClusterParameterGroupCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "DBParameterGroupAlreadyExists":
+    case "DBParameterGroupAlreadyExistsFault":
     case "com.amazonaws.neptune#DBParameterGroupAlreadyExistsFault":
       response = {
         ...(await deserializeAws_queryDBParameterGroupAlreadyExistsFaultResponse(parsedOutput, context)),
@@ -2256,7 +2256,7 @@ const deserializeAws_queryCreateDBClusterParameterGroupCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "DBParameterGroupQuotaExceeded":
+    case "DBParameterGroupQuotaExceededFault":
     case "com.amazonaws.neptune#DBParameterGroupQuotaExceededFault":
       response = {
         ...(await deserializeAws_queryDBParameterGroupQuotaExceededFaultResponse(parsedOutput, context)),
@@ -2342,7 +2342,7 @@ const deserializeAws_queryCreateDBClusterSnapshotCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "SnapshotQuotaExceeded":
+    case "SnapshotQuotaExceededFault":
     case "com.amazonaws.neptune#SnapshotQuotaExceededFault":
       response = {
         ...(await deserializeAws_querySnapshotQuotaExceededFaultResponse(parsedOutput, context)),
@@ -2396,7 +2396,7 @@ const deserializeAws_queryCreateDBInstanceCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "AuthorizationNotFound":
+    case "AuthorizationNotFoundFault":
     case "com.amazonaws.neptune#AuthorizationNotFoundFault":
       response = {
         ...(await deserializeAws_queryAuthorizationNotFoundFaultResponse(parsedOutput, context)),
@@ -2412,7 +2412,7 @@ const deserializeAws_queryCreateDBInstanceCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "DBInstanceAlreadyExists":
+    case "DBInstanceAlreadyExistsFault":
     case "com.amazonaws.neptune#DBInstanceAlreadyExistsFault":
       response = {
         ...(await deserializeAws_queryDBInstanceAlreadyExistsFaultResponse(parsedOutput, context)),
@@ -2420,7 +2420,7 @@ const deserializeAws_queryCreateDBInstanceCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "DBParameterGroupNotFound":
+    case "DBParameterGroupNotFoundFault":
     case "com.amazonaws.neptune#DBParameterGroupNotFoundFault":
       response = {
         ...(await deserializeAws_queryDBParameterGroupNotFoundFaultResponse(parsedOutput, context)),
@@ -2428,7 +2428,7 @@ const deserializeAws_queryCreateDBInstanceCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "DBSecurityGroupNotFound":
+    case "DBSecurityGroupNotFoundFault":
     case "com.amazonaws.neptune#DBSecurityGroupNotFoundFault":
       response = {
         ...(await deserializeAws_queryDBSecurityGroupNotFoundFaultResponse(parsedOutput, context)),
@@ -2460,7 +2460,7 @@ const deserializeAws_queryCreateDBInstanceCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InstanceQuotaExceeded":
+    case "InstanceQuotaExceededFault":
     case "com.amazonaws.neptune#InstanceQuotaExceededFault":
       response = {
         ...(await deserializeAws_queryInstanceQuotaExceededFaultResponse(parsedOutput, context)),
@@ -2468,7 +2468,7 @@ const deserializeAws_queryCreateDBInstanceCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InsufficientDBInstanceCapacity":
+    case "InsufficientDBInstanceCapacityFault":
     case "com.amazonaws.neptune#InsufficientDBInstanceCapacityFault":
       response = {
         ...(await deserializeAws_queryInsufficientDBInstanceCapacityFaultResponse(parsedOutput, context)),
@@ -2524,7 +2524,7 @@ const deserializeAws_queryCreateDBInstanceCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "StorageQuotaExceeded":
+    case "StorageQuotaExceededFault":
     case "com.amazonaws.neptune#StorageQuotaExceededFault":
       response = {
         ...(await deserializeAws_queryStorageQuotaExceededFaultResponse(parsedOutput, context)),
@@ -2532,7 +2532,7 @@ const deserializeAws_queryCreateDBInstanceCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "StorageTypeNotSupported":
+    case "StorageTypeNotSupportedFault":
     case "com.amazonaws.neptune#StorageTypeNotSupportedFault":
       response = {
         ...(await deserializeAws_queryStorageTypeNotSupportedFaultResponse(parsedOutput, context)),
@@ -2586,7 +2586,7 @@ const deserializeAws_queryCreateDBParameterGroupCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "DBParameterGroupAlreadyExists":
+    case "DBParameterGroupAlreadyExistsFault":
     case "com.amazonaws.neptune#DBParameterGroupAlreadyExistsFault":
       response = {
         ...(await deserializeAws_queryDBParameterGroupAlreadyExistsFaultResponse(parsedOutput, context)),
@@ -2594,7 +2594,7 @@ const deserializeAws_queryCreateDBParameterGroupCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "DBParameterGroupQuotaExceeded":
+    case "DBParameterGroupQuotaExceededFault":
     case "com.amazonaws.neptune#DBParameterGroupQuotaExceededFault":
       response = {
         ...(await deserializeAws_queryDBParameterGroupQuotaExceededFaultResponse(parsedOutput, context)),
@@ -2648,7 +2648,7 @@ const deserializeAws_queryCreateDBSubnetGroupCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "DBSubnetGroupAlreadyExists":
+    case "DBSubnetGroupAlreadyExistsFault":
     case "com.amazonaws.neptune#DBSubnetGroupAlreadyExistsFault":
       response = {
         ...(await deserializeAws_queryDBSubnetGroupAlreadyExistsFaultResponse(parsedOutput, context)),
@@ -2664,7 +2664,7 @@ const deserializeAws_queryCreateDBSubnetGroupCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "DBSubnetGroupQuotaExceeded":
+    case "DBSubnetGroupQuotaExceededFault":
     case "com.amazonaws.neptune#DBSubnetGroupQuotaExceededFault":
       response = {
         ...(await deserializeAws_queryDBSubnetGroupQuotaExceededFaultResponse(parsedOutput, context)),
@@ -2734,7 +2734,7 @@ const deserializeAws_queryCreateEventSubscriptionCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "EventSubscriptionQuotaExceeded":
+    case "EventSubscriptionQuotaExceededFault":
     case "com.amazonaws.neptune#EventSubscriptionQuotaExceededFault":
       response = {
         ...(await deserializeAws_queryEventSubscriptionQuotaExceededFaultResponse(parsedOutput, context)),
@@ -2742,7 +2742,7 @@ const deserializeAws_queryCreateEventSubscriptionCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "SNSInvalidTopic":
+    case "SNSInvalidTopicFault":
     case "com.amazonaws.neptune#SNSInvalidTopicFault":
       response = {
         ...(await deserializeAws_querySNSInvalidTopicFaultResponse(parsedOutput, context)),
@@ -2750,7 +2750,7 @@ const deserializeAws_queryCreateEventSubscriptionCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "SNSNoAuthorization":
+    case "SNSNoAuthorizationFault":
     case "com.amazonaws.neptune#SNSNoAuthorizationFault":
       response = {
         ...(await deserializeAws_querySNSNoAuthorizationFaultResponse(parsedOutput, context)),
@@ -2758,7 +2758,7 @@ const deserializeAws_queryCreateEventSubscriptionCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "SNSTopicArnNotFound":
+    case "SNSTopicArnNotFoundFault":
     case "com.amazonaws.neptune#SNSTopicArnNotFoundFault":
       response = {
         ...(await deserializeAws_querySNSTopicArnNotFoundFaultResponse(parsedOutput, context)),
@@ -2766,7 +2766,7 @@ const deserializeAws_queryCreateEventSubscriptionCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "SourceNotFound":
+    case "SourceNotFoundFault":
     case "com.amazonaws.neptune#SourceNotFoundFault":
       response = {
         ...(await deserializeAws_querySourceNotFoundFaultResponse(parsedOutput, context)),
@@ -2774,7 +2774,7 @@ const deserializeAws_queryCreateEventSubscriptionCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "SubscriptionAlreadyExist":
+    case "SubscriptionAlreadyExistFault":
     case "com.amazonaws.neptune#SubscriptionAlreadyExistFault":
       response = {
         ...(await deserializeAws_querySubscriptionAlreadyExistFaultResponse(parsedOutput, context)),
@@ -2782,7 +2782,7 @@ const deserializeAws_queryCreateEventSubscriptionCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "SubscriptionCategoryNotFound":
+    case "SubscriptionCategoryNotFoundFault":
     case "com.amazonaws.neptune#SubscriptionCategoryNotFoundFault":
       response = {
         ...(await deserializeAws_querySubscriptionCategoryNotFoundFaultResponse(parsedOutput, context)),
@@ -2868,7 +2868,7 @@ const deserializeAws_queryDeleteDBClusterCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "SnapshotQuotaExceeded":
+    case "SnapshotQuotaExceededFault":
     case "com.amazonaws.neptune#SnapshotQuotaExceededFault":
       response = {
         ...(await deserializeAws_querySnapshotQuotaExceededFaultResponse(parsedOutput, context)),
@@ -2989,7 +2989,7 @@ const deserializeAws_queryDeleteDBClusterParameterGroupCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "DBParameterGroupNotFound":
+    case "DBParameterGroupNotFoundFault":
     case "com.amazonaws.neptune#DBParameterGroupNotFoundFault":
       response = {
         ...(await deserializeAws_queryDBParameterGroupNotFoundFaultResponse(parsedOutput, context)),
@@ -2997,7 +2997,7 @@ const deserializeAws_queryDeleteDBClusterParameterGroupCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidDBParameterGroupState":
+    case "InvalidDBParameterGroupStateFault":
     case "com.amazonaws.neptune#InvalidDBParameterGroupStateFault":
       response = {
         ...(await deserializeAws_queryInvalidDBParameterGroupStateFaultResponse(parsedOutput, context)),
@@ -3113,7 +3113,7 @@ const deserializeAws_queryDeleteDBInstanceCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "DBInstanceNotFound":
+    case "DBInstanceNotFoundFault":
     case "com.amazonaws.neptune#DBInstanceNotFoundFault":
       response = {
         ...(await deserializeAws_queryDBInstanceNotFoundFaultResponse(parsedOutput, context)),
@@ -3121,7 +3121,7 @@ const deserializeAws_queryDeleteDBInstanceCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "DBSnapshotAlreadyExists":
+    case "DBSnapshotAlreadyExistsFault":
     case "com.amazonaws.neptune#DBSnapshotAlreadyExistsFault":
       response = {
         ...(await deserializeAws_queryDBSnapshotAlreadyExistsFaultResponse(parsedOutput, context)),
@@ -3137,7 +3137,7 @@ const deserializeAws_queryDeleteDBInstanceCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidDBInstanceState":
+    case "InvalidDBInstanceStateFault":
     case "com.amazonaws.neptune#InvalidDBInstanceStateFault":
       response = {
         ...(await deserializeAws_queryInvalidDBInstanceStateFaultResponse(parsedOutput, context)),
@@ -3145,7 +3145,7 @@ const deserializeAws_queryDeleteDBInstanceCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "SnapshotQuotaExceeded":
+    case "SnapshotQuotaExceededFault":
     case "com.amazonaws.neptune#SnapshotQuotaExceededFault":
       response = {
         ...(await deserializeAws_querySnapshotQuotaExceededFaultResponse(parsedOutput, context)),
@@ -3196,7 +3196,7 @@ const deserializeAws_queryDeleteDBParameterGroupCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "DBParameterGroupNotFound":
+    case "DBParameterGroupNotFoundFault":
     case "com.amazonaws.neptune#DBParameterGroupNotFoundFault":
       response = {
         ...(await deserializeAws_queryDBParameterGroupNotFoundFaultResponse(parsedOutput, context)),
@@ -3204,7 +3204,7 @@ const deserializeAws_queryDeleteDBParameterGroupCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidDBParameterGroupState":
+    case "InvalidDBParameterGroupStateFault":
     case "com.amazonaws.neptune#InvalidDBParameterGroupStateFault":
       response = {
         ...(await deserializeAws_queryInvalidDBParameterGroupStateFaultResponse(parsedOutput, context)),
@@ -3325,7 +3325,7 @@ const deserializeAws_queryDeleteEventSubscriptionCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "InvalidEventSubscriptionState":
+    case "InvalidEventSubscriptionStateFault":
     case "com.amazonaws.neptune#InvalidEventSubscriptionStateFault":
       response = {
         ...(await deserializeAws_queryInvalidEventSubscriptionStateFaultResponse(parsedOutput, context)),
@@ -3333,7 +3333,7 @@ const deserializeAws_queryDeleteEventSubscriptionCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "SubscriptionNotFound":
+    case "SubscriptionNotFoundFault":
     case "com.amazonaws.neptune#SubscriptionNotFoundFault":
       response = {
         ...(await deserializeAws_querySubscriptionNotFoundFaultResponse(parsedOutput, context)),
@@ -3441,7 +3441,7 @@ const deserializeAws_queryDescribeDBClusterParameterGroupsCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "DBParameterGroupNotFound":
+    case "DBParameterGroupNotFoundFault":
     case "com.amazonaws.neptune#DBParameterGroupNotFoundFault":
       response = {
         ...(await deserializeAws_queryDBParameterGroupNotFoundFaultResponse(parsedOutput, context)),
@@ -3495,7 +3495,7 @@ const deserializeAws_queryDescribeDBClusterParametersCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "DBParameterGroupNotFound":
+    case "DBParameterGroupNotFoundFault":
     case "com.amazonaws.neptune#DBParameterGroupNotFoundFault":
       response = {
         ...(await deserializeAws_queryDBParameterGroupNotFoundFaultResponse(parsedOutput, context)),
@@ -3760,7 +3760,7 @@ const deserializeAws_queryDescribeDBInstancesCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "DBInstanceNotFound":
+    case "DBInstanceNotFoundFault":
     case "com.amazonaws.neptune#DBInstanceNotFoundFault":
       response = {
         ...(await deserializeAws_queryDBInstanceNotFoundFaultResponse(parsedOutput, context)),
@@ -3814,7 +3814,7 @@ const deserializeAws_queryDescribeDBParameterGroupsCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "DBParameterGroupNotFound":
+    case "DBParameterGroupNotFoundFault":
     case "com.amazonaws.neptune#DBParameterGroupNotFoundFault":
       response = {
         ...(await deserializeAws_queryDBParameterGroupNotFoundFaultResponse(parsedOutput, context)),
@@ -3868,7 +3868,7 @@ const deserializeAws_queryDescribeDBParametersCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "DBParameterGroupNotFound":
+    case "DBParameterGroupNotFoundFault":
     case "com.amazonaws.neptune#DBParameterGroupNotFoundFault":
       response = {
         ...(await deserializeAws_queryDBParameterGroupNotFoundFaultResponse(parsedOutput, context)),
@@ -4166,7 +4166,7 @@ const deserializeAws_queryDescribeEventSubscriptionsCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "SubscriptionNotFound":
+    case "SubscriptionNotFoundFault":
     case "com.amazonaws.neptune#SubscriptionNotFoundFault":
       response = {
         ...(await deserializeAws_querySubscriptionNotFoundFaultResponse(parsedOutput, context)),
@@ -4329,7 +4329,7 @@ const deserializeAws_queryDescribeValidDBInstanceModificationsCommandError = asy
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "DBInstanceNotFound":
+    case "DBInstanceNotFoundFault":
     case "com.amazonaws.neptune#DBInstanceNotFoundFault":
       response = {
         ...(await deserializeAws_queryDBInstanceNotFoundFaultResponse(parsedOutput, context)),
@@ -4337,7 +4337,7 @@ const deserializeAws_queryDescribeValidDBInstanceModificationsCommandError = asy
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidDBInstanceState":
+    case "InvalidDBInstanceStateFault":
     case "com.amazonaws.neptune#InvalidDBInstanceStateFault":
       response = {
         ...(await deserializeAws_queryInvalidDBInstanceStateFaultResponse(parsedOutput, context)),
@@ -4407,7 +4407,7 @@ const deserializeAws_queryFailoverDBClusterCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidDBInstanceState":
+    case "InvalidDBInstanceStateFault":
     case "com.amazonaws.neptune#InvalidDBInstanceStateFault":
       response = {
         ...(await deserializeAws_queryInvalidDBInstanceStateFaultResponse(parsedOutput, context)),
@@ -4469,7 +4469,7 @@ const deserializeAws_queryListTagsForResourceCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "DBInstanceNotFound":
+    case "DBInstanceNotFoundFault":
     case "com.amazonaws.neptune#DBInstanceNotFoundFault":
       response = {
         ...(await deserializeAws_queryDBInstanceNotFoundFaultResponse(parsedOutput, context)),
@@ -4477,7 +4477,7 @@ const deserializeAws_queryListTagsForResourceCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "DBSnapshotNotFound":
+    case "DBSnapshotNotFoundFault":
     case "com.amazonaws.neptune#DBSnapshotNotFoundFault":
       response = {
         ...(await deserializeAws_queryDBSnapshotNotFoundFaultResponse(parsedOutput, context)),
@@ -4547,7 +4547,7 @@ const deserializeAws_queryModifyDBClusterCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "DBClusterParameterGroupNotFound":
+    case "DBClusterParameterGroupNotFoundFault":
     case "com.amazonaws.neptune#DBClusterParameterGroupNotFoundFault":
       response = {
         ...(await deserializeAws_queryDBClusterParameterGroupNotFoundFaultResponse(parsedOutput, context)),
@@ -4571,7 +4571,7 @@ const deserializeAws_queryModifyDBClusterCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidDBInstanceState":
+    case "InvalidDBInstanceStateFault":
     case "com.amazonaws.neptune#InvalidDBInstanceStateFault":
       response = {
         ...(await deserializeAws_queryInvalidDBInstanceStateFaultResponse(parsedOutput, context)),
@@ -4579,7 +4579,7 @@ const deserializeAws_queryModifyDBClusterCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidDBSecurityGroupState":
+    case "InvalidDBSecurityGroupStateFault":
     case "com.amazonaws.neptune#InvalidDBSecurityGroupStateFault":
       response = {
         ...(await deserializeAws_queryInvalidDBSecurityGroupStateFaultResponse(parsedOutput, context)),
@@ -4611,7 +4611,7 @@ const deserializeAws_queryModifyDBClusterCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "StorageQuotaExceeded":
+    case "StorageQuotaExceededFault":
     case "com.amazonaws.neptune#StorageQuotaExceededFault":
       response = {
         ...(await deserializeAws_queryStorageQuotaExceededFaultResponse(parsedOutput, context)),
@@ -4673,7 +4673,7 @@ const deserializeAws_queryModifyDBClusterEndpointCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "DBInstanceNotFound":
+    case "DBInstanceNotFoundFault":
     case "com.amazonaws.neptune#DBInstanceNotFoundFault":
       response = {
         ...(await deserializeAws_queryDBInstanceNotFoundFaultResponse(parsedOutput, context)),
@@ -4697,7 +4697,7 @@ const deserializeAws_queryModifyDBClusterEndpointCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidDBInstanceState":
+    case "InvalidDBInstanceStateFault":
     case "com.amazonaws.neptune#InvalidDBInstanceStateFault":
       response = {
         ...(await deserializeAws_queryInvalidDBInstanceStateFaultResponse(parsedOutput, context)),
@@ -4751,7 +4751,7 @@ const deserializeAws_queryModifyDBClusterParameterGroupCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "DBParameterGroupNotFound":
+    case "DBParameterGroupNotFoundFault":
     case "com.amazonaws.neptune#DBParameterGroupNotFoundFault":
       response = {
         ...(await deserializeAws_queryDBParameterGroupNotFoundFaultResponse(parsedOutput, context)),
@@ -4759,7 +4759,7 @@ const deserializeAws_queryModifyDBClusterParameterGroupCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidDBParameterGroupState":
+    case "InvalidDBParameterGroupStateFault":
     case "com.amazonaws.neptune#InvalidDBParameterGroupStateFault":
       response = {
         ...(await deserializeAws_queryInvalidDBParameterGroupStateFaultResponse(parsedOutput, context)),
@@ -4832,7 +4832,7 @@ const deserializeAws_queryModifyDBClusterSnapshotAttributeCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "SharedSnapshotQuotaExceeded":
+    case "SharedSnapshotQuotaExceededFault":
     case "com.amazonaws.neptune#SharedSnapshotQuotaExceededFault":
       response = {
         ...(await deserializeAws_querySharedSnapshotQuotaExceededFaultResponse(parsedOutput, context)),
@@ -4886,7 +4886,7 @@ const deserializeAws_queryModifyDBInstanceCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "AuthorizationNotFound":
+    case "AuthorizationNotFoundFault":
     case "com.amazonaws.neptune#AuthorizationNotFoundFault":
       response = {
         ...(await deserializeAws_queryAuthorizationNotFoundFaultResponse(parsedOutput, context)),
@@ -4894,7 +4894,7 @@ const deserializeAws_queryModifyDBInstanceCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "CertificateNotFound":
+    case "CertificateNotFoundFault":
     case "com.amazonaws.neptune#CertificateNotFoundFault":
       response = {
         ...(await deserializeAws_queryCertificateNotFoundFaultResponse(parsedOutput, context)),
@@ -4902,7 +4902,7 @@ const deserializeAws_queryModifyDBInstanceCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "DBInstanceAlreadyExists":
+    case "DBInstanceAlreadyExistsFault":
     case "com.amazonaws.neptune#DBInstanceAlreadyExistsFault":
       response = {
         ...(await deserializeAws_queryDBInstanceAlreadyExistsFaultResponse(parsedOutput, context)),
@@ -4910,7 +4910,7 @@ const deserializeAws_queryModifyDBInstanceCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "DBInstanceNotFound":
+    case "DBInstanceNotFoundFault":
     case "com.amazonaws.neptune#DBInstanceNotFoundFault":
       response = {
         ...(await deserializeAws_queryDBInstanceNotFoundFaultResponse(parsedOutput, context)),
@@ -4918,7 +4918,7 @@ const deserializeAws_queryModifyDBInstanceCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "DBParameterGroupNotFound":
+    case "DBParameterGroupNotFoundFault":
     case "com.amazonaws.neptune#DBParameterGroupNotFoundFault":
       response = {
         ...(await deserializeAws_queryDBParameterGroupNotFoundFaultResponse(parsedOutput, context)),
@@ -4926,7 +4926,7 @@ const deserializeAws_queryModifyDBInstanceCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "DBSecurityGroupNotFound":
+    case "DBSecurityGroupNotFoundFault":
     case "com.amazonaws.neptune#DBSecurityGroupNotFoundFault":
       response = {
         ...(await deserializeAws_queryDBSecurityGroupNotFoundFaultResponse(parsedOutput, context)),
@@ -4934,7 +4934,7 @@ const deserializeAws_queryModifyDBInstanceCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "DBUpgradeDependencyFailure":
+    case "DBUpgradeDependencyFailureFault":
     case "com.amazonaws.neptune#DBUpgradeDependencyFailureFault":
       response = {
         ...(await deserializeAws_queryDBUpgradeDependencyFailureFaultResponse(parsedOutput, context)),
@@ -4950,7 +4950,7 @@ const deserializeAws_queryModifyDBInstanceCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InsufficientDBInstanceCapacity":
+    case "InsufficientDBInstanceCapacityFault":
     case "com.amazonaws.neptune#InsufficientDBInstanceCapacityFault":
       response = {
         ...(await deserializeAws_queryInsufficientDBInstanceCapacityFaultResponse(parsedOutput, context)),
@@ -4958,7 +4958,7 @@ const deserializeAws_queryModifyDBInstanceCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidDBInstanceState":
+    case "InvalidDBInstanceStateFault":
     case "com.amazonaws.neptune#InvalidDBInstanceStateFault":
       response = {
         ...(await deserializeAws_queryInvalidDBInstanceStateFaultResponse(parsedOutput, context)),
@@ -4966,7 +4966,7 @@ const deserializeAws_queryModifyDBInstanceCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidDBSecurityGroupState":
+    case "InvalidDBSecurityGroupStateFault":
     case "com.amazonaws.neptune#InvalidDBSecurityGroupStateFault":
       response = {
         ...(await deserializeAws_queryInvalidDBSecurityGroupStateFaultResponse(parsedOutput, context)),
@@ -4998,7 +4998,7 @@ const deserializeAws_queryModifyDBInstanceCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "StorageQuotaExceeded":
+    case "StorageQuotaExceededFault":
     case "com.amazonaws.neptune#StorageQuotaExceededFault":
       response = {
         ...(await deserializeAws_queryStorageQuotaExceededFaultResponse(parsedOutput, context)),
@@ -5006,7 +5006,7 @@ const deserializeAws_queryModifyDBInstanceCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "StorageTypeNotSupported":
+    case "StorageTypeNotSupportedFault":
     case "com.amazonaws.neptune#StorageTypeNotSupportedFault":
       response = {
         ...(await deserializeAws_queryStorageTypeNotSupportedFaultResponse(parsedOutput, context)),
@@ -5060,7 +5060,7 @@ const deserializeAws_queryModifyDBParameterGroupCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "DBParameterGroupNotFound":
+    case "DBParameterGroupNotFoundFault":
     case "com.amazonaws.neptune#DBParameterGroupNotFoundFault":
       response = {
         ...(await deserializeAws_queryDBParameterGroupNotFoundFaultResponse(parsedOutput, context)),
@@ -5068,7 +5068,7 @@ const deserializeAws_queryModifyDBParameterGroupCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidDBParameterGroupState":
+    case "InvalidDBParameterGroupStateFault":
     case "com.amazonaws.neptune#InvalidDBParameterGroupStateFault":
       response = {
         ...(await deserializeAws_queryInvalidDBParameterGroupStateFaultResponse(parsedOutput, context)),
@@ -5208,7 +5208,7 @@ const deserializeAws_queryModifyEventSubscriptionCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "EventSubscriptionQuotaExceeded":
+    case "EventSubscriptionQuotaExceededFault":
     case "com.amazonaws.neptune#EventSubscriptionQuotaExceededFault":
       response = {
         ...(await deserializeAws_queryEventSubscriptionQuotaExceededFaultResponse(parsedOutput, context)),
@@ -5216,7 +5216,7 @@ const deserializeAws_queryModifyEventSubscriptionCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "SNSInvalidTopic":
+    case "SNSInvalidTopicFault":
     case "com.amazonaws.neptune#SNSInvalidTopicFault":
       response = {
         ...(await deserializeAws_querySNSInvalidTopicFaultResponse(parsedOutput, context)),
@@ -5224,7 +5224,7 @@ const deserializeAws_queryModifyEventSubscriptionCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "SNSNoAuthorization":
+    case "SNSNoAuthorizationFault":
     case "com.amazonaws.neptune#SNSNoAuthorizationFault":
       response = {
         ...(await deserializeAws_querySNSNoAuthorizationFaultResponse(parsedOutput, context)),
@@ -5232,7 +5232,7 @@ const deserializeAws_queryModifyEventSubscriptionCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "SNSTopicArnNotFound":
+    case "SNSTopicArnNotFoundFault":
     case "com.amazonaws.neptune#SNSTopicArnNotFoundFault":
       response = {
         ...(await deserializeAws_querySNSTopicArnNotFoundFaultResponse(parsedOutput, context)),
@@ -5240,7 +5240,7 @@ const deserializeAws_queryModifyEventSubscriptionCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "SubscriptionCategoryNotFound":
+    case "SubscriptionCategoryNotFoundFault":
     case "com.amazonaws.neptune#SubscriptionCategoryNotFoundFault":
       response = {
         ...(await deserializeAws_querySubscriptionCategoryNotFoundFaultResponse(parsedOutput, context)),
@@ -5248,7 +5248,7 @@ const deserializeAws_queryModifyEventSubscriptionCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "SubscriptionNotFound":
+    case "SubscriptionNotFoundFault":
     case "com.amazonaws.neptune#SubscriptionNotFoundFault":
       response = {
         ...(await deserializeAws_querySubscriptionNotFoundFaultResponse(parsedOutput, context)),
@@ -5364,7 +5364,7 @@ const deserializeAws_queryRebootDBInstanceCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "DBInstanceNotFound":
+    case "DBInstanceNotFoundFault":
     case "com.amazonaws.neptune#DBInstanceNotFoundFault":
       response = {
         ...(await deserializeAws_queryDBInstanceNotFoundFaultResponse(parsedOutput, context)),
@@ -5372,7 +5372,7 @@ const deserializeAws_queryRebootDBInstanceCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidDBInstanceState":
+    case "InvalidDBInstanceStateFault":
     case "com.amazonaws.neptune#InvalidDBInstanceStateFault":
       response = {
         ...(await deserializeAws_queryInvalidDBInstanceStateFaultResponse(parsedOutput, context)),
@@ -5431,7 +5431,7 @@ const deserializeAws_queryRemoveRoleFromDBClusterCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "DBClusterRoleNotFound":
+    case "DBClusterRoleNotFoundFault":
     case "com.amazonaws.neptune#DBClusterRoleNotFoundFault":
       response = {
         ...(await deserializeAws_queryDBClusterRoleNotFoundFaultResponse(parsedOutput, context)),
@@ -5496,7 +5496,7 @@ const deserializeAws_queryRemoveSourceIdentifierFromSubscriptionCommandError = a
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "SourceNotFound":
+    case "SourceNotFoundFault":
     case "com.amazonaws.neptune#SourceNotFoundFault":
       response = {
         ...(await deserializeAws_querySourceNotFoundFaultResponse(parsedOutput, context)),
@@ -5504,7 +5504,7 @@ const deserializeAws_queryRemoveSourceIdentifierFromSubscriptionCommandError = a
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "SubscriptionNotFound":
+    case "SubscriptionNotFoundFault":
     case "com.amazonaws.neptune#SubscriptionNotFoundFault":
       response = {
         ...(await deserializeAws_querySubscriptionNotFoundFaultResponse(parsedOutput, context)),
@@ -5563,7 +5563,7 @@ const deserializeAws_queryRemoveTagsFromResourceCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "DBInstanceNotFound":
+    case "DBInstanceNotFoundFault":
     case "com.amazonaws.neptune#DBInstanceNotFoundFault":
       response = {
         ...(await deserializeAws_queryDBInstanceNotFoundFaultResponse(parsedOutput, context)),
@@ -5571,7 +5571,7 @@ const deserializeAws_queryRemoveTagsFromResourceCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "DBSnapshotNotFound":
+    case "DBSnapshotNotFoundFault":
     case "com.amazonaws.neptune#DBSnapshotNotFoundFault":
       response = {
         ...(await deserializeAws_queryDBSnapshotNotFoundFaultResponse(parsedOutput, context)),
@@ -5625,7 +5625,7 @@ const deserializeAws_queryResetDBClusterParameterGroupCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "DBParameterGroupNotFound":
+    case "DBParameterGroupNotFoundFault":
     case "com.amazonaws.neptune#DBParameterGroupNotFoundFault":
       response = {
         ...(await deserializeAws_queryDBParameterGroupNotFoundFaultResponse(parsedOutput, context)),
@@ -5633,7 +5633,7 @@ const deserializeAws_queryResetDBClusterParameterGroupCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidDBParameterGroupState":
+    case "InvalidDBParameterGroupStateFault":
     case "com.amazonaws.neptune#InvalidDBParameterGroupStateFault":
       response = {
         ...(await deserializeAws_queryInvalidDBParameterGroupStateFaultResponse(parsedOutput, context)),
@@ -5687,7 +5687,7 @@ const deserializeAws_queryResetDBParameterGroupCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "DBParameterGroupNotFound":
+    case "DBParameterGroupNotFoundFault":
     case "com.amazonaws.neptune#DBParameterGroupNotFoundFault":
       response = {
         ...(await deserializeAws_queryDBParameterGroupNotFoundFaultResponse(parsedOutput, context)),
@@ -5695,7 +5695,7 @@ const deserializeAws_queryResetDBParameterGroupCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidDBParameterGroupState":
+    case "InvalidDBParameterGroupStateFault":
     case "com.amazonaws.neptune#InvalidDBParameterGroupStateFault":
       response = {
         ...(await deserializeAws_queryInvalidDBParameterGroupStateFaultResponse(parsedOutput, context)),
@@ -5757,7 +5757,7 @@ const deserializeAws_queryRestoreDBClusterFromSnapshotCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "DBClusterParameterGroupNotFound":
+    case "DBClusterParameterGroupNotFoundFault":
     case "com.amazonaws.neptune#DBClusterParameterGroupNotFoundFault":
       response = {
         ...(await deserializeAws_queryDBClusterParameterGroupNotFoundFaultResponse(parsedOutput, context)),
@@ -5781,7 +5781,7 @@ const deserializeAws_queryRestoreDBClusterFromSnapshotCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "DBSnapshotNotFound":
+    case "DBSnapshotNotFoundFault":
     case "com.amazonaws.neptune#DBSnapshotNotFoundFault":
       response = {
         ...(await deserializeAws_queryDBSnapshotNotFoundFaultResponse(parsedOutput, context)),
@@ -5805,7 +5805,7 @@ const deserializeAws_queryRestoreDBClusterFromSnapshotCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InsufficientStorageClusterCapacity":
+    case "InsufficientStorageClusterCapacityFault":
     case "com.amazonaws.neptune#InsufficientStorageClusterCapacityFault":
       response = {
         ...(await deserializeAws_queryInsufficientStorageClusterCapacityFaultResponse(parsedOutput, context)),
@@ -5821,7 +5821,7 @@ const deserializeAws_queryRestoreDBClusterFromSnapshotCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidDBSnapshotState":
+    case "InvalidDBSnapshotStateFault":
     case "com.amazonaws.neptune#InvalidDBSnapshotStateFault":
       response = {
         ...(await deserializeAws_queryInvalidDBSnapshotStateFaultResponse(parsedOutput, context)),
@@ -5869,7 +5869,7 @@ const deserializeAws_queryRestoreDBClusterFromSnapshotCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "StorageQuotaExceeded":
+    case "StorageQuotaExceededFault":
     case "com.amazonaws.neptune#StorageQuotaExceededFault":
       response = {
         ...(await deserializeAws_queryStorageQuotaExceededFaultResponse(parsedOutput, context)),
@@ -5939,7 +5939,7 @@ const deserializeAws_queryRestoreDBClusterToPointInTimeCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "DBClusterParameterGroupNotFound":
+    case "DBClusterParameterGroupNotFoundFault":
     case "com.amazonaws.neptune#DBClusterParameterGroupNotFoundFault":
       response = {
         ...(await deserializeAws_queryDBClusterParameterGroupNotFoundFaultResponse(parsedOutput, context)),
@@ -5979,7 +5979,7 @@ const deserializeAws_queryRestoreDBClusterToPointInTimeCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InsufficientStorageClusterCapacity":
+    case "InsufficientStorageClusterCapacityFault":
     case "com.amazonaws.neptune#InsufficientStorageClusterCapacityFault":
       response = {
         ...(await deserializeAws_queryInsufficientStorageClusterCapacityFaultResponse(parsedOutput, context)),
@@ -6003,7 +6003,7 @@ const deserializeAws_queryRestoreDBClusterToPointInTimeCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidDBSnapshotState":
+    case "InvalidDBSnapshotStateFault":
     case "com.amazonaws.neptune#InvalidDBSnapshotStateFault":
       response = {
         ...(await deserializeAws_queryInvalidDBSnapshotStateFaultResponse(parsedOutput, context)),
@@ -6051,7 +6051,7 @@ const deserializeAws_queryRestoreDBClusterToPointInTimeCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "StorageQuotaExceeded":
+    case "StorageQuotaExceededFault":
     case "com.amazonaws.neptune#StorageQuotaExceededFault":
       response = {
         ...(await deserializeAws_queryStorageQuotaExceededFaultResponse(parsedOutput, context)),
@@ -6121,7 +6121,7 @@ const deserializeAws_queryStartDBClusterCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidDBInstanceState":
+    case "InvalidDBInstanceStateFault":
     case "com.amazonaws.neptune#InvalidDBInstanceStateFault":
       response = {
         ...(await deserializeAws_queryInvalidDBInstanceStateFaultResponse(parsedOutput, context)),
@@ -6191,7 +6191,7 @@ const deserializeAws_queryStopDBClusterCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidDBInstanceState":
+    case "InvalidDBInstanceStateFault":
     case "com.amazonaws.neptune#InvalidDBInstanceStateFault":
       response = {
         ...(await deserializeAws_queryInvalidDBInstanceStateFaultResponse(parsedOutput, context)),

--- a/clients/client-organizations/src/protocols/Aws_json1_1.ts
+++ b/clients/client-organizations/src/protocols/Aws_json1_1.ts
@@ -983,14 +983,6 @@ const deserializeAws_json1_1AcceptHandshakeCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadRestJsonErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "AWSOrganizationsNotInUseException":
-    case "com.amazonaws.organizations#AWSOrganizationsNotInUseException":
-      response = {
-        ...(await deserializeAws_json1_1AWSOrganizationsNotInUseExceptionResponse(parsedOutput, context)),
-        name: errorCode,
-        $metadata: deserializeMetadata(output),
-      };
-      break;
     case "AccessDeniedException":
     case "com.amazonaws.organizations#AccessDeniedException":
       response = {
@@ -1003,6 +995,14 @@ const deserializeAws_json1_1AcceptHandshakeCommandError = async (
     case "com.amazonaws.organizations#AccessDeniedForDependencyException":
       response = {
         ...(await deserializeAws_json1_1AccessDeniedForDependencyExceptionResponse(parsedOutput, context)),
+        name: errorCode,
+        $metadata: deserializeMetadata(output),
+      };
+      break;
+    case "AWSOrganizationsNotInUseException":
+    case "com.amazonaws.organizations#AWSOrganizationsNotInUseException":
+      response = {
+        ...(await deserializeAws_json1_1AWSOrganizationsNotInUseExceptionResponse(parsedOutput, context)),
         name: errorCode,
         $metadata: deserializeMetadata(output),
       };
@@ -1114,18 +1114,18 @@ const deserializeAws_json1_1AttachPolicyCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadRestJsonErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "AWSOrganizationsNotInUseException":
-    case "com.amazonaws.organizations#AWSOrganizationsNotInUseException":
-      response = {
-        ...(await deserializeAws_json1_1AWSOrganizationsNotInUseExceptionResponse(parsedOutput, context)),
-        name: errorCode,
-        $metadata: deserializeMetadata(output),
-      };
-      break;
     case "AccessDeniedException":
     case "com.amazonaws.organizations#AccessDeniedException":
       response = {
         ...(await deserializeAws_json1_1AccessDeniedExceptionResponse(parsedOutput, context)),
+        name: errorCode,
+        $metadata: deserializeMetadata(output),
+      };
+      break;
+    case "AWSOrganizationsNotInUseException":
+    case "com.amazonaws.organizations#AWSOrganizationsNotInUseException":
+      response = {
+        ...(await deserializeAws_json1_1AWSOrganizationsNotInUseExceptionResponse(parsedOutput, context)),
         name: errorCode,
         $metadata: deserializeMetadata(output),
       };
@@ -1374,18 +1374,18 @@ const deserializeAws_json1_1CreateAccountCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadRestJsonErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "AWSOrganizationsNotInUseException":
-    case "com.amazonaws.organizations#AWSOrganizationsNotInUseException":
-      response = {
-        ...(await deserializeAws_json1_1AWSOrganizationsNotInUseExceptionResponse(parsedOutput, context)),
-        name: errorCode,
-        $metadata: deserializeMetadata(output),
-      };
-      break;
     case "AccessDeniedException":
     case "com.amazonaws.organizations#AccessDeniedException":
       response = {
         ...(await deserializeAws_json1_1AccessDeniedExceptionResponse(parsedOutput, context)),
+        name: errorCode,
+        $metadata: deserializeMetadata(output),
+      };
+      break;
+    case "AWSOrganizationsNotInUseException":
+    case "com.amazonaws.organizations#AWSOrganizationsNotInUseException":
+      response = {
+        ...(await deserializeAws_json1_1AWSOrganizationsNotInUseExceptionResponse(parsedOutput, context)),
         name: errorCode,
         $metadata: deserializeMetadata(output),
       };
@@ -1492,18 +1492,18 @@ const deserializeAws_json1_1CreateGovCloudAccountCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadRestJsonErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "AWSOrganizationsNotInUseException":
-    case "com.amazonaws.organizations#AWSOrganizationsNotInUseException":
-      response = {
-        ...(await deserializeAws_json1_1AWSOrganizationsNotInUseExceptionResponse(parsedOutput, context)),
-        name: errorCode,
-        $metadata: deserializeMetadata(output),
-      };
-      break;
     case "AccessDeniedException":
     case "com.amazonaws.organizations#AccessDeniedException":
       response = {
         ...(await deserializeAws_json1_1AccessDeniedExceptionResponse(parsedOutput, context)),
+        name: errorCode,
+        $metadata: deserializeMetadata(output),
+      };
+      break;
+    case "AWSOrganizationsNotInUseException":
+    case "com.amazonaws.organizations#AWSOrganizationsNotInUseException":
+      response = {
+        ...(await deserializeAws_json1_1AWSOrganizationsNotInUseExceptionResponse(parsedOutput, context)),
         name: errorCode,
         $metadata: deserializeMetadata(output),
       };
@@ -1720,18 +1720,18 @@ const deserializeAws_json1_1CreateOrganizationalUnitCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadRestJsonErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "AWSOrganizationsNotInUseException":
-    case "com.amazonaws.organizations#AWSOrganizationsNotInUseException":
-      response = {
-        ...(await deserializeAws_json1_1AWSOrganizationsNotInUseExceptionResponse(parsedOutput, context)),
-        name: errorCode,
-        $metadata: deserializeMetadata(output),
-      };
-      break;
     case "AccessDeniedException":
     case "com.amazonaws.organizations#AccessDeniedException":
       response = {
         ...(await deserializeAws_json1_1AccessDeniedExceptionResponse(parsedOutput, context)),
+        name: errorCode,
+        $metadata: deserializeMetadata(output),
+      };
+      break;
+    case "AWSOrganizationsNotInUseException":
+    case "com.amazonaws.organizations#AWSOrganizationsNotInUseException":
+      response = {
+        ...(await deserializeAws_json1_1AWSOrganizationsNotInUseExceptionResponse(parsedOutput, context)),
         name: errorCode,
         $metadata: deserializeMetadata(output),
       };
@@ -1838,18 +1838,18 @@ const deserializeAws_json1_1CreatePolicyCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadRestJsonErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "AWSOrganizationsNotInUseException":
-    case "com.amazonaws.organizations#AWSOrganizationsNotInUseException":
-      response = {
-        ...(await deserializeAws_json1_1AWSOrganizationsNotInUseExceptionResponse(parsedOutput, context)),
-        name: errorCode,
-        $metadata: deserializeMetadata(output),
-      };
-      break;
     case "AccessDeniedException":
     case "com.amazonaws.organizations#AccessDeniedException":
       response = {
         ...(await deserializeAws_json1_1AccessDeniedExceptionResponse(parsedOutput, context)),
+        name: errorCode,
+        $metadata: deserializeMetadata(output),
+      };
+      break;
+    case "AWSOrganizationsNotInUseException":
+    case "com.amazonaws.organizations#AWSOrganizationsNotInUseException":
+      response = {
+        ...(await deserializeAws_json1_1AWSOrganizationsNotInUseExceptionResponse(parsedOutput, context)),
         name: errorCode,
         $metadata: deserializeMetadata(output),
       };
@@ -2079,18 +2079,18 @@ const deserializeAws_json1_1DeleteOrganizationCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadRestJsonErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "AWSOrganizationsNotInUseException":
-    case "com.amazonaws.organizations#AWSOrganizationsNotInUseException":
-      response = {
-        ...(await deserializeAws_json1_1AWSOrganizationsNotInUseExceptionResponse(parsedOutput, context)),
-        name: errorCode,
-        $metadata: deserializeMetadata(output),
-      };
-      break;
     case "AccessDeniedException":
     case "com.amazonaws.organizations#AccessDeniedException":
       response = {
         ...(await deserializeAws_json1_1AccessDeniedExceptionResponse(parsedOutput, context)),
+        name: errorCode,
+        $metadata: deserializeMetadata(output),
+      };
+      break;
+    case "AWSOrganizationsNotInUseException":
+    case "com.amazonaws.organizations#AWSOrganizationsNotInUseException":
+      response = {
+        ...(await deserializeAws_json1_1AWSOrganizationsNotInUseExceptionResponse(parsedOutput, context)),
         name: errorCode,
         $metadata: deserializeMetadata(output),
       };
@@ -2178,18 +2178,18 @@ const deserializeAws_json1_1DeleteOrganizationalUnitCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadRestJsonErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "AWSOrganizationsNotInUseException":
-    case "com.amazonaws.organizations#AWSOrganizationsNotInUseException":
-      response = {
-        ...(await deserializeAws_json1_1AWSOrganizationsNotInUseExceptionResponse(parsedOutput, context)),
-        name: errorCode,
-        $metadata: deserializeMetadata(output),
-      };
-      break;
     case "AccessDeniedException":
     case "com.amazonaws.organizations#AccessDeniedException":
       response = {
         ...(await deserializeAws_json1_1AccessDeniedExceptionResponse(parsedOutput, context)),
+        name: errorCode,
+        $metadata: deserializeMetadata(output),
+      };
+      break;
+    case "AWSOrganizationsNotInUseException":
+    case "com.amazonaws.organizations#AWSOrganizationsNotInUseException":
+      response = {
+        ...(await deserializeAws_json1_1AWSOrganizationsNotInUseExceptionResponse(parsedOutput, context)),
         name: errorCode,
         $metadata: deserializeMetadata(output),
       };
@@ -2285,18 +2285,18 @@ const deserializeAws_json1_1DeletePolicyCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadRestJsonErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "AWSOrganizationsNotInUseException":
-    case "com.amazonaws.organizations#AWSOrganizationsNotInUseException":
-      response = {
-        ...(await deserializeAws_json1_1AWSOrganizationsNotInUseExceptionResponse(parsedOutput, context)),
-        name: errorCode,
-        $metadata: deserializeMetadata(output),
-      };
-      break;
     case "AccessDeniedException":
     case "com.amazonaws.organizations#AccessDeniedException":
       response = {
         ...(await deserializeAws_json1_1AccessDeniedExceptionResponse(parsedOutput, context)),
+        name: errorCode,
+        $metadata: deserializeMetadata(output),
+      };
+      break;
+    case "AWSOrganizationsNotInUseException":
+    case "com.amazonaws.organizations#AWSOrganizationsNotInUseException":
+      response = {
+        ...(await deserializeAws_json1_1AWSOrganizationsNotInUseExceptionResponse(parsedOutput, context)),
         name: errorCode,
         $metadata: deserializeMetadata(output),
       };
@@ -2400,14 +2400,6 @@ const deserializeAws_json1_1DeregisterDelegatedAdministratorCommandError = async
   let errorCode = "UnknownError";
   errorCode = loadRestJsonErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "AWSOrganizationsNotInUseException":
-    case "com.amazonaws.organizations#AWSOrganizationsNotInUseException":
-      response = {
-        ...(await deserializeAws_json1_1AWSOrganizationsNotInUseExceptionResponse(parsedOutput, context)),
-        name: errorCode,
-        $metadata: deserializeMetadata(output),
-      };
-      break;
     case "AccessDeniedException":
     case "com.amazonaws.organizations#AccessDeniedException":
       response = {
@@ -2428,6 +2420,14 @@ const deserializeAws_json1_1DeregisterDelegatedAdministratorCommandError = async
     case "com.amazonaws.organizations#AccountNotRegisteredException":
       response = {
         ...(await deserializeAws_json1_1AccountNotRegisteredExceptionResponse(parsedOutput, context)),
+        name: errorCode,
+        $metadata: deserializeMetadata(output),
+      };
+      break;
+    case "AWSOrganizationsNotInUseException":
+    case "com.amazonaws.organizations#AWSOrganizationsNotInUseException":
+      response = {
+        ...(await deserializeAws_json1_1AWSOrganizationsNotInUseExceptionResponse(parsedOutput, context)),
         name: errorCode,
         $metadata: deserializeMetadata(output),
       };
@@ -2526,14 +2526,6 @@ const deserializeAws_json1_1DescribeAccountCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadRestJsonErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "AWSOrganizationsNotInUseException":
-    case "com.amazonaws.organizations#AWSOrganizationsNotInUseException":
-      response = {
-        ...(await deserializeAws_json1_1AWSOrganizationsNotInUseExceptionResponse(parsedOutput, context)),
-        name: errorCode,
-        $metadata: deserializeMetadata(output),
-      };
-      break;
     case "AccessDeniedException":
     case "com.amazonaws.organizations#AccessDeniedException":
       response = {
@@ -2546,6 +2538,14 @@ const deserializeAws_json1_1DescribeAccountCommandError = async (
     case "com.amazonaws.organizations#AccountNotFoundException":
       response = {
         ...(await deserializeAws_json1_1AccountNotFoundExceptionResponse(parsedOutput, context)),
+        name: errorCode,
+        $metadata: deserializeMetadata(output),
+      };
+      break;
+    case "AWSOrganizationsNotInUseException":
+    case "com.amazonaws.organizations#AWSOrganizationsNotInUseException":
+      response = {
+        ...(await deserializeAws_json1_1AWSOrganizationsNotInUseExceptionResponse(parsedOutput, context)),
         name: errorCode,
         $metadata: deserializeMetadata(output),
       };
@@ -2620,18 +2620,18 @@ const deserializeAws_json1_1DescribeCreateAccountStatusCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadRestJsonErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "AWSOrganizationsNotInUseException":
-    case "com.amazonaws.organizations#AWSOrganizationsNotInUseException":
-      response = {
-        ...(await deserializeAws_json1_1AWSOrganizationsNotInUseExceptionResponse(parsedOutput, context)),
-        name: errorCode,
-        $metadata: deserializeMetadata(output),
-      };
-      break;
     case "AccessDeniedException":
     case "com.amazonaws.organizations#AccessDeniedException":
       response = {
         ...(await deserializeAws_json1_1AccessDeniedExceptionResponse(parsedOutput, context)),
+        name: errorCode,
+        $metadata: deserializeMetadata(output),
+      };
+      break;
+    case "AWSOrganizationsNotInUseException":
+    case "com.amazonaws.organizations#AWSOrganizationsNotInUseException":
+      response = {
+        ...(await deserializeAws_json1_1AWSOrganizationsNotInUseExceptionResponse(parsedOutput, context)),
         name: errorCode,
         $metadata: deserializeMetadata(output),
       };
@@ -2722,18 +2722,18 @@ const deserializeAws_json1_1DescribeEffectivePolicyCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadRestJsonErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "AWSOrganizationsNotInUseException":
-    case "com.amazonaws.organizations#AWSOrganizationsNotInUseException":
-      response = {
-        ...(await deserializeAws_json1_1AWSOrganizationsNotInUseExceptionResponse(parsedOutput, context)),
-        name: errorCode,
-        $metadata: deserializeMetadata(output),
-      };
-      break;
     case "AccessDeniedException":
     case "com.amazonaws.organizations#AccessDeniedException":
       response = {
         ...(await deserializeAws_json1_1AccessDeniedExceptionResponse(parsedOutput, context)),
+        name: errorCode,
+        $metadata: deserializeMetadata(output),
+      };
+      break;
+    case "AWSOrganizationsNotInUseException":
+    case "com.amazonaws.organizations#AWSOrganizationsNotInUseException":
+      response = {
+        ...(await deserializeAws_json1_1AWSOrganizationsNotInUseExceptionResponse(parsedOutput, context)),
         name: errorCode,
         $metadata: deserializeMetadata(output),
       };
@@ -2934,18 +2934,18 @@ const deserializeAws_json1_1DescribeOrganizationCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadRestJsonErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "AWSOrganizationsNotInUseException":
-    case "com.amazonaws.organizations#AWSOrganizationsNotInUseException":
-      response = {
-        ...(await deserializeAws_json1_1AWSOrganizationsNotInUseExceptionResponse(parsedOutput, context)),
-        name: errorCode,
-        $metadata: deserializeMetadata(output),
-      };
-      break;
     case "AccessDeniedException":
     case "com.amazonaws.organizations#AccessDeniedException":
       response = {
         ...(await deserializeAws_json1_1AccessDeniedExceptionResponse(parsedOutput, context)),
+        name: errorCode,
+        $metadata: deserializeMetadata(output),
+      };
+      break;
+    case "AWSOrganizationsNotInUseException":
+    case "com.amazonaws.organizations#AWSOrganizationsNotInUseException":
+      response = {
+        ...(await deserializeAws_json1_1AWSOrganizationsNotInUseExceptionResponse(parsedOutput, context)),
         name: errorCode,
         $metadata: deserializeMetadata(output),
       };
@@ -3020,18 +3020,18 @@ const deserializeAws_json1_1DescribeOrganizationalUnitCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadRestJsonErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "AWSOrganizationsNotInUseException":
-    case "com.amazonaws.organizations#AWSOrganizationsNotInUseException":
-      response = {
-        ...(await deserializeAws_json1_1AWSOrganizationsNotInUseExceptionResponse(parsedOutput, context)),
-        name: errorCode,
-        $metadata: deserializeMetadata(output),
-      };
-      break;
     case "AccessDeniedException":
     case "com.amazonaws.organizations#AccessDeniedException":
       response = {
         ...(await deserializeAws_json1_1AccessDeniedExceptionResponse(parsedOutput, context)),
+        name: errorCode,
+        $metadata: deserializeMetadata(output),
+      };
+      break;
+    case "AWSOrganizationsNotInUseException":
+    case "com.amazonaws.organizations#AWSOrganizationsNotInUseException":
+      response = {
+        ...(await deserializeAws_json1_1AWSOrganizationsNotInUseExceptionResponse(parsedOutput, context)),
         name: errorCode,
         $metadata: deserializeMetadata(output),
       };
@@ -3114,18 +3114,18 @@ const deserializeAws_json1_1DescribePolicyCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadRestJsonErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "AWSOrganizationsNotInUseException":
-    case "com.amazonaws.organizations#AWSOrganizationsNotInUseException":
-      response = {
-        ...(await deserializeAws_json1_1AWSOrganizationsNotInUseExceptionResponse(parsedOutput, context)),
-        name: errorCode,
-        $metadata: deserializeMetadata(output),
-      };
-      break;
     case "AccessDeniedException":
     case "com.amazonaws.organizations#AccessDeniedException":
       response = {
         ...(await deserializeAws_json1_1AccessDeniedExceptionResponse(parsedOutput, context)),
+        name: errorCode,
+        $metadata: deserializeMetadata(output),
+      };
+      break;
+    case "AWSOrganizationsNotInUseException":
+    case "com.amazonaws.organizations#AWSOrganizationsNotInUseException":
+      response = {
+        ...(await deserializeAws_json1_1AWSOrganizationsNotInUseExceptionResponse(parsedOutput, context)),
         name: errorCode,
         $metadata: deserializeMetadata(output),
       };
@@ -3213,18 +3213,18 @@ const deserializeAws_json1_1DetachPolicyCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadRestJsonErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "AWSOrganizationsNotInUseException":
-    case "com.amazonaws.organizations#AWSOrganizationsNotInUseException":
-      response = {
-        ...(await deserializeAws_json1_1AWSOrganizationsNotInUseExceptionResponse(parsedOutput, context)),
-        name: errorCode,
-        $metadata: deserializeMetadata(output),
-      };
-      break;
     case "AccessDeniedException":
     case "com.amazonaws.organizations#AccessDeniedException":
       response = {
         ...(await deserializeAws_json1_1AccessDeniedExceptionResponse(parsedOutput, context)),
+        name: errorCode,
+        $metadata: deserializeMetadata(output),
+      };
+      break;
+    case "AWSOrganizationsNotInUseException":
+    case "com.amazonaws.organizations#AWSOrganizationsNotInUseException":
+      response = {
+        ...(await deserializeAws_json1_1AWSOrganizationsNotInUseExceptionResponse(parsedOutput, context)),
         name: errorCode,
         $metadata: deserializeMetadata(output),
       };
@@ -3352,18 +3352,18 @@ const deserializeAws_json1_1DisableAWSServiceAccessCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadRestJsonErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "AWSOrganizationsNotInUseException":
-    case "com.amazonaws.organizations#AWSOrganizationsNotInUseException":
-      response = {
-        ...(await deserializeAws_json1_1AWSOrganizationsNotInUseExceptionResponse(parsedOutput, context)),
-        name: errorCode,
-        $metadata: deserializeMetadata(output),
-      };
-      break;
     case "AccessDeniedException":
     case "com.amazonaws.organizations#AccessDeniedException":
       response = {
         ...(await deserializeAws_json1_1AccessDeniedExceptionResponse(parsedOutput, context)),
+        name: errorCode,
+        $metadata: deserializeMetadata(output),
+      };
+      break;
+    case "AWSOrganizationsNotInUseException":
+    case "com.amazonaws.organizations#AWSOrganizationsNotInUseException":
+      response = {
+        ...(await deserializeAws_json1_1AWSOrganizationsNotInUseExceptionResponse(parsedOutput, context)),
         name: errorCode,
         $metadata: deserializeMetadata(output),
       };
@@ -3462,18 +3462,18 @@ const deserializeAws_json1_1DisablePolicyTypeCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadRestJsonErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "AWSOrganizationsNotInUseException":
-    case "com.amazonaws.organizations#AWSOrganizationsNotInUseException":
-      response = {
-        ...(await deserializeAws_json1_1AWSOrganizationsNotInUseExceptionResponse(parsedOutput, context)),
-        name: errorCode,
-        $metadata: deserializeMetadata(output),
-      };
-      break;
     case "AccessDeniedException":
     case "com.amazonaws.organizations#AccessDeniedException":
       response = {
         ...(await deserializeAws_json1_1AccessDeniedExceptionResponse(parsedOutput, context)),
+        name: errorCode,
+        $metadata: deserializeMetadata(output),
+      };
+      break;
+    case "AWSOrganizationsNotInUseException":
+    case "com.amazonaws.organizations#AWSOrganizationsNotInUseException":
+      response = {
+        ...(await deserializeAws_json1_1AWSOrganizationsNotInUseExceptionResponse(parsedOutput, context)),
         name: errorCode,
         $metadata: deserializeMetadata(output),
       };
@@ -3596,18 +3596,18 @@ const deserializeAws_json1_1EnableAllFeaturesCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadRestJsonErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "AWSOrganizationsNotInUseException":
-    case "com.amazonaws.organizations#AWSOrganizationsNotInUseException":
-      response = {
-        ...(await deserializeAws_json1_1AWSOrganizationsNotInUseExceptionResponse(parsedOutput, context)),
-        name: errorCode,
-        $metadata: deserializeMetadata(output),
-      };
-      break;
     case "AccessDeniedException":
     case "com.amazonaws.organizations#AccessDeniedException":
       response = {
         ...(await deserializeAws_json1_1AccessDeniedExceptionResponse(parsedOutput, context)),
+        name: errorCode,
+        $metadata: deserializeMetadata(output),
+      };
+      break;
+    case "AWSOrganizationsNotInUseException":
+    case "com.amazonaws.organizations#AWSOrganizationsNotInUseException":
+      response = {
+        ...(await deserializeAws_json1_1AWSOrganizationsNotInUseExceptionResponse(parsedOutput, context)),
         name: errorCode,
         $metadata: deserializeMetadata(output),
       };
@@ -3695,18 +3695,18 @@ const deserializeAws_json1_1EnableAWSServiceAccessCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadRestJsonErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "AWSOrganizationsNotInUseException":
-    case "com.amazonaws.organizations#AWSOrganizationsNotInUseException":
-      response = {
-        ...(await deserializeAws_json1_1AWSOrganizationsNotInUseExceptionResponse(parsedOutput, context)),
-        name: errorCode,
-        $metadata: deserializeMetadata(output),
-      };
-      break;
     case "AccessDeniedException":
     case "com.amazonaws.organizations#AccessDeniedException":
       response = {
         ...(await deserializeAws_json1_1AccessDeniedExceptionResponse(parsedOutput, context)),
+        name: errorCode,
+        $metadata: deserializeMetadata(output),
+      };
+      break;
+    case "AWSOrganizationsNotInUseException":
+    case "com.amazonaws.organizations#AWSOrganizationsNotInUseException":
+      response = {
+        ...(await deserializeAws_json1_1AWSOrganizationsNotInUseExceptionResponse(parsedOutput, context)),
         name: errorCode,
         $metadata: deserializeMetadata(output),
       };
@@ -3805,18 +3805,18 @@ const deserializeAws_json1_1EnablePolicyTypeCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadRestJsonErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "AWSOrganizationsNotInUseException":
-    case "com.amazonaws.organizations#AWSOrganizationsNotInUseException":
-      response = {
-        ...(await deserializeAws_json1_1AWSOrganizationsNotInUseExceptionResponse(parsedOutput, context)),
-        name: errorCode,
-        $metadata: deserializeMetadata(output),
-      };
-      break;
     case "AccessDeniedException":
     case "com.amazonaws.organizations#AccessDeniedException":
       response = {
         ...(await deserializeAws_json1_1AccessDeniedExceptionResponse(parsedOutput, context)),
+        name: errorCode,
+        $metadata: deserializeMetadata(output),
+      };
+      break;
+    case "AWSOrganizationsNotInUseException":
+    case "com.amazonaws.organizations#AWSOrganizationsNotInUseException":
+      response = {
+        ...(await deserializeAws_json1_1AWSOrganizationsNotInUseExceptionResponse(parsedOutput, context)),
         name: errorCode,
         $metadata: deserializeMetadata(output),
       };
@@ -3947,14 +3947,6 @@ const deserializeAws_json1_1InviteAccountToOrganizationCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadRestJsonErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "AWSOrganizationsNotInUseException":
-    case "com.amazonaws.organizations#AWSOrganizationsNotInUseException":
-      response = {
-        ...(await deserializeAws_json1_1AWSOrganizationsNotInUseExceptionResponse(parsedOutput, context)),
-        name: errorCode,
-        $metadata: deserializeMetadata(output),
-      };
-      break;
     case "AccessDeniedException":
     case "com.amazonaws.organizations#AccessDeniedException":
       response = {
@@ -3967,6 +3959,14 @@ const deserializeAws_json1_1InviteAccountToOrganizationCommandError = async (
     case "com.amazonaws.organizations#AccountOwnerNotVerifiedException":
       response = {
         ...(await deserializeAws_json1_1AccountOwnerNotVerifiedExceptionResponse(parsedOutput, context)),
+        name: errorCode,
+        $metadata: deserializeMetadata(output),
+      };
+      break;
+    case "AWSOrganizationsNotInUseException":
+    case "com.amazonaws.organizations#AWSOrganizationsNotInUseException":
+      response = {
+        ...(await deserializeAws_json1_1AWSOrganizationsNotInUseExceptionResponse(parsedOutput, context)),
         name: errorCode,
         $metadata: deserializeMetadata(output),
       };
@@ -4078,14 +4078,6 @@ const deserializeAws_json1_1LeaveOrganizationCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadRestJsonErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "AWSOrganizationsNotInUseException":
-    case "com.amazonaws.organizations#AWSOrganizationsNotInUseException":
-      response = {
-        ...(await deserializeAws_json1_1AWSOrganizationsNotInUseExceptionResponse(parsedOutput, context)),
-        name: errorCode,
-        $metadata: deserializeMetadata(output),
-      };
-      break;
     case "AccessDeniedException":
     case "com.amazonaws.organizations#AccessDeniedException":
       response = {
@@ -4098,6 +4090,14 @@ const deserializeAws_json1_1LeaveOrganizationCommandError = async (
     case "com.amazonaws.organizations#AccountNotFoundException":
       response = {
         ...(await deserializeAws_json1_1AccountNotFoundExceptionResponse(parsedOutput, context)),
+        name: errorCode,
+        $metadata: deserializeMetadata(output),
+      };
+      break;
+    case "AWSOrganizationsNotInUseException":
+    case "com.amazonaws.organizations#AWSOrganizationsNotInUseException":
+      response = {
+        ...(await deserializeAws_json1_1AWSOrganizationsNotInUseExceptionResponse(parsedOutput, context)),
         name: errorCode,
         $metadata: deserializeMetadata(output),
       };
@@ -4196,18 +4196,18 @@ const deserializeAws_json1_1ListAccountsCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadRestJsonErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "AWSOrganizationsNotInUseException":
-    case "com.amazonaws.organizations#AWSOrganizationsNotInUseException":
-      response = {
-        ...(await deserializeAws_json1_1AWSOrganizationsNotInUseExceptionResponse(parsedOutput, context)),
-        name: errorCode,
-        $metadata: deserializeMetadata(output),
-      };
-      break;
     case "AccessDeniedException":
     case "com.amazonaws.organizations#AccessDeniedException":
       response = {
         ...(await deserializeAws_json1_1AccessDeniedExceptionResponse(parsedOutput, context)),
+        name: errorCode,
+        $metadata: deserializeMetadata(output),
+      };
+      break;
+    case "AWSOrganizationsNotInUseException":
+    case "com.amazonaws.organizations#AWSOrganizationsNotInUseException":
+      response = {
+        ...(await deserializeAws_json1_1AWSOrganizationsNotInUseExceptionResponse(parsedOutput, context)),
         name: errorCode,
         $metadata: deserializeMetadata(output),
       };
@@ -4282,18 +4282,18 @@ const deserializeAws_json1_1ListAccountsForParentCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadRestJsonErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "AWSOrganizationsNotInUseException":
-    case "com.amazonaws.organizations#AWSOrganizationsNotInUseException":
-      response = {
-        ...(await deserializeAws_json1_1AWSOrganizationsNotInUseExceptionResponse(parsedOutput, context)),
-        name: errorCode,
-        $metadata: deserializeMetadata(output),
-      };
-      break;
     case "AccessDeniedException":
     case "com.amazonaws.organizations#AccessDeniedException":
       response = {
         ...(await deserializeAws_json1_1AccessDeniedExceptionResponse(parsedOutput, context)),
+        name: errorCode,
+        $metadata: deserializeMetadata(output),
+      };
+      break;
+    case "AWSOrganizationsNotInUseException":
+    case "com.amazonaws.organizations#AWSOrganizationsNotInUseException":
+      response = {
+        ...(await deserializeAws_json1_1AWSOrganizationsNotInUseExceptionResponse(parsedOutput, context)),
         name: errorCode,
         $metadata: deserializeMetadata(output),
       };
@@ -4376,18 +4376,18 @@ const deserializeAws_json1_1ListAWSServiceAccessForOrganizationCommandError = as
   let errorCode = "UnknownError";
   errorCode = loadRestJsonErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "AWSOrganizationsNotInUseException":
-    case "com.amazonaws.organizations#AWSOrganizationsNotInUseException":
-      response = {
-        ...(await deserializeAws_json1_1AWSOrganizationsNotInUseExceptionResponse(parsedOutput, context)),
-        name: errorCode,
-        $metadata: deserializeMetadata(output),
-      };
-      break;
     case "AccessDeniedException":
     case "com.amazonaws.organizations#AccessDeniedException":
       response = {
         ...(await deserializeAws_json1_1AccessDeniedExceptionResponse(parsedOutput, context)),
+        name: errorCode,
+        $metadata: deserializeMetadata(output),
+      };
+      break;
+    case "AWSOrganizationsNotInUseException":
+    case "com.amazonaws.organizations#AWSOrganizationsNotInUseException":
+      response = {
+        ...(await deserializeAws_json1_1AWSOrganizationsNotInUseExceptionResponse(parsedOutput, context)),
         name: errorCode,
         $metadata: deserializeMetadata(output),
       };
@@ -4478,18 +4478,18 @@ const deserializeAws_json1_1ListChildrenCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadRestJsonErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "AWSOrganizationsNotInUseException":
-    case "com.amazonaws.organizations#AWSOrganizationsNotInUseException":
-      response = {
-        ...(await deserializeAws_json1_1AWSOrganizationsNotInUseExceptionResponse(parsedOutput, context)),
-        name: errorCode,
-        $metadata: deserializeMetadata(output),
-      };
-      break;
     case "AccessDeniedException":
     case "com.amazonaws.organizations#AccessDeniedException":
       response = {
         ...(await deserializeAws_json1_1AccessDeniedExceptionResponse(parsedOutput, context)),
+        name: errorCode,
+        $metadata: deserializeMetadata(output),
+      };
+      break;
+    case "AWSOrganizationsNotInUseException":
+    case "com.amazonaws.organizations#AWSOrganizationsNotInUseException":
+      response = {
+        ...(await deserializeAws_json1_1AWSOrganizationsNotInUseExceptionResponse(parsedOutput, context)),
         name: errorCode,
         $metadata: deserializeMetadata(output),
       };
@@ -4572,18 +4572,18 @@ const deserializeAws_json1_1ListCreateAccountStatusCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadRestJsonErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "AWSOrganizationsNotInUseException":
-    case "com.amazonaws.organizations#AWSOrganizationsNotInUseException":
-      response = {
-        ...(await deserializeAws_json1_1AWSOrganizationsNotInUseExceptionResponse(parsedOutput, context)),
-        name: errorCode,
-        $metadata: deserializeMetadata(output),
-      };
-      break;
     case "AccessDeniedException":
     case "com.amazonaws.organizations#AccessDeniedException":
       response = {
         ...(await deserializeAws_json1_1AccessDeniedExceptionResponse(parsedOutput, context)),
+        name: errorCode,
+        $metadata: deserializeMetadata(output),
+      };
+      break;
+    case "AWSOrganizationsNotInUseException":
+    case "com.amazonaws.organizations#AWSOrganizationsNotInUseException":
+      response = {
+        ...(await deserializeAws_json1_1AWSOrganizationsNotInUseExceptionResponse(parsedOutput, context)),
         name: errorCode,
         $metadata: deserializeMetadata(output),
       };
@@ -4666,18 +4666,18 @@ const deserializeAws_json1_1ListDelegatedAdministratorsCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadRestJsonErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "AWSOrganizationsNotInUseException":
-    case "com.amazonaws.organizations#AWSOrganizationsNotInUseException":
-      response = {
-        ...(await deserializeAws_json1_1AWSOrganizationsNotInUseExceptionResponse(parsedOutput, context)),
-        name: errorCode,
-        $metadata: deserializeMetadata(output),
-      };
-      break;
     case "AccessDeniedException":
     case "com.amazonaws.organizations#AccessDeniedException":
       response = {
         ...(await deserializeAws_json1_1AccessDeniedExceptionResponse(parsedOutput, context)),
+        name: errorCode,
+        $metadata: deserializeMetadata(output),
+      };
+      break;
+    case "AWSOrganizationsNotInUseException":
+    case "com.amazonaws.organizations#AWSOrganizationsNotInUseException":
+      response = {
+        ...(await deserializeAws_json1_1AWSOrganizationsNotInUseExceptionResponse(parsedOutput, context)),
         name: errorCode,
         $metadata: deserializeMetadata(output),
       };
@@ -4768,14 +4768,6 @@ const deserializeAws_json1_1ListDelegatedServicesForAccountCommandError = async 
   let errorCode = "UnknownError";
   errorCode = loadRestJsonErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "AWSOrganizationsNotInUseException":
-    case "com.amazonaws.organizations#AWSOrganizationsNotInUseException":
-      response = {
-        ...(await deserializeAws_json1_1AWSOrganizationsNotInUseExceptionResponse(parsedOutput, context)),
-        name: errorCode,
-        $metadata: deserializeMetadata(output),
-      };
-      break;
     case "AccessDeniedException":
     case "com.amazonaws.organizations#AccessDeniedException":
       response = {
@@ -4796,6 +4788,14 @@ const deserializeAws_json1_1ListDelegatedServicesForAccountCommandError = async 
     case "com.amazonaws.organizations#AccountNotRegisteredException":
       response = {
         ...(await deserializeAws_json1_1AccountNotRegisteredExceptionResponse(parsedOutput, context)),
+        name: errorCode,
+        $metadata: deserializeMetadata(output),
+      };
+      break;
+    case "AWSOrganizationsNotInUseException":
+    case "com.amazonaws.organizations#AWSOrganizationsNotInUseException":
+      response = {
+        ...(await deserializeAws_json1_1AWSOrganizationsNotInUseExceptionResponse(parsedOutput, context)),
         name: errorCode,
         $metadata: deserializeMetadata(output),
       };
@@ -4972,18 +4972,18 @@ const deserializeAws_json1_1ListHandshakesForOrganizationCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadRestJsonErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "AWSOrganizationsNotInUseException":
-    case "com.amazonaws.organizations#AWSOrganizationsNotInUseException":
-      response = {
-        ...(await deserializeAws_json1_1AWSOrganizationsNotInUseExceptionResponse(parsedOutput, context)),
-        name: errorCode,
-        $metadata: deserializeMetadata(output),
-      };
-      break;
     case "AccessDeniedException":
     case "com.amazonaws.organizations#AccessDeniedException":
       response = {
         ...(await deserializeAws_json1_1AccessDeniedExceptionResponse(parsedOutput, context)),
+        name: errorCode,
+        $metadata: deserializeMetadata(output),
+      };
+      break;
+    case "AWSOrganizationsNotInUseException":
+    case "com.amazonaws.organizations#AWSOrganizationsNotInUseException":
+      response = {
+        ...(await deserializeAws_json1_1AWSOrganizationsNotInUseExceptionResponse(parsedOutput, context)),
         name: errorCode,
         $metadata: deserializeMetadata(output),
       };
@@ -5066,18 +5066,18 @@ const deserializeAws_json1_1ListOrganizationalUnitsForParentCommandError = async
   let errorCode = "UnknownError";
   errorCode = loadRestJsonErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "AWSOrganizationsNotInUseException":
-    case "com.amazonaws.organizations#AWSOrganizationsNotInUseException":
-      response = {
-        ...(await deserializeAws_json1_1AWSOrganizationsNotInUseExceptionResponse(parsedOutput, context)),
-        name: errorCode,
-        $metadata: deserializeMetadata(output),
-      };
-      break;
     case "AccessDeniedException":
     case "com.amazonaws.organizations#AccessDeniedException":
       response = {
         ...(await deserializeAws_json1_1AccessDeniedExceptionResponse(parsedOutput, context)),
+        name: errorCode,
+        $metadata: deserializeMetadata(output),
+      };
+      break;
+    case "AWSOrganizationsNotInUseException":
+    case "com.amazonaws.organizations#AWSOrganizationsNotInUseException":
+      response = {
+        ...(await deserializeAws_json1_1AWSOrganizationsNotInUseExceptionResponse(parsedOutput, context)),
         name: errorCode,
         $metadata: deserializeMetadata(output),
       };
@@ -5160,18 +5160,18 @@ const deserializeAws_json1_1ListParentsCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadRestJsonErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "AWSOrganizationsNotInUseException":
-    case "com.amazonaws.organizations#AWSOrganizationsNotInUseException":
-      response = {
-        ...(await deserializeAws_json1_1AWSOrganizationsNotInUseExceptionResponse(parsedOutput, context)),
-        name: errorCode,
-        $metadata: deserializeMetadata(output),
-      };
-      break;
     case "AccessDeniedException":
     case "com.amazonaws.organizations#AccessDeniedException":
       response = {
         ...(await deserializeAws_json1_1AccessDeniedExceptionResponse(parsedOutput, context)),
+        name: errorCode,
+        $metadata: deserializeMetadata(output),
+      };
+      break;
+    case "AWSOrganizationsNotInUseException":
+    case "com.amazonaws.organizations#AWSOrganizationsNotInUseException":
+      response = {
+        ...(await deserializeAws_json1_1AWSOrganizationsNotInUseExceptionResponse(parsedOutput, context)),
         name: errorCode,
         $metadata: deserializeMetadata(output),
       };
@@ -5254,18 +5254,18 @@ const deserializeAws_json1_1ListPoliciesCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadRestJsonErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "AWSOrganizationsNotInUseException":
-    case "com.amazonaws.organizations#AWSOrganizationsNotInUseException":
-      response = {
-        ...(await deserializeAws_json1_1AWSOrganizationsNotInUseExceptionResponse(parsedOutput, context)),
-        name: errorCode,
-        $metadata: deserializeMetadata(output),
-      };
-      break;
     case "AccessDeniedException":
     case "com.amazonaws.organizations#AccessDeniedException":
       response = {
         ...(await deserializeAws_json1_1AccessDeniedExceptionResponse(parsedOutput, context)),
+        name: errorCode,
+        $metadata: deserializeMetadata(output),
+      };
+      break;
+    case "AWSOrganizationsNotInUseException":
+    case "com.amazonaws.organizations#AWSOrganizationsNotInUseException":
+      response = {
+        ...(await deserializeAws_json1_1AWSOrganizationsNotInUseExceptionResponse(parsedOutput, context)),
         name: errorCode,
         $metadata: deserializeMetadata(output),
       };
@@ -5348,18 +5348,18 @@ const deserializeAws_json1_1ListPoliciesForTargetCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadRestJsonErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "AWSOrganizationsNotInUseException":
-    case "com.amazonaws.organizations#AWSOrganizationsNotInUseException":
-      response = {
-        ...(await deserializeAws_json1_1AWSOrganizationsNotInUseExceptionResponse(parsedOutput, context)),
-        name: errorCode,
-        $metadata: deserializeMetadata(output),
-      };
-      break;
     case "AccessDeniedException":
     case "com.amazonaws.organizations#AccessDeniedException":
       response = {
         ...(await deserializeAws_json1_1AccessDeniedExceptionResponse(parsedOutput, context)),
+        name: errorCode,
+        $metadata: deserializeMetadata(output),
+      };
+      break;
+    case "AWSOrganizationsNotInUseException":
+    case "com.amazonaws.organizations#AWSOrganizationsNotInUseException":
+      response = {
+        ...(await deserializeAws_json1_1AWSOrganizationsNotInUseExceptionResponse(parsedOutput, context)),
         name: errorCode,
         $metadata: deserializeMetadata(output),
       };
@@ -5450,18 +5450,18 @@ const deserializeAws_json1_1ListRootsCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadRestJsonErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "AWSOrganizationsNotInUseException":
-    case "com.amazonaws.organizations#AWSOrganizationsNotInUseException":
-      response = {
-        ...(await deserializeAws_json1_1AWSOrganizationsNotInUseExceptionResponse(parsedOutput, context)),
-        name: errorCode,
-        $metadata: deserializeMetadata(output),
-      };
-      break;
     case "AccessDeniedException":
     case "com.amazonaws.organizations#AccessDeniedException":
       response = {
         ...(await deserializeAws_json1_1AccessDeniedExceptionResponse(parsedOutput, context)),
+        name: errorCode,
+        $metadata: deserializeMetadata(output),
+      };
+      break;
+    case "AWSOrganizationsNotInUseException":
+    case "com.amazonaws.organizations#AWSOrganizationsNotInUseException":
+      response = {
+        ...(await deserializeAws_json1_1AWSOrganizationsNotInUseExceptionResponse(parsedOutput, context)),
         name: errorCode,
         $metadata: deserializeMetadata(output),
       };
@@ -5536,18 +5536,18 @@ const deserializeAws_json1_1ListTagsForResourceCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadRestJsonErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "AWSOrganizationsNotInUseException":
-    case "com.amazonaws.organizations#AWSOrganizationsNotInUseException":
-      response = {
-        ...(await deserializeAws_json1_1AWSOrganizationsNotInUseExceptionResponse(parsedOutput, context)),
-        name: errorCode,
-        $metadata: deserializeMetadata(output),
-      };
-      break;
     case "AccessDeniedException":
     case "com.amazonaws.organizations#AccessDeniedException":
       response = {
         ...(await deserializeAws_json1_1AccessDeniedExceptionResponse(parsedOutput, context)),
+        name: errorCode,
+        $metadata: deserializeMetadata(output),
+      };
+      break;
+    case "AWSOrganizationsNotInUseException":
+    case "com.amazonaws.organizations#AWSOrganizationsNotInUseException":
+      response = {
+        ...(await deserializeAws_json1_1AWSOrganizationsNotInUseExceptionResponse(parsedOutput, context)),
         name: errorCode,
         $metadata: deserializeMetadata(output),
       };
@@ -5630,18 +5630,18 @@ const deserializeAws_json1_1ListTargetsForPolicyCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadRestJsonErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "AWSOrganizationsNotInUseException":
-    case "com.amazonaws.organizations#AWSOrganizationsNotInUseException":
-      response = {
-        ...(await deserializeAws_json1_1AWSOrganizationsNotInUseExceptionResponse(parsedOutput, context)),
-        name: errorCode,
-        $metadata: deserializeMetadata(output),
-      };
-      break;
     case "AccessDeniedException":
     case "com.amazonaws.organizations#AccessDeniedException":
       response = {
         ...(await deserializeAws_json1_1AccessDeniedExceptionResponse(parsedOutput, context)),
+        name: errorCode,
+        $metadata: deserializeMetadata(output),
+      };
+      break;
+    case "AWSOrganizationsNotInUseException":
+    case "com.amazonaws.organizations#AWSOrganizationsNotInUseException":
+      response = {
+        ...(await deserializeAws_json1_1AWSOrganizationsNotInUseExceptionResponse(parsedOutput, context)),
         name: errorCode,
         $metadata: deserializeMetadata(output),
       };
@@ -5729,14 +5729,6 @@ const deserializeAws_json1_1MoveAccountCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadRestJsonErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "AWSOrganizationsNotInUseException":
-    case "com.amazonaws.organizations#AWSOrganizationsNotInUseException":
-      response = {
-        ...(await deserializeAws_json1_1AWSOrganizationsNotInUseExceptionResponse(parsedOutput, context)),
-        name: errorCode,
-        $metadata: deserializeMetadata(output),
-      };
-      break;
     case "AccessDeniedException":
     case "com.amazonaws.organizations#AccessDeniedException":
       response = {
@@ -5749,6 +5741,14 @@ const deserializeAws_json1_1MoveAccountCommandError = async (
     case "com.amazonaws.organizations#AccountNotFoundException":
       response = {
         ...(await deserializeAws_json1_1AccountNotFoundExceptionResponse(parsedOutput, context)),
+        name: errorCode,
+        $metadata: deserializeMetadata(output),
+      };
+      break;
+    case "AWSOrganizationsNotInUseException":
+    case "com.amazonaws.organizations#AWSOrganizationsNotInUseException":
+      response = {
+        ...(await deserializeAws_json1_1AWSOrganizationsNotInUseExceptionResponse(parsedOutput, context)),
         name: errorCode,
         $metadata: deserializeMetadata(output),
       };
@@ -5852,14 +5852,6 @@ const deserializeAws_json1_1RegisterDelegatedAdministratorCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadRestJsonErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "AWSOrganizationsNotInUseException":
-    case "com.amazonaws.organizations#AWSOrganizationsNotInUseException":
-      response = {
-        ...(await deserializeAws_json1_1AWSOrganizationsNotInUseExceptionResponse(parsedOutput, context)),
-        name: errorCode,
-        $metadata: deserializeMetadata(output),
-      };
-      break;
     case "AccessDeniedException":
     case "com.amazonaws.organizations#AccessDeniedException":
       response = {
@@ -5880,6 +5872,14 @@ const deserializeAws_json1_1RegisterDelegatedAdministratorCommandError = async (
     case "com.amazonaws.organizations#AccountNotFoundException":
       response = {
         ...(await deserializeAws_json1_1AccountNotFoundExceptionResponse(parsedOutput, context)),
+        name: errorCode,
+        $metadata: deserializeMetadata(output),
+      };
+      break;
+    case "AWSOrganizationsNotInUseException":
+    case "com.amazonaws.organizations#AWSOrganizationsNotInUseException":
+      response = {
+        ...(await deserializeAws_json1_1AWSOrganizationsNotInUseExceptionResponse(parsedOutput, context)),
         name: errorCode,
         $metadata: deserializeMetadata(output),
       };
@@ -5975,14 +5975,6 @@ const deserializeAws_json1_1RemoveAccountFromOrganizationCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadRestJsonErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "AWSOrganizationsNotInUseException":
-    case "com.amazonaws.organizations#AWSOrganizationsNotInUseException":
-      response = {
-        ...(await deserializeAws_json1_1AWSOrganizationsNotInUseExceptionResponse(parsedOutput, context)),
-        name: errorCode,
-        $metadata: deserializeMetadata(output),
-      };
-      break;
     case "AccessDeniedException":
     case "com.amazonaws.organizations#AccessDeniedException":
       response = {
@@ -5995,6 +5987,14 @@ const deserializeAws_json1_1RemoveAccountFromOrganizationCommandError = async (
     case "com.amazonaws.organizations#AccountNotFoundException":
       response = {
         ...(await deserializeAws_json1_1AccountNotFoundExceptionResponse(parsedOutput, context)),
+        name: errorCode,
+        $metadata: deserializeMetadata(output),
+      };
+      break;
+    case "AWSOrganizationsNotInUseException":
+    case "com.amazonaws.organizations#AWSOrganizationsNotInUseException":
+      response = {
+        ...(await deserializeAws_json1_1AWSOrganizationsNotInUseExceptionResponse(parsedOutput, context)),
         name: errorCode,
         $metadata: deserializeMetadata(output),
       };
@@ -6090,18 +6090,18 @@ const deserializeAws_json1_1TagResourceCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadRestJsonErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "AWSOrganizationsNotInUseException":
-    case "com.amazonaws.organizations#AWSOrganizationsNotInUseException":
-      response = {
-        ...(await deserializeAws_json1_1AWSOrganizationsNotInUseExceptionResponse(parsedOutput, context)),
-        name: errorCode,
-        $metadata: deserializeMetadata(output),
-      };
-      break;
     case "AccessDeniedException":
     case "com.amazonaws.organizations#AccessDeniedException":
       response = {
         ...(await deserializeAws_json1_1AccessDeniedExceptionResponse(parsedOutput, context)),
+        name: errorCode,
+        $metadata: deserializeMetadata(output),
+      };
+      break;
+    case "AWSOrganizationsNotInUseException":
+    case "com.amazonaws.organizations#AWSOrganizationsNotInUseException":
+      response = {
+        ...(await deserializeAws_json1_1AWSOrganizationsNotInUseExceptionResponse(parsedOutput, context)),
         name: errorCode,
         $metadata: deserializeMetadata(output),
       };
@@ -6197,18 +6197,18 @@ const deserializeAws_json1_1UntagResourceCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadRestJsonErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "AWSOrganizationsNotInUseException":
-    case "com.amazonaws.organizations#AWSOrganizationsNotInUseException":
-      response = {
-        ...(await deserializeAws_json1_1AWSOrganizationsNotInUseExceptionResponse(parsedOutput, context)),
-        name: errorCode,
-        $metadata: deserializeMetadata(output),
-      };
-      break;
     case "AccessDeniedException":
     case "com.amazonaws.organizations#AccessDeniedException":
       response = {
         ...(await deserializeAws_json1_1AccessDeniedExceptionResponse(parsedOutput, context)),
+        name: errorCode,
+        $metadata: deserializeMetadata(output),
+      };
+      break;
+    case "AWSOrganizationsNotInUseException":
+    case "com.amazonaws.organizations#AWSOrganizationsNotInUseException":
+      response = {
+        ...(await deserializeAws_json1_1AWSOrganizationsNotInUseExceptionResponse(parsedOutput, context)),
         name: errorCode,
         $metadata: deserializeMetadata(output),
       };
@@ -6307,18 +6307,18 @@ const deserializeAws_json1_1UpdateOrganizationalUnitCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadRestJsonErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "AWSOrganizationsNotInUseException":
-    case "com.amazonaws.organizations#AWSOrganizationsNotInUseException":
-      response = {
-        ...(await deserializeAws_json1_1AWSOrganizationsNotInUseExceptionResponse(parsedOutput, context)),
-        name: errorCode,
-        $metadata: deserializeMetadata(output),
-      };
-      break;
     case "AccessDeniedException":
     case "com.amazonaws.organizations#AccessDeniedException":
       response = {
         ...(await deserializeAws_json1_1AccessDeniedExceptionResponse(parsedOutput, context)),
+        name: errorCode,
+        $metadata: deserializeMetadata(output),
+      };
+      break;
+    case "AWSOrganizationsNotInUseException":
+    case "com.amazonaws.organizations#AWSOrganizationsNotInUseException":
+      response = {
+        ...(await deserializeAws_json1_1AWSOrganizationsNotInUseExceptionResponse(parsedOutput, context)),
         name: errorCode,
         $metadata: deserializeMetadata(output),
       };
@@ -6417,18 +6417,18 @@ const deserializeAws_json1_1UpdatePolicyCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadRestJsonErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "AWSOrganizationsNotInUseException":
-    case "com.amazonaws.organizations#AWSOrganizationsNotInUseException":
-      response = {
-        ...(await deserializeAws_json1_1AWSOrganizationsNotInUseExceptionResponse(parsedOutput, context)),
-        name: errorCode,
-        $metadata: deserializeMetadata(output),
-      };
-      break;
     case "AccessDeniedException":
     case "com.amazonaws.organizations#AccessDeniedException":
       response = {
         ...(await deserializeAws_json1_1AccessDeniedExceptionResponse(parsedOutput, context)),
+        name: errorCode,
+        $metadata: deserializeMetadata(output),
+      };
+      break;
+    case "AWSOrganizationsNotInUseException":
+    case "com.amazonaws.organizations#AWSOrganizationsNotInUseException":
+      response = {
+        ...(await deserializeAws_json1_1AWSOrganizationsNotInUseExceptionResponse(parsedOutput, context)),
         name: errorCode,
         $metadata: deserializeMetadata(output),
       };

--- a/clients/client-rds/src/protocols/Aws_query.ts
+++ b/clients/client-rds/src/protocols/Aws_query.ts
@@ -3243,7 +3243,7 @@ const deserializeAws_queryAddRoleToDBClusterCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "DBClusterRoleAlreadyExists":
+    case "DBClusterRoleAlreadyExistsFault":
     case "com.amazonaws.rds#DBClusterRoleAlreadyExistsFault":
       response = {
         ...(await deserializeAws_queryDBClusterRoleAlreadyExistsFaultResponse(parsedOutput, context)),
@@ -3251,7 +3251,7 @@ const deserializeAws_queryAddRoleToDBClusterCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "DBClusterRoleQuotaExceeded":
+    case "DBClusterRoleQuotaExceededFault":
     case "com.amazonaws.rds#DBClusterRoleQuotaExceededFault":
       response = {
         ...(await deserializeAws_queryDBClusterRoleQuotaExceededFaultResponse(parsedOutput, context)),
@@ -3310,7 +3310,7 @@ const deserializeAws_queryAddRoleToDBInstanceCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "DBInstanceNotFound":
+    case "DBInstanceNotFoundFault":
     case "com.amazonaws.rds#DBInstanceNotFoundFault":
       response = {
         ...(await deserializeAws_queryDBInstanceNotFoundFaultResponse(parsedOutput, context)),
@@ -3318,7 +3318,7 @@ const deserializeAws_queryAddRoleToDBInstanceCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "DBInstanceRoleAlreadyExists":
+    case "DBInstanceRoleAlreadyExistsFault":
     case "com.amazonaws.rds#DBInstanceRoleAlreadyExistsFault":
       response = {
         ...(await deserializeAws_queryDBInstanceRoleAlreadyExistsFaultResponse(parsedOutput, context)),
@@ -3326,7 +3326,7 @@ const deserializeAws_queryAddRoleToDBInstanceCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "DBInstanceRoleQuotaExceeded":
+    case "DBInstanceRoleQuotaExceededFault":
     case "com.amazonaws.rds#DBInstanceRoleQuotaExceededFault":
       response = {
         ...(await deserializeAws_queryDBInstanceRoleQuotaExceededFaultResponse(parsedOutput, context)),
@@ -3334,7 +3334,7 @@ const deserializeAws_queryAddRoleToDBInstanceCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidDBInstanceState":
+    case "InvalidDBInstanceStateFault":
     case "com.amazonaws.rds#InvalidDBInstanceStateFault":
       response = {
         ...(await deserializeAws_queryInvalidDBInstanceStateFaultResponse(parsedOutput, context)),
@@ -3391,7 +3391,7 @@ const deserializeAws_queryAddSourceIdentifierToSubscriptionCommandError = async 
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "SourceNotFound":
+    case "SourceNotFoundFault":
     case "com.amazonaws.rds#SourceNotFoundFault":
       response = {
         ...(await deserializeAws_querySourceNotFoundFaultResponse(parsedOutput, context)),
@@ -3399,7 +3399,7 @@ const deserializeAws_queryAddSourceIdentifierToSubscriptionCommandError = async 
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "SubscriptionNotFound":
+    case "SubscriptionNotFoundFault":
     case "com.amazonaws.rds#SubscriptionNotFoundFault":
       response = {
         ...(await deserializeAws_querySubscriptionNotFoundFaultResponse(parsedOutput, context)),
@@ -3458,7 +3458,7 @@ const deserializeAws_queryAddTagsToResourceCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "DBInstanceNotFound":
+    case "DBInstanceNotFoundFault":
     case "com.amazonaws.rds#DBInstanceNotFoundFault":
       response = {
         ...(await deserializeAws_queryDBInstanceNotFoundFaultResponse(parsedOutput, context)),
@@ -3482,7 +3482,7 @@ const deserializeAws_queryAddTagsToResourceCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "DBSnapshotNotFound":
+    case "DBSnapshotNotFoundFault":
     case "com.amazonaws.rds#DBSnapshotNotFoundFault":
       response = {
         ...(await deserializeAws_queryDBSnapshotNotFoundFaultResponse(parsedOutput, context)),
@@ -3544,7 +3544,7 @@ const deserializeAws_queryApplyPendingMaintenanceActionCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidDBInstanceState":
+    case "InvalidDBInstanceStateFault":
     case "com.amazonaws.rds#InvalidDBInstanceStateFault":
       response = {
         ...(await deserializeAws_queryInvalidDBInstanceStateFaultResponse(parsedOutput, context)),
@@ -3609,7 +3609,7 @@ const deserializeAws_queryAuthorizeDBSecurityGroupIngressCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "AuthorizationAlreadyExists":
+    case "AuthorizationAlreadyExistsFault":
     case "com.amazonaws.rds#AuthorizationAlreadyExistsFault":
       response = {
         ...(await deserializeAws_queryAuthorizationAlreadyExistsFaultResponse(parsedOutput, context)),
@@ -3617,7 +3617,7 @@ const deserializeAws_queryAuthorizeDBSecurityGroupIngressCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "AuthorizationQuotaExceeded":
+    case "AuthorizationQuotaExceededFault":
     case "com.amazonaws.rds#AuthorizationQuotaExceededFault":
       response = {
         ...(await deserializeAws_queryAuthorizationQuotaExceededFaultResponse(parsedOutput, context)),
@@ -3625,7 +3625,7 @@ const deserializeAws_queryAuthorizeDBSecurityGroupIngressCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "DBSecurityGroupNotFound":
+    case "DBSecurityGroupNotFoundFault":
     case "com.amazonaws.rds#DBSecurityGroupNotFoundFault":
       response = {
         ...(await deserializeAws_queryDBSecurityGroupNotFoundFaultResponse(parsedOutput, context)),
@@ -3633,7 +3633,7 @@ const deserializeAws_queryAuthorizeDBSecurityGroupIngressCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidDBSecurityGroupState":
+    case "InvalidDBSecurityGroupStateFault":
     case "com.amazonaws.rds#InvalidDBSecurityGroupStateFault":
       response = {
         ...(await deserializeAws_queryInvalidDBSecurityGroupStateFaultResponse(parsedOutput, context)),
@@ -3749,7 +3749,7 @@ const deserializeAws_queryCancelExportTaskCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "ExportTaskNotFound":
+    case "ExportTaskNotFoundFault":
     case "com.amazonaws.rds#ExportTaskNotFoundFault":
       response = {
         ...(await deserializeAws_queryExportTaskNotFoundFaultResponse(parsedOutput, context)),
@@ -3811,7 +3811,7 @@ const deserializeAws_queryCopyDBClusterParameterGroupCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "DBParameterGroupAlreadyExists":
+    case "DBParameterGroupAlreadyExistsFault":
     case "com.amazonaws.rds#DBParameterGroupAlreadyExistsFault":
       response = {
         ...(await deserializeAws_queryDBParameterGroupAlreadyExistsFaultResponse(parsedOutput, context)),
@@ -3819,7 +3819,7 @@ const deserializeAws_queryCopyDBClusterParameterGroupCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "DBParameterGroupNotFound":
+    case "DBParameterGroupNotFoundFault":
     case "com.amazonaws.rds#DBParameterGroupNotFoundFault":
       response = {
         ...(await deserializeAws_queryDBParameterGroupNotFoundFaultResponse(parsedOutput, context)),
@@ -3827,7 +3827,7 @@ const deserializeAws_queryCopyDBClusterParameterGroupCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "DBParameterGroupQuotaExceeded":
+    case "DBParameterGroupQuotaExceededFault":
     case "com.amazonaws.rds#DBParameterGroupQuotaExceededFault":
       response = {
         ...(await deserializeAws_queryDBParameterGroupQuotaExceededFaultResponse(parsedOutput, context)),
@@ -3921,7 +3921,7 @@ const deserializeAws_queryCopyDBClusterSnapshotCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "SnapshotQuotaExceeded":
+    case "SnapshotQuotaExceededFault":
     case "com.amazonaws.rds#SnapshotQuotaExceededFault":
       response = {
         ...(await deserializeAws_querySnapshotQuotaExceededFaultResponse(parsedOutput, context)),
@@ -3975,7 +3975,7 @@ const deserializeAws_queryCopyDBParameterGroupCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "DBParameterGroupAlreadyExists":
+    case "DBParameterGroupAlreadyExistsFault":
     case "com.amazonaws.rds#DBParameterGroupAlreadyExistsFault":
       response = {
         ...(await deserializeAws_queryDBParameterGroupAlreadyExistsFaultResponse(parsedOutput, context)),
@@ -3983,7 +3983,7 @@ const deserializeAws_queryCopyDBParameterGroupCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "DBParameterGroupNotFound":
+    case "DBParameterGroupNotFoundFault":
     case "com.amazonaws.rds#DBParameterGroupNotFoundFault":
       response = {
         ...(await deserializeAws_queryDBParameterGroupNotFoundFaultResponse(parsedOutput, context)),
@@ -3991,7 +3991,7 @@ const deserializeAws_queryCopyDBParameterGroupCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "DBParameterGroupQuotaExceeded":
+    case "DBParameterGroupQuotaExceededFault":
     case "com.amazonaws.rds#DBParameterGroupQuotaExceededFault":
       response = {
         ...(await deserializeAws_queryDBParameterGroupQuotaExceededFaultResponse(parsedOutput, context)),
@@ -4045,7 +4045,7 @@ const deserializeAws_queryCopyDBSnapshotCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "CustomAvailabilityZoneNotFound":
+    case "CustomAvailabilityZoneNotFoundFault":
     case "com.amazonaws.rds#CustomAvailabilityZoneNotFoundFault":
       response = {
         ...(await deserializeAws_queryCustomAvailabilityZoneNotFoundFaultResponse(parsedOutput, context)),
@@ -4053,7 +4053,7 @@ const deserializeAws_queryCopyDBSnapshotCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "DBSnapshotAlreadyExists":
+    case "DBSnapshotAlreadyExistsFault":
     case "com.amazonaws.rds#DBSnapshotAlreadyExistsFault":
       response = {
         ...(await deserializeAws_queryDBSnapshotAlreadyExistsFaultResponse(parsedOutput, context)),
@@ -4061,7 +4061,7 @@ const deserializeAws_queryCopyDBSnapshotCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "DBSnapshotNotFound":
+    case "DBSnapshotNotFoundFault":
     case "com.amazonaws.rds#DBSnapshotNotFoundFault":
       response = {
         ...(await deserializeAws_queryDBSnapshotNotFoundFaultResponse(parsedOutput, context)),
@@ -4069,7 +4069,7 @@ const deserializeAws_queryCopyDBSnapshotCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidDBSnapshotState":
+    case "InvalidDBSnapshotStateFault":
     case "com.amazonaws.rds#InvalidDBSnapshotStateFault":
       response = {
         ...(await deserializeAws_queryInvalidDBSnapshotStateFaultResponse(parsedOutput, context)),
@@ -4085,7 +4085,7 @@ const deserializeAws_queryCopyDBSnapshotCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "SnapshotQuotaExceeded":
+    case "SnapshotQuotaExceededFault":
     case "com.amazonaws.rds#SnapshotQuotaExceededFault":
       response = {
         ...(await deserializeAws_querySnapshotQuotaExceededFaultResponse(parsedOutput, context)),
@@ -4209,7 +4209,7 @@ const deserializeAws_queryCreateCustomAvailabilityZoneCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "CustomAvailabilityZoneAlreadyExists":
+    case "CustomAvailabilityZoneAlreadyExistsFault":
     case "com.amazonaws.rds#CustomAvailabilityZoneAlreadyExistsFault":
       response = {
         ...(await deserializeAws_queryCustomAvailabilityZoneAlreadyExistsFaultResponse(parsedOutput, context)),
@@ -4217,7 +4217,7 @@ const deserializeAws_queryCreateCustomAvailabilityZoneCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "CustomAvailabilityZoneQuotaExceeded":
+    case "CustomAvailabilityZoneQuotaExceededFault":
     case "com.amazonaws.rds#CustomAvailabilityZoneQuotaExceededFault":
       response = {
         ...(await deserializeAws_queryCustomAvailabilityZoneQuotaExceededFaultResponse(parsedOutput, context)),
@@ -4365,7 +4365,7 @@ const deserializeAws_queryCreateDBClusterCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "DBClusterParameterGroupNotFound":
+    case "DBClusterParameterGroupNotFoundFault":
     case "com.amazonaws.rds#DBClusterParameterGroupNotFoundFault":
       response = {
         ...(await deserializeAws_queryDBClusterParameterGroupNotFoundFaultResponse(parsedOutput, context)),
@@ -4381,7 +4381,7 @@ const deserializeAws_queryCreateDBClusterCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "DBInstanceNotFound":
+    case "DBInstanceNotFoundFault":
     case "com.amazonaws.rds#DBInstanceNotFoundFault":
       response = {
         ...(await deserializeAws_queryDBInstanceNotFoundFaultResponse(parsedOutput, context)),
@@ -4421,7 +4421,7 @@ const deserializeAws_queryCreateDBClusterCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InsufficientStorageClusterCapacity":
+    case "InsufficientStorageClusterCapacityFault":
     case "com.amazonaws.rds#InsufficientStorageClusterCapacityFault":
       response = {
         ...(await deserializeAws_queryInsufficientStorageClusterCapacityFaultResponse(parsedOutput, context)),
@@ -4437,7 +4437,7 @@ const deserializeAws_queryCreateDBClusterCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidDBInstanceState":
+    case "InvalidDBInstanceStateFault":
     case "com.amazonaws.rds#InvalidDBInstanceStateFault":
       response = {
         ...(await deserializeAws_queryInvalidDBInstanceStateFaultResponse(parsedOutput, context)),
@@ -4485,7 +4485,7 @@ const deserializeAws_queryCreateDBClusterCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "StorageQuotaExceeded":
+    case "StorageQuotaExceededFault":
     case "com.amazonaws.rds#StorageQuotaExceededFault":
       response = {
         ...(await deserializeAws_queryStorageQuotaExceededFaultResponse(parsedOutput, context)),
@@ -4563,7 +4563,7 @@ const deserializeAws_queryCreateDBClusterEndpointCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "DBInstanceNotFound":
+    case "DBInstanceNotFoundFault":
     case "com.amazonaws.rds#DBInstanceNotFoundFault":
       response = {
         ...(await deserializeAws_queryDBInstanceNotFoundFaultResponse(parsedOutput, context)),
@@ -4579,7 +4579,7 @@ const deserializeAws_queryCreateDBClusterEndpointCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidDBInstanceState":
+    case "InvalidDBInstanceStateFault":
     case "com.amazonaws.rds#InvalidDBInstanceStateFault":
       response = {
         ...(await deserializeAws_queryInvalidDBInstanceStateFaultResponse(parsedOutput, context)),
@@ -4633,7 +4633,7 @@ const deserializeAws_queryCreateDBClusterParameterGroupCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "DBParameterGroupAlreadyExists":
+    case "DBParameterGroupAlreadyExistsFault":
     case "com.amazonaws.rds#DBParameterGroupAlreadyExistsFault":
       response = {
         ...(await deserializeAws_queryDBParameterGroupAlreadyExistsFaultResponse(parsedOutput, context)),
@@ -4641,7 +4641,7 @@ const deserializeAws_queryCreateDBClusterParameterGroupCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "DBParameterGroupQuotaExceeded":
+    case "DBParameterGroupQuotaExceededFault":
     case "com.amazonaws.rds#DBParameterGroupQuotaExceededFault":
       response = {
         ...(await deserializeAws_queryDBParameterGroupQuotaExceededFaultResponse(parsedOutput, context)),
@@ -4727,7 +4727,7 @@ const deserializeAws_queryCreateDBClusterSnapshotCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "SnapshotQuotaExceeded":
+    case "SnapshotQuotaExceededFault":
     case "com.amazonaws.rds#SnapshotQuotaExceededFault":
       response = {
         ...(await deserializeAws_querySnapshotQuotaExceededFaultResponse(parsedOutput, context)),
@@ -4781,7 +4781,7 @@ const deserializeAws_queryCreateDBInstanceCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "AuthorizationNotFound":
+    case "AuthorizationNotFoundFault":
     case "com.amazonaws.rds#AuthorizationNotFoundFault":
       response = {
         ...(await deserializeAws_queryAuthorizationNotFoundFaultResponse(parsedOutput, context)),
@@ -4805,7 +4805,7 @@ const deserializeAws_queryCreateDBInstanceCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "DBInstanceAlreadyExists":
+    case "DBInstanceAlreadyExistsFault":
     case "com.amazonaws.rds#DBInstanceAlreadyExistsFault":
       response = {
         ...(await deserializeAws_queryDBInstanceAlreadyExistsFaultResponse(parsedOutput, context)),
@@ -4813,7 +4813,7 @@ const deserializeAws_queryCreateDBInstanceCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "DBParameterGroupNotFound":
+    case "DBParameterGroupNotFoundFault":
     case "com.amazonaws.rds#DBParameterGroupNotFoundFault":
       response = {
         ...(await deserializeAws_queryDBParameterGroupNotFoundFaultResponse(parsedOutput, context)),
@@ -4821,7 +4821,7 @@ const deserializeAws_queryCreateDBInstanceCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "DBSecurityGroupNotFound":
+    case "DBSecurityGroupNotFoundFault":
     case "com.amazonaws.rds#DBSecurityGroupNotFoundFault":
       response = {
         ...(await deserializeAws_queryDBSecurityGroupNotFoundFaultResponse(parsedOutput, context)),
@@ -4853,7 +4853,7 @@ const deserializeAws_queryCreateDBInstanceCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InstanceQuotaExceeded":
+    case "InstanceQuotaExceededFault":
     case "com.amazonaws.rds#InstanceQuotaExceededFault":
       response = {
         ...(await deserializeAws_queryInstanceQuotaExceededFaultResponse(parsedOutput, context)),
@@ -4861,7 +4861,7 @@ const deserializeAws_queryCreateDBInstanceCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InsufficientDBInstanceCapacity":
+    case "InsufficientDBInstanceCapacityFault":
     case "com.amazonaws.rds#InsufficientDBInstanceCapacityFault":
       response = {
         ...(await deserializeAws_queryInsufficientDBInstanceCapacityFaultResponse(parsedOutput, context)),
@@ -4917,7 +4917,7 @@ const deserializeAws_queryCreateDBInstanceCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "StorageQuotaExceeded":
+    case "StorageQuotaExceededFault":
     case "com.amazonaws.rds#StorageQuotaExceededFault":
       response = {
         ...(await deserializeAws_queryStorageQuotaExceededFaultResponse(parsedOutput, context)),
@@ -4925,7 +4925,7 @@ const deserializeAws_queryCreateDBInstanceCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "StorageTypeNotSupported":
+    case "StorageTypeNotSupportedFault":
     case "com.amazonaws.rds#StorageTypeNotSupportedFault":
       response = {
         ...(await deserializeAws_queryStorageTypeNotSupportedFaultResponse(parsedOutput, context)),
@@ -4979,7 +4979,7 @@ const deserializeAws_queryCreateDBInstanceReadReplicaCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "DBInstanceAlreadyExists":
+    case "DBInstanceAlreadyExistsFault":
     case "com.amazonaws.rds#DBInstanceAlreadyExistsFault":
       response = {
         ...(await deserializeAws_queryDBInstanceAlreadyExistsFaultResponse(parsedOutput, context)),
@@ -4987,7 +4987,7 @@ const deserializeAws_queryCreateDBInstanceReadReplicaCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "DBInstanceNotFound":
+    case "DBInstanceNotFoundFault":
     case "com.amazonaws.rds#DBInstanceNotFoundFault":
       response = {
         ...(await deserializeAws_queryDBInstanceNotFoundFaultResponse(parsedOutput, context)),
@@ -4995,7 +4995,7 @@ const deserializeAws_queryCreateDBInstanceReadReplicaCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "DBParameterGroupNotFound":
+    case "DBParameterGroupNotFoundFault":
     case "com.amazonaws.rds#DBParameterGroupNotFoundFault":
       response = {
         ...(await deserializeAws_queryDBParameterGroupNotFoundFaultResponse(parsedOutput, context)),
@@ -5003,7 +5003,7 @@ const deserializeAws_queryCreateDBInstanceReadReplicaCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "DBSecurityGroupNotFound":
+    case "DBSecurityGroupNotFoundFault":
     case "com.amazonaws.rds#DBSecurityGroupNotFoundFault":
       response = {
         ...(await deserializeAws_queryDBSecurityGroupNotFoundFaultResponse(parsedOutput, context)),
@@ -5043,7 +5043,7 @@ const deserializeAws_queryCreateDBInstanceReadReplicaCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InstanceQuotaExceeded":
+    case "InstanceQuotaExceededFault":
     case "com.amazonaws.rds#InstanceQuotaExceededFault":
       response = {
         ...(await deserializeAws_queryInstanceQuotaExceededFaultResponse(parsedOutput, context)),
@@ -5051,7 +5051,7 @@ const deserializeAws_queryCreateDBInstanceReadReplicaCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InsufficientDBInstanceCapacity":
+    case "InsufficientDBInstanceCapacityFault":
     case "com.amazonaws.rds#InsufficientDBInstanceCapacityFault":
       response = {
         ...(await deserializeAws_queryInsufficientDBInstanceCapacityFaultResponse(parsedOutput, context)),
@@ -5059,7 +5059,7 @@ const deserializeAws_queryCreateDBInstanceReadReplicaCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidDBInstanceState":
+    case "InvalidDBInstanceStateFault":
     case "com.amazonaws.rds#InvalidDBInstanceStateFault":
       response = {
         ...(await deserializeAws_queryInvalidDBInstanceStateFaultResponse(parsedOutput, context)),
@@ -5115,7 +5115,7 @@ const deserializeAws_queryCreateDBInstanceReadReplicaCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "StorageQuotaExceeded":
+    case "StorageQuotaExceededFault":
     case "com.amazonaws.rds#StorageQuotaExceededFault":
       response = {
         ...(await deserializeAws_queryStorageQuotaExceededFaultResponse(parsedOutput, context)),
@@ -5123,7 +5123,7 @@ const deserializeAws_queryCreateDBInstanceReadReplicaCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "StorageTypeNotSupported":
+    case "StorageTypeNotSupportedFault":
     case "com.amazonaws.rds#StorageTypeNotSupportedFault":
       response = {
         ...(await deserializeAws_queryStorageTypeNotSupportedFaultResponse(parsedOutput, context)),
@@ -5177,7 +5177,7 @@ const deserializeAws_queryCreateDBParameterGroupCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "DBParameterGroupAlreadyExists":
+    case "DBParameterGroupAlreadyExistsFault":
     case "com.amazonaws.rds#DBParameterGroupAlreadyExistsFault":
       response = {
         ...(await deserializeAws_queryDBParameterGroupAlreadyExistsFaultResponse(parsedOutput, context)),
@@ -5185,7 +5185,7 @@ const deserializeAws_queryCreateDBParameterGroupCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "DBParameterGroupQuotaExceeded":
+    case "DBParameterGroupQuotaExceededFault":
     case "com.amazonaws.rds#DBParameterGroupQuotaExceededFault":
       response = {
         ...(await deserializeAws_queryDBParameterGroupQuotaExceededFaultResponse(parsedOutput, context)),
@@ -5395,7 +5395,7 @@ const deserializeAws_queryCreateDBSecurityGroupCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "DBSecurityGroupAlreadyExists":
+    case "DBSecurityGroupAlreadyExistsFault":
     case "com.amazonaws.rds#DBSecurityGroupAlreadyExistsFault":
       response = {
         ...(await deserializeAws_queryDBSecurityGroupAlreadyExistsFaultResponse(parsedOutput, context)),
@@ -5403,7 +5403,7 @@ const deserializeAws_queryCreateDBSecurityGroupCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "DBSecurityGroupNotSupported":
+    case "DBSecurityGroupNotSupportedFault":
     case "com.amazonaws.rds#DBSecurityGroupNotSupportedFault":
       response = {
         ...(await deserializeAws_queryDBSecurityGroupNotSupportedFaultResponse(parsedOutput, context)),
@@ -5411,7 +5411,7 @@ const deserializeAws_queryCreateDBSecurityGroupCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "QuotaExceeded.DBSecurityGroup":
+    case "DBSecurityGroupQuotaExceededFault":
     case "com.amazonaws.rds#DBSecurityGroupQuotaExceededFault":
       response = {
         ...(await deserializeAws_queryDBSecurityGroupQuotaExceededFaultResponse(parsedOutput, context)),
@@ -5465,7 +5465,7 @@ const deserializeAws_queryCreateDBSnapshotCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "DBInstanceNotFound":
+    case "DBInstanceNotFoundFault":
     case "com.amazonaws.rds#DBInstanceNotFoundFault":
       response = {
         ...(await deserializeAws_queryDBInstanceNotFoundFaultResponse(parsedOutput, context)),
@@ -5473,7 +5473,7 @@ const deserializeAws_queryCreateDBSnapshotCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "DBSnapshotAlreadyExists":
+    case "DBSnapshotAlreadyExistsFault":
     case "com.amazonaws.rds#DBSnapshotAlreadyExistsFault":
       response = {
         ...(await deserializeAws_queryDBSnapshotAlreadyExistsFaultResponse(parsedOutput, context)),
@@ -5481,7 +5481,7 @@ const deserializeAws_queryCreateDBSnapshotCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidDBInstanceState":
+    case "InvalidDBInstanceStateFault":
     case "com.amazonaws.rds#InvalidDBInstanceStateFault":
       response = {
         ...(await deserializeAws_queryInvalidDBInstanceStateFaultResponse(parsedOutput, context)),
@@ -5489,7 +5489,7 @@ const deserializeAws_queryCreateDBSnapshotCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "SnapshotQuotaExceeded":
+    case "SnapshotQuotaExceededFault":
     case "com.amazonaws.rds#SnapshotQuotaExceededFault":
       response = {
         ...(await deserializeAws_querySnapshotQuotaExceededFaultResponse(parsedOutput, context)),
@@ -5543,7 +5543,7 @@ const deserializeAws_queryCreateDBSubnetGroupCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "DBSubnetGroupAlreadyExists":
+    case "DBSubnetGroupAlreadyExistsFault":
     case "com.amazonaws.rds#DBSubnetGroupAlreadyExistsFault":
       response = {
         ...(await deserializeAws_queryDBSubnetGroupAlreadyExistsFaultResponse(parsedOutput, context)),
@@ -5559,7 +5559,7 @@ const deserializeAws_queryCreateDBSubnetGroupCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "DBSubnetGroupQuotaExceeded":
+    case "DBSubnetGroupQuotaExceededFault":
     case "com.amazonaws.rds#DBSubnetGroupQuotaExceededFault":
       response = {
         ...(await deserializeAws_queryDBSubnetGroupQuotaExceededFaultResponse(parsedOutput, context)),
@@ -5629,7 +5629,7 @@ const deserializeAws_queryCreateEventSubscriptionCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "EventSubscriptionQuotaExceeded":
+    case "EventSubscriptionQuotaExceededFault":
     case "com.amazonaws.rds#EventSubscriptionQuotaExceededFault":
       response = {
         ...(await deserializeAws_queryEventSubscriptionQuotaExceededFaultResponse(parsedOutput, context)),
@@ -5637,7 +5637,7 @@ const deserializeAws_queryCreateEventSubscriptionCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "SNSInvalidTopic":
+    case "SNSInvalidTopicFault":
     case "com.amazonaws.rds#SNSInvalidTopicFault":
       response = {
         ...(await deserializeAws_querySNSInvalidTopicFaultResponse(parsedOutput, context)),
@@ -5645,7 +5645,7 @@ const deserializeAws_queryCreateEventSubscriptionCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "SNSNoAuthorization":
+    case "SNSNoAuthorizationFault":
     case "com.amazonaws.rds#SNSNoAuthorizationFault":
       response = {
         ...(await deserializeAws_querySNSNoAuthorizationFaultResponse(parsedOutput, context)),
@@ -5653,7 +5653,7 @@ const deserializeAws_queryCreateEventSubscriptionCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "SNSTopicArnNotFound":
+    case "SNSTopicArnNotFoundFault":
     case "com.amazonaws.rds#SNSTopicArnNotFoundFault":
       response = {
         ...(await deserializeAws_querySNSTopicArnNotFoundFaultResponse(parsedOutput, context)),
@@ -5661,7 +5661,7 @@ const deserializeAws_queryCreateEventSubscriptionCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "SourceNotFound":
+    case "SourceNotFoundFault":
     case "com.amazonaws.rds#SourceNotFoundFault":
       response = {
         ...(await deserializeAws_querySourceNotFoundFaultResponse(parsedOutput, context)),
@@ -5669,7 +5669,7 @@ const deserializeAws_queryCreateEventSubscriptionCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "SubscriptionAlreadyExist":
+    case "SubscriptionAlreadyExistFault":
     case "com.amazonaws.rds#SubscriptionAlreadyExistFault":
       response = {
         ...(await deserializeAws_querySubscriptionAlreadyExistFaultResponse(parsedOutput, context)),
@@ -5677,7 +5677,7 @@ const deserializeAws_queryCreateEventSubscriptionCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "SubscriptionCategoryNotFound":
+    case "SubscriptionCategoryNotFoundFault":
     case "com.amazonaws.rds#SubscriptionCategoryNotFoundFault":
       response = {
         ...(await deserializeAws_querySubscriptionCategoryNotFoundFaultResponse(parsedOutput, context)),
@@ -5871,7 +5871,7 @@ const deserializeAws_queryDeleteCustomAvailabilityZoneCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "CustomAvailabilityZoneNotFound":
+    case "CustomAvailabilityZoneNotFoundFault":
     case "com.amazonaws.rds#CustomAvailabilityZoneNotFoundFault":
       response = {
         ...(await deserializeAws_queryCustomAvailabilityZoneNotFoundFaultResponse(parsedOutput, context)),
@@ -6027,7 +6027,7 @@ const deserializeAws_queryDeleteDBClusterCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "SnapshotQuotaExceeded":
+    case "SnapshotQuotaExceededFault":
     case "com.amazonaws.rds#SnapshotQuotaExceededFault":
       response = {
         ...(await deserializeAws_querySnapshotQuotaExceededFaultResponse(parsedOutput, context)),
@@ -6148,7 +6148,7 @@ const deserializeAws_queryDeleteDBClusterParameterGroupCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "DBParameterGroupNotFound":
+    case "DBParameterGroupNotFoundFault":
     case "com.amazonaws.rds#DBParameterGroupNotFoundFault":
       response = {
         ...(await deserializeAws_queryDBParameterGroupNotFoundFaultResponse(parsedOutput, context)),
@@ -6156,7 +6156,7 @@ const deserializeAws_queryDeleteDBClusterParameterGroupCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidDBParameterGroupState":
+    case "InvalidDBParameterGroupStateFault":
     case "com.amazonaws.rds#InvalidDBParameterGroupStateFault":
       response = {
         ...(await deserializeAws_queryInvalidDBParameterGroupStateFaultResponse(parsedOutput, context)),
@@ -6272,7 +6272,7 @@ const deserializeAws_queryDeleteDBInstanceCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "DBInstanceAutomatedBackupQuotaExceeded":
+    case "DBInstanceAutomatedBackupQuotaExceededFault":
     case "com.amazonaws.rds#DBInstanceAutomatedBackupQuotaExceededFault":
       response = {
         ...(await deserializeAws_queryDBInstanceAutomatedBackupQuotaExceededFaultResponse(parsedOutput, context)),
@@ -6280,7 +6280,7 @@ const deserializeAws_queryDeleteDBInstanceCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "DBInstanceNotFound":
+    case "DBInstanceNotFoundFault":
     case "com.amazonaws.rds#DBInstanceNotFoundFault":
       response = {
         ...(await deserializeAws_queryDBInstanceNotFoundFaultResponse(parsedOutput, context)),
@@ -6288,7 +6288,7 @@ const deserializeAws_queryDeleteDBInstanceCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "DBSnapshotAlreadyExists":
+    case "DBSnapshotAlreadyExistsFault":
     case "com.amazonaws.rds#DBSnapshotAlreadyExistsFault":
       response = {
         ...(await deserializeAws_queryDBSnapshotAlreadyExistsFaultResponse(parsedOutput, context)),
@@ -6304,7 +6304,7 @@ const deserializeAws_queryDeleteDBInstanceCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidDBInstanceState":
+    case "InvalidDBInstanceStateFault":
     case "com.amazonaws.rds#InvalidDBInstanceStateFault":
       response = {
         ...(await deserializeAws_queryInvalidDBInstanceStateFaultResponse(parsedOutput, context)),
@@ -6312,7 +6312,7 @@ const deserializeAws_queryDeleteDBInstanceCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "SnapshotQuotaExceeded":
+    case "SnapshotQuotaExceededFault":
     case "com.amazonaws.rds#SnapshotQuotaExceededFault":
       response = {
         ...(await deserializeAws_querySnapshotQuotaExceededFaultResponse(parsedOutput, context)),
@@ -6369,7 +6369,7 @@ const deserializeAws_queryDeleteDBInstanceAutomatedBackupCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "DBInstanceAutomatedBackupNotFound":
+    case "DBInstanceAutomatedBackupNotFoundFault":
     case "com.amazonaws.rds#DBInstanceAutomatedBackupNotFoundFault":
       response = {
         ...(await deserializeAws_queryDBInstanceAutomatedBackupNotFoundFaultResponse(parsedOutput, context)),
@@ -6377,7 +6377,7 @@ const deserializeAws_queryDeleteDBInstanceAutomatedBackupCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidDBInstanceAutomatedBackupState":
+    case "InvalidDBInstanceAutomatedBackupStateFault":
     case "com.amazonaws.rds#InvalidDBInstanceAutomatedBackupStateFault":
       response = {
         ...(await deserializeAws_queryInvalidDBInstanceAutomatedBackupStateFaultResponse(parsedOutput, context)),
@@ -6428,7 +6428,7 @@ const deserializeAws_queryDeleteDBParameterGroupCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "DBParameterGroupNotFound":
+    case "DBParameterGroupNotFoundFault":
     case "com.amazonaws.rds#DBParameterGroupNotFoundFault":
       response = {
         ...(await deserializeAws_queryDBParameterGroupNotFoundFaultResponse(parsedOutput, context)),
@@ -6436,7 +6436,7 @@ const deserializeAws_queryDeleteDBParameterGroupCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidDBParameterGroupState":
+    case "InvalidDBParameterGroupStateFault":
     case "com.amazonaws.rds#InvalidDBParameterGroupStateFault":
       response = {
         ...(await deserializeAws_queryInvalidDBParameterGroupStateFaultResponse(parsedOutput, context)),
@@ -6611,7 +6611,7 @@ const deserializeAws_queryDeleteDBSecurityGroupCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "DBSecurityGroupNotFound":
+    case "DBSecurityGroupNotFoundFault":
     case "com.amazonaws.rds#DBSecurityGroupNotFoundFault":
       response = {
         ...(await deserializeAws_queryDBSecurityGroupNotFoundFaultResponse(parsedOutput, context)),
@@ -6619,7 +6619,7 @@ const deserializeAws_queryDeleteDBSecurityGroupCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidDBSecurityGroupState":
+    case "InvalidDBSecurityGroupStateFault":
     case "com.amazonaws.rds#InvalidDBSecurityGroupStateFault":
       response = {
         ...(await deserializeAws_queryInvalidDBSecurityGroupStateFaultResponse(parsedOutput, context)),
@@ -6673,7 +6673,7 @@ const deserializeAws_queryDeleteDBSnapshotCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "DBSnapshotNotFound":
+    case "DBSnapshotNotFoundFault":
     case "com.amazonaws.rds#DBSnapshotNotFoundFault":
       response = {
         ...(await deserializeAws_queryDBSnapshotNotFoundFaultResponse(parsedOutput, context)),
@@ -6681,7 +6681,7 @@ const deserializeAws_queryDeleteDBSnapshotCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidDBSnapshotState":
+    case "InvalidDBSnapshotStateFault":
     case "com.amazonaws.rds#InvalidDBSnapshotStateFault":
       response = {
         ...(await deserializeAws_queryInvalidDBSnapshotStateFaultResponse(parsedOutput, context)),
@@ -6802,7 +6802,7 @@ const deserializeAws_queryDeleteEventSubscriptionCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "InvalidEventSubscriptionState":
+    case "InvalidEventSubscriptionStateFault":
     case "com.amazonaws.rds#InvalidEventSubscriptionStateFault":
       response = {
         ...(await deserializeAws_queryInvalidEventSubscriptionStateFaultResponse(parsedOutput, context)),
@@ -6810,7 +6810,7 @@ const deserializeAws_queryDeleteEventSubscriptionCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "SubscriptionNotFound":
+    case "SubscriptionNotFoundFault":
     case "com.amazonaws.rds#SubscriptionNotFoundFault":
       response = {
         ...(await deserializeAws_querySubscriptionNotFoundFaultResponse(parsedOutput, context)),
@@ -6926,7 +6926,7 @@ const deserializeAws_queryDeleteInstallationMediaCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "InstallationMediaNotFound":
+    case "InstallationMediaNotFoundFault":
     case "com.amazonaws.rds#InstallationMediaNotFoundFault":
       response = {
         ...(await deserializeAws_queryInstallationMediaNotFoundFaultResponse(parsedOutput, context)),
@@ -7163,7 +7163,7 @@ const deserializeAws_queryDescribeCertificatesCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "CertificateNotFound":
+    case "CertificateNotFoundFault":
     case "com.amazonaws.rds#CertificateNotFoundFault":
       response = {
         ...(await deserializeAws_queryCertificateNotFoundFaultResponse(parsedOutput, context)),
@@ -7217,7 +7217,7 @@ const deserializeAws_queryDescribeCustomAvailabilityZonesCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "CustomAvailabilityZoneNotFound":
+    case "CustomAvailabilityZoneNotFoundFault":
     case "com.amazonaws.rds#CustomAvailabilityZoneNotFoundFault":
       response = {
         ...(await deserializeAws_queryCustomAvailabilityZoneNotFoundFaultResponse(parsedOutput, context)),
@@ -7387,7 +7387,7 @@ const deserializeAws_queryDescribeDBClusterParameterGroupsCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "DBParameterGroupNotFound":
+    case "DBParameterGroupNotFoundFault":
     case "com.amazonaws.rds#DBParameterGroupNotFoundFault":
       response = {
         ...(await deserializeAws_queryDBParameterGroupNotFoundFaultResponse(parsedOutput, context)),
@@ -7441,7 +7441,7 @@ const deserializeAws_queryDescribeDBClusterParametersCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "DBParameterGroupNotFound":
+    case "DBParameterGroupNotFoundFault":
     case "com.amazonaws.rds#DBParameterGroupNotFoundFault":
       response = {
         ...(await deserializeAws_queryDBParameterGroupNotFoundFaultResponse(parsedOutput, context)),
@@ -7709,7 +7709,7 @@ const deserializeAws_queryDescribeDBInstanceAutomatedBackupsCommandError = async
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "DBInstanceAutomatedBackupNotFound":
+    case "DBInstanceAutomatedBackupNotFoundFault":
     case "com.amazonaws.rds#DBInstanceAutomatedBackupNotFoundFault":
       response = {
         ...(await deserializeAws_queryDBInstanceAutomatedBackupNotFoundFaultResponse(parsedOutput, context)),
@@ -7763,7 +7763,7 @@ const deserializeAws_queryDescribeDBInstancesCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "DBInstanceNotFound":
+    case "DBInstanceNotFoundFault":
     case "com.amazonaws.rds#DBInstanceNotFoundFault":
       response = {
         ...(await deserializeAws_queryDBInstanceNotFoundFaultResponse(parsedOutput, context)),
@@ -7817,7 +7817,7 @@ const deserializeAws_queryDescribeDBLogFilesCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "DBInstanceNotFound":
+    case "DBInstanceNotFoundFault":
     case "com.amazonaws.rds#DBInstanceNotFoundFault":
       response = {
         ...(await deserializeAws_queryDBInstanceNotFoundFaultResponse(parsedOutput, context)),
@@ -7871,7 +7871,7 @@ const deserializeAws_queryDescribeDBParameterGroupsCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "DBParameterGroupNotFound":
+    case "DBParameterGroupNotFoundFault":
     case "com.amazonaws.rds#DBParameterGroupNotFoundFault":
       response = {
         ...(await deserializeAws_queryDBParameterGroupNotFoundFaultResponse(parsedOutput, context)),
@@ -7925,7 +7925,7 @@ const deserializeAws_queryDescribeDBParametersCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "DBParameterGroupNotFound":
+    case "DBParameterGroupNotFoundFault":
     case "com.amazonaws.rds#DBParameterGroupNotFoundFault":
       response = {
         ...(await deserializeAws_queryDBParameterGroupNotFoundFaultResponse(parsedOutput, context)),
@@ -8243,7 +8243,7 @@ const deserializeAws_queryDescribeDBSecurityGroupsCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "DBSecurityGroupNotFound":
+    case "DBSecurityGroupNotFoundFault":
     case "com.amazonaws.rds#DBSecurityGroupNotFoundFault":
       response = {
         ...(await deserializeAws_queryDBSecurityGroupNotFoundFaultResponse(parsedOutput, context)),
@@ -8297,7 +8297,7 @@ const deserializeAws_queryDescribeDBSnapshotAttributesCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "DBSnapshotNotFound":
+    case "DBSnapshotNotFoundFault":
     case "com.amazonaws.rds#DBSnapshotNotFoundFault":
       response = {
         ...(await deserializeAws_queryDBSnapshotNotFoundFaultResponse(parsedOutput, context)),
@@ -8351,7 +8351,7 @@ const deserializeAws_queryDescribeDBSnapshotsCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "DBSnapshotNotFound":
+    case "DBSnapshotNotFoundFault":
     case "com.amazonaws.rds#DBSnapshotNotFoundFault":
       response = {
         ...(await deserializeAws_queryDBSnapshotNotFoundFaultResponse(parsedOutput, context)),
@@ -8649,7 +8649,7 @@ const deserializeAws_queryDescribeEventSubscriptionsCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "SubscriptionNotFound":
+    case "SubscriptionNotFoundFault":
     case "com.amazonaws.rds#SubscriptionNotFoundFault":
       response = {
         ...(await deserializeAws_querySubscriptionNotFoundFaultResponse(parsedOutput, context)),
@@ -8703,7 +8703,7 @@ const deserializeAws_queryDescribeExportTasksCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "ExportTaskNotFound":
+    case "ExportTaskNotFoundFault":
     case "com.amazonaws.rds#ExportTaskNotFoundFault":
       response = {
         ...(await deserializeAws_queryExportTaskNotFoundFaultResponse(parsedOutput, context)),
@@ -8811,7 +8811,7 @@ const deserializeAws_queryDescribeInstallationMediaCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "InstallationMediaNotFound":
+    case "InstallationMediaNotFoundFault":
     case "com.amazonaws.rds#InstallationMediaNotFoundFault":
       response = {
         ...(await deserializeAws_queryInstallationMediaNotFoundFaultResponse(parsedOutput, context)),
@@ -9071,7 +9071,7 @@ const deserializeAws_queryDescribeReservedDBInstancesCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "ReservedDBInstanceNotFound":
+    case "ReservedDBInstanceNotFoundFault":
     case "com.amazonaws.rds#ReservedDBInstanceNotFoundFault":
       response = {
         ...(await deserializeAws_queryReservedDBInstanceNotFoundFaultResponse(parsedOutput, context)),
@@ -9128,7 +9128,7 @@ const deserializeAws_queryDescribeReservedDBInstancesOfferingsCommandError = asy
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "ReservedDBInstancesOfferingNotFound":
+    case "ReservedDBInstancesOfferingNotFoundFault":
     case "com.amazonaws.rds#ReservedDBInstancesOfferingNotFoundFault":
       response = {
         ...(await deserializeAws_queryReservedDBInstancesOfferingNotFoundFaultResponse(parsedOutput, context)),
@@ -9231,7 +9231,7 @@ const deserializeAws_queryDescribeValidDBInstanceModificationsCommandError = asy
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "DBInstanceNotFound":
+    case "DBInstanceNotFoundFault":
     case "com.amazonaws.rds#DBInstanceNotFoundFault":
       response = {
         ...(await deserializeAws_queryDBInstanceNotFoundFaultResponse(parsedOutput, context)),
@@ -9239,7 +9239,7 @@ const deserializeAws_queryDescribeValidDBInstanceModificationsCommandError = asy
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidDBInstanceState":
+    case "InvalidDBInstanceStateFault":
     case "com.amazonaws.rds#InvalidDBInstanceStateFault":
       response = {
         ...(await deserializeAws_queryInvalidDBInstanceStateFaultResponse(parsedOutput, context)),
@@ -9293,7 +9293,7 @@ const deserializeAws_queryDownloadDBLogFilePortionCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "DBInstanceNotFound":
+    case "DBInstanceNotFoundFault":
     case "com.amazonaws.rds#DBInstanceNotFoundFault":
       response = {
         ...(await deserializeAws_queryDBInstanceNotFoundFaultResponse(parsedOutput, context)),
@@ -9371,7 +9371,7 @@ const deserializeAws_queryFailoverDBClusterCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidDBInstanceState":
+    case "InvalidDBInstanceStateFault":
     case "com.amazonaws.rds#InvalidDBInstanceStateFault":
       response = {
         ...(await deserializeAws_queryInvalidDBInstanceStateFaultResponse(parsedOutput, context)),
@@ -9503,7 +9503,7 @@ const deserializeAws_queryImportInstallationMediaCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "CustomAvailabilityZoneNotFound":
+    case "CustomAvailabilityZoneNotFoundFault":
     case "com.amazonaws.rds#CustomAvailabilityZoneNotFoundFault":
       response = {
         ...(await deserializeAws_queryCustomAvailabilityZoneNotFoundFaultResponse(parsedOutput, context)),
@@ -9511,7 +9511,7 @@ const deserializeAws_queryImportInstallationMediaCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InstallationMediaAlreadyExists":
+    case "InstallationMediaAlreadyExistsFault":
     case "com.amazonaws.rds#InstallationMediaAlreadyExistsFault":
       response = {
         ...(await deserializeAws_queryInstallationMediaAlreadyExistsFaultResponse(parsedOutput, context)),
@@ -9573,7 +9573,7 @@ const deserializeAws_queryListTagsForResourceCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "DBInstanceNotFound":
+    case "DBInstanceNotFoundFault":
     case "com.amazonaws.rds#DBInstanceNotFoundFault":
       response = {
         ...(await deserializeAws_queryDBInstanceNotFoundFaultResponse(parsedOutput, context)),
@@ -9597,7 +9597,7 @@ const deserializeAws_queryListTagsForResourceCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "DBSnapshotNotFound":
+    case "DBSnapshotNotFoundFault":
     case "com.amazonaws.rds#DBSnapshotNotFoundFault":
       response = {
         ...(await deserializeAws_queryDBSnapshotNotFoundFaultResponse(parsedOutput, context)),
@@ -9651,7 +9651,7 @@ const deserializeAws_queryModifyCertificatesCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "CertificateNotFound":
+    case "CertificateNotFoundFault":
     case "com.amazonaws.rds#CertificateNotFoundFault":
       response = {
         ...(await deserializeAws_queryCertificateNotFoundFaultResponse(parsedOutput, context)),
@@ -9853,7 +9853,7 @@ const deserializeAws_queryModifyDBClusterCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "DBClusterParameterGroupNotFound":
+    case "DBClusterParameterGroupNotFoundFault":
     case "com.amazonaws.rds#DBClusterParameterGroupNotFoundFault":
       response = {
         ...(await deserializeAws_queryDBClusterParameterGroupNotFoundFaultResponse(parsedOutput, context)),
@@ -9885,7 +9885,7 @@ const deserializeAws_queryModifyDBClusterCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidDBInstanceState":
+    case "InvalidDBInstanceStateFault":
     case "com.amazonaws.rds#InvalidDBInstanceStateFault":
       response = {
         ...(await deserializeAws_queryInvalidDBInstanceStateFaultResponse(parsedOutput, context)),
@@ -9893,7 +9893,7 @@ const deserializeAws_queryModifyDBClusterCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidDBSecurityGroupState":
+    case "InvalidDBSecurityGroupStateFault":
     case "com.amazonaws.rds#InvalidDBSecurityGroupStateFault":
       response = {
         ...(await deserializeAws_queryInvalidDBSecurityGroupStateFaultResponse(parsedOutput, context)),
@@ -9925,7 +9925,7 @@ const deserializeAws_queryModifyDBClusterCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "StorageQuotaExceeded":
+    case "StorageQuotaExceededFault":
     case "com.amazonaws.rds#StorageQuotaExceededFault":
       response = {
         ...(await deserializeAws_queryStorageQuotaExceededFaultResponse(parsedOutput, context)),
@@ -9987,7 +9987,7 @@ const deserializeAws_queryModifyDBClusterEndpointCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "DBInstanceNotFound":
+    case "DBInstanceNotFoundFault":
     case "com.amazonaws.rds#DBInstanceNotFoundFault":
       response = {
         ...(await deserializeAws_queryDBInstanceNotFoundFaultResponse(parsedOutput, context)),
@@ -10011,7 +10011,7 @@ const deserializeAws_queryModifyDBClusterEndpointCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidDBInstanceState":
+    case "InvalidDBInstanceStateFault":
     case "com.amazonaws.rds#InvalidDBInstanceStateFault":
       response = {
         ...(await deserializeAws_queryInvalidDBInstanceStateFaultResponse(parsedOutput, context)),
@@ -10065,7 +10065,7 @@ const deserializeAws_queryModifyDBClusterParameterGroupCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "DBParameterGroupNotFound":
+    case "DBParameterGroupNotFoundFault":
     case "com.amazonaws.rds#DBParameterGroupNotFoundFault":
       response = {
         ...(await deserializeAws_queryDBParameterGroupNotFoundFaultResponse(parsedOutput, context)),
@@ -10073,7 +10073,7 @@ const deserializeAws_queryModifyDBClusterParameterGroupCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidDBParameterGroupState":
+    case "InvalidDBParameterGroupStateFault":
     case "com.amazonaws.rds#InvalidDBParameterGroupStateFault":
       response = {
         ...(await deserializeAws_queryInvalidDBParameterGroupStateFaultResponse(parsedOutput, context)),
@@ -10146,7 +10146,7 @@ const deserializeAws_queryModifyDBClusterSnapshotAttributeCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "SharedSnapshotQuotaExceeded":
+    case "SharedSnapshotQuotaExceededFault":
     case "com.amazonaws.rds#SharedSnapshotQuotaExceededFault":
       response = {
         ...(await deserializeAws_querySharedSnapshotQuotaExceededFaultResponse(parsedOutput, context)),
@@ -10200,7 +10200,7 @@ const deserializeAws_queryModifyDBInstanceCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "AuthorizationNotFound":
+    case "AuthorizationNotFoundFault":
     case "com.amazonaws.rds#AuthorizationNotFoundFault":
       response = {
         ...(await deserializeAws_queryAuthorizationNotFoundFaultResponse(parsedOutput, context)),
@@ -10216,7 +10216,7 @@ const deserializeAws_queryModifyDBInstanceCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "CertificateNotFound":
+    case "CertificateNotFoundFault":
     case "com.amazonaws.rds#CertificateNotFoundFault":
       response = {
         ...(await deserializeAws_queryCertificateNotFoundFaultResponse(parsedOutput, context)),
@@ -10224,7 +10224,7 @@ const deserializeAws_queryModifyDBInstanceCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "DBInstanceAlreadyExists":
+    case "DBInstanceAlreadyExistsFault":
     case "com.amazonaws.rds#DBInstanceAlreadyExistsFault":
       response = {
         ...(await deserializeAws_queryDBInstanceAlreadyExistsFaultResponse(parsedOutput, context)),
@@ -10232,7 +10232,7 @@ const deserializeAws_queryModifyDBInstanceCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "DBInstanceNotFound":
+    case "DBInstanceNotFoundFault":
     case "com.amazonaws.rds#DBInstanceNotFoundFault":
       response = {
         ...(await deserializeAws_queryDBInstanceNotFoundFaultResponse(parsedOutput, context)),
@@ -10240,7 +10240,7 @@ const deserializeAws_queryModifyDBInstanceCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "DBParameterGroupNotFound":
+    case "DBParameterGroupNotFoundFault":
     case "com.amazonaws.rds#DBParameterGroupNotFoundFault":
       response = {
         ...(await deserializeAws_queryDBParameterGroupNotFoundFaultResponse(parsedOutput, context)),
@@ -10248,7 +10248,7 @@ const deserializeAws_queryModifyDBInstanceCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "DBSecurityGroupNotFound":
+    case "DBSecurityGroupNotFoundFault":
     case "com.amazonaws.rds#DBSecurityGroupNotFoundFault":
       response = {
         ...(await deserializeAws_queryDBSecurityGroupNotFoundFaultResponse(parsedOutput, context)),
@@ -10256,7 +10256,7 @@ const deserializeAws_queryModifyDBInstanceCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "DBUpgradeDependencyFailure":
+    case "DBUpgradeDependencyFailureFault":
     case "com.amazonaws.rds#DBUpgradeDependencyFailureFault":
       response = {
         ...(await deserializeAws_queryDBUpgradeDependencyFailureFaultResponse(parsedOutput, context)),
@@ -10272,7 +10272,7 @@ const deserializeAws_queryModifyDBInstanceCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InsufficientDBInstanceCapacity":
+    case "InsufficientDBInstanceCapacityFault":
     case "com.amazonaws.rds#InsufficientDBInstanceCapacityFault":
       response = {
         ...(await deserializeAws_queryInsufficientDBInstanceCapacityFaultResponse(parsedOutput, context)),
@@ -10288,7 +10288,7 @@ const deserializeAws_queryModifyDBInstanceCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidDBInstanceState":
+    case "InvalidDBInstanceStateFault":
     case "com.amazonaws.rds#InvalidDBInstanceStateFault":
       response = {
         ...(await deserializeAws_queryInvalidDBInstanceStateFaultResponse(parsedOutput, context)),
@@ -10296,7 +10296,7 @@ const deserializeAws_queryModifyDBInstanceCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidDBSecurityGroupState":
+    case "InvalidDBSecurityGroupStateFault":
     case "com.amazonaws.rds#InvalidDBSecurityGroupStateFault":
       response = {
         ...(await deserializeAws_queryInvalidDBSecurityGroupStateFaultResponse(parsedOutput, context)),
@@ -10336,7 +10336,7 @@ const deserializeAws_queryModifyDBInstanceCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "StorageQuotaExceeded":
+    case "StorageQuotaExceededFault":
     case "com.amazonaws.rds#StorageQuotaExceededFault":
       response = {
         ...(await deserializeAws_queryStorageQuotaExceededFaultResponse(parsedOutput, context)),
@@ -10344,7 +10344,7 @@ const deserializeAws_queryModifyDBInstanceCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "StorageTypeNotSupported":
+    case "StorageTypeNotSupportedFault":
     case "com.amazonaws.rds#StorageTypeNotSupportedFault":
       response = {
         ...(await deserializeAws_queryStorageTypeNotSupportedFaultResponse(parsedOutput, context)),
@@ -10398,7 +10398,7 @@ const deserializeAws_queryModifyDBParameterGroupCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "DBParameterGroupNotFound":
+    case "DBParameterGroupNotFoundFault":
     case "com.amazonaws.rds#DBParameterGroupNotFoundFault":
       response = {
         ...(await deserializeAws_queryDBParameterGroupNotFoundFaultResponse(parsedOutput, context)),
@@ -10406,7 +10406,7 @@ const deserializeAws_queryModifyDBParameterGroupCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidDBParameterGroupState":
+    case "InvalidDBParameterGroupStateFault":
     case "com.amazonaws.rds#InvalidDBParameterGroupStateFault":
       response = {
         ...(await deserializeAws_queryInvalidDBParameterGroupStateFaultResponse(parsedOutput, context)),
@@ -10678,7 +10678,7 @@ const deserializeAws_queryModifyDBSnapshotCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "DBSnapshotNotFound":
+    case "DBSnapshotNotFoundFault":
     case "com.amazonaws.rds#DBSnapshotNotFoundFault":
       response = {
         ...(await deserializeAws_queryDBSnapshotNotFoundFaultResponse(parsedOutput, context)),
@@ -10732,7 +10732,7 @@ const deserializeAws_queryModifyDBSnapshotAttributeCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "DBSnapshotNotFound":
+    case "DBSnapshotNotFoundFault":
     case "com.amazonaws.rds#DBSnapshotNotFoundFault":
       response = {
         ...(await deserializeAws_queryDBSnapshotNotFoundFaultResponse(parsedOutput, context)),
@@ -10740,7 +10740,7 @@ const deserializeAws_queryModifyDBSnapshotAttributeCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidDBSnapshotState":
+    case "InvalidDBSnapshotStateFault":
     case "com.amazonaws.rds#InvalidDBSnapshotStateFault":
       response = {
         ...(await deserializeAws_queryInvalidDBSnapshotStateFaultResponse(parsedOutput, context)),
@@ -10748,7 +10748,7 @@ const deserializeAws_queryModifyDBSnapshotAttributeCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "SharedSnapshotQuotaExceeded":
+    case "SharedSnapshotQuotaExceededFault":
     case "com.amazonaws.rds#SharedSnapshotQuotaExceededFault":
       response = {
         ...(await deserializeAws_querySharedSnapshotQuotaExceededFaultResponse(parsedOutput, context)),
@@ -10888,7 +10888,7 @@ const deserializeAws_queryModifyEventSubscriptionCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "EventSubscriptionQuotaExceeded":
+    case "EventSubscriptionQuotaExceededFault":
     case "com.amazonaws.rds#EventSubscriptionQuotaExceededFault":
       response = {
         ...(await deserializeAws_queryEventSubscriptionQuotaExceededFaultResponse(parsedOutput, context)),
@@ -10896,7 +10896,7 @@ const deserializeAws_queryModifyEventSubscriptionCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "SNSInvalidTopic":
+    case "SNSInvalidTopicFault":
     case "com.amazonaws.rds#SNSInvalidTopicFault":
       response = {
         ...(await deserializeAws_querySNSInvalidTopicFaultResponse(parsedOutput, context)),
@@ -10904,7 +10904,7 @@ const deserializeAws_queryModifyEventSubscriptionCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "SNSNoAuthorization":
+    case "SNSNoAuthorizationFault":
     case "com.amazonaws.rds#SNSNoAuthorizationFault":
       response = {
         ...(await deserializeAws_querySNSNoAuthorizationFaultResponse(parsedOutput, context)),
@@ -10912,7 +10912,7 @@ const deserializeAws_queryModifyEventSubscriptionCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "SNSTopicArnNotFound":
+    case "SNSTopicArnNotFoundFault":
     case "com.amazonaws.rds#SNSTopicArnNotFoundFault":
       response = {
         ...(await deserializeAws_querySNSTopicArnNotFoundFaultResponse(parsedOutput, context)),
@@ -10920,7 +10920,7 @@ const deserializeAws_queryModifyEventSubscriptionCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "SubscriptionCategoryNotFound":
+    case "SubscriptionCategoryNotFoundFault":
     case "com.amazonaws.rds#SubscriptionCategoryNotFoundFault":
       response = {
         ...(await deserializeAws_querySubscriptionCategoryNotFoundFaultResponse(parsedOutput, context)),
@@ -10928,7 +10928,7 @@ const deserializeAws_queryModifyEventSubscriptionCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "SubscriptionNotFound":
+    case "SubscriptionNotFoundFault":
     case "com.amazonaws.rds#SubscriptionNotFoundFault":
       response = {
         ...(await deserializeAws_querySubscriptionNotFoundFaultResponse(parsedOutput, context)),
@@ -10998,7 +10998,7 @@ const deserializeAws_queryModifyGlobalClusterCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidDBInstanceState":
+    case "InvalidDBInstanceStateFault":
     case "com.amazonaws.rds#InvalidDBInstanceStateFault":
       response = {
         ...(await deserializeAws_queryInvalidDBInstanceStateFaultResponse(parsedOutput, context)),
@@ -11122,7 +11122,7 @@ const deserializeAws_queryPromoteReadReplicaCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "DBInstanceNotFound":
+    case "DBInstanceNotFoundFault":
     case "com.amazonaws.rds#DBInstanceNotFoundFault":
       response = {
         ...(await deserializeAws_queryDBInstanceNotFoundFaultResponse(parsedOutput, context)),
@@ -11130,7 +11130,7 @@ const deserializeAws_queryPromoteReadReplicaCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidDBInstanceState":
+    case "InvalidDBInstanceStateFault":
     case "com.amazonaws.rds#InvalidDBInstanceStateFault":
       response = {
         ...(await deserializeAws_queryInvalidDBInstanceStateFaultResponse(parsedOutput, context)),
@@ -11249,7 +11249,7 @@ const deserializeAws_queryPurchaseReservedDBInstancesOfferingCommandError = asyn
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "ReservedDBInstanceAlreadyExists":
+    case "ReservedDBInstanceAlreadyExistsFault":
     case "com.amazonaws.rds#ReservedDBInstanceAlreadyExistsFault":
       response = {
         ...(await deserializeAws_queryReservedDBInstanceAlreadyExistsFaultResponse(parsedOutput, context)),
@@ -11257,7 +11257,7 @@ const deserializeAws_queryPurchaseReservedDBInstancesOfferingCommandError = asyn
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ReservedDBInstanceQuotaExceeded":
+    case "ReservedDBInstanceQuotaExceededFault":
     case "com.amazonaws.rds#ReservedDBInstanceQuotaExceededFault":
       response = {
         ...(await deserializeAws_queryReservedDBInstanceQuotaExceededFaultResponse(parsedOutput, context)),
@@ -11265,7 +11265,7 @@ const deserializeAws_queryPurchaseReservedDBInstancesOfferingCommandError = asyn
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ReservedDBInstancesOfferingNotFound":
+    case "ReservedDBInstancesOfferingNotFoundFault":
     case "com.amazonaws.rds#ReservedDBInstancesOfferingNotFoundFault":
       response = {
         ...(await deserializeAws_queryReservedDBInstancesOfferingNotFoundFaultResponse(parsedOutput, context)),
@@ -11335,7 +11335,7 @@ const deserializeAws_queryRebootDBClusterCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidDBInstanceState":
+    case "InvalidDBInstanceStateFault":
     case "com.amazonaws.rds#InvalidDBInstanceStateFault":
       response = {
         ...(await deserializeAws_queryInvalidDBInstanceStateFaultResponse(parsedOutput, context)),
@@ -11389,7 +11389,7 @@ const deserializeAws_queryRebootDBInstanceCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "DBInstanceNotFound":
+    case "DBInstanceNotFoundFault":
     case "com.amazonaws.rds#DBInstanceNotFoundFault":
       response = {
         ...(await deserializeAws_queryDBInstanceNotFoundFaultResponse(parsedOutput, context)),
@@ -11397,7 +11397,7 @@ const deserializeAws_queryRebootDBInstanceCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidDBInstanceState":
+    case "InvalidDBInstanceStateFault":
     case "com.amazonaws.rds#InvalidDBInstanceStateFault":
       response = {
         ...(await deserializeAws_queryInvalidDBInstanceStateFaultResponse(parsedOutput, context)),
@@ -11459,7 +11459,7 @@ const deserializeAws_queryRegisterDBProxyTargetsCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "DBInstanceNotFound":
+    case "DBInstanceNotFoundFault":
     case "com.amazonaws.rds#DBInstanceNotFoundFault":
       response = {
         ...(await deserializeAws_queryDBInstanceNotFoundFaultResponse(parsedOutput, context)),
@@ -11507,7 +11507,7 @@ const deserializeAws_queryRegisterDBProxyTargetsCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidDBInstanceState":
+    case "InvalidDBInstanceStateFault":
     case "com.amazonaws.rds#InvalidDBInstanceStateFault":
       response = {
         ...(await deserializeAws_queryInvalidDBInstanceStateFaultResponse(parsedOutput, context)),
@@ -11644,7 +11644,7 @@ const deserializeAws_queryRemoveRoleFromDBClusterCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "DBClusterRoleNotFound":
+    case "DBClusterRoleNotFoundFault":
     case "com.amazonaws.rds#DBClusterRoleNotFoundFault":
       response = {
         ...(await deserializeAws_queryDBClusterRoleNotFoundFaultResponse(parsedOutput, context)),
@@ -11703,7 +11703,7 @@ const deserializeAws_queryRemoveRoleFromDBInstanceCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "DBInstanceNotFound":
+    case "DBInstanceNotFoundFault":
     case "com.amazonaws.rds#DBInstanceNotFoundFault":
       response = {
         ...(await deserializeAws_queryDBInstanceNotFoundFaultResponse(parsedOutput, context)),
@@ -11711,7 +11711,7 @@ const deserializeAws_queryRemoveRoleFromDBInstanceCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "DBInstanceRoleNotFound":
+    case "DBInstanceRoleNotFoundFault":
     case "com.amazonaws.rds#DBInstanceRoleNotFoundFault":
       response = {
         ...(await deserializeAws_queryDBInstanceRoleNotFoundFaultResponse(parsedOutput, context)),
@@ -11719,7 +11719,7 @@ const deserializeAws_queryRemoveRoleFromDBInstanceCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidDBInstanceState":
+    case "InvalidDBInstanceStateFault":
     case "com.amazonaws.rds#InvalidDBInstanceStateFault":
       response = {
         ...(await deserializeAws_queryInvalidDBInstanceStateFaultResponse(parsedOutput, context)),
@@ -11776,7 +11776,7 @@ const deserializeAws_queryRemoveSourceIdentifierFromSubscriptionCommandError = a
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "SourceNotFound":
+    case "SourceNotFoundFault":
     case "com.amazonaws.rds#SourceNotFoundFault":
       response = {
         ...(await deserializeAws_querySourceNotFoundFaultResponse(parsedOutput, context)),
@@ -11784,7 +11784,7 @@ const deserializeAws_queryRemoveSourceIdentifierFromSubscriptionCommandError = a
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "SubscriptionNotFound":
+    case "SubscriptionNotFoundFault":
     case "com.amazonaws.rds#SubscriptionNotFoundFault":
       response = {
         ...(await deserializeAws_querySubscriptionNotFoundFaultResponse(parsedOutput, context)),
@@ -11843,7 +11843,7 @@ const deserializeAws_queryRemoveTagsFromResourceCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "DBInstanceNotFound":
+    case "DBInstanceNotFoundFault":
     case "com.amazonaws.rds#DBInstanceNotFoundFault":
       response = {
         ...(await deserializeAws_queryDBInstanceNotFoundFaultResponse(parsedOutput, context)),
@@ -11867,7 +11867,7 @@ const deserializeAws_queryRemoveTagsFromResourceCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "DBSnapshotNotFound":
+    case "DBSnapshotNotFoundFault":
     case "com.amazonaws.rds#DBSnapshotNotFoundFault":
       response = {
         ...(await deserializeAws_queryDBSnapshotNotFoundFaultResponse(parsedOutput, context)),
@@ -11921,7 +11921,7 @@ const deserializeAws_queryResetDBClusterParameterGroupCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "DBParameterGroupNotFound":
+    case "DBParameterGroupNotFoundFault":
     case "com.amazonaws.rds#DBParameterGroupNotFoundFault":
       response = {
         ...(await deserializeAws_queryDBParameterGroupNotFoundFaultResponse(parsedOutput, context)),
@@ -11929,7 +11929,7 @@ const deserializeAws_queryResetDBClusterParameterGroupCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidDBParameterGroupState":
+    case "InvalidDBParameterGroupStateFault":
     case "com.amazonaws.rds#InvalidDBParameterGroupStateFault":
       response = {
         ...(await deserializeAws_queryInvalidDBParameterGroupStateFaultResponse(parsedOutput, context)),
@@ -11983,7 +11983,7 @@ const deserializeAws_queryResetDBParameterGroupCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "DBParameterGroupNotFound":
+    case "DBParameterGroupNotFoundFault":
     case "com.amazonaws.rds#DBParameterGroupNotFoundFault":
       response = {
         ...(await deserializeAws_queryDBParameterGroupNotFoundFaultResponse(parsedOutput, context)),
@@ -11991,7 +11991,7 @@ const deserializeAws_queryResetDBParameterGroupCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidDBParameterGroupState":
+    case "InvalidDBParameterGroupStateFault":
     case "com.amazonaws.rds#InvalidDBParameterGroupStateFault":
       response = {
         ...(await deserializeAws_queryInvalidDBParameterGroupStateFaultResponse(parsedOutput, context)),
@@ -12061,7 +12061,7 @@ const deserializeAws_queryRestoreDBClusterFromS3CommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "DBClusterParameterGroupNotFound":
+    case "DBClusterParameterGroupNotFoundFault":
     case "com.amazonaws.rds#DBClusterParameterGroupNotFoundFault":
       response = {
         ...(await deserializeAws_queryDBClusterParameterGroupNotFoundFaultResponse(parsedOutput, context)),
@@ -12093,7 +12093,7 @@ const deserializeAws_queryRestoreDBClusterFromS3CommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InsufficientStorageClusterCapacity":
+    case "InsufficientStorageClusterCapacityFault":
     case "com.amazonaws.rds#InsufficientStorageClusterCapacityFault":
       response = {
         ...(await deserializeAws_queryInsufficientStorageClusterCapacityFaultResponse(parsedOutput, context)),
@@ -12149,7 +12149,7 @@ const deserializeAws_queryRestoreDBClusterFromS3CommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "StorageQuotaExceeded":
+    case "StorageQuotaExceededFault":
     case "com.amazonaws.rds#StorageQuotaExceededFault":
       response = {
         ...(await deserializeAws_queryStorageQuotaExceededFaultResponse(parsedOutput, context)),
@@ -12211,7 +12211,7 @@ const deserializeAws_queryRestoreDBClusterFromSnapshotCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "DBClusterParameterGroupNotFound":
+    case "DBClusterParameterGroupNotFoundFault":
     case "com.amazonaws.rds#DBClusterParameterGroupNotFoundFault":
       response = {
         ...(await deserializeAws_queryDBClusterParameterGroupNotFoundFaultResponse(parsedOutput, context)),
@@ -12235,7 +12235,7 @@ const deserializeAws_queryRestoreDBClusterFromSnapshotCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "DBSnapshotNotFound":
+    case "DBSnapshotNotFoundFault":
     case "com.amazonaws.rds#DBSnapshotNotFoundFault":
       response = {
         ...(await deserializeAws_queryDBSnapshotNotFoundFaultResponse(parsedOutput, context)),
@@ -12267,7 +12267,7 @@ const deserializeAws_queryRestoreDBClusterFromSnapshotCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InsufficientStorageClusterCapacity":
+    case "InsufficientStorageClusterCapacityFault":
     case "com.amazonaws.rds#InsufficientStorageClusterCapacityFault":
       response = {
         ...(await deserializeAws_queryInsufficientStorageClusterCapacityFaultResponse(parsedOutput, context)),
@@ -12283,7 +12283,7 @@ const deserializeAws_queryRestoreDBClusterFromSnapshotCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidDBSnapshotState":
+    case "InvalidDBSnapshotStateFault":
     case "com.amazonaws.rds#InvalidDBSnapshotStateFault":
       response = {
         ...(await deserializeAws_queryInvalidDBSnapshotStateFaultResponse(parsedOutput, context)),
@@ -12331,7 +12331,7 @@ const deserializeAws_queryRestoreDBClusterFromSnapshotCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "StorageQuotaExceeded":
+    case "StorageQuotaExceededFault":
     case "com.amazonaws.rds#StorageQuotaExceededFault":
       response = {
         ...(await deserializeAws_queryStorageQuotaExceededFaultResponse(parsedOutput, context)),
@@ -12401,7 +12401,7 @@ const deserializeAws_queryRestoreDBClusterToPointInTimeCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "DBClusterParameterGroupNotFound":
+    case "DBClusterParameterGroupNotFoundFault":
     case "com.amazonaws.rds#DBClusterParameterGroupNotFoundFault":
       response = {
         ...(await deserializeAws_queryDBClusterParameterGroupNotFoundFaultResponse(parsedOutput, context)),
@@ -12449,7 +12449,7 @@ const deserializeAws_queryRestoreDBClusterToPointInTimeCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InsufficientStorageClusterCapacity":
+    case "InsufficientStorageClusterCapacityFault":
     case "com.amazonaws.rds#InsufficientStorageClusterCapacityFault":
       response = {
         ...(await deserializeAws_queryInsufficientStorageClusterCapacityFaultResponse(parsedOutput, context)),
@@ -12473,7 +12473,7 @@ const deserializeAws_queryRestoreDBClusterToPointInTimeCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidDBSnapshotState":
+    case "InvalidDBSnapshotStateFault":
     case "com.amazonaws.rds#InvalidDBSnapshotStateFault":
       response = {
         ...(await deserializeAws_queryInvalidDBSnapshotStateFaultResponse(parsedOutput, context)),
@@ -12521,7 +12521,7 @@ const deserializeAws_queryRestoreDBClusterToPointInTimeCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "StorageQuotaExceeded":
+    case "StorageQuotaExceededFault":
     case "com.amazonaws.rds#StorageQuotaExceededFault":
       response = {
         ...(await deserializeAws_queryStorageQuotaExceededFaultResponse(parsedOutput, context)),
@@ -12578,7 +12578,7 @@ const deserializeAws_queryRestoreDBInstanceFromDBSnapshotCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "AuthorizationNotFound":
+    case "AuthorizationNotFoundFault":
     case "com.amazonaws.rds#AuthorizationNotFoundFault":
       response = {
         ...(await deserializeAws_queryAuthorizationNotFoundFaultResponse(parsedOutput, context)),
@@ -12594,7 +12594,7 @@ const deserializeAws_queryRestoreDBInstanceFromDBSnapshotCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "DBInstanceAlreadyExists":
+    case "DBInstanceAlreadyExistsFault":
     case "com.amazonaws.rds#DBInstanceAlreadyExistsFault":
       response = {
         ...(await deserializeAws_queryDBInstanceAlreadyExistsFaultResponse(parsedOutput, context)),
@@ -12602,7 +12602,7 @@ const deserializeAws_queryRestoreDBInstanceFromDBSnapshotCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "DBParameterGroupNotFound":
+    case "DBParameterGroupNotFoundFault":
     case "com.amazonaws.rds#DBParameterGroupNotFoundFault":
       response = {
         ...(await deserializeAws_queryDBParameterGroupNotFoundFaultResponse(parsedOutput, context)),
@@ -12610,7 +12610,7 @@ const deserializeAws_queryRestoreDBInstanceFromDBSnapshotCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "DBSecurityGroupNotFound":
+    case "DBSecurityGroupNotFoundFault":
     case "com.amazonaws.rds#DBSecurityGroupNotFoundFault":
       response = {
         ...(await deserializeAws_queryDBSecurityGroupNotFoundFaultResponse(parsedOutput, context)),
@@ -12618,7 +12618,7 @@ const deserializeAws_queryRestoreDBInstanceFromDBSnapshotCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "DBSnapshotNotFound":
+    case "DBSnapshotNotFoundFault":
     case "com.amazonaws.rds#DBSnapshotNotFoundFault":
       response = {
         ...(await deserializeAws_queryDBSnapshotNotFoundFaultResponse(parsedOutput, context)),
@@ -12650,7 +12650,7 @@ const deserializeAws_queryRestoreDBInstanceFromDBSnapshotCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InstanceQuotaExceeded":
+    case "InstanceQuotaExceededFault":
     case "com.amazonaws.rds#InstanceQuotaExceededFault":
       response = {
         ...(await deserializeAws_queryInstanceQuotaExceededFaultResponse(parsedOutput, context)),
@@ -12658,7 +12658,7 @@ const deserializeAws_queryRestoreDBInstanceFromDBSnapshotCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InsufficientDBInstanceCapacity":
+    case "InsufficientDBInstanceCapacityFault":
     case "com.amazonaws.rds#InsufficientDBInstanceCapacityFault":
       response = {
         ...(await deserializeAws_queryInsufficientDBInstanceCapacityFaultResponse(parsedOutput, context)),
@@ -12666,7 +12666,7 @@ const deserializeAws_queryRestoreDBInstanceFromDBSnapshotCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidDBSnapshotState":
+    case "InvalidDBSnapshotStateFault":
     case "com.amazonaws.rds#InvalidDBSnapshotStateFault":
       response = {
         ...(await deserializeAws_queryInvalidDBSnapshotStateFaultResponse(parsedOutput, context)),
@@ -12722,7 +12722,7 @@ const deserializeAws_queryRestoreDBInstanceFromDBSnapshotCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "StorageQuotaExceeded":
+    case "StorageQuotaExceededFault":
     case "com.amazonaws.rds#StorageQuotaExceededFault":
       response = {
         ...(await deserializeAws_queryStorageQuotaExceededFaultResponse(parsedOutput, context)),
@@ -12730,7 +12730,7 @@ const deserializeAws_queryRestoreDBInstanceFromDBSnapshotCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "StorageTypeNotSupported":
+    case "StorageTypeNotSupportedFault":
     case "com.amazonaws.rds#StorageTypeNotSupportedFault":
       response = {
         ...(await deserializeAws_queryStorageTypeNotSupportedFaultResponse(parsedOutput, context)),
@@ -12784,7 +12784,7 @@ const deserializeAws_queryRestoreDBInstanceFromS3CommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "AuthorizationNotFound":
+    case "AuthorizationNotFoundFault":
     case "com.amazonaws.rds#AuthorizationNotFoundFault":
       response = {
         ...(await deserializeAws_queryAuthorizationNotFoundFaultResponse(parsedOutput, context)),
@@ -12800,7 +12800,7 @@ const deserializeAws_queryRestoreDBInstanceFromS3CommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "DBInstanceAlreadyExists":
+    case "DBInstanceAlreadyExistsFault":
     case "com.amazonaws.rds#DBInstanceAlreadyExistsFault":
       response = {
         ...(await deserializeAws_queryDBInstanceAlreadyExistsFaultResponse(parsedOutput, context)),
@@ -12808,7 +12808,7 @@ const deserializeAws_queryRestoreDBInstanceFromS3CommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "DBParameterGroupNotFound":
+    case "DBParameterGroupNotFoundFault":
     case "com.amazonaws.rds#DBParameterGroupNotFoundFault":
       response = {
         ...(await deserializeAws_queryDBParameterGroupNotFoundFaultResponse(parsedOutput, context)),
@@ -12816,7 +12816,7 @@ const deserializeAws_queryRestoreDBInstanceFromS3CommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "DBSecurityGroupNotFound":
+    case "DBSecurityGroupNotFoundFault":
     case "com.amazonaws.rds#DBSecurityGroupNotFoundFault":
       response = {
         ...(await deserializeAws_queryDBSecurityGroupNotFoundFaultResponse(parsedOutput, context)),
@@ -12840,7 +12840,7 @@ const deserializeAws_queryRestoreDBInstanceFromS3CommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InstanceQuotaExceeded":
+    case "InstanceQuotaExceededFault":
     case "com.amazonaws.rds#InstanceQuotaExceededFault":
       response = {
         ...(await deserializeAws_queryInstanceQuotaExceededFaultResponse(parsedOutput, context)),
@@ -12848,7 +12848,7 @@ const deserializeAws_queryRestoreDBInstanceFromS3CommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InsufficientDBInstanceCapacity":
+    case "InsufficientDBInstanceCapacityFault":
     case "com.amazonaws.rds#InsufficientDBInstanceCapacityFault":
       response = {
         ...(await deserializeAws_queryInsufficientDBInstanceCapacityFaultResponse(parsedOutput, context)),
@@ -12904,7 +12904,7 @@ const deserializeAws_queryRestoreDBInstanceFromS3CommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "StorageQuotaExceeded":
+    case "StorageQuotaExceededFault":
     case "com.amazonaws.rds#StorageQuotaExceededFault":
       response = {
         ...(await deserializeAws_queryStorageQuotaExceededFaultResponse(parsedOutput, context)),
@@ -12912,7 +12912,7 @@ const deserializeAws_queryRestoreDBInstanceFromS3CommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "StorageTypeNotSupported":
+    case "StorageTypeNotSupportedFault":
     case "com.amazonaws.rds#StorageTypeNotSupportedFault":
       response = {
         ...(await deserializeAws_queryStorageTypeNotSupportedFaultResponse(parsedOutput, context)),
@@ -12969,7 +12969,7 @@ const deserializeAws_queryRestoreDBInstanceToPointInTimeCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "AuthorizationNotFound":
+    case "AuthorizationNotFoundFault":
     case "com.amazonaws.rds#AuthorizationNotFoundFault":
       response = {
         ...(await deserializeAws_queryAuthorizationNotFoundFaultResponse(parsedOutput, context)),
@@ -12985,7 +12985,7 @@ const deserializeAws_queryRestoreDBInstanceToPointInTimeCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "DBInstanceAlreadyExists":
+    case "DBInstanceAlreadyExistsFault":
     case "com.amazonaws.rds#DBInstanceAlreadyExistsFault":
       response = {
         ...(await deserializeAws_queryDBInstanceAlreadyExistsFaultResponse(parsedOutput, context)),
@@ -12993,7 +12993,7 @@ const deserializeAws_queryRestoreDBInstanceToPointInTimeCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "DBInstanceAutomatedBackupNotFound":
+    case "DBInstanceAutomatedBackupNotFoundFault":
     case "com.amazonaws.rds#DBInstanceAutomatedBackupNotFoundFault":
       response = {
         ...(await deserializeAws_queryDBInstanceAutomatedBackupNotFoundFaultResponse(parsedOutput, context)),
@@ -13001,7 +13001,7 @@ const deserializeAws_queryRestoreDBInstanceToPointInTimeCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "DBInstanceNotFound":
+    case "DBInstanceNotFoundFault":
     case "com.amazonaws.rds#DBInstanceNotFoundFault":
       response = {
         ...(await deserializeAws_queryDBInstanceNotFoundFaultResponse(parsedOutput, context)),
@@ -13009,7 +13009,7 @@ const deserializeAws_queryRestoreDBInstanceToPointInTimeCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "DBParameterGroupNotFound":
+    case "DBParameterGroupNotFoundFault":
     case "com.amazonaws.rds#DBParameterGroupNotFoundFault":
       response = {
         ...(await deserializeAws_queryDBParameterGroupNotFoundFaultResponse(parsedOutput, context)),
@@ -13017,7 +13017,7 @@ const deserializeAws_queryRestoreDBInstanceToPointInTimeCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "DBSecurityGroupNotFound":
+    case "DBSecurityGroupNotFoundFault":
     case "com.amazonaws.rds#DBSecurityGroupNotFoundFault":
       response = {
         ...(await deserializeAws_queryDBSecurityGroupNotFoundFaultResponse(parsedOutput, context)),
@@ -13049,7 +13049,7 @@ const deserializeAws_queryRestoreDBInstanceToPointInTimeCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InstanceQuotaExceeded":
+    case "InstanceQuotaExceededFault":
     case "com.amazonaws.rds#InstanceQuotaExceededFault":
       response = {
         ...(await deserializeAws_queryInstanceQuotaExceededFaultResponse(parsedOutput, context)),
@@ -13057,7 +13057,7 @@ const deserializeAws_queryRestoreDBInstanceToPointInTimeCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InsufficientDBInstanceCapacity":
+    case "InsufficientDBInstanceCapacityFault":
     case "com.amazonaws.rds#InsufficientDBInstanceCapacityFault":
       response = {
         ...(await deserializeAws_queryInsufficientDBInstanceCapacityFaultResponse(parsedOutput, context)),
@@ -13065,7 +13065,7 @@ const deserializeAws_queryRestoreDBInstanceToPointInTimeCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidDBInstanceState":
+    case "InvalidDBInstanceStateFault":
     case "com.amazonaws.rds#InvalidDBInstanceStateFault":
       response = {
         ...(await deserializeAws_queryInvalidDBInstanceStateFaultResponse(parsedOutput, context)),
@@ -13113,7 +13113,7 @@ const deserializeAws_queryRestoreDBInstanceToPointInTimeCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "PointInTimeRestoreNotEnabled":
+    case "PointInTimeRestoreNotEnabledFault":
     case "com.amazonaws.rds#PointInTimeRestoreNotEnabledFault":
       response = {
         ...(await deserializeAws_queryPointInTimeRestoreNotEnabledFaultResponse(parsedOutput, context)),
@@ -13129,7 +13129,7 @@ const deserializeAws_queryRestoreDBInstanceToPointInTimeCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "StorageQuotaExceeded":
+    case "StorageQuotaExceededFault":
     case "com.amazonaws.rds#StorageQuotaExceededFault":
       response = {
         ...(await deserializeAws_queryStorageQuotaExceededFaultResponse(parsedOutput, context)),
@@ -13137,7 +13137,7 @@ const deserializeAws_queryRestoreDBInstanceToPointInTimeCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "StorageTypeNotSupported":
+    case "StorageTypeNotSupportedFault":
     case "com.amazonaws.rds#StorageTypeNotSupportedFault":
       response = {
         ...(await deserializeAws_queryStorageTypeNotSupportedFaultResponse(parsedOutput, context)),
@@ -13191,7 +13191,7 @@ const deserializeAws_queryRevokeDBSecurityGroupIngressCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "AuthorizationNotFound":
+    case "AuthorizationNotFoundFault":
     case "com.amazonaws.rds#AuthorizationNotFoundFault":
       response = {
         ...(await deserializeAws_queryAuthorizationNotFoundFaultResponse(parsedOutput, context)),
@@ -13199,7 +13199,7 @@ const deserializeAws_queryRevokeDBSecurityGroupIngressCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "DBSecurityGroupNotFound":
+    case "DBSecurityGroupNotFoundFault":
     case "com.amazonaws.rds#DBSecurityGroupNotFoundFault":
       response = {
         ...(await deserializeAws_queryDBSecurityGroupNotFoundFaultResponse(parsedOutput, context)),
@@ -13207,7 +13207,7 @@ const deserializeAws_queryRevokeDBSecurityGroupIngressCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidDBSecurityGroupState":
+    case "InvalidDBSecurityGroupStateFault":
     case "com.amazonaws.rds#InvalidDBSecurityGroupStateFault":
       response = {
         ...(await deserializeAws_queryInvalidDBSecurityGroupStateFaultResponse(parsedOutput, context)),
@@ -13269,7 +13269,7 @@ const deserializeAws_queryStartActivityStreamCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "DBInstanceNotFound":
+    case "DBInstanceNotFoundFault":
     case "com.amazonaws.rds#DBInstanceNotFoundFault":
       response = {
         ...(await deserializeAws_queryDBInstanceNotFoundFaultResponse(parsedOutput, context)),
@@ -13285,7 +13285,7 @@ const deserializeAws_queryStartActivityStreamCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidDBInstanceState":
+    case "InvalidDBInstanceStateFault":
     case "com.amazonaws.rds#InvalidDBInstanceStateFault":
       response = {
         ...(await deserializeAws_queryInvalidDBInstanceStateFaultResponse(parsedOutput, context)),
@@ -13371,7 +13371,7 @@ const deserializeAws_queryStartDBClusterCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidDBInstanceState":
+    case "InvalidDBInstanceStateFault":
     case "com.amazonaws.rds#InvalidDBInstanceStateFault":
       response = {
         ...(await deserializeAws_queryInvalidDBInstanceStateFaultResponse(parsedOutput, context)),
@@ -13425,7 +13425,7 @@ const deserializeAws_queryStartDBInstanceCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "AuthorizationNotFound":
+    case "AuthorizationNotFoundFault":
     case "com.amazonaws.rds#AuthorizationNotFoundFault":
       response = {
         ...(await deserializeAws_queryAuthorizationNotFoundFaultResponse(parsedOutput, context)),
@@ -13441,7 +13441,7 @@ const deserializeAws_queryStartDBInstanceCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "DBInstanceNotFound":
+    case "DBInstanceNotFoundFault":
     case "com.amazonaws.rds#DBInstanceNotFoundFault":
       response = {
         ...(await deserializeAws_queryDBInstanceNotFoundFaultResponse(parsedOutput, context)),
@@ -13465,7 +13465,7 @@ const deserializeAws_queryStartDBInstanceCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InsufficientDBInstanceCapacity":
+    case "InsufficientDBInstanceCapacityFault":
     case "com.amazonaws.rds#InsufficientDBInstanceCapacityFault":
       response = {
         ...(await deserializeAws_queryInsufficientDBInstanceCapacityFaultResponse(parsedOutput, context)),
@@ -13481,7 +13481,7 @@ const deserializeAws_queryStartDBInstanceCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidDBInstanceState":
+    case "InvalidDBInstanceStateFault":
     case "com.amazonaws.rds#InvalidDBInstanceStateFault":
       response = {
         ...(await deserializeAws_queryInvalidDBInstanceStateFaultResponse(parsedOutput, context)),
@@ -13562,7 +13562,7 @@ const deserializeAws_queryStartDBInstanceAutomatedBackupsReplicationCommandError
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "DBInstanceAutomatedBackupQuotaExceeded":
+    case "DBInstanceAutomatedBackupQuotaExceededFault":
     case "com.amazonaws.rds#DBInstanceAutomatedBackupQuotaExceededFault":
       response = {
         ...(await deserializeAws_queryDBInstanceAutomatedBackupQuotaExceededFaultResponse(parsedOutput, context)),
@@ -13570,7 +13570,7 @@ const deserializeAws_queryStartDBInstanceAutomatedBackupsReplicationCommandError
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "DBInstanceNotFound":
+    case "DBInstanceNotFoundFault":
     case "com.amazonaws.rds#DBInstanceNotFoundFault":
       response = {
         ...(await deserializeAws_queryDBInstanceNotFoundFaultResponse(parsedOutput, context)),
@@ -13578,7 +13578,7 @@ const deserializeAws_queryStartDBInstanceAutomatedBackupsReplicationCommandError
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidDBInstanceState":
+    case "InvalidDBInstanceStateFault":
     case "com.amazonaws.rds#InvalidDBInstanceStateFault":
       response = {
         ...(await deserializeAws_queryInvalidDBInstanceStateFaultResponse(parsedOutput, context)),
@@ -13594,7 +13594,7 @@ const deserializeAws_queryStartDBInstanceAutomatedBackupsReplicationCommandError
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "StorageTypeNotSupported":
+    case "StorageTypeNotSupportedFault":
     case "com.amazonaws.rds#StorageTypeNotSupportedFault":
       response = {
         ...(await deserializeAws_queryStorageTypeNotSupportedFaultResponse(parsedOutput, context)),
@@ -13656,7 +13656,7 @@ const deserializeAws_queryStartExportTaskCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "DBSnapshotNotFound":
+    case "DBSnapshotNotFoundFault":
     case "com.amazonaws.rds#DBSnapshotNotFoundFault":
       response = {
         ...(await deserializeAws_queryDBSnapshotNotFoundFaultResponse(parsedOutput, context)),
@@ -13664,7 +13664,7 @@ const deserializeAws_queryStartExportTaskCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ExportTaskAlreadyExists":
+    case "ExportTaskAlreadyExistsFault":
     case "com.amazonaws.rds#ExportTaskAlreadyExistsFault":
       response = {
         ...(await deserializeAws_queryExportTaskAlreadyExistsFaultResponse(parsedOutput, context)),
@@ -13672,7 +13672,7 @@ const deserializeAws_queryStartExportTaskCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "IamRoleMissingPermissions":
+    case "IamRoleMissingPermissionsFault":
     case "com.amazonaws.rds#IamRoleMissingPermissionsFault":
       response = {
         ...(await deserializeAws_queryIamRoleMissingPermissionsFaultResponse(parsedOutput, context)),
@@ -13680,7 +13680,7 @@ const deserializeAws_queryStartExportTaskCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "IamRoleNotFound":
+    case "IamRoleNotFoundFault":
     case "com.amazonaws.rds#IamRoleNotFoundFault":
       response = {
         ...(await deserializeAws_queryIamRoleNotFoundFaultResponse(parsedOutput, context)),
@@ -13688,7 +13688,7 @@ const deserializeAws_queryStartExportTaskCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidExportOnly":
+    case "InvalidExportOnlyFault":
     case "com.amazonaws.rds#InvalidExportOnlyFault":
       response = {
         ...(await deserializeAws_queryInvalidExportOnlyFaultResponse(parsedOutput, context)),
@@ -13696,7 +13696,7 @@ const deserializeAws_queryStartExportTaskCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidExportSourceState":
+    case "InvalidExportSourceStateFault":
     case "com.amazonaws.rds#InvalidExportSourceStateFault":
       response = {
         ...(await deserializeAws_queryInvalidExportSourceStateFaultResponse(parsedOutput, context)),
@@ -13774,7 +13774,7 @@ const deserializeAws_queryStopActivityStreamCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "DBInstanceNotFound":
+    case "DBInstanceNotFoundFault":
     case "com.amazonaws.rds#DBInstanceNotFoundFault":
       response = {
         ...(await deserializeAws_queryDBInstanceNotFoundFaultResponse(parsedOutput, context)),
@@ -13790,7 +13790,7 @@ const deserializeAws_queryStopActivityStreamCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidDBInstanceState":
+    case "InvalidDBInstanceStateFault":
     case "com.amazonaws.rds#InvalidDBInstanceStateFault":
       response = {
         ...(await deserializeAws_queryInvalidDBInstanceStateFaultResponse(parsedOutput, context)),
@@ -13868,7 +13868,7 @@ const deserializeAws_queryStopDBClusterCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidDBInstanceState":
+    case "InvalidDBInstanceStateFault":
     case "com.amazonaws.rds#InvalidDBInstanceStateFault":
       response = {
         ...(await deserializeAws_queryInvalidDBInstanceStateFaultResponse(parsedOutput, context)),
@@ -13922,7 +13922,7 @@ const deserializeAws_queryStopDBInstanceCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "DBInstanceNotFound":
+    case "DBInstanceNotFoundFault":
     case "com.amazonaws.rds#DBInstanceNotFoundFault":
       response = {
         ...(await deserializeAws_queryDBInstanceNotFoundFaultResponse(parsedOutput, context)),
@@ -13930,7 +13930,7 @@ const deserializeAws_queryStopDBInstanceCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "DBSnapshotAlreadyExists":
+    case "DBSnapshotAlreadyExistsFault":
     case "com.amazonaws.rds#DBSnapshotAlreadyExistsFault":
       response = {
         ...(await deserializeAws_queryDBSnapshotAlreadyExistsFaultResponse(parsedOutput, context)),
@@ -13946,7 +13946,7 @@ const deserializeAws_queryStopDBInstanceCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidDBInstanceState":
+    case "InvalidDBInstanceStateFault":
     case "com.amazonaws.rds#InvalidDBInstanceStateFault":
       response = {
         ...(await deserializeAws_queryInvalidDBInstanceStateFaultResponse(parsedOutput, context)),
@@ -13954,7 +13954,7 @@ const deserializeAws_queryStopDBInstanceCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "SnapshotQuotaExceeded":
+    case "SnapshotQuotaExceededFault":
     case "com.amazonaws.rds#SnapshotQuotaExceededFault":
       response = {
         ...(await deserializeAws_querySnapshotQuotaExceededFaultResponse(parsedOutput, context)),
@@ -14011,7 +14011,7 @@ const deserializeAws_queryStopDBInstanceAutomatedBackupsReplicationCommandError 
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "DBInstanceNotFound":
+    case "DBInstanceNotFoundFault":
     case "com.amazonaws.rds#DBInstanceNotFoundFault":
       response = {
         ...(await deserializeAws_queryDBInstanceNotFoundFaultResponse(parsedOutput, context)),
@@ -14019,7 +14019,7 @@ const deserializeAws_queryStopDBInstanceAutomatedBackupsReplicationCommandError 
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidDBInstanceState":
+    case "InvalidDBInstanceStateFault":
     case "com.amazonaws.rds#InvalidDBInstanceStateFault":
       response = {
         ...(await deserializeAws_queryInvalidDBInstanceStateFaultResponse(parsedOutput, context)),

--- a/clients/client-redshift/src/protocols/Aws_query.ts
+++ b/clients/client-redshift/src/protocols/Aws_query.ts
@@ -2740,7 +2740,7 @@ const deserializeAws_queryAcceptReservedNodeExchangeCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidReservedNodeState":
+    case "InvalidReservedNodeStateFault":
     case "com.amazonaws.redshift#InvalidReservedNodeStateFault":
       response = {
         ...(await deserializeAws_queryInvalidReservedNodeStateFaultResponse(parsedOutput, context)),
@@ -2748,7 +2748,7 @@ const deserializeAws_queryAcceptReservedNodeExchangeCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ReservedNodeAlreadyExists":
+    case "ReservedNodeAlreadyExistsFault":
     case "com.amazonaws.redshift#ReservedNodeAlreadyExistsFault":
       response = {
         ...(await deserializeAws_queryReservedNodeAlreadyExistsFaultResponse(parsedOutput, context)),
@@ -2756,7 +2756,7 @@ const deserializeAws_queryAcceptReservedNodeExchangeCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ReservedNodeAlreadyMigrated":
+    case "ReservedNodeAlreadyMigratedFault":
     case "com.amazonaws.redshift#ReservedNodeAlreadyMigratedFault":
       response = {
         ...(await deserializeAws_queryReservedNodeAlreadyMigratedFaultResponse(parsedOutput, context)),
@@ -2764,7 +2764,7 @@ const deserializeAws_queryAcceptReservedNodeExchangeCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ReservedNodeNotFound":
+    case "ReservedNodeNotFoundFault":
     case "com.amazonaws.redshift#ReservedNodeNotFoundFault":
       response = {
         ...(await deserializeAws_queryReservedNodeNotFoundFaultResponse(parsedOutput, context)),
@@ -2772,7 +2772,7 @@ const deserializeAws_queryAcceptReservedNodeExchangeCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ReservedNodeOfferingNotFound":
+    case "ReservedNodeOfferingNotFoundFault":
     case "com.amazonaws.redshift#ReservedNodeOfferingNotFoundFault":
       response = {
         ...(await deserializeAws_queryReservedNodeOfferingNotFoundFaultResponse(parsedOutput, context)),
@@ -2780,7 +2780,7 @@ const deserializeAws_queryAcceptReservedNodeExchangeCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "UnsupportedOperation":
+    case "UnsupportedOperationFault":
     case "com.amazonaws.redshift#UnsupportedOperationFault":
       response = {
         ...(await deserializeAws_queryUnsupportedOperationFaultResponse(parsedOutput, context)),
@@ -2834,7 +2834,7 @@ const deserializeAws_queryAddPartnerCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "ClusterNotFound":
+    case "ClusterNotFoundFault":
     case "com.amazonaws.redshift#ClusterNotFoundFault":
       response = {
         ...(await deserializeAws_queryClusterNotFoundFaultResponse(parsedOutput, context)),
@@ -2842,7 +2842,7 @@ const deserializeAws_queryAddPartnerCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "PartnerNotFound":
+    case "PartnerNotFoundFault":
     case "com.amazonaws.redshift#PartnerNotFoundFault":
       response = {
         ...(await deserializeAws_queryPartnerNotFoundFaultResponse(parsedOutput, context)),
@@ -2850,7 +2850,7 @@ const deserializeAws_queryAddPartnerCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "UnauthorizedPartnerIntegration":
+    case "UnauthorizedPartnerIntegrationFault":
     case "com.amazonaws.redshift#UnauthorizedPartnerIntegrationFault":
       response = {
         ...(await deserializeAws_queryUnauthorizedPartnerIntegrationFaultResponse(parsedOutput, context)),
@@ -2969,7 +2969,7 @@ const deserializeAws_queryAuthorizeClusterSecurityGroupIngressCommandError = asy
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "AuthorizationAlreadyExists":
+    case "AuthorizationAlreadyExistsFault":
     case "com.amazonaws.redshift#AuthorizationAlreadyExistsFault":
       response = {
         ...(await deserializeAws_queryAuthorizationAlreadyExistsFaultResponse(parsedOutput, context)),
@@ -2977,7 +2977,7 @@ const deserializeAws_queryAuthorizeClusterSecurityGroupIngressCommandError = asy
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "AuthorizationQuotaExceeded":
+    case "AuthorizationQuotaExceededFault":
     case "com.amazonaws.redshift#AuthorizationQuotaExceededFault":
       response = {
         ...(await deserializeAws_queryAuthorizationQuotaExceededFaultResponse(parsedOutput, context)),
@@ -2985,7 +2985,7 @@ const deserializeAws_queryAuthorizeClusterSecurityGroupIngressCommandError = asy
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ClusterSecurityGroupNotFound":
+    case "ClusterSecurityGroupNotFoundFault":
     case "com.amazonaws.redshift#ClusterSecurityGroupNotFoundFault":
       response = {
         ...(await deserializeAws_queryClusterSecurityGroupNotFoundFaultResponse(parsedOutput, context)),
@@ -2993,7 +2993,7 @@ const deserializeAws_queryAuthorizeClusterSecurityGroupIngressCommandError = asy
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidClusterSecurityGroupState":
+    case "InvalidClusterSecurityGroupStateFault":
     case "com.amazonaws.redshift#InvalidClusterSecurityGroupStateFault":
       response = {
         ...(await deserializeAws_queryInvalidClusterSecurityGroupStateFaultResponse(parsedOutput, context)),
@@ -3101,7 +3101,7 @@ const deserializeAws_queryAuthorizeEndpointAccessCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "ClusterNotFound":
+    case "ClusterNotFoundFault":
     case "com.amazonaws.redshift#ClusterNotFoundFault":
       response = {
         ...(await deserializeAws_queryClusterNotFoundFaultResponse(parsedOutput, context)),
@@ -3109,7 +3109,7 @@ const deserializeAws_queryAuthorizeEndpointAccessCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "EndpointAuthorizationAlreadyExists":
+    case "EndpointAuthorizationAlreadyExistsFault":
     case "com.amazonaws.redshift#EndpointAuthorizationAlreadyExistsFault":
       response = {
         ...(await deserializeAws_queryEndpointAuthorizationAlreadyExistsFaultResponse(parsedOutput, context)),
@@ -3117,7 +3117,7 @@ const deserializeAws_queryAuthorizeEndpointAccessCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "EndpointAuthorizationsPerClusterLimitExceeded":
+    case "EndpointAuthorizationsPerClusterLimitExceededFault":
     case "com.amazonaws.redshift#EndpointAuthorizationsPerClusterLimitExceededFault":
       response = {
         ...(await deserializeAws_queryEndpointAuthorizationsPerClusterLimitExceededFaultResponse(
@@ -3128,7 +3128,7 @@ const deserializeAws_queryAuthorizeEndpointAccessCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidAuthorizationState":
+    case "InvalidAuthorizationStateFault":
     case "com.amazonaws.redshift#InvalidAuthorizationStateFault":
       response = {
         ...(await deserializeAws_queryInvalidAuthorizationStateFaultResponse(parsedOutput, context)),
@@ -3136,7 +3136,7 @@ const deserializeAws_queryAuthorizeEndpointAccessCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidClusterState":
+    case "InvalidClusterStateFault":
     case "com.amazonaws.redshift#InvalidClusterStateFault":
       response = {
         ...(await deserializeAws_queryInvalidClusterStateFaultResponse(parsedOutput, context)),
@@ -3144,7 +3144,7 @@ const deserializeAws_queryAuthorizeEndpointAccessCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "UnsupportedOperation":
+    case "UnsupportedOperationFault":
     case "com.amazonaws.redshift#UnsupportedOperationFault":
       response = {
         ...(await deserializeAws_queryUnsupportedOperationFaultResponse(parsedOutput, context)),
@@ -3198,7 +3198,7 @@ const deserializeAws_queryAuthorizeSnapshotAccessCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "AuthorizationAlreadyExists":
+    case "AuthorizationAlreadyExistsFault":
     case "com.amazonaws.redshift#AuthorizationAlreadyExistsFault":
       response = {
         ...(await deserializeAws_queryAuthorizationAlreadyExistsFaultResponse(parsedOutput, context)),
@@ -3206,7 +3206,7 @@ const deserializeAws_queryAuthorizeSnapshotAccessCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "AuthorizationQuotaExceeded":
+    case "AuthorizationQuotaExceededFault":
     case "com.amazonaws.redshift#AuthorizationQuotaExceededFault":
       response = {
         ...(await deserializeAws_queryAuthorizationQuotaExceededFaultResponse(parsedOutput, context)),
@@ -3214,7 +3214,7 @@ const deserializeAws_queryAuthorizeSnapshotAccessCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ClusterSnapshotNotFound":
+    case "ClusterSnapshotNotFoundFault":
     case "com.amazonaws.redshift#ClusterSnapshotNotFoundFault":
       response = {
         ...(await deserializeAws_queryClusterSnapshotNotFoundFaultResponse(parsedOutput, context)),
@@ -3230,7 +3230,7 @@ const deserializeAws_queryAuthorizeSnapshotAccessCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidClusterSnapshotState":
+    case "InvalidClusterSnapshotStateFault":
     case "com.amazonaws.redshift#InvalidClusterSnapshotStateFault":
       response = {
         ...(await deserializeAws_queryInvalidClusterSnapshotStateFaultResponse(parsedOutput, context)),
@@ -3292,7 +3292,7 @@ const deserializeAws_queryBatchDeleteClusterSnapshotsCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "BatchDeleteRequestSizeExceeded":
+    case "BatchDeleteRequestSizeExceededFault":
     case "com.amazonaws.redshift#BatchDeleteRequestSizeExceededFault":
       response = {
         ...(await deserializeAws_queryBatchDeleteRequestSizeExceededFaultResponse(parsedOutput, context)),
@@ -3411,7 +3411,7 @@ const deserializeAws_queryCancelResizeCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "ClusterNotFound":
+    case "ClusterNotFoundFault":
     case "com.amazonaws.redshift#ClusterNotFoundFault":
       response = {
         ...(await deserializeAws_queryClusterNotFoundFaultResponse(parsedOutput, context)),
@@ -3419,7 +3419,7 @@ const deserializeAws_queryCancelResizeCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidClusterState":
+    case "InvalidClusterStateFault":
     case "com.amazonaws.redshift#InvalidClusterStateFault":
       response = {
         ...(await deserializeAws_queryInvalidClusterStateFaultResponse(parsedOutput, context)),
@@ -3427,7 +3427,7 @@ const deserializeAws_queryCancelResizeCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ResizeNotFound":
+    case "ResizeNotFoundFault":
     case "com.amazonaws.redshift#ResizeNotFoundFault":
       response = {
         ...(await deserializeAws_queryResizeNotFoundFaultResponse(parsedOutput, context)),
@@ -3435,7 +3435,7 @@ const deserializeAws_queryCancelResizeCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "UnsupportedOperation":
+    case "UnsupportedOperationFault":
     case "com.amazonaws.redshift#UnsupportedOperationFault":
       response = {
         ...(await deserializeAws_queryUnsupportedOperationFaultResponse(parsedOutput, context)),
@@ -3489,7 +3489,7 @@ const deserializeAws_queryCopyClusterSnapshotCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "ClusterSnapshotAlreadyExists":
+    case "ClusterSnapshotAlreadyExistsFault":
     case "com.amazonaws.redshift#ClusterSnapshotAlreadyExistsFault":
       response = {
         ...(await deserializeAws_queryClusterSnapshotAlreadyExistsFaultResponse(parsedOutput, context)),
@@ -3497,7 +3497,7 @@ const deserializeAws_queryCopyClusterSnapshotCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ClusterSnapshotNotFound":
+    case "ClusterSnapshotNotFoundFault":
     case "com.amazonaws.redshift#ClusterSnapshotNotFoundFault":
       response = {
         ...(await deserializeAws_queryClusterSnapshotNotFoundFaultResponse(parsedOutput, context)),
@@ -3505,7 +3505,7 @@ const deserializeAws_queryCopyClusterSnapshotCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ClusterSnapshotQuotaExceeded":
+    case "ClusterSnapshotQuotaExceededFault":
     case "com.amazonaws.redshift#ClusterSnapshotQuotaExceededFault":
       response = {
         ...(await deserializeAws_queryClusterSnapshotQuotaExceededFaultResponse(parsedOutput, context)),
@@ -3513,7 +3513,7 @@ const deserializeAws_queryCopyClusterSnapshotCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidClusterSnapshotState":
+    case "InvalidClusterSnapshotStateFault":
     case "com.amazonaws.redshift#InvalidClusterSnapshotStateFault":
       response = {
         ...(await deserializeAws_queryInvalidClusterSnapshotStateFaultResponse(parsedOutput, context)),
@@ -3645,7 +3645,7 @@ const deserializeAws_queryCreateClusterCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "ClusterAlreadyExists":
+    case "ClusterAlreadyExistsFault":
     case "com.amazonaws.redshift#ClusterAlreadyExistsFault":
       response = {
         ...(await deserializeAws_queryClusterAlreadyExistsFaultResponse(parsedOutput, context)),
@@ -3653,7 +3653,7 @@ const deserializeAws_queryCreateClusterCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ClusterParameterGroupNotFound":
+    case "ClusterParameterGroupNotFoundFault":
     case "com.amazonaws.redshift#ClusterParameterGroupNotFoundFault":
       response = {
         ...(await deserializeAws_queryClusterParameterGroupNotFoundFaultResponse(parsedOutput, context)),
@@ -3661,7 +3661,7 @@ const deserializeAws_queryCreateClusterCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ClusterQuotaExceeded":
+    case "ClusterQuotaExceededFault":
     case "com.amazonaws.redshift#ClusterQuotaExceededFault":
       response = {
         ...(await deserializeAws_queryClusterQuotaExceededFaultResponse(parsedOutput, context)),
@@ -3669,7 +3669,7 @@ const deserializeAws_queryCreateClusterCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ClusterSecurityGroupNotFound":
+    case "ClusterSecurityGroupNotFoundFault":
     case "com.amazonaws.redshift#ClusterSecurityGroupNotFoundFault":
       response = {
         ...(await deserializeAws_queryClusterSecurityGroupNotFoundFaultResponse(parsedOutput, context)),
@@ -3709,7 +3709,7 @@ const deserializeAws_queryCreateClusterCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InsufficientClusterCapacity":
+    case "InsufficientClusterCapacityFault":
     case "com.amazonaws.redshift#InsufficientClusterCapacityFault":
       response = {
         ...(await deserializeAws_queryInsufficientClusterCapacityFaultResponse(parsedOutput, context)),
@@ -3725,7 +3725,7 @@ const deserializeAws_queryCreateClusterCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidClusterTrack":
+    case "InvalidClusterTrackFault":
     case "com.amazonaws.redshift#InvalidClusterTrackFault":
       response = {
         ...(await deserializeAws_queryInvalidClusterTrackFaultResponse(parsedOutput, context)),
@@ -3781,7 +3781,7 @@ const deserializeAws_queryCreateClusterCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "NumberOfNodesPerClusterLimitExceeded":
+    case "NumberOfNodesPerClusterLimitExceededFault":
     case "com.amazonaws.redshift#NumberOfNodesPerClusterLimitExceededFault":
       response = {
         ...(await deserializeAws_queryNumberOfNodesPerClusterLimitExceededFaultResponse(parsedOutput, context)),
@@ -3789,7 +3789,7 @@ const deserializeAws_queryCreateClusterCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "NumberOfNodesQuotaExceeded":
+    case "NumberOfNodesQuotaExceededFault":
     case "com.amazonaws.redshift#NumberOfNodesQuotaExceededFault":
       response = {
         ...(await deserializeAws_queryNumberOfNodesQuotaExceededFaultResponse(parsedOutput, context)),
@@ -3797,7 +3797,7 @@ const deserializeAws_queryCreateClusterCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "SnapshotScheduleNotFound":
+    case "SnapshotScheduleNotFoundFault":
     case "com.amazonaws.redshift#SnapshotScheduleNotFoundFault":
       response = {
         ...(await deserializeAws_querySnapshotScheduleNotFoundFaultResponse(parsedOutput, context)),
@@ -3867,7 +3867,7 @@ const deserializeAws_queryCreateClusterParameterGroupCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "ClusterParameterGroupAlreadyExists":
+    case "ClusterParameterGroupAlreadyExistsFault":
     case "com.amazonaws.redshift#ClusterParameterGroupAlreadyExistsFault":
       response = {
         ...(await deserializeAws_queryClusterParameterGroupAlreadyExistsFaultResponse(parsedOutput, context)),
@@ -3875,7 +3875,7 @@ const deserializeAws_queryCreateClusterParameterGroupCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ClusterParameterGroupQuotaExceeded":
+    case "ClusterParameterGroupQuotaExceededFault":
     case "com.amazonaws.redshift#ClusterParameterGroupQuotaExceededFault":
       response = {
         ...(await deserializeAws_queryClusterParameterGroupQuotaExceededFaultResponse(parsedOutput, context)),
@@ -3945,10 +3945,18 @@ const deserializeAws_queryCreateClusterSecurityGroupCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "ClusterSecurityGroupAlreadyExists":
+    case "ClusterSecurityGroupAlreadyExistsFault":
     case "com.amazonaws.redshift#ClusterSecurityGroupAlreadyExistsFault":
       response = {
         ...(await deserializeAws_queryClusterSecurityGroupAlreadyExistsFaultResponse(parsedOutput, context)),
+        name: errorCode,
+        $metadata: deserializeMetadata(output),
+      };
+      break;
+    case "ClusterSecurityGroupQuotaExceededFault":
+    case "com.amazonaws.redshift#ClusterSecurityGroupQuotaExceededFault":
+      response = {
+        ...(await deserializeAws_queryClusterSecurityGroupQuotaExceededFaultResponse(parsedOutput, context)),
         name: errorCode,
         $metadata: deserializeMetadata(output),
       };
@@ -3957,14 +3965,6 @@ const deserializeAws_queryCreateClusterSecurityGroupCommandError = async (
     case "com.amazonaws.redshift#InvalidTagFault":
       response = {
         ...(await deserializeAws_queryInvalidTagFaultResponse(parsedOutput, context)),
-        name: errorCode,
-        $metadata: deserializeMetadata(output),
-      };
-      break;
-    case "QuotaExceeded.ClusterSecurityGroup":
-    case "com.amazonaws.redshift#ClusterSecurityGroupQuotaExceededFault":
-      response = {
-        ...(await deserializeAws_queryClusterSecurityGroupQuotaExceededFaultResponse(parsedOutput, context)),
         name: errorCode,
         $metadata: deserializeMetadata(output),
       };
@@ -4023,7 +4023,7 @@ const deserializeAws_queryCreateClusterSnapshotCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "ClusterNotFound":
+    case "ClusterNotFoundFault":
     case "com.amazonaws.redshift#ClusterNotFoundFault":
       response = {
         ...(await deserializeAws_queryClusterNotFoundFaultResponse(parsedOutput, context)),
@@ -4031,7 +4031,7 @@ const deserializeAws_queryCreateClusterSnapshotCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ClusterSnapshotAlreadyExists":
+    case "ClusterSnapshotAlreadyExistsFault":
     case "com.amazonaws.redshift#ClusterSnapshotAlreadyExistsFault":
       response = {
         ...(await deserializeAws_queryClusterSnapshotAlreadyExistsFaultResponse(parsedOutput, context)),
@@ -4039,7 +4039,7 @@ const deserializeAws_queryCreateClusterSnapshotCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ClusterSnapshotQuotaExceeded":
+    case "ClusterSnapshotQuotaExceededFault":
     case "com.amazonaws.redshift#ClusterSnapshotQuotaExceededFault":
       response = {
         ...(await deserializeAws_queryClusterSnapshotQuotaExceededFaultResponse(parsedOutput, context)),
@@ -4047,7 +4047,7 @@ const deserializeAws_queryCreateClusterSnapshotCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidClusterState":
+    case "InvalidClusterStateFault":
     case "com.amazonaws.redshift#InvalidClusterStateFault":
       response = {
         ...(await deserializeAws_queryInvalidClusterStateFaultResponse(parsedOutput, context)),
@@ -4125,7 +4125,7 @@ const deserializeAws_queryCreateClusterSubnetGroupCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "ClusterSubnetGroupAlreadyExists":
+    case "ClusterSubnetGroupAlreadyExistsFault":
     case "com.amazonaws.redshift#ClusterSubnetGroupAlreadyExistsFault":
       response = {
         ...(await deserializeAws_queryClusterSubnetGroupAlreadyExistsFaultResponse(parsedOutput, context)),
@@ -4133,7 +4133,7 @@ const deserializeAws_queryCreateClusterSubnetGroupCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ClusterSubnetGroupQuotaExceeded":
+    case "ClusterSubnetGroupQuotaExceededFault":
     case "com.amazonaws.redshift#ClusterSubnetGroupQuotaExceededFault":
       response = {
         ...(await deserializeAws_queryClusterSubnetGroupQuotaExceededFaultResponse(parsedOutput, context)),
@@ -4235,7 +4235,7 @@ const deserializeAws_queryCreateEndpointAccessCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "AccessToClusterDenied":
+    case "AccessToClusterDeniedFault":
     case "com.amazonaws.redshift#AccessToClusterDeniedFault":
       response = {
         ...(await deserializeAws_queryAccessToClusterDeniedFaultResponse(parsedOutput, context)),
@@ -4243,7 +4243,7 @@ const deserializeAws_queryCreateEndpointAccessCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ClusterNotFound":
+    case "ClusterNotFoundFault":
     case "com.amazonaws.redshift#ClusterNotFoundFault":
       response = {
         ...(await deserializeAws_queryClusterNotFoundFaultResponse(parsedOutput, context)),
@@ -4259,7 +4259,7 @@ const deserializeAws_queryCreateEndpointAccessCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "EndpointAlreadyExists":
+    case "EndpointAlreadyExistsFault":
     case "com.amazonaws.redshift#EndpointAlreadyExistsFault":
       response = {
         ...(await deserializeAws_queryEndpointAlreadyExistsFaultResponse(parsedOutput, context)),
@@ -4267,7 +4267,7 @@ const deserializeAws_queryCreateEndpointAccessCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "EndpointsPerAuthorizationLimitExceeded":
+    case "EndpointsPerAuthorizationLimitExceededFault":
     case "com.amazonaws.redshift#EndpointsPerAuthorizationLimitExceededFault":
       response = {
         ...(await deserializeAws_queryEndpointsPerAuthorizationLimitExceededFaultResponse(parsedOutput, context)),
@@ -4275,7 +4275,7 @@ const deserializeAws_queryCreateEndpointAccessCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "EndpointsPerClusterLimitExceeded":
+    case "EndpointsPerClusterLimitExceededFault":
     case "com.amazonaws.redshift#EndpointsPerClusterLimitExceededFault":
       response = {
         ...(await deserializeAws_queryEndpointsPerClusterLimitExceededFaultResponse(parsedOutput, context)),
@@ -4283,7 +4283,7 @@ const deserializeAws_queryCreateEndpointAccessCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidClusterSecurityGroupState":
+    case "InvalidClusterSecurityGroupStateFault":
     case "com.amazonaws.redshift#InvalidClusterSecurityGroupStateFault":
       response = {
         ...(await deserializeAws_queryInvalidClusterSecurityGroupStateFaultResponse(parsedOutput, context)),
@@ -4291,7 +4291,7 @@ const deserializeAws_queryCreateEndpointAccessCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidClusterState":
+    case "InvalidClusterStateFault":
     case "com.amazonaws.redshift#InvalidClusterStateFault":
       response = {
         ...(await deserializeAws_queryInvalidClusterStateFaultResponse(parsedOutput, context)),
@@ -4307,7 +4307,7 @@ const deserializeAws_queryCreateEndpointAccessCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "UnsupportedOperation":
+    case "UnsupportedOperationFault":
     case "com.amazonaws.redshift#UnsupportedOperationFault":
       response = {
         ...(await deserializeAws_queryUnsupportedOperationFaultResponse(parsedOutput, context)),
@@ -4361,7 +4361,7 @@ const deserializeAws_queryCreateEventSubscriptionCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "EventSubscriptionQuotaExceeded":
+    case "EventSubscriptionQuotaExceededFault":
     case "com.amazonaws.redshift#EventSubscriptionQuotaExceededFault":
       response = {
         ...(await deserializeAws_queryEventSubscriptionQuotaExceededFaultResponse(parsedOutput, context)),
@@ -4377,7 +4377,7 @@ const deserializeAws_queryCreateEventSubscriptionCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "SNSInvalidTopic":
+    case "SNSInvalidTopicFault":
     case "com.amazonaws.redshift#SNSInvalidTopicFault":
       response = {
         ...(await deserializeAws_querySNSInvalidTopicFaultResponse(parsedOutput, context)),
@@ -4385,7 +4385,7 @@ const deserializeAws_queryCreateEventSubscriptionCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "SNSNoAuthorization":
+    case "SNSNoAuthorizationFault":
     case "com.amazonaws.redshift#SNSNoAuthorizationFault":
       response = {
         ...(await deserializeAws_querySNSNoAuthorizationFaultResponse(parsedOutput, context)),
@@ -4393,7 +4393,7 @@ const deserializeAws_queryCreateEventSubscriptionCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "SNSTopicArnNotFound":
+    case "SNSTopicArnNotFoundFault":
     case "com.amazonaws.redshift#SNSTopicArnNotFoundFault":
       response = {
         ...(await deserializeAws_querySNSTopicArnNotFoundFaultResponse(parsedOutput, context)),
@@ -4401,7 +4401,7 @@ const deserializeAws_queryCreateEventSubscriptionCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "SourceNotFound":
+    case "SourceNotFoundFault":
     case "com.amazonaws.redshift#SourceNotFoundFault":
       response = {
         ...(await deserializeAws_querySourceNotFoundFaultResponse(parsedOutput, context)),
@@ -4409,7 +4409,7 @@ const deserializeAws_queryCreateEventSubscriptionCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "SubscriptionAlreadyExist":
+    case "SubscriptionAlreadyExistFault":
     case "com.amazonaws.redshift#SubscriptionAlreadyExistFault":
       response = {
         ...(await deserializeAws_querySubscriptionAlreadyExistFaultResponse(parsedOutput, context)),
@@ -4417,7 +4417,7 @@ const deserializeAws_queryCreateEventSubscriptionCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "SubscriptionCategoryNotFound":
+    case "SubscriptionCategoryNotFoundFault":
     case "com.amazonaws.redshift#SubscriptionCategoryNotFoundFault":
       response = {
         ...(await deserializeAws_querySubscriptionCategoryNotFoundFaultResponse(parsedOutput, context)),
@@ -4425,7 +4425,7 @@ const deserializeAws_queryCreateEventSubscriptionCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "SubscriptionEventIdNotFound":
+    case "SubscriptionEventIdNotFoundFault":
     case "com.amazonaws.redshift#SubscriptionEventIdNotFoundFault":
       response = {
         ...(await deserializeAws_querySubscriptionEventIdNotFoundFaultResponse(parsedOutput, context)),
@@ -4433,7 +4433,7 @@ const deserializeAws_queryCreateEventSubscriptionCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "SubscriptionSeverityNotFound":
+    case "SubscriptionSeverityNotFoundFault":
     case "com.amazonaws.redshift#SubscriptionSeverityNotFoundFault":
       response = {
         ...(await deserializeAws_querySubscriptionSeverityNotFoundFaultResponse(parsedOutput, context)),
@@ -4651,15 +4651,7 @@ const deserializeAws_queryCreateScheduledActionCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "InvalidSchedule":
-    case "com.amazonaws.redshift#InvalidScheduleFault":
-      response = {
-        ...(await deserializeAws_queryInvalidScheduleFaultResponse(parsedOutput, context)),
-        name: errorCode,
-        $metadata: deserializeMetadata(output),
-      };
-      break;
-    case "InvalidScheduledAction":
+    case "InvalidScheduledActionFault":
     case "com.amazonaws.redshift#InvalidScheduledActionFault":
       response = {
         ...(await deserializeAws_queryInvalidScheduledActionFaultResponse(parsedOutput, context)),
@@ -4667,7 +4659,15 @@ const deserializeAws_queryCreateScheduledActionCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ScheduledActionAlreadyExists":
+    case "InvalidScheduleFault":
+    case "com.amazonaws.redshift#InvalidScheduleFault":
+      response = {
+        ...(await deserializeAws_queryInvalidScheduleFaultResponse(parsedOutput, context)),
+        name: errorCode,
+        $metadata: deserializeMetadata(output),
+      };
+      break;
+    case "ScheduledActionAlreadyExistsFault":
     case "com.amazonaws.redshift#ScheduledActionAlreadyExistsFault":
       response = {
         ...(await deserializeAws_queryScheduledActionAlreadyExistsFaultResponse(parsedOutput, context)),
@@ -4675,7 +4675,7 @@ const deserializeAws_queryCreateScheduledActionCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ScheduledActionQuotaExceeded":
+    case "ScheduledActionQuotaExceededFault":
     case "com.amazonaws.redshift#ScheduledActionQuotaExceededFault":
       response = {
         ...(await deserializeAws_queryScheduledActionQuotaExceededFaultResponse(parsedOutput, context)),
@@ -4683,7 +4683,7 @@ const deserializeAws_queryCreateScheduledActionCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ScheduledActionTypeUnsupported":
+    case "ScheduledActionTypeUnsupportedFault":
     case "com.amazonaws.redshift#ScheduledActionTypeUnsupportedFault":
       response = {
         ...(await deserializeAws_queryScheduledActionTypeUnsupportedFaultResponse(parsedOutput, context)),
@@ -4839,7 +4839,7 @@ const deserializeAws_queryCreateSnapshotScheduleCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "InvalidSchedule":
+    case "InvalidScheduleFault":
     case "com.amazonaws.redshift#InvalidScheduleFault":
       response = {
         ...(await deserializeAws_queryInvalidScheduleFaultResponse(parsedOutput, context)),
@@ -4855,7 +4855,7 @@ const deserializeAws_queryCreateSnapshotScheduleCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ScheduleDefinitionTypeUnsupported":
+    case "ScheduleDefinitionTypeUnsupportedFault":
     case "com.amazonaws.redshift#ScheduleDefinitionTypeUnsupportedFault":
       response = {
         ...(await deserializeAws_queryScheduleDefinitionTypeUnsupportedFaultResponse(parsedOutput, context)),
@@ -4863,7 +4863,7 @@ const deserializeAws_queryCreateSnapshotScheduleCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "SnapshotScheduleAlreadyExists":
+    case "SnapshotScheduleAlreadyExistsFault":
     case "com.amazonaws.redshift#SnapshotScheduleAlreadyExistsFault":
       response = {
         ...(await deserializeAws_querySnapshotScheduleAlreadyExistsFaultResponse(parsedOutput, context)),
@@ -4871,7 +4871,7 @@ const deserializeAws_queryCreateSnapshotScheduleCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "SnapshotScheduleQuotaExceeded":
+    case "SnapshotScheduleQuotaExceededFault":
     case "com.amazonaws.redshift#SnapshotScheduleQuotaExceededFault":
       response = {
         ...(await deserializeAws_querySnapshotScheduleQuotaExceededFaultResponse(parsedOutput, context)),
@@ -4930,7 +4930,7 @@ const deserializeAws_queryCreateTagsCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "InvalidClusterState":
+    case "InvalidClusterStateFault":
     case "com.amazonaws.redshift#InvalidClusterStateFault":
       response = {
         ...(await deserializeAws_queryInvalidClusterStateFaultResponse(parsedOutput, context)),
@@ -5008,7 +5008,7 @@ const deserializeAws_queryCreateUsageLimitCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "ClusterNotFound":
+    case "ClusterNotFoundFault":
     case "com.amazonaws.redshift#ClusterNotFoundFault":
       response = {
         ...(await deserializeAws_queryClusterNotFoundFaultResponse(parsedOutput, context)),
@@ -5016,7 +5016,7 @@ const deserializeAws_queryCreateUsageLimitCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidClusterState":
+    case "InvalidClusterStateFault":
     case "com.amazonaws.redshift#InvalidClusterStateFault":
       response = {
         ...(await deserializeAws_queryInvalidClusterStateFaultResponse(parsedOutput, context)),
@@ -5024,7 +5024,7 @@ const deserializeAws_queryCreateUsageLimitCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidUsageLimit":
+    case "InvalidUsageLimitFault":
     case "com.amazonaws.redshift#InvalidUsageLimitFault":
       response = {
         ...(await deserializeAws_queryInvalidUsageLimitFaultResponse(parsedOutput, context)),
@@ -5048,7 +5048,7 @@ const deserializeAws_queryCreateUsageLimitCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "UnsupportedOperation":
+    case "UnsupportedOperationFault":
     case "com.amazonaws.redshift#UnsupportedOperationFault":
       response = {
         ...(await deserializeAws_queryUnsupportedOperationFaultResponse(parsedOutput, context)),
@@ -5056,7 +5056,7 @@ const deserializeAws_queryCreateUsageLimitCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "UsageLimitAlreadyExists":
+    case "UsageLimitAlreadyExistsFault":
     case "com.amazonaws.redshift#UsageLimitAlreadyExistsFault":
       response = {
         ...(await deserializeAws_queryUsageLimitAlreadyExistsFaultResponse(parsedOutput, context)),
@@ -5226,7 +5226,7 @@ const deserializeAws_queryDeleteClusterCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "ClusterNotFound":
+    case "ClusterNotFoundFault":
     case "com.amazonaws.redshift#ClusterNotFoundFault":
       response = {
         ...(await deserializeAws_queryClusterNotFoundFaultResponse(parsedOutput, context)),
@@ -5234,7 +5234,7 @@ const deserializeAws_queryDeleteClusterCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ClusterSnapshotAlreadyExists":
+    case "ClusterSnapshotAlreadyExistsFault":
     case "com.amazonaws.redshift#ClusterSnapshotAlreadyExistsFault":
       response = {
         ...(await deserializeAws_queryClusterSnapshotAlreadyExistsFaultResponse(parsedOutput, context)),
@@ -5242,7 +5242,7 @@ const deserializeAws_queryDeleteClusterCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ClusterSnapshotQuotaExceeded":
+    case "ClusterSnapshotQuotaExceededFault":
     case "com.amazonaws.redshift#ClusterSnapshotQuotaExceededFault":
       response = {
         ...(await deserializeAws_queryClusterSnapshotQuotaExceededFaultResponse(parsedOutput, context)),
@@ -5250,7 +5250,7 @@ const deserializeAws_queryDeleteClusterCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidClusterState":
+    case "InvalidClusterStateFault":
     case "com.amazonaws.redshift#InvalidClusterStateFault":
       response = {
         ...(await deserializeAws_queryInvalidClusterStateFaultResponse(parsedOutput, context)),
@@ -5309,7 +5309,7 @@ const deserializeAws_queryDeleteClusterParameterGroupCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "ClusterParameterGroupNotFound":
+    case "ClusterParameterGroupNotFoundFault":
     case "com.amazonaws.redshift#ClusterParameterGroupNotFoundFault":
       response = {
         ...(await deserializeAws_queryClusterParameterGroupNotFoundFaultResponse(parsedOutput, context)),
@@ -5317,7 +5317,7 @@ const deserializeAws_queryDeleteClusterParameterGroupCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidClusterParameterGroupState":
+    case "InvalidClusterParameterGroupStateFault":
     case "com.amazonaws.redshift#InvalidClusterParameterGroupStateFault":
       response = {
         ...(await deserializeAws_queryInvalidClusterParameterGroupStateFaultResponse(parsedOutput, context)),
@@ -5368,7 +5368,7 @@ const deserializeAws_queryDeleteClusterSecurityGroupCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "ClusterSecurityGroupNotFound":
+    case "ClusterSecurityGroupNotFoundFault":
     case "com.amazonaws.redshift#ClusterSecurityGroupNotFoundFault":
       response = {
         ...(await deserializeAws_queryClusterSecurityGroupNotFoundFaultResponse(parsedOutput, context)),
@@ -5376,7 +5376,7 @@ const deserializeAws_queryDeleteClusterSecurityGroupCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidClusterSecurityGroupState":
+    case "InvalidClusterSecurityGroupStateFault":
     case "com.amazonaws.redshift#InvalidClusterSecurityGroupStateFault":
       response = {
         ...(await deserializeAws_queryInvalidClusterSecurityGroupStateFaultResponse(parsedOutput, context)),
@@ -5430,7 +5430,7 @@ const deserializeAws_queryDeleteClusterSnapshotCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "ClusterSnapshotNotFound":
+    case "ClusterSnapshotNotFoundFault":
     case "com.amazonaws.redshift#ClusterSnapshotNotFoundFault":
       response = {
         ...(await deserializeAws_queryClusterSnapshotNotFoundFaultResponse(parsedOutput, context)),
@@ -5438,7 +5438,7 @@ const deserializeAws_queryDeleteClusterSnapshotCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidClusterSnapshotState":
+    case "InvalidClusterSnapshotStateFault":
     case "com.amazonaws.redshift#InvalidClusterSnapshotStateFault":
       response = {
         ...(await deserializeAws_queryInvalidClusterSnapshotStateFaultResponse(parsedOutput, context)),
@@ -5559,7 +5559,7 @@ const deserializeAws_queryDeleteEndpointAccessCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "ClusterNotFound":
+    case "ClusterNotFoundFault":
     case "com.amazonaws.redshift#ClusterNotFoundFault":
       response = {
         ...(await deserializeAws_queryClusterNotFoundFaultResponse(parsedOutput, context)),
@@ -5567,7 +5567,7 @@ const deserializeAws_queryDeleteEndpointAccessCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "EndpointNotFound":
+    case "EndpointNotFoundFault":
     case "com.amazonaws.redshift#EndpointNotFoundFault":
       response = {
         ...(await deserializeAws_queryEndpointNotFoundFaultResponse(parsedOutput, context)),
@@ -5575,7 +5575,7 @@ const deserializeAws_queryDeleteEndpointAccessCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidClusterSecurityGroupState":
+    case "InvalidClusterSecurityGroupStateFault":
     case "com.amazonaws.redshift#InvalidClusterSecurityGroupStateFault":
       response = {
         ...(await deserializeAws_queryInvalidClusterSecurityGroupStateFaultResponse(parsedOutput, context)),
@@ -5583,7 +5583,7 @@ const deserializeAws_queryDeleteEndpointAccessCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidClusterState":
+    case "InvalidClusterStateFault":
     case "com.amazonaws.redshift#InvalidClusterStateFault":
       response = {
         ...(await deserializeAws_queryInvalidClusterStateFaultResponse(parsedOutput, context)),
@@ -5591,7 +5591,7 @@ const deserializeAws_queryDeleteEndpointAccessCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidEndpointState":
+    case "InvalidEndpointStateFault":
     case "com.amazonaws.redshift#InvalidEndpointStateFault":
       response = {
         ...(await deserializeAws_queryInvalidEndpointStateFaultResponse(parsedOutput, context)),
@@ -5650,7 +5650,7 @@ const deserializeAws_queryDeleteEventSubscriptionCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "SubscriptionNotFound":
+    case "SubscriptionNotFoundFault":
     case "com.amazonaws.redshift#SubscriptionNotFoundFault":
       response = {
         ...(await deserializeAws_querySubscriptionNotFoundFaultResponse(parsedOutput, context)),
@@ -5822,7 +5822,7 @@ const deserializeAws_queryDeletePartnerCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "ClusterNotFound":
+    case "ClusterNotFoundFault":
     case "com.amazonaws.redshift#ClusterNotFoundFault":
       response = {
         ...(await deserializeAws_queryClusterNotFoundFaultResponse(parsedOutput, context)),
@@ -5830,7 +5830,7 @@ const deserializeAws_queryDeletePartnerCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "PartnerNotFound":
+    case "PartnerNotFoundFault":
     case "com.amazonaws.redshift#PartnerNotFoundFault":
       response = {
         ...(await deserializeAws_queryPartnerNotFoundFaultResponse(parsedOutput, context)),
@@ -5838,7 +5838,7 @@ const deserializeAws_queryDeletePartnerCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "UnauthorizedPartnerIntegration":
+    case "UnauthorizedPartnerIntegrationFault":
     case "com.amazonaws.redshift#UnauthorizedPartnerIntegrationFault":
       response = {
         ...(await deserializeAws_queryUnauthorizedPartnerIntegrationFaultResponse(parsedOutput, context)),
@@ -5889,7 +5889,7 @@ const deserializeAws_queryDeleteScheduledActionCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "ScheduledActionNotFound":
+    case "ScheduledActionNotFoundFault":
     case "com.amazonaws.redshift#ScheduledActionNotFoundFault":
       response = {
         ...(await deserializeAws_queryScheduledActionNotFoundFaultResponse(parsedOutput, context)),
@@ -6007,7 +6007,7 @@ const deserializeAws_queryDeleteSnapshotScheduleCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "InvalidClusterSnapshotScheduleState":
+    case "InvalidClusterSnapshotScheduleStateFault":
     case "com.amazonaws.redshift#InvalidClusterSnapshotScheduleStateFault":
       response = {
         ...(await deserializeAws_queryInvalidClusterSnapshotScheduleStateFaultResponse(parsedOutput, context)),
@@ -6015,7 +6015,7 @@ const deserializeAws_queryDeleteSnapshotScheduleCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "SnapshotScheduleNotFound":
+    case "SnapshotScheduleNotFoundFault":
     case "com.amazonaws.redshift#SnapshotScheduleNotFoundFault":
       response = {
         ...(await deserializeAws_querySnapshotScheduleNotFoundFaultResponse(parsedOutput, context)),
@@ -6125,7 +6125,7 @@ const deserializeAws_queryDeleteUsageLimitCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "UnsupportedOperation":
+    case "UnsupportedOperationFault":
     case "com.amazonaws.redshift#UnsupportedOperationFault":
       response = {
         ...(await deserializeAws_queryUnsupportedOperationFaultResponse(parsedOutput, context)),
@@ -6133,7 +6133,7 @@ const deserializeAws_queryDeleteUsageLimitCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "UsageLimitNotFound":
+    case "UsageLimitNotFoundFault":
     case "com.amazonaws.redshift#UsageLimitNotFoundFault":
       response = {
         ...(await deserializeAws_queryUsageLimitNotFoundFaultResponse(parsedOutput, context)),
@@ -6298,7 +6298,7 @@ const deserializeAws_queryDescribeClusterDbRevisionsCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "ClusterNotFound":
+    case "ClusterNotFoundFault":
     case "com.amazonaws.redshift#ClusterNotFoundFault":
       response = {
         ...(await deserializeAws_queryClusterNotFoundFaultResponse(parsedOutput, context)),
@@ -6306,7 +6306,7 @@ const deserializeAws_queryDescribeClusterDbRevisionsCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidClusterState":
+    case "InvalidClusterStateFault":
     case "com.amazonaws.redshift#InvalidClusterStateFault":
       response = {
         ...(await deserializeAws_queryInvalidClusterStateFaultResponse(parsedOutput, context)),
@@ -6360,7 +6360,7 @@ const deserializeAws_queryDescribeClusterParameterGroupsCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "ClusterParameterGroupNotFound":
+    case "ClusterParameterGroupNotFoundFault":
     case "com.amazonaws.redshift#ClusterParameterGroupNotFoundFault":
       response = {
         ...(await deserializeAws_queryClusterParameterGroupNotFoundFaultResponse(parsedOutput, context)),
@@ -6422,7 +6422,7 @@ const deserializeAws_queryDescribeClusterParametersCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "ClusterParameterGroupNotFound":
+    case "ClusterParameterGroupNotFoundFault":
     case "com.amazonaws.redshift#ClusterParameterGroupNotFoundFault":
       response = {
         ...(await deserializeAws_queryClusterParameterGroupNotFoundFaultResponse(parsedOutput, context)),
@@ -6476,7 +6476,7 @@ const deserializeAws_queryDescribeClustersCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "ClusterNotFound":
+    case "ClusterNotFoundFault":
     case "com.amazonaws.redshift#ClusterNotFoundFault":
       response = {
         ...(await deserializeAws_queryClusterNotFoundFaultResponse(parsedOutput, context)),
@@ -6538,7 +6538,7 @@ const deserializeAws_queryDescribeClusterSecurityGroupsCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "ClusterSecurityGroupNotFound":
+    case "ClusterSecurityGroupNotFoundFault":
     case "com.amazonaws.redshift#ClusterSecurityGroupNotFoundFault":
       response = {
         ...(await deserializeAws_queryClusterSecurityGroupNotFoundFaultResponse(parsedOutput, context)),
@@ -6600,7 +6600,7 @@ const deserializeAws_queryDescribeClusterSnapshotsCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "ClusterNotFound":
+    case "ClusterNotFoundFault":
     case "com.amazonaws.redshift#ClusterNotFoundFault":
       response = {
         ...(await deserializeAws_queryClusterNotFoundFaultResponse(parsedOutput, context)),
@@ -6608,7 +6608,7 @@ const deserializeAws_queryDescribeClusterSnapshotsCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ClusterSnapshotNotFound":
+    case "ClusterSnapshotNotFoundFault":
     case "com.amazonaws.redshift#ClusterSnapshotNotFoundFault":
       response = {
         ...(await deserializeAws_queryClusterSnapshotNotFoundFaultResponse(parsedOutput, context)),
@@ -6732,7 +6732,7 @@ const deserializeAws_queryDescribeClusterTracksCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "InvalidClusterTrack":
+    case "InvalidClusterTrackFault":
     case "com.amazonaws.redshift#InvalidClusterTrackFault":
       response = {
         ...(await deserializeAws_queryInvalidClusterTrackFaultResponse(parsedOutput, context)),
@@ -7051,7 +7051,7 @@ const deserializeAws_queryDescribeEndpointAccessCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "ClusterNotFound":
+    case "ClusterNotFoundFault":
     case "com.amazonaws.redshift#ClusterNotFoundFault":
       response = {
         ...(await deserializeAws_queryClusterNotFoundFaultResponse(parsedOutput, context)),
@@ -7059,7 +7059,7 @@ const deserializeAws_queryDescribeEndpointAccessCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "EndpointNotFound":
+    case "EndpointNotFoundFault":
     case "com.amazonaws.redshift#EndpointNotFoundFault":
       response = {
         ...(await deserializeAws_queryEndpointNotFoundFaultResponse(parsedOutput, context)),
@@ -7067,7 +7067,7 @@ const deserializeAws_queryDescribeEndpointAccessCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidClusterState":
+    case "InvalidClusterStateFault":
     case "com.amazonaws.redshift#InvalidClusterStateFault":
       response = {
         ...(await deserializeAws_queryInvalidClusterStateFaultResponse(parsedOutput, context)),
@@ -7121,7 +7121,7 @@ const deserializeAws_queryDescribeEndpointAuthorizationCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "ClusterNotFound":
+    case "ClusterNotFoundFault":
     case "com.amazonaws.redshift#ClusterNotFoundFault":
       response = {
         ...(await deserializeAws_queryClusterNotFoundFaultResponse(parsedOutput, context)),
@@ -7129,7 +7129,7 @@ const deserializeAws_queryDescribeEndpointAuthorizationCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "UnsupportedOperation":
+    case "UnsupportedOperationFault":
     case "com.amazonaws.redshift#UnsupportedOperationFault":
       response = {
         ...(await deserializeAws_queryUnsupportedOperationFaultResponse(parsedOutput, context)),
@@ -7283,7 +7283,7 @@ const deserializeAws_queryDescribeEventSubscriptionsCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "SubscriptionNotFound":
+    case "SubscriptionNotFoundFault":
     case "com.amazonaws.redshift#SubscriptionNotFoundFault":
       response = {
         ...(await deserializeAws_querySubscriptionNotFoundFaultResponse(parsedOutput, context)),
@@ -7461,7 +7461,7 @@ const deserializeAws_queryDescribeLoggingStatusCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "ClusterNotFound":
+    case "ClusterNotFoundFault":
     case "com.amazonaws.redshift#ClusterNotFoundFault":
       response = {
         ...(await deserializeAws_queryClusterNotFoundFaultResponse(parsedOutput, context)),
@@ -7515,7 +7515,7 @@ const deserializeAws_queryDescribeNodeConfigurationOptionsCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "AccessToSnapshotDenied":
+    case "AccessToSnapshotDeniedFault":
     case "com.amazonaws.redshift#AccessToSnapshotDeniedFault":
       response = {
         ...(await deserializeAws_queryAccessToSnapshotDeniedFaultResponse(parsedOutput, context)),
@@ -7523,7 +7523,7 @@ const deserializeAws_queryDescribeNodeConfigurationOptionsCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ClusterNotFound":
+    case "ClusterNotFoundFault":
     case "com.amazonaws.redshift#ClusterNotFoundFault":
       response = {
         ...(await deserializeAws_queryClusterNotFoundFaultResponse(parsedOutput, context)),
@@ -7531,7 +7531,7 @@ const deserializeAws_queryDescribeNodeConfigurationOptionsCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ClusterSnapshotNotFound":
+    case "ClusterSnapshotNotFoundFault":
     case "com.amazonaws.redshift#ClusterSnapshotNotFoundFault":
       response = {
         ...(await deserializeAws_queryClusterSnapshotNotFoundFaultResponse(parsedOutput, context)),
@@ -7539,7 +7539,7 @@ const deserializeAws_queryDescribeNodeConfigurationOptionsCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidClusterSnapshotState":
+    case "InvalidClusterSnapshotStateFault":
     case "com.amazonaws.redshift#InvalidClusterSnapshotStateFault":
       response = {
         ...(await deserializeAws_queryInvalidClusterSnapshotStateFaultResponse(parsedOutput, context)),
@@ -7639,7 +7639,7 @@ const deserializeAws_queryDescribePartnersCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "ClusterNotFound":
+    case "ClusterNotFoundFault":
     case "com.amazonaws.redshift#ClusterNotFoundFault":
       response = {
         ...(await deserializeAws_queryClusterNotFoundFaultResponse(parsedOutput, context)),
@@ -7647,7 +7647,7 @@ const deserializeAws_queryDescribePartnersCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "UnauthorizedPartnerIntegration":
+    case "UnauthorizedPartnerIntegrationFault":
     case "com.amazonaws.redshift#UnauthorizedPartnerIntegrationFault":
       response = {
         ...(await deserializeAws_queryUnauthorizedPartnerIntegrationFaultResponse(parsedOutput, context)),
@@ -7704,7 +7704,7 @@ const deserializeAws_queryDescribeReservedNodeExchangeStatusCommandError = async
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "ReservedNodeExchangeNotFond":
+    case "ReservedNodeExchangeNotFoundFault":
     case "com.amazonaws.redshift#ReservedNodeExchangeNotFoundFault":
       response = {
         ...(await deserializeAws_queryReservedNodeExchangeNotFoundFaultResponse(parsedOutput, context)),
@@ -7712,7 +7712,7 @@ const deserializeAws_queryDescribeReservedNodeExchangeStatusCommandError = async
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ReservedNodeNotFound":
+    case "ReservedNodeNotFoundFault":
     case "com.amazonaws.redshift#ReservedNodeNotFoundFault":
       response = {
         ...(await deserializeAws_queryReservedNodeNotFoundFaultResponse(parsedOutput, context)),
@@ -7720,7 +7720,7 @@ const deserializeAws_queryDescribeReservedNodeExchangeStatusCommandError = async
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "UnsupportedOperation":
+    case "UnsupportedOperationFault":
     case "com.amazonaws.redshift#UnsupportedOperationFault":
       response = {
         ...(await deserializeAws_queryUnsupportedOperationFaultResponse(parsedOutput, context)),
@@ -7782,7 +7782,7 @@ const deserializeAws_queryDescribeReservedNodeOfferingsCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ReservedNodeOfferingNotFound":
+    case "ReservedNodeOfferingNotFoundFault":
     case "com.amazonaws.redshift#ReservedNodeOfferingNotFoundFault":
       response = {
         ...(await deserializeAws_queryReservedNodeOfferingNotFoundFaultResponse(parsedOutput, context)),
@@ -7790,7 +7790,7 @@ const deserializeAws_queryDescribeReservedNodeOfferingsCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "UnsupportedOperation":
+    case "UnsupportedOperationFault":
     case "com.amazonaws.redshift#UnsupportedOperationFault":
       response = {
         ...(await deserializeAws_queryUnsupportedOperationFaultResponse(parsedOutput, context)),
@@ -7852,7 +7852,7 @@ const deserializeAws_queryDescribeReservedNodesCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ReservedNodeNotFound":
+    case "ReservedNodeNotFoundFault":
     case "com.amazonaws.redshift#ReservedNodeNotFoundFault":
       response = {
         ...(await deserializeAws_queryReservedNodeNotFoundFaultResponse(parsedOutput, context)),
@@ -7906,7 +7906,7 @@ const deserializeAws_queryDescribeResizeCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "ClusterNotFound":
+    case "ClusterNotFoundFault":
     case "com.amazonaws.redshift#ClusterNotFoundFault":
       response = {
         ...(await deserializeAws_queryClusterNotFoundFaultResponse(parsedOutput, context)),
@@ -7914,7 +7914,7 @@ const deserializeAws_queryDescribeResizeCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ResizeNotFound":
+    case "ResizeNotFoundFault":
     case "com.amazonaws.redshift#ResizeNotFoundFault":
       response = {
         ...(await deserializeAws_queryResizeNotFoundFaultResponse(parsedOutput, context)),
@@ -7968,7 +7968,7 @@ const deserializeAws_queryDescribeScheduledActionsCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "ScheduledActionNotFound":
+    case "ScheduledActionNotFoundFault":
     case "com.amazonaws.redshift#ScheduledActionNotFoundFault":
       response = {
         ...(await deserializeAws_queryScheduledActionNotFoundFaultResponse(parsedOutput, context)),
@@ -8184,7 +8184,7 @@ const deserializeAws_queryDescribeTableRestoreStatusCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "ClusterNotFound":
+    case "ClusterNotFoundFault":
     case "com.amazonaws.redshift#ClusterNotFoundFault":
       response = {
         ...(await deserializeAws_queryClusterNotFoundFaultResponse(parsedOutput, context)),
@@ -8308,7 +8308,7 @@ const deserializeAws_queryDescribeUsageLimitsCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "ClusterNotFound":
+    case "ClusterNotFoundFault":
     case "com.amazonaws.redshift#ClusterNotFoundFault":
       response = {
         ...(await deserializeAws_queryClusterNotFoundFaultResponse(parsedOutput, context)),
@@ -8316,7 +8316,7 @@ const deserializeAws_queryDescribeUsageLimitsCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "UnsupportedOperation":
+    case "UnsupportedOperationFault":
     case "com.amazonaws.redshift#UnsupportedOperationFault":
       response = {
         ...(await deserializeAws_queryUnsupportedOperationFaultResponse(parsedOutput, context)),
@@ -8370,7 +8370,7 @@ const deserializeAws_queryDisableLoggingCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "ClusterNotFound":
+    case "ClusterNotFoundFault":
     case "com.amazonaws.redshift#ClusterNotFoundFault":
       response = {
         ...(await deserializeAws_queryClusterNotFoundFaultResponse(parsedOutput, context)),
@@ -8378,7 +8378,7 @@ const deserializeAws_queryDisableLoggingCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidClusterState":
+    case "InvalidClusterStateFault":
     case "com.amazonaws.redshift#InvalidClusterStateFault":
       response = {
         ...(await deserializeAws_queryInvalidClusterStateFaultResponse(parsedOutput, context)),
@@ -8432,7 +8432,7 @@ const deserializeAws_queryDisableSnapshotCopyCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "ClusterNotFound":
+    case "ClusterNotFoundFault":
     case "com.amazonaws.redshift#ClusterNotFoundFault":
       response = {
         ...(await deserializeAws_queryClusterNotFoundFaultResponse(parsedOutput, context)),
@@ -8440,7 +8440,7 @@ const deserializeAws_queryDisableSnapshotCopyCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidClusterState":
+    case "InvalidClusterStateFault":
     case "com.amazonaws.redshift#InvalidClusterStateFault":
       response = {
         ...(await deserializeAws_queryInvalidClusterStateFaultResponse(parsedOutput, context)),
@@ -8580,7 +8580,7 @@ const deserializeAws_queryEnableLoggingCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ClusterNotFound":
+    case "ClusterNotFoundFault":
     case "com.amazonaws.redshift#ClusterNotFoundFault":
       response = {
         ...(await deserializeAws_queryClusterNotFoundFaultResponse(parsedOutput, context)),
@@ -8596,7 +8596,7 @@ const deserializeAws_queryEnableLoggingCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidClusterState":
+    case "InvalidClusterStateFault":
     case "com.amazonaws.redshift#InvalidClusterStateFault":
       response = {
         ...(await deserializeAws_queryInvalidClusterStateFaultResponse(parsedOutput, context)),
@@ -8666,7 +8666,7 @@ const deserializeAws_queryEnableSnapshotCopyCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "ClusterNotFound":
+    case "ClusterNotFoundFault":
     case "com.amazonaws.redshift#ClusterNotFoundFault":
       response = {
         ...(await deserializeAws_queryClusterNotFoundFaultResponse(parsedOutput, context)),
@@ -8698,7 +8698,7 @@ const deserializeAws_queryEnableSnapshotCopyCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidClusterState":
+    case "InvalidClusterStateFault":
     case "com.amazonaws.redshift#InvalidClusterStateFault":
       response = {
         ...(await deserializeAws_queryInvalidClusterStateFaultResponse(parsedOutput, context)),
@@ -8800,7 +8800,7 @@ const deserializeAws_queryGetClusterCredentialsCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "ClusterNotFound":
+    case "ClusterNotFoundFault":
     case "com.amazonaws.redshift#ClusterNotFoundFault":
       response = {
         ...(await deserializeAws_queryClusterNotFoundFaultResponse(parsedOutput, context)),
@@ -8808,7 +8808,7 @@ const deserializeAws_queryGetClusterCredentialsCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "UnsupportedOperation":
+    case "UnsupportedOperationFault":
     case "com.amazonaws.redshift#UnsupportedOperationFault":
       response = {
         ...(await deserializeAws_queryUnsupportedOperationFaultResponse(parsedOutput, context)),
@@ -8865,7 +8865,7 @@ const deserializeAws_queryGetReservedNodeExchangeConfigurationOptionsCommandErro
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "ClusterNotFound":
+    case "ClusterNotFoundFault":
     case "com.amazonaws.redshift#ClusterNotFoundFault":
       response = {
         ...(await deserializeAws_queryClusterNotFoundFaultResponse(parsedOutput, context)),
@@ -8873,7 +8873,7 @@ const deserializeAws_queryGetReservedNodeExchangeConfigurationOptionsCommandErro
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ClusterSnapshotNotFound":
+    case "ClusterSnapshotNotFoundFault":
     case "com.amazonaws.redshift#ClusterSnapshotNotFoundFault":
       response = {
         ...(await deserializeAws_queryClusterSnapshotNotFoundFaultResponse(parsedOutput, context)),
@@ -8889,7 +8889,7 @@ const deserializeAws_queryGetReservedNodeExchangeConfigurationOptionsCommandErro
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidReservedNodeState":
+    case "InvalidReservedNodeStateFault":
     case "com.amazonaws.redshift#InvalidReservedNodeStateFault":
       response = {
         ...(await deserializeAws_queryInvalidReservedNodeStateFaultResponse(parsedOutput, context)),
@@ -8897,7 +8897,7 @@ const deserializeAws_queryGetReservedNodeExchangeConfigurationOptionsCommandErro
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ReservedNodeAlreadyMigrated":
+    case "ReservedNodeAlreadyMigratedFault":
     case "com.amazonaws.redshift#ReservedNodeAlreadyMigratedFault":
       response = {
         ...(await deserializeAws_queryReservedNodeAlreadyMigratedFaultResponse(parsedOutput, context)),
@@ -8905,7 +8905,7 @@ const deserializeAws_queryGetReservedNodeExchangeConfigurationOptionsCommandErro
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ReservedNodeNotFound":
+    case "ReservedNodeNotFoundFault":
     case "com.amazonaws.redshift#ReservedNodeNotFoundFault":
       response = {
         ...(await deserializeAws_queryReservedNodeNotFoundFaultResponse(parsedOutput, context)),
@@ -8913,7 +8913,7 @@ const deserializeAws_queryGetReservedNodeExchangeConfigurationOptionsCommandErro
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ReservedNodeOfferingNotFound":
+    case "ReservedNodeOfferingNotFoundFault":
     case "com.amazonaws.redshift#ReservedNodeOfferingNotFoundFault":
       response = {
         ...(await deserializeAws_queryReservedNodeOfferingNotFoundFaultResponse(parsedOutput, context)),
@@ -8921,7 +8921,7 @@ const deserializeAws_queryGetReservedNodeExchangeConfigurationOptionsCommandErro
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "UnsupportedOperation":
+    case "UnsupportedOperationFault":
     case "com.amazonaws.redshift#UnsupportedOperationFault":
       response = {
         ...(await deserializeAws_queryUnsupportedOperationFaultResponse(parsedOutput, context)),
@@ -8986,7 +8986,7 @@ const deserializeAws_queryGetReservedNodeExchangeOfferingsCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidReservedNodeState":
+    case "InvalidReservedNodeStateFault":
     case "com.amazonaws.redshift#InvalidReservedNodeStateFault":
       response = {
         ...(await deserializeAws_queryInvalidReservedNodeStateFaultResponse(parsedOutput, context)),
@@ -8994,7 +8994,7 @@ const deserializeAws_queryGetReservedNodeExchangeOfferingsCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ReservedNodeAlreadyMigrated":
+    case "ReservedNodeAlreadyMigratedFault":
     case "com.amazonaws.redshift#ReservedNodeAlreadyMigratedFault":
       response = {
         ...(await deserializeAws_queryReservedNodeAlreadyMigratedFaultResponse(parsedOutput, context)),
@@ -9002,7 +9002,7 @@ const deserializeAws_queryGetReservedNodeExchangeOfferingsCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ReservedNodeNotFound":
+    case "ReservedNodeNotFoundFault":
     case "com.amazonaws.redshift#ReservedNodeNotFoundFault":
       response = {
         ...(await deserializeAws_queryReservedNodeNotFoundFaultResponse(parsedOutput, context)),
@@ -9010,7 +9010,7 @@ const deserializeAws_queryGetReservedNodeExchangeOfferingsCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ReservedNodeOfferingNotFound":
+    case "ReservedNodeOfferingNotFoundFault":
     case "com.amazonaws.redshift#ReservedNodeOfferingNotFoundFault":
       response = {
         ...(await deserializeAws_queryReservedNodeOfferingNotFoundFaultResponse(parsedOutput, context)),
@@ -9018,7 +9018,7 @@ const deserializeAws_queryGetReservedNodeExchangeOfferingsCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "UnsupportedOperation":
+    case "UnsupportedOperationFault":
     case "com.amazonaws.redshift#UnsupportedOperationFault":
       response = {
         ...(await deserializeAws_queryUnsupportedOperationFaultResponse(parsedOutput, context)),
@@ -9072,7 +9072,7 @@ const deserializeAws_queryModifyAquaConfigurationCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "ClusterNotFound":
+    case "ClusterNotFoundFault":
     case "com.amazonaws.redshift#ClusterNotFoundFault":
       response = {
         ...(await deserializeAws_queryClusterNotFoundFaultResponse(parsedOutput, context)),
@@ -9080,7 +9080,7 @@ const deserializeAws_queryModifyAquaConfigurationCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidClusterState":
+    case "InvalidClusterStateFault":
     case "com.amazonaws.redshift#InvalidClusterStateFault":
       response = {
         ...(await deserializeAws_queryInvalidClusterStateFaultResponse(parsedOutput, context)),
@@ -9088,7 +9088,7 @@ const deserializeAws_queryModifyAquaConfigurationCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "UnsupportedOperation":
+    case "UnsupportedOperationFault":
     case "com.amazonaws.redshift#UnsupportedOperationFault":
       response = {
         ...(await deserializeAws_queryUnsupportedOperationFaultResponse(parsedOutput, context)),
@@ -9212,7 +9212,7 @@ const deserializeAws_queryModifyClusterCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "ClusterAlreadyExists":
+    case "ClusterAlreadyExistsFault":
     case "com.amazonaws.redshift#ClusterAlreadyExistsFault":
       response = {
         ...(await deserializeAws_queryClusterAlreadyExistsFaultResponse(parsedOutput, context)),
@@ -9220,7 +9220,7 @@ const deserializeAws_queryModifyClusterCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ClusterNotFound":
+    case "ClusterNotFoundFault":
     case "com.amazonaws.redshift#ClusterNotFoundFault":
       response = {
         ...(await deserializeAws_queryClusterNotFoundFaultResponse(parsedOutput, context)),
@@ -9228,7 +9228,7 @@ const deserializeAws_queryModifyClusterCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ClusterParameterGroupNotFound":
+    case "ClusterParameterGroupNotFoundFault":
     case "com.amazonaws.redshift#ClusterParameterGroupNotFoundFault":
       response = {
         ...(await deserializeAws_queryClusterParameterGroupNotFoundFaultResponse(parsedOutput, context)),
@@ -9236,7 +9236,7 @@ const deserializeAws_queryModifyClusterCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ClusterSecurityGroupNotFound":
+    case "ClusterSecurityGroupNotFoundFault":
     case "com.amazonaws.redshift#ClusterSecurityGroupNotFoundFault":
       response = {
         ...(await deserializeAws_queryClusterSecurityGroupNotFoundFaultResponse(parsedOutput, context)),
@@ -9268,7 +9268,7 @@ const deserializeAws_queryModifyClusterCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InsufficientClusterCapacity":
+    case "InsufficientClusterCapacityFault":
     case "com.amazonaws.redshift#InsufficientClusterCapacityFault":
       response = {
         ...(await deserializeAws_queryInsufficientClusterCapacityFaultResponse(parsedOutput, context)),
@@ -9276,7 +9276,7 @@ const deserializeAws_queryModifyClusterCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidClusterSecurityGroupState":
+    case "InvalidClusterSecurityGroupStateFault":
     case "com.amazonaws.redshift#InvalidClusterSecurityGroupStateFault":
       response = {
         ...(await deserializeAws_queryInvalidClusterSecurityGroupStateFaultResponse(parsedOutput, context)),
@@ -9284,7 +9284,7 @@ const deserializeAws_queryModifyClusterCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidClusterState":
+    case "InvalidClusterStateFault":
     case "com.amazonaws.redshift#InvalidClusterStateFault":
       response = {
         ...(await deserializeAws_queryInvalidClusterStateFaultResponse(parsedOutput, context)),
@@ -9292,7 +9292,7 @@ const deserializeAws_queryModifyClusterCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidClusterTrack":
+    case "InvalidClusterTrackFault":
     case "com.amazonaws.redshift#InvalidClusterTrackFault":
       response = {
         ...(await deserializeAws_queryInvalidClusterTrackFaultResponse(parsedOutput, context)),
@@ -9324,7 +9324,7 @@ const deserializeAws_queryModifyClusterCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "NumberOfNodesPerClusterLimitExceeded":
+    case "NumberOfNodesPerClusterLimitExceededFault":
     case "com.amazonaws.redshift#NumberOfNodesPerClusterLimitExceededFault":
       response = {
         ...(await deserializeAws_queryNumberOfNodesPerClusterLimitExceededFaultResponse(parsedOutput, context)),
@@ -9332,7 +9332,7 @@ const deserializeAws_queryModifyClusterCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "NumberOfNodesQuotaExceeded":
+    case "NumberOfNodesQuotaExceededFault":
     case "com.amazonaws.redshift#NumberOfNodesQuotaExceededFault":
       response = {
         ...(await deserializeAws_queryNumberOfNodesQuotaExceededFaultResponse(parsedOutput, context)),
@@ -9340,7 +9340,7 @@ const deserializeAws_queryModifyClusterCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "TableLimitExceeded":
+    case "TableLimitExceededFault":
     case "com.amazonaws.redshift#TableLimitExceededFault":
       response = {
         ...(await deserializeAws_queryTableLimitExceededFaultResponse(parsedOutput, context)),
@@ -9410,7 +9410,7 @@ const deserializeAws_queryModifyClusterDbRevisionCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "ClusterNotFound":
+    case "ClusterNotFoundFault":
     case "com.amazonaws.redshift#ClusterNotFoundFault":
       response = {
         ...(await deserializeAws_queryClusterNotFoundFaultResponse(parsedOutput, context)),
@@ -9418,7 +9418,7 @@ const deserializeAws_queryModifyClusterDbRevisionCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ClusterOnLatestRevision":
+    case "ClusterOnLatestRevisionFault":
     case "com.amazonaws.redshift#ClusterOnLatestRevisionFault":
       response = {
         ...(await deserializeAws_queryClusterOnLatestRevisionFaultResponse(parsedOutput, context)),
@@ -9426,7 +9426,7 @@ const deserializeAws_queryModifyClusterDbRevisionCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidClusterState":
+    case "InvalidClusterStateFault":
     case "com.amazonaws.redshift#InvalidClusterStateFault":
       response = {
         ...(await deserializeAws_queryInvalidClusterStateFaultResponse(parsedOutput, context)),
@@ -9480,7 +9480,7 @@ const deserializeAws_queryModifyClusterIamRolesCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "ClusterNotFound":
+    case "ClusterNotFoundFault":
     case "com.amazonaws.redshift#ClusterNotFoundFault":
       response = {
         ...(await deserializeAws_queryClusterNotFoundFaultResponse(parsedOutput, context)),
@@ -9488,7 +9488,7 @@ const deserializeAws_queryModifyClusterIamRolesCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidClusterState":
+    case "InvalidClusterStateFault":
     case "com.amazonaws.redshift#InvalidClusterStateFault":
       response = {
         ...(await deserializeAws_queryInvalidClusterStateFaultResponse(parsedOutput, context)),
@@ -9542,7 +9542,7 @@ const deserializeAws_queryModifyClusterMaintenanceCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "ClusterNotFound":
+    case "ClusterNotFoundFault":
     case "com.amazonaws.redshift#ClusterNotFoundFault":
       response = {
         ...(await deserializeAws_queryClusterNotFoundFaultResponse(parsedOutput, context)),
@@ -9550,7 +9550,7 @@ const deserializeAws_queryModifyClusterMaintenanceCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidClusterState":
+    case "InvalidClusterStateFault":
     case "com.amazonaws.redshift#InvalidClusterStateFault":
       response = {
         ...(await deserializeAws_queryInvalidClusterStateFaultResponse(parsedOutput, context)),
@@ -9604,7 +9604,7 @@ const deserializeAws_queryModifyClusterParameterGroupCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "ClusterParameterGroupNotFound":
+    case "ClusterParameterGroupNotFoundFault":
     case "com.amazonaws.redshift#ClusterParameterGroupNotFoundFault":
       response = {
         ...(await deserializeAws_queryClusterParameterGroupNotFoundFaultResponse(parsedOutput, context)),
@@ -9612,7 +9612,7 @@ const deserializeAws_queryModifyClusterParameterGroupCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidClusterParameterGroupState":
+    case "InvalidClusterParameterGroupStateFault":
     case "com.amazonaws.redshift#InvalidClusterParameterGroupStateFault":
       response = {
         ...(await deserializeAws_queryInvalidClusterParameterGroupStateFaultResponse(parsedOutput, context)),
@@ -9666,7 +9666,7 @@ const deserializeAws_queryModifyClusterSnapshotCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "ClusterSnapshotNotFound":
+    case "ClusterSnapshotNotFoundFault":
     case "com.amazonaws.redshift#ClusterSnapshotNotFoundFault":
       response = {
         ...(await deserializeAws_queryClusterSnapshotNotFoundFaultResponse(parsedOutput, context)),
@@ -9674,7 +9674,7 @@ const deserializeAws_queryModifyClusterSnapshotCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidClusterSnapshotState":
+    case "InvalidClusterSnapshotStateFault":
     case "com.amazonaws.redshift#InvalidClusterSnapshotStateFault":
       response = {
         ...(await deserializeAws_queryInvalidClusterSnapshotStateFaultResponse(parsedOutput, context)),
@@ -9733,7 +9733,7 @@ const deserializeAws_queryModifyClusterSnapshotScheduleCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "ClusterNotFound":
+    case "ClusterNotFoundFault":
     case "com.amazonaws.redshift#ClusterNotFoundFault":
       response = {
         ...(await deserializeAws_queryClusterNotFoundFaultResponse(parsedOutput, context)),
@@ -9741,7 +9741,7 @@ const deserializeAws_queryModifyClusterSnapshotScheduleCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidClusterSnapshotScheduleState":
+    case "InvalidClusterSnapshotScheduleStateFault":
     case "com.amazonaws.redshift#InvalidClusterSnapshotScheduleStateFault":
       response = {
         ...(await deserializeAws_queryInvalidClusterSnapshotScheduleStateFaultResponse(parsedOutput, context)),
@@ -9749,7 +9749,7 @@ const deserializeAws_queryModifyClusterSnapshotScheduleCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "SnapshotScheduleNotFound":
+    case "SnapshotScheduleNotFoundFault":
     case "com.amazonaws.redshift#SnapshotScheduleNotFoundFault":
       response = {
         ...(await deserializeAws_querySnapshotScheduleNotFoundFaultResponse(parsedOutput, context)),
@@ -9897,7 +9897,7 @@ const deserializeAws_queryModifyEndpointAccessCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "ClusterNotFound":
+    case "ClusterNotFoundFault":
     case "com.amazonaws.redshift#ClusterNotFoundFault":
       response = {
         ...(await deserializeAws_queryClusterNotFoundFaultResponse(parsedOutput, context)),
@@ -9905,7 +9905,7 @@ const deserializeAws_queryModifyEndpointAccessCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "EndpointNotFound":
+    case "EndpointNotFoundFault":
     case "com.amazonaws.redshift#EndpointNotFoundFault":
       response = {
         ...(await deserializeAws_queryEndpointNotFoundFaultResponse(parsedOutput, context)),
@@ -9913,7 +9913,7 @@ const deserializeAws_queryModifyEndpointAccessCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidClusterSecurityGroupState":
+    case "InvalidClusterSecurityGroupStateFault":
     case "com.amazonaws.redshift#InvalidClusterSecurityGroupStateFault":
       response = {
         ...(await deserializeAws_queryInvalidClusterSecurityGroupStateFaultResponse(parsedOutput, context)),
@@ -9921,7 +9921,7 @@ const deserializeAws_queryModifyEndpointAccessCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidClusterState":
+    case "InvalidClusterStateFault":
     case "com.amazonaws.redshift#InvalidClusterStateFault":
       response = {
         ...(await deserializeAws_queryInvalidClusterStateFaultResponse(parsedOutput, context)),
@@ -9929,7 +9929,7 @@ const deserializeAws_queryModifyEndpointAccessCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidEndpointState":
+    case "InvalidEndpointStateFault":
     case "com.amazonaws.redshift#InvalidEndpointStateFault":
       response = {
         ...(await deserializeAws_queryInvalidEndpointStateFaultResponse(parsedOutput, context)),
@@ -9999,7 +9999,7 @@ const deserializeAws_queryModifyEventSubscriptionCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "SNSInvalidTopic":
+    case "SNSInvalidTopicFault":
     case "com.amazonaws.redshift#SNSInvalidTopicFault":
       response = {
         ...(await deserializeAws_querySNSInvalidTopicFaultResponse(parsedOutput, context)),
@@ -10007,7 +10007,7 @@ const deserializeAws_queryModifyEventSubscriptionCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "SNSNoAuthorization":
+    case "SNSNoAuthorizationFault":
     case "com.amazonaws.redshift#SNSNoAuthorizationFault":
       response = {
         ...(await deserializeAws_querySNSNoAuthorizationFaultResponse(parsedOutput, context)),
@@ -10015,7 +10015,7 @@ const deserializeAws_queryModifyEventSubscriptionCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "SNSTopicArnNotFound":
+    case "SNSTopicArnNotFoundFault":
     case "com.amazonaws.redshift#SNSTopicArnNotFoundFault":
       response = {
         ...(await deserializeAws_querySNSTopicArnNotFoundFaultResponse(parsedOutput, context)),
@@ -10023,7 +10023,7 @@ const deserializeAws_queryModifyEventSubscriptionCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "SourceNotFound":
+    case "SourceNotFoundFault":
     case "com.amazonaws.redshift#SourceNotFoundFault":
       response = {
         ...(await deserializeAws_querySourceNotFoundFaultResponse(parsedOutput, context)),
@@ -10031,7 +10031,7 @@ const deserializeAws_queryModifyEventSubscriptionCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "SubscriptionCategoryNotFound":
+    case "SubscriptionCategoryNotFoundFault":
     case "com.amazonaws.redshift#SubscriptionCategoryNotFoundFault":
       response = {
         ...(await deserializeAws_querySubscriptionCategoryNotFoundFaultResponse(parsedOutput, context)),
@@ -10039,7 +10039,7 @@ const deserializeAws_queryModifyEventSubscriptionCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "SubscriptionEventIdNotFound":
+    case "SubscriptionEventIdNotFoundFault":
     case "com.amazonaws.redshift#SubscriptionEventIdNotFoundFault":
       response = {
         ...(await deserializeAws_querySubscriptionEventIdNotFoundFaultResponse(parsedOutput, context)),
@@ -10047,7 +10047,7 @@ const deserializeAws_queryModifyEventSubscriptionCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "SubscriptionNotFound":
+    case "SubscriptionNotFoundFault":
     case "com.amazonaws.redshift#SubscriptionNotFoundFault":
       response = {
         ...(await deserializeAws_querySubscriptionNotFoundFaultResponse(parsedOutput, context)),
@@ -10055,7 +10055,7 @@ const deserializeAws_queryModifyEventSubscriptionCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "SubscriptionSeverityNotFound":
+    case "SubscriptionSeverityNotFoundFault":
     case "com.amazonaws.redshift#SubscriptionSeverityNotFoundFault":
       response = {
         ...(await deserializeAws_querySubscriptionSeverityNotFoundFaultResponse(parsedOutput, context)),
@@ -10109,15 +10109,7 @@ const deserializeAws_queryModifyScheduledActionCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "InvalidSchedule":
-    case "com.amazonaws.redshift#InvalidScheduleFault":
-      response = {
-        ...(await deserializeAws_queryInvalidScheduleFaultResponse(parsedOutput, context)),
-        name: errorCode,
-        $metadata: deserializeMetadata(output),
-      };
-      break;
-    case "InvalidScheduledAction":
+    case "InvalidScheduledActionFault":
     case "com.amazonaws.redshift#InvalidScheduledActionFault":
       response = {
         ...(await deserializeAws_queryInvalidScheduledActionFaultResponse(parsedOutput, context)),
@@ -10125,7 +10117,15 @@ const deserializeAws_queryModifyScheduledActionCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ScheduledActionNotFound":
+    case "InvalidScheduleFault":
+    case "com.amazonaws.redshift#InvalidScheduleFault":
+      response = {
+        ...(await deserializeAws_queryInvalidScheduleFaultResponse(parsedOutput, context)),
+        name: errorCode,
+        $metadata: deserializeMetadata(output),
+      };
+      break;
+    case "ScheduledActionNotFoundFault":
     case "com.amazonaws.redshift#ScheduledActionNotFoundFault":
       response = {
         ...(await deserializeAws_queryScheduledActionNotFoundFaultResponse(parsedOutput, context)),
@@ -10133,7 +10133,7 @@ const deserializeAws_queryModifyScheduledActionCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ScheduledActionTypeUnsupported":
+    case "ScheduledActionTypeUnsupportedFault":
     case "com.amazonaws.redshift#ScheduledActionTypeUnsupportedFault":
       response = {
         ...(await deserializeAws_queryScheduledActionTypeUnsupportedFaultResponse(parsedOutput, context)),
@@ -10198,7 +10198,7 @@ const deserializeAws_queryModifySnapshotCopyRetentionPeriodCommandError = async 
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "ClusterNotFound":
+    case "ClusterNotFoundFault":
     case "com.amazonaws.redshift#ClusterNotFoundFault":
       response = {
         ...(await deserializeAws_queryClusterNotFoundFaultResponse(parsedOutput, context)),
@@ -10206,7 +10206,7 @@ const deserializeAws_queryModifySnapshotCopyRetentionPeriodCommandError = async 
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidClusterState":
+    case "InvalidClusterStateFault":
     case "com.amazonaws.redshift#InvalidClusterStateFault":
       response = {
         ...(await deserializeAws_queryInvalidClusterStateFaultResponse(parsedOutput, context)),
@@ -10284,7 +10284,7 @@ const deserializeAws_queryModifySnapshotScheduleCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "InvalidSchedule":
+    case "InvalidScheduleFault":
     case "com.amazonaws.redshift#InvalidScheduleFault":
       response = {
         ...(await deserializeAws_queryInvalidScheduleFaultResponse(parsedOutput, context)),
@@ -10292,7 +10292,7 @@ const deserializeAws_queryModifySnapshotScheduleCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "SnapshotScheduleNotFound":
+    case "SnapshotScheduleNotFoundFault":
     case "com.amazonaws.redshift#SnapshotScheduleNotFoundFault":
       response = {
         ...(await deserializeAws_querySnapshotScheduleNotFoundFaultResponse(parsedOutput, context)),
@@ -10300,7 +10300,7 @@ const deserializeAws_queryModifySnapshotScheduleCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "SnapshotScheduleUpdateInProgress":
+    case "SnapshotScheduleUpdateInProgressFault":
     case "com.amazonaws.redshift#SnapshotScheduleUpdateInProgressFault":
       response = {
         ...(await deserializeAws_querySnapshotScheduleUpdateInProgressFaultResponse(parsedOutput, context)),
@@ -10354,7 +10354,7 @@ const deserializeAws_queryModifyUsageLimitCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "InvalidUsageLimit":
+    case "InvalidUsageLimitFault":
     case "com.amazonaws.redshift#InvalidUsageLimitFault":
       response = {
         ...(await deserializeAws_queryInvalidUsageLimitFaultResponse(parsedOutput, context)),
@@ -10362,7 +10362,7 @@ const deserializeAws_queryModifyUsageLimitCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "UnsupportedOperation":
+    case "UnsupportedOperationFault":
     case "com.amazonaws.redshift#UnsupportedOperationFault":
       response = {
         ...(await deserializeAws_queryUnsupportedOperationFaultResponse(parsedOutput, context)),
@@ -10370,7 +10370,7 @@ const deserializeAws_queryModifyUsageLimitCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "UsageLimitNotFound":
+    case "UsageLimitNotFoundFault":
     case "com.amazonaws.redshift#UsageLimitNotFoundFault":
       response = {
         ...(await deserializeAws_queryUsageLimitNotFoundFaultResponse(parsedOutput, context)),
@@ -10424,7 +10424,7 @@ const deserializeAws_queryPauseClusterCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "ClusterNotFound":
+    case "ClusterNotFoundFault":
     case "com.amazonaws.redshift#ClusterNotFoundFault":
       response = {
         ...(await deserializeAws_queryClusterNotFoundFaultResponse(parsedOutput, context)),
@@ -10432,7 +10432,7 @@ const deserializeAws_queryPauseClusterCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidClusterState":
+    case "InvalidClusterStateFault":
     case "com.amazonaws.redshift#InvalidClusterStateFault":
       response = {
         ...(await deserializeAws_queryInvalidClusterStateFaultResponse(parsedOutput, context)),
@@ -10486,7 +10486,7 @@ const deserializeAws_queryPurchaseReservedNodeOfferingCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "ReservedNodeAlreadyExists":
+    case "ReservedNodeAlreadyExistsFault":
     case "com.amazonaws.redshift#ReservedNodeAlreadyExistsFault":
       response = {
         ...(await deserializeAws_queryReservedNodeAlreadyExistsFaultResponse(parsedOutput, context)),
@@ -10494,7 +10494,7 @@ const deserializeAws_queryPurchaseReservedNodeOfferingCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ReservedNodeOfferingNotFound":
+    case "ReservedNodeOfferingNotFoundFault":
     case "com.amazonaws.redshift#ReservedNodeOfferingNotFoundFault":
       response = {
         ...(await deserializeAws_queryReservedNodeOfferingNotFoundFaultResponse(parsedOutput, context)),
@@ -10502,7 +10502,7 @@ const deserializeAws_queryPurchaseReservedNodeOfferingCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ReservedNodeQuotaExceeded":
+    case "ReservedNodeQuotaExceededFault":
     case "com.amazonaws.redshift#ReservedNodeQuotaExceededFault":
       response = {
         ...(await deserializeAws_queryReservedNodeQuotaExceededFaultResponse(parsedOutput, context)),
@@ -10510,7 +10510,7 @@ const deserializeAws_queryPurchaseReservedNodeOfferingCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "UnsupportedOperation":
+    case "UnsupportedOperationFault":
     case "com.amazonaws.redshift#UnsupportedOperationFault":
       response = {
         ...(await deserializeAws_queryUnsupportedOperationFaultResponse(parsedOutput, context)),
@@ -10564,7 +10564,7 @@ const deserializeAws_queryRebootClusterCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "ClusterNotFound":
+    case "ClusterNotFoundFault":
     case "com.amazonaws.redshift#ClusterNotFoundFault":
       response = {
         ...(await deserializeAws_queryClusterNotFoundFaultResponse(parsedOutput, context)),
@@ -10572,7 +10572,7 @@ const deserializeAws_queryRebootClusterCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidClusterState":
+    case "InvalidClusterStateFault":
     case "com.amazonaws.redshift#InvalidClusterStateFault":
       response = {
         ...(await deserializeAws_queryInvalidClusterStateFaultResponse(parsedOutput, context)),
@@ -10680,7 +10680,7 @@ const deserializeAws_queryResetClusterParameterGroupCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "ClusterParameterGroupNotFound":
+    case "ClusterParameterGroupNotFoundFault":
     case "com.amazonaws.redshift#ClusterParameterGroupNotFoundFault":
       response = {
         ...(await deserializeAws_queryClusterParameterGroupNotFoundFaultResponse(parsedOutput, context)),
@@ -10688,7 +10688,7 @@ const deserializeAws_queryResetClusterParameterGroupCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidClusterParameterGroupState":
+    case "InvalidClusterParameterGroupStateFault":
     case "com.amazonaws.redshift#InvalidClusterParameterGroupStateFault":
       response = {
         ...(await deserializeAws_queryInvalidClusterParameterGroupStateFaultResponse(parsedOutput, context)),
@@ -10742,7 +10742,7 @@ const deserializeAws_queryResizeClusterCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "ClusterNotFound":
+    case "ClusterNotFoundFault":
     case "com.amazonaws.redshift#ClusterNotFoundFault":
       response = {
         ...(await deserializeAws_queryClusterNotFoundFaultResponse(parsedOutput, context)),
@@ -10758,7 +10758,7 @@ const deserializeAws_queryResizeClusterCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InsufficientClusterCapacity":
+    case "InsufficientClusterCapacityFault":
     case "com.amazonaws.redshift#InsufficientClusterCapacityFault":
       response = {
         ...(await deserializeAws_queryInsufficientClusterCapacityFaultResponse(parsedOutput, context)),
@@ -10766,7 +10766,7 @@ const deserializeAws_queryResizeClusterCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidClusterState":
+    case "InvalidClusterStateFault":
     case "com.amazonaws.redshift#InvalidClusterStateFault":
       response = {
         ...(await deserializeAws_queryInvalidClusterStateFaultResponse(parsedOutput, context)),
@@ -10774,7 +10774,7 @@ const deserializeAws_queryResizeClusterCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidReservedNodeState":
+    case "InvalidReservedNodeStateFault":
     case "com.amazonaws.redshift#InvalidReservedNodeStateFault":
       response = {
         ...(await deserializeAws_queryInvalidReservedNodeStateFaultResponse(parsedOutput, context)),
@@ -10790,7 +10790,7 @@ const deserializeAws_queryResizeClusterCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "NumberOfNodesPerClusterLimitExceeded":
+    case "NumberOfNodesPerClusterLimitExceededFault":
     case "com.amazonaws.redshift#NumberOfNodesPerClusterLimitExceededFault":
       response = {
         ...(await deserializeAws_queryNumberOfNodesPerClusterLimitExceededFaultResponse(parsedOutput, context)),
@@ -10798,7 +10798,7 @@ const deserializeAws_queryResizeClusterCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "NumberOfNodesQuotaExceeded":
+    case "NumberOfNodesQuotaExceededFault":
     case "com.amazonaws.redshift#NumberOfNodesQuotaExceededFault":
       response = {
         ...(await deserializeAws_queryNumberOfNodesQuotaExceededFaultResponse(parsedOutput, context)),
@@ -10806,7 +10806,7 @@ const deserializeAws_queryResizeClusterCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ReservedNodeAlreadyExists":
+    case "ReservedNodeAlreadyExistsFault":
     case "com.amazonaws.redshift#ReservedNodeAlreadyExistsFault":
       response = {
         ...(await deserializeAws_queryReservedNodeAlreadyExistsFaultResponse(parsedOutput, context)),
@@ -10814,7 +10814,7 @@ const deserializeAws_queryResizeClusterCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ReservedNodeAlreadyMigrated":
+    case "ReservedNodeAlreadyMigratedFault":
     case "com.amazonaws.redshift#ReservedNodeAlreadyMigratedFault":
       response = {
         ...(await deserializeAws_queryReservedNodeAlreadyMigratedFaultResponse(parsedOutput, context)),
@@ -10822,7 +10822,7 @@ const deserializeAws_queryResizeClusterCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ReservedNodeNotFound":
+    case "ReservedNodeNotFoundFault":
     case "com.amazonaws.redshift#ReservedNodeNotFoundFault":
       response = {
         ...(await deserializeAws_queryReservedNodeNotFoundFaultResponse(parsedOutput, context)),
@@ -10830,7 +10830,7 @@ const deserializeAws_queryResizeClusterCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ReservedNodeOfferingNotFound":
+    case "ReservedNodeOfferingNotFoundFault":
     case "com.amazonaws.redshift#ReservedNodeOfferingNotFoundFault":
       response = {
         ...(await deserializeAws_queryReservedNodeOfferingNotFoundFaultResponse(parsedOutput, context)),
@@ -10846,7 +10846,7 @@ const deserializeAws_queryResizeClusterCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "UnsupportedOperation":
+    case "UnsupportedOperationFault":
     case "com.amazonaws.redshift#UnsupportedOperationFault":
       response = {
         ...(await deserializeAws_queryUnsupportedOperationFaultResponse(parsedOutput, context)),
@@ -10908,7 +10908,7 @@ const deserializeAws_queryRestoreFromClusterSnapshotCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "AccessToSnapshotDenied":
+    case "AccessToSnapshotDeniedFault":
     case "com.amazonaws.redshift#AccessToSnapshotDeniedFault":
       response = {
         ...(await deserializeAws_queryAccessToSnapshotDeniedFaultResponse(parsedOutput, context)),
@@ -10916,7 +10916,7 @@ const deserializeAws_queryRestoreFromClusterSnapshotCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ClusterAlreadyExists":
+    case "ClusterAlreadyExistsFault":
     case "com.amazonaws.redshift#ClusterAlreadyExistsFault":
       response = {
         ...(await deserializeAws_queryClusterAlreadyExistsFaultResponse(parsedOutput, context)),
@@ -10924,7 +10924,7 @@ const deserializeAws_queryRestoreFromClusterSnapshotCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ClusterParameterGroupNotFound":
+    case "ClusterParameterGroupNotFoundFault":
     case "com.amazonaws.redshift#ClusterParameterGroupNotFoundFault":
       response = {
         ...(await deserializeAws_queryClusterParameterGroupNotFoundFaultResponse(parsedOutput, context)),
@@ -10932,7 +10932,7 @@ const deserializeAws_queryRestoreFromClusterSnapshotCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ClusterQuotaExceeded":
+    case "ClusterQuotaExceededFault":
     case "com.amazonaws.redshift#ClusterQuotaExceededFault":
       response = {
         ...(await deserializeAws_queryClusterQuotaExceededFaultResponse(parsedOutput, context)),
@@ -10940,7 +10940,7 @@ const deserializeAws_queryRestoreFromClusterSnapshotCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ClusterSecurityGroupNotFound":
+    case "ClusterSecurityGroupNotFoundFault":
     case "com.amazonaws.redshift#ClusterSecurityGroupNotFoundFault":
       response = {
         ...(await deserializeAws_queryClusterSecurityGroupNotFoundFaultResponse(parsedOutput, context)),
@@ -10948,7 +10948,7 @@ const deserializeAws_queryRestoreFromClusterSnapshotCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ClusterSnapshotNotFound":
+    case "ClusterSnapshotNotFoundFault":
     case "com.amazonaws.redshift#ClusterSnapshotNotFoundFault":
       response = {
         ...(await deserializeAws_queryClusterSnapshotNotFoundFaultResponse(parsedOutput, context)),
@@ -10996,7 +10996,7 @@ const deserializeAws_queryRestoreFromClusterSnapshotCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InsufficientClusterCapacity":
+    case "InsufficientClusterCapacityFault":
     case "com.amazonaws.redshift#InsufficientClusterCapacityFault":
       response = {
         ...(await deserializeAws_queryInsufficientClusterCapacityFaultResponse(parsedOutput, context)),
@@ -11004,7 +11004,7 @@ const deserializeAws_queryRestoreFromClusterSnapshotCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidClusterSnapshotState":
+    case "InvalidClusterSnapshotStateFault":
     case "com.amazonaws.redshift#InvalidClusterSnapshotStateFault":
       response = {
         ...(await deserializeAws_queryInvalidClusterSnapshotStateFaultResponse(parsedOutput, context)),
@@ -11020,7 +11020,7 @@ const deserializeAws_queryRestoreFromClusterSnapshotCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidClusterTrack":
+    case "InvalidClusterTrackFault":
     case "com.amazonaws.redshift#InvalidClusterTrackFault":
       response = {
         ...(await deserializeAws_queryInvalidClusterTrackFaultResponse(parsedOutput, context)),
@@ -11036,7 +11036,7 @@ const deserializeAws_queryRestoreFromClusterSnapshotCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidReservedNodeState":
+    case "InvalidReservedNodeStateFault":
     case "com.amazonaws.redshift#InvalidReservedNodeStateFault":
       response = {
         ...(await deserializeAws_queryInvalidReservedNodeStateFaultResponse(parsedOutput, context)),
@@ -11044,7 +11044,7 @@ const deserializeAws_queryRestoreFromClusterSnapshotCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidRestore":
+    case "InvalidRestoreFault":
     case "com.amazonaws.redshift#InvalidRestoreFault":
       response = {
         ...(await deserializeAws_queryInvalidRestoreFaultResponse(parsedOutput, context)),
@@ -11084,7 +11084,7 @@ const deserializeAws_queryRestoreFromClusterSnapshotCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "NumberOfNodesPerClusterLimitExceeded":
+    case "NumberOfNodesPerClusterLimitExceededFault":
     case "com.amazonaws.redshift#NumberOfNodesPerClusterLimitExceededFault":
       response = {
         ...(await deserializeAws_queryNumberOfNodesPerClusterLimitExceededFaultResponse(parsedOutput, context)),
@@ -11092,7 +11092,7 @@ const deserializeAws_queryRestoreFromClusterSnapshotCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "NumberOfNodesQuotaExceeded":
+    case "NumberOfNodesQuotaExceededFault":
     case "com.amazonaws.redshift#NumberOfNodesQuotaExceededFault":
       response = {
         ...(await deserializeAws_queryNumberOfNodesQuotaExceededFaultResponse(parsedOutput, context)),
@@ -11100,7 +11100,7 @@ const deserializeAws_queryRestoreFromClusterSnapshotCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ReservedNodeAlreadyExists":
+    case "ReservedNodeAlreadyExistsFault":
     case "com.amazonaws.redshift#ReservedNodeAlreadyExistsFault":
       response = {
         ...(await deserializeAws_queryReservedNodeAlreadyExistsFaultResponse(parsedOutput, context)),
@@ -11108,7 +11108,7 @@ const deserializeAws_queryRestoreFromClusterSnapshotCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ReservedNodeAlreadyMigrated":
+    case "ReservedNodeAlreadyMigratedFault":
     case "com.amazonaws.redshift#ReservedNodeAlreadyMigratedFault":
       response = {
         ...(await deserializeAws_queryReservedNodeAlreadyMigratedFaultResponse(parsedOutput, context)),
@@ -11116,7 +11116,7 @@ const deserializeAws_queryRestoreFromClusterSnapshotCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ReservedNodeNotFound":
+    case "ReservedNodeNotFoundFault":
     case "com.amazonaws.redshift#ReservedNodeNotFoundFault":
       response = {
         ...(await deserializeAws_queryReservedNodeNotFoundFaultResponse(parsedOutput, context)),
@@ -11124,7 +11124,7 @@ const deserializeAws_queryRestoreFromClusterSnapshotCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ReservedNodeOfferingNotFound":
+    case "ReservedNodeOfferingNotFoundFault":
     case "com.amazonaws.redshift#ReservedNodeOfferingNotFoundFault":
       response = {
         ...(await deserializeAws_queryReservedNodeOfferingNotFoundFaultResponse(parsedOutput, context)),
@@ -11132,7 +11132,7 @@ const deserializeAws_queryRestoreFromClusterSnapshotCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "SnapshotScheduleNotFound":
+    case "SnapshotScheduleNotFoundFault":
     case "com.amazonaws.redshift#SnapshotScheduleNotFoundFault":
       response = {
         ...(await deserializeAws_querySnapshotScheduleNotFoundFaultResponse(parsedOutput, context)),
@@ -11156,7 +11156,7 @@ const deserializeAws_queryRestoreFromClusterSnapshotCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "UnsupportedOperation":
+    case "UnsupportedOperationFault":
     case "com.amazonaws.redshift#UnsupportedOperationFault":
       response = {
         ...(await deserializeAws_queryUnsupportedOperationFaultResponse(parsedOutput, context)),
@@ -11213,7 +11213,7 @@ const deserializeAws_queryRestoreTableFromClusterSnapshotCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "ClusterNotFound":
+    case "ClusterNotFoundFault":
     case "com.amazonaws.redshift#ClusterNotFoundFault":
       response = {
         ...(await deserializeAws_queryClusterNotFoundFaultResponse(parsedOutput, context)),
@@ -11221,7 +11221,7 @@ const deserializeAws_queryRestoreTableFromClusterSnapshotCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ClusterSnapshotNotFound":
+    case "ClusterSnapshotNotFoundFault":
     case "com.amazonaws.redshift#ClusterSnapshotNotFoundFault":
       response = {
         ...(await deserializeAws_queryClusterSnapshotNotFoundFaultResponse(parsedOutput, context)),
@@ -11237,7 +11237,7 @@ const deserializeAws_queryRestoreTableFromClusterSnapshotCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidClusterSnapshotState":
+    case "InvalidClusterSnapshotStateFault":
     case "com.amazonaws.redshift#InvalidClusterSnapshotStateFault":
       response = {
         ...(await deserializeAws_queryInvalidClusterSnapshotStateFaultResponse(parsedOutput, context)),
@@ -11245,7 +11245,7 @@ const deserializeAws_queryRestoreTableFromClusterSnapshotCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidClusterState":
+    case "InvalidClusterStateFault":
     case "com.amazonaws.redshift#InvalidClusterStateFault":
       response = {
         ...(await deserializeAws_queryInvalidClusterStateFaultResponse(parsedOutput, context)),
@@ -11253,7 +11253,7 @@ const deserializeAws_queryRestoreTableFromClusterSnapshotCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidTableRestoreArgument":
+    case "InvalidTableRestoreArgumentFault":
     case "com.amazonaws.redshift#InvalidTableRestoreArgumentFault":
       response = {
         ...(await deserializeAws_queryInvalidTableRestoreArgumentFaultResponse(parsedOutput, context)),
@@ -11261,7 +11261,7 @@ const deserializeAws_queryRestoreTableFromClusterSnapshotCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "UnsupportedOperation":
+    case "UnsupportedOperationFault":
     case "com.amazonaws.redshift#UnsupportedOperationFault":
       response = {
         ...(await deserializeAws_queryUnsupportedOperationFaultResponse(parsedOutput, context)),
@@ -11315,7 +11315,7 @@ const deserializeAws_queryResumeClusterCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "ClusterNotFound":
+    case "ClusterNotFoundFault":
     case "com.amazonaws.redshift#ClusterNotFoundFault":
       response = {
         ...(await deserializeAws_queryClusterNotFoundFaultResponse(parsedOutput, context)),
@@ -11323,7 +11323,7 @@ const deserializeAws_queryResumeClusterCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InsufficientClusterCapacity":
+    case "InsufficientClusterCapacityFault":
     case "com.amazonaws.redshift#InsufficientClusterCapacityFault":
       response = {
         ...(await deserializeAws_queryInsufficientClusterCapacityFaultResponse(parsedOutput, context)),
@@ -11331,7 +11331,7 @@ const deserializeAws_queryResumeClusterCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidClusterState":
+    case "InvalidClusterStateFault":
     case "com.amazonaws.redshift#InvalidClusterStateFault":
       response = {
         ...(await deserializeAws_queryInvalidClusterStateFaultResponse(parsedOutput, context)),
@@ -11388,7 +11388,7 @@ const deserializeAws_queryRevokeClusterSecurityGroupIngressCommandError = async 
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "AuthorizationNotFound":
+    case "AuthorizationNotFoundFault":
     case "com.amazonaws.redshift#AuthorizationNotFoundFault":
       response = {
         ...(await deserializeAws_queryAuthorizationNotFoundFaultResponse(parsedOutput, context)),
@@ -11396,7 +11396,7 @@ const deserializeAws_queryRevokeClusterSecurityGroupIngressCommandError = async 
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ClusterSecurityGroupNotFound":
+    case "ClusterSecurityGroupNotFoundFault":
     case "com.amazonaws.redshift#ClusterSecurityGroupNotFoundFault":
       response = {
         ...(await deserializeAws_queryClusterSecurityGroupNotFoundFaultResponse(parsedOutput, context)),
@@ -11404,7 +11404,7 @@ const deserializeAws_queryRevokeClusterSecurityGroupIngressCommandError = async 
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidClusterSecurityGroupState":
+    case "InvalidClusterSecurityGroupStateFault":
     case "com.amazonaws.redshift#InvalidClusterSecurityGroupStateFault":
       response = {
         ...(await deserializeAws_queryInvalidClusterSecurityGroupStateFaultResponse(parsedOutput, context)),
@@ -11458,7 +11458,7 @@ const deserializeAws_queryRevokeEndpointAccessCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "ClusterNotFound":
+    case "ClusterNotFoundFault":
     case "com.amazonaws.redshift#ClusterNotFoundFault":
       response = {
         ...(await deserializeAws_queryClusterNotFoundFaultResponse(parsedOutput, context)),
@@ -11466,7 +11466,7 @@ const deserializeAws_queryRevokeEndpointAccessCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "EndpointAuthorizationNotFound":
+    case "EndpointAuthorizationNotFoundFault":
     case "com.amazonaws.redshift#EndpointAuthorizationNotFoundFault":
       response = {
         ...(await deserializeAws_queryEndpointAuthorizationNotFoundFaultResponse(parsedOutput, context)),
@@ -11474,7 +11474,7 @@ const deserializeAws_queryRevokeEndpointAccessCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "EndpointNotFound":
+    case "EndpointNotFoundFault":
     case "com.amazonaws.redshift#EndpointNotFoundFault":
       response = {
         ...(await deserializeAws_queryEndpointNotFoundFaultResponse(parsedOutput, context)),
@@ -11482,7 +11482,7 @@ const deserializeAws_queryRevokeEndpointAccessCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidAuthorizationState":
+    case "InvalidAuthorizationStateFault":
     case "com.amazonaws.redshift#InvalidAuthorizationStateFault":
       response = {
         ...(await deserializeAws_queryInvalidAuthorizationStateFaultResponse(parsedOutput, context)),
@@ -11490,7 +11490,7 @@ const deserializeAws_queryRevokeEndpointAccessCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidClusterSecurityGroupState":
+    case "InvalidClusterSecurityGroupStateFault":
     case "com.amazonaws.redshift#InvalidClusterSecurityGroupStateFault":
       response = {
         ...(await deserializeAws_queryInvalidClusterSecurityGroupStateFaultResponse(parsedOutput, context)),
@@ -11498,7 +11498,7 @@ const deserializeAws_queryRevokeEndpointAccessCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidClusterState":
+    case "InvalidClusterStateFault":
     case "com.amazonaws.redshift#InvalidClusterStateFault":
       response = {
         ...(await deserializeAws_queryInvalidClusterStateFaultResponse(parsedOutput, context)),
@@ -11506,7 +11506,7 @@ const deserializeAws_queryRevokeEndpointAccessCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidEndpointState":
+    case "InvalidEndpointStateFault":
     case "com.amazonaws.redshift#InvalidEndpointStateFault":
       response = {
         ...(await deserializeAws_queryInvalidEndpointStateFaultResponse(parsedOutput, context)),
@@ -11560,7 +11560,7 @@ const deserializeAws_queryRevokeSnapshotAccessCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "AccessToSnapshotDenied":
+    case "AccessToSnapshotDeniedFault":
     case "com.amazonaws.redshift#AccessToSnapshotDeniedFault":
       response = {
         ...(await deserializeAws_queryAccessToSnapshotDeniedFaultResponse(parsedOutput, context)),
@@ -11568,7 +11568,7 @@ const deserializeAws_queryRevokeSnapshotAccessCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "AuthorizationNotFound":
+    case "AuthorizationNotFoundFault":
     case "com.amazonaws.redshift#AuthorizationNotFoundFault":
       response = {
         ...(await deserializeAws_queryAuthorizationNotFoundFaultResponse(parsedOutput, context)),
@@ -11576,7 +11576,7 @@ const deserializeAws_queryRevokeSnapshotAccessCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ClusterSnapshotNotFound":
+    case "ClusterSnapshotNotFoundFault":
     case "com.amazonaws.redshift#ClusterSnapshotNotFoundFault":
       response = {
         ...(await deserializeAws_queryClusterSnapshotNotFoundFaultResponse(parsedOutput, context)),
@@ -11630,7 +11630,7 @@ const deserializeAws_queryRotateEncryptionKeyCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "ClusterNotFound":
+    case "ClusterNotFoundFault":
     case "com.amazonaws.redshift#ClusterNotFoundFault":
       response = {
         ...(await deserializeAws_queryClusterNotFoundFaultResponse(parsedOutput, context)),
@@ -11646,7 +11646,7 @@ const deserializeAws_queryRotateEncryptionKeyCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidClusterState":
+    case "InvalidClusterStateFault":
     case "com.amazonaws.redshift#InvalidClusterStateFault":
       response = {
         ...(await deserializeAws_queryInvalidClusterStateFaultResponse(parsedOutput, context)),
@@ -11700,7 +11700,7 @@ const deserializeAws_queryUpdatePartnerStatusCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "ClusterNotFound":
+    case "ClusterNotFoundFault":
     case "com.amazonaws.redshift#ClusterNotFoundFault":
       response = {
         ...(await deserializeAws_queryClusterNotFoundFaultResponse(parsedOutput, context)),
@@ -11708,7 +11708,7 @@ const deserializeAws_queryUpdatePartnerStatusCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "PartnerNotFound":
+    case "PartnerNotFoundFault":
     case "com.amazonaws.redshift#PartnerNotFoundFault":
       response = {
         ...(await deserializeAws_queryPartnerNotFoundFaultResponse(parsedOutput, context)),
@@ -11716,7 +11716,7 @@ const deserializeAws_queryUpdatePartnerStatusCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "UnauthorizedPartnerIntegration":
+    case "UnauthorizedPartnerIntegrationFault":
     case "com.amazonaws.redshift#UnauthorizedPartnerIntegrationFault":
       response = {
         ...(await deserializeAws_queryUnauthorizedPartnerIntegrationFaultResponse(parsedOutput, context)),

--- a/clients/client-route-53/src/protocols/Aws_restXml.ts
+++ b/clients/client-route-53/src/protocols/Aws_restXml.ts
@@ -2639,18 +2639,18 @@ const deserializeAws_restXmlActivateKeySigningKeyCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidKMSArn":
-    case "com.amazonaws.route53#InvalidKMSArn":
-      response = {
-        ...(await deserializeAws_restXmlInvalidKMSArnResponse(parsedOutput, context)),
-        name: errorCode,
-        $metadata: deserializeMetadata(output),
-      };
-      break;
     case "InvalidKeySigningKeyStatus":
     case "com.amazonaws.route53#InvalidKeySigningKeyStatus":
       response = {
         ...(await deserializeAws_restXmlInvalidKeySigningKeyStatusResponse(parsedOutput, context)),
+        name: errorCode,
+        $metadata: deserializeMetadata(output),
+      };
+      break;
+    case "InvalidKMSArn":
+    case "com.amazonaws.route53#InvalidKMSArn":
+      response = {
+        ...(await deserializeAws_restXmlInvalidKMSArnResponse(parsedOutput, context)),
         name: errorCode,
         $metadata: deserializeMetadata(output),
       };
@@ -3241,14 +3241,6 @@ const deserializeAws_restXmlCreateKeySigningKeyCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidKMSArn":
-    case "com.amazonaws.route53#InvalidKMSArn":
-      response = {
-        ...(await deserializeAws_restXmlInvalidKMSArnResponse(parsedOutput, context)),
-        name: errorCode,
-        $metadata: deserializeMetadata(output),
-      };
-      break;
     case "InvalidKeySigningKeyName":
     case "com.amazonaws.route53#InvalidKeySigningKeyName":
       response = {
@@ -3261,6 +3253,14 @@ const deserializeAws_restXmlCreateKeySigningKeyCommandError = async (
     case "com.amazonaws.route53#InvalidKeySigningKeyStatus":
       response = {
         ...(await deserializeAws_restXmlInvalidKeySigningKeyStatusResponse(parsedOutput, context)),
+        name: errorCode,
+        $metadata: deserializeMetadata(output),
+      };
+      break;
+    case "InvalidKMSArn":
+    case "com.amazonaws.route53#InvalidKMSArn":
+      response = {
+        ...(await deserializeAws_restXmlInvalidKMSArnResponse(parsedOutput, context)),
         name: errorCode,
         $metadata: deserializeMetadata(output),
       };
@@ -4182,18 +4182,18 @@ const deserializeAws_restXmlDeleteKeySigningKeyCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidKMSArn":
-    case "com.amazonaws.route53#InvalidKMSArn":
-      response = {
-        ...(await deserializeAws_restXmlInvalidKMSArnResponse(parsedOutput, context)),
-        name: errorCode,
-        $metadata: deserializeMetadata(output),
-      };
-      break;
     case "InvalidKeySigningKeyStatus":
     case "com.amazonaws.route53#InvalidKeySigningKeyStatus":
       response = {
         ...(await deserializeAws_restXmlInvalidKeySigningKeyStatusResponse(parsedOutput, context)),
+        name: errorCode,
+        $metadata: deserializeMetadata(output),
+      };
+      break;
+    case "InvalidKMSArn":
+    case "com.amazonaws.route53#InvalidKMSArn":
+      response = {
+        ...(await deserializeAws_restXmlInvalidKMSArnResponse(parsedOutput, context)),
         name: errorCode,
         $metadata: deserializeMetadata(output),
       };
@@ -4660,18 +4660,18 @@ const deserializeAws_restXmlDisableHostedZoneDNSSECCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidKMSArn":
-    case "com.amazonaws.route53#InvalidKMSArn":
-      response = {
-        ...(await deserializeAws_restXmlInvalidKMSArnResponse(parsedOutput, context)),
-        name: errorCode,
-        $metadata: deserializeMetadata(output),
-      };
-      break;
     case "InvalidKeySigningKeyStatus":
     case "com.amazonaws.route53#InvalidKeySigningKeyStatus":
       response = {
         ...(await deserializeAws_restXmlInvalidKeySigningKeyStatusResponse(parsedOutput, context)),
+        name: errorCode,
+        $metadata: deserializeMetadata(output),
+      };
+      break;
+    case "InvalidKMSArn":
+    case "com.amazonaws.route53#InvalidKMSArn":
+      response = {
+        ...(await deserializeAws_restXmlInvalidKMSArnResponse(parsedOutput, context)),
         name: errorCode,
         $metadata: deserializeMetadata(output),
       };
@@ -4866,18 +4866,18 @@ const deserializeAws_restXmlEnableHostedZoneDNSSECCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidKMSArn":
-    case "com.amazonaws.route53#InvalidKMSArn":
-      response = {
-        ...(await deserializeAws_restXmlInvalidKMSArnResponse(parsedOutput, context)),
-        name: errorCode,
-        $metadata: deserializeMetadata(output),
-      };
-      break;
     case "InvalidKeySigningKeyStatus":
     case "com.amazonaws.route53#InvalidKeySigningKeyStatus":
       response = {
         ...(await deserializeAws_restXmlInvalidKeySigningKeyStatusResponse(parsedOutput, context)),
+        name: errorCode,
+        $metadata: deserializeMetadata(output),
+      };
+      break;
+    case "InvalidKMSArn":
+    case "com.amazonaws.route53#InvalidKMSArn":
+      response = {
+        ...(await deserializeAws_restXmlInvalidKMSArnResponse(parsedOutput, context)),
         name: errorCode,
         $metadata: deserializeMetadata(output),
       };

--- a/clients/client-service-quotas/src/protocols/Aws_json1_1.ts
+++ b/clients/client-service-quotas/src/protocols/Aws_json1_1.ts
@@ -421,18 +421,18 @@ const deserializeAws_json1_1AssociateServiceQuotaTemplateCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadRestJsonErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "AWSServiceAccessNotEnabledException":
-    case "com.amazonaws.servicequotas#AWSServiceAccessNotEnabledException":
-      response = {
-        ...(await deserializeAws_json1_1AWSServiceAccessNotEnabledExceptionResponse(parsedOutput, context)),
-        name: errorCode,
-        $metadata: deserializeMetadata(output),
-      };
-      break;
     case "AccessDeniedException":
     case "com.amazonaws.servicequotas#AccessDeniedException":
       response = {
         ...(await deserializeAws_json1_1AccessDeniedExceptionResponse(parsedOutput, context)),
+        name: errorCode,
+        $metadata: deserializeMetadata(output),
+      };
+      break;
+    case "AWSServiceAccessNotEnabledException":
+    case "com.amazonaws.servicequotas#AWSServiceAccessNotEnabledException":
+      response = {
+        ...(await deserializeAws_json1_1AWSServiceAccessNotEnabledExceptionResponse(parsedOutput, context)),
         name: errorCode,
         $metadata: deserializeMetadata(output),
       };
@@ -531,18 +531,18 @@ const deserializeAws_json1_1DeleteServiceQuotaIncreaseRequestFromTemplateCommand
   let errorCode = "UnknownError";
   errorCode = loadRestJsonErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "AWSServiceAccessNotEnabledException":
-    case "com.amazonaws.servicequotas#AWSServiceAccessNotEnabledException":
-      response = {
-        ...(await deserializeAws_json1_1AWSServiceAccessNotEnabledExceptionResponse(parsedOutput, context)),
-        name: errorCode,
-        $metadata: deserializeMetadata(output),
-      };
-      break;
     case "AccessDeniedException":
     case "com.amazonaws.servicequotas#AccessDeniedException":
       response = {
         ...(await deserializeAws_json1_1AccessDeniedExceptionResponse(parsedOutput, context)),
+        name: errorCode,
+        $metadata: deserializeMetadata(output),
+      };
+      break;
+    case "AWSServiceAccessNotEnabledException":
+    case "com.amazonaws.servicequotas#AWSServiceAccessNotEnabledException":
+      response = {
+        ...(await deserializeAws_json1_1AWSServiceAccessNotEnabledExceptionResponse(parsedOutput, context)),
         name: errorCode,
         $metadata: deserializeMetadata(output),
       };
@@ -649,18 +649,18 @@ const deserializeAws_json1_1DisassociateServiceQuotaTemplateCommandError = async
   let errorCode = "UnknownError";
   errorCode = loadRestJsonErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "AWSServiceAccessNotEnabledException":
-    case "com.amazonaws.servicequotas#AWSServiceAccessNotEnabledException":
-      response = {
-        ...(await deserializeAws_json1_1AWSServiceAccessNotEnabledExceptionResponse(parsedOutput, context)),
-        name: errorCode,
-        $metadata: deserializeMetadata(output),
-      };
-      break;
     case "AccessDeniedException":
     case "com.amazonaws.servicequotas#AccessDeniedException":
       response = {
         ...(await deserializeAws_json1_1AccessDeniedExceptionResponse(parsedOutput, context)),
+        name: errorCode,
+        $metadata: deserializeMetadata(output),
+      };
+      break;
+    case "AWSServiceAccessNotEnabledException":
+    case "com.amazonaws.servicequotas#AWSServiceAccessNotEnabledException":
+      response = {
+        ...(await deserializeAws_json1_1AWSServiceAccessNotEnabledExceptionResponse(parsedOutput, context)),
         name: errorCode,
         $metadata: deserializeMetadata(output),
       };
@@ -759,18 +759,18 @@ const deserializeAws_json1_1GetAssociationForServiceQuotaTemplateCommandError = 
   let errorCode = "UnknownError";
   errorCode = loadRestJsonErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "AWSServiceAccessNotEnabledException":
-    case "com.amazonaws.servicequotas#AWSServiceAccessNotEnabledException":
-      response = {
-        ...(await deserializeAws_json1_1AWSServiceAccessNotEnabledExceptionResponse(parsedOutput, context)),
-        name: errorCode,
-        $metadata: deserializeMetadata(output),
-      };
-      break;
     case "AccessDeniedException":
     case "com.amazonaws.servicequotas#AccessDeniedException":
       response = {
         ...(await deserializeAws_json1_1AccessDeniedExceptionResponse(parsedOutput, context)),
+        name: errorCode,
+        $metadata: deserializeMetadata(output),
+      };
+      break;
+    case "AWSServiceAccessNotEnabledException":
+    case "com.amazonaws.servicequotas#AWSServiceAccessNotEnabledException":
+      response = {
+        ...(await deserializeAws_json1_1AWSServiceAccessNotEnabledExceptionResponse(parsedOutput, context)),
         name: errorCode,
         $metadata: deserializeMetadata(output),
       };
@@ -1127,18 +1127,18 @@ const deserializeAws_json1_1GetServiceQuotaIncreaseRequestFromTemplateCommandErr
   let errorCode = "UnknownError";
   errorCode = loadRestJsonErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "AWSServiceAccessNotEnabledException":
-    case "com.amazonaws.servicequotas#AWSServiceAccessNotEnabledException":
-      response = {
-        ...(await deserializeAws_json1_1AWSServiceAccessNotEnabledExceptionResponse(parsedOutput, context)),
-        name: errorCode,
-        $metadata: deserializeMetadata(output),
-      };
-      break;
     case "AccessDeniedException":
     case "com.amazonaws.servicequotas#AccessDeniedException":
       response = {
         ...(await deserializeAws_json1_1AccessDeniedExceptionResponse(parsedOutput, context)),
+        name: errorCode,
+        $metadata: deserializeMetadata(output),
+      };
+      break;
+    case "AWSServiceAccessNotEnabledException":
+    case "com.amazonaws.servicequotas#AWSServiceAccessNotEnabledException":
+      response = {
+        ...(await deserializeAws_json1_1AWSServiceAccessNotEnabledExceptionResponse(parsedOutput, context)),
         name: errorCode,
         $metadata: deserializeMetadata(output),
       };
@@ -1527,18 +1527,18 @@ const deserializeAws_json1_1ListServiceQuotaIncreaseRequestsInTemplateCommandErr
   let errorCode = "UnknownError";
   errorCode = loadRestJsonErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "AWSServiceAccessNotEnabledException":
-    case "com.amazonaws.servicequotas#AWSServiceAccessNotEnabledException":
-      response = {
-        ...(await deserializeAws_json1_1AWSServiceAccessNotEnabledExceptionResponse(parsedOutput, context)),
-        name: errorCode,
-        $metadata: deserializeMetadata(output),
-      };
-      break;
     case "AccessDeniedException":
     case "com.amazonaws.servicequotas#AccessDeniedException":
       response = {
         ...(await deserializeAws_json1_1AccessDeniedExceptionResponse(parsedOutput, context)),
+        name: errorCode,
+        $metadata: deserializeMetadata(output),
+      };
+      break;
+    case "AWSServiceAccessNotEnabledException":
+    case "com.amazonaws.servicequotas#AWSServiceAccessNotEnabledException":
+      response = {
+        ...(await deserializeAws_json1_1AWSServiceAccessNotEnabledExceptionResponse(parsedOutput, context)),
         name: errorCode,
         $metadata: deserializeMetadata(output),
       };
@@ -1903,18 +1903,18 @@ const deserializeAws_json1_1PutServiceQuotaIncreaseRequestIntoTemplateCommandErr
   let errorCode = "UnknownError";
   errorCode = loadRestJsonErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "AWSServiceAccessNotEnabledException":
-    case "com.amazonaws.servicequotas#AWSServiceAccessNotEnabledException":
-      response = {
-        ...(await deserializeAws_json1_1AWSServiceAccessNotEnabledExceptionResponse(parsedOutput, context)),
-        name: errorCode,
-        $metadata: deserializeMetadata(output),
-      };
-      break;
     case "AccessDeniedException":
     case "com.amazonaws.servicequotas#AccessDeniedException":
       response = {
         ...(await deserializeAws_json1_1AccessDeniedExceptionResponse(parsedOutput, context)),
+        name: errorCode,
+        $metadata: deserializeMetadata(output),
+      };
+      break;
+    case "AWSServiceAccessNotEnabledException":
+    case "com.amazonaws.servicequotas#AWSServiceAccessNotEnabledException":
+      response = {
+        ...(await deserializeAws_json1_1AWSServiceAccessNotEnabledExceptionResponse(parsedOutput, context)),
         name: errorCode,
         $metadata: deserializeMetadata(output),
       };

--- a/clients/client-ses/src/protocols/Aws_query.ts
+++ b/clients/client-ses/src/protocols/Aws_query.ts
@@ -1609,7 +1609,7 @@ const deserializeAws_queryCloneReceiptRuleSetCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "AlreadyExists":
+    case "AlreadyExistsException":
     case "com.amazonaws.ses#AlreadyExistsException":
       response = {
         ...(await deserializeAws_queryAlreadyExistsExceptionResponse(parsedOutput, context)),
@@ -1617,7 +1617,7 @@ const deserializeAws_queryCloneReceiptRuleSetCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "LimitExceeded":
+    case "LimitExceededException":
     case "com.amazonaws.ses#LimitExceededException":
       response = {
         ...(await deserializeAws_queryLimitExceededExceptionResponse(parsedOutput, context)),
@@ -1625,7 +1625,7 @@ const deserializeAws_queryCloneReceiptRuleSetCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "RuleSetDoesNotExist":
+    case "RuleSetDoesNotExistException":
     case "com.amazonaws.ses#RuleSetDoesNotExistException":
       response = {
         ...(await deserializeAws_queryRuleSetDoesNotExistExceptionResponse(parsedOutput, context)),
@@ -1679,7 +1679,7 @@ const deserializeAws_queryCreateConfigurationSetCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "ConfigurationSetAlreadyExists":
+    case "ConfigurationSetAlreadyExistsException":
     case "com.amazonaws.ses#ConfigurationSetAlreadyExistsException":
       response = {
         ...(await deserializeAws_queryConfigurationSetAlreadyExistsExceptionResponse(parsedOutput, context)),
@@ -1687,7 +1687,7 @@ const deserializeAws_queryCreateConfigurationSetCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidConfigurationSet":
+    case "InvalidConfigurationSetException":
     case "com.amazonaws.ses#InvalidConfigurationSetException":
       response = {
         ...(await deserializeAws_queryInvalidConfigurationSetExceptionResponse(parsedOutput, context)),
@@ -1695,7 +1695,7 @@ const deserializeAws_queryCreateConfigurationSetCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "LimitExceeded":
+    case "LimitExceededException":
     case "com.amazonaws.ses#LimitExceededException":
       response = {
         ...(await deserializeAws_queryLimitExceededExceptionResponse(parsedOutput, context)),
@@ -1752,7 +1752,7 @@ const deserializeAws_queryCreateConfigurationSetEventDestinationCommandError = a
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "ConfigurationSetDoesNotExist":
+    case "ConfigurationSetDoesNotExistException":
     case "com.amazonaws.ses#ConfigurationSetDoesNotExistException":
       response = {
         ...(await deserializeAws_queryConfigurationSetDoesNotExistExceptionResponse(parsedOutput, context)),
@@ -1760,7 +1760,7 @@ const deserializeAws_queryCreateConfigurationSetEventDestinationCommandError = a
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "EventDestinationAlreadyExists":
+    case "EventDestinationAlreadyExistsException":
     case "com.amazonaws.ses#EventDestinationAlreadyExistsException":
       response = {
         ...(await deserializeAws_queryEventDestinationAlreadyExistsExceptionResponse(parsedOutput, context)),
@@ -1768,7 +1768,7 @@ const deserializeAws_queryCreateConfigurationSetEventDestinationCommandError = a
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidCloudWatchDestination":
+    case "InvalidCloudWatchDestinationException":
     case "com.amazonaws.ses#InvalidCloudWatchDestinationException":
       response = {
         ...(await deserializeAws_queryInvalidCloudWatchDestinationExceptionResponse(parsedOutput, context)),
@@ -1776,7 +1776,7 @@ const deserializeAws_queryCreateConfigurationSetEventDestinationCommandError = a
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidFirehoseDestination":
+    case "InvalidFirehoseDestinationException":
     case "com.amazonaws.ses#InvalidFirehoseDestinationException":
       response = {
         ...(await deserializeAws_queryInvalidFirehoseDestinationExceptionResponse(parsedOutput, context)),
@@ -1784,7 +1784,7 @@ const deserializeAws_queryCreateConfigurationSetEventDestinationCommandError = a
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidSNSDestination":
+    case "InvalidSNSDestinationException":
     case "com.amazonaws.ses#InvalidSNSDestinationException":
       response = {
         ...(await deserializeAws_queryInvalidSNSDestinationExceptionResponse(parsedOutput, context)),
@@ -1792,7 +1792,7 @@ const deserializeAws_queryCreateConfigurationSetEventDestinationCommandError = a
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "LimitExceeded":
+    case "LimitExceededException":
     case "com.amazonaws.ses#LimitExceededException":
       response = {
         ...(await deserializeAws_queryLimitExceededExceptionResponse(parsedOutput, context)),
@@ -1849,7 +1849,7 @@ const deserializeAws_queryCreateConfigurationSetTrackingOptionsCommandError = as
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "ConfigurationSetDoesNotExist":
+    case "ConfigurationSetDoesNotExistException":
     case "com.amazonaws.ses#ConfigurationSetDoesNotExistException":
       response = {
         ...(await deserializeAws_queryConfigurationSetDoesNotExistExceptionResponse(parsedOutput, context)),
@@ -1857,7 +1857,7 @@ const deserializeAws_queryCreateConfigurationSetTrackingOptionsCommandError = as
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidTrackingOptions":
+    case "InvalidTrackingOptionsException":
     case "com.amazonaws.ses#InvalidTrackingOptionsException":
       response = {
         ...(await deserializeAws_queryInvalidTrackingOptionsExceptionResponse(parsedOutput, context)),
@@ -1916,7 +1916,7 @@ const deserializeAws_queryCreateCustomVerificationEmailTemplateCommandError = as
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "CustomVerificationEmailInvalidContent":
+    case "CustomVerificationEmailInvalidContentException":
     case "com.amazonaws.ses#CustomVerificationEmailInvalidContentException":
       response = {
         ...(await deserializeAws_queryCustomVerificationEmailInvalidContentExceptionResponse(parsedOutput, context)),
@@ -1924,7 +1924,7 @@ const deserializeAws_queryCreateCustomVerificationEmailTemplateCommandError = as
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "CustomVerificationEmailTemplateAlreadyExists":
+    case "CustomVerificationEmailTemplateAlreadyExistsException":
     case "com.amazonaws.ses#CustomVerificationEmailTemplateAlreadyExistsException":
       response = {
         ...(await deserializeAws_queryCustomVerificationEmailTemplateAlreadyExistsExceptionResponse(
@@ -1935,7 +1935,7 @@ const deserializeAws_queryCreateCustomVerificationEmailTemplateCommandError = as
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "FromEmailAddressNotVerified":
+    case "FromEmailAddressNotVerifiedException":
     case "com.amazonaws.ses#FromEmailAddressNotVerifiedException":
       response = {
         ...(await deserializeAws_queryFromEmailAddressNotVerifiedExceptionResponse(parsedOutput, context)),
@@ -1943,7 +1943,7 @@ const deserializeAws_queryCreateCustomVerificationEmailTemplateCommandError = as
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "LimitExceeded":
+    case "LimitExceededException":
     case "com.amazonaws.ses#LimitExceededException":
       response = {
         ...(await deserializeAws_queryLimitExceededExceptionResponse(parsedOutput, context)),
@@ -1997,7 +1997,7 @@ const deserializeAws_queryCreateReceiptFilterCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "AlreadyExists":
+    case "AlreadyExistsException":
     case "com.amazonaws.ses#AlreadyExistsException":
       response = {
         ...(await deserializeAws_queryAlreadyExistsExceptionResponse(parsedOutput, context)),
@@ -2005,7 +2005,7 @@ const deserializeAws_queryCreateReceiptFilterCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "LimitExceeded":
+    case "LimitExceededException":
     case "com.amazonaws.ses#LimitExceededException":
       response = {
         ...(await deserializeAws_queryLimitExceededExceptionResponse(parsedOutput, context)),
@@ -2059,7 +2059,7 @@ const deserializeAws_queryCreateReceiptRuleCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "AlreadyExists":
+    case "AlreadyExistsException":
     case "com.amazonaws.ses#AlreadyExistsException":
       response = {
         ...(await deserializeAws_queryAlreadyExistsExceptionResponse(parsedOutput, context)),
@@ -2067,7 +2067,7 @@ const deserializeAws_queryCreateReceiptRuleCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidLambdaFunction":
+    case "InvalidLambdaFunctionException":
     case "com.amazonaws.ses#InvalidLambdaFunctionException":
       response = {
         ...(await deserializeAws_queryInvalidLambdaFunctionExceptionResponse(parsedOutput, context)),
@@ -2075,7 +2075,7 @@ const deserializeAws_queryCreateReceiptRuleCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidS3Configuration":
+    case "InvalidS3ConfigurationException":
     case "com.amazonaws.ses#InvalidS3ConfigurationException":
       response = {
         ...(await deserializeAws_queryInvalidS3ConfigurationExceptionResponse(parsedOutput, context)),
@@ -2083,7 +2083,7 @@ const deserializeAws_queryCreateReceiptRuleCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidSnsTopic":
+    case "InvalidSnsTopicException":
     case "com.amazonaws.ses#InvalidSnsTopicException":
       response = {
         ...(await deserializeAws_queryInvalidSnsTopicExceptionResponse(parsedOutput, context)),
@@ -2091,7 +2091,7 @@ const deserializeAws_queryCreateReceiptRuleCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "LimitExceeded":
+    case "LimitExceededException":
     case "com.amazonaws.ses#LimitExceededException":
       response = {
         ...(await deserializeAws_queryLimitExceededExceptionResponse(parsedOutput, context)),
@@ -2099,7 +2099,7 @@ const deserializeAws_queryCreateReceiptRuleCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "RuleDoesNotExist":
+    case "RuleDoesNotExistException":
     case "com.amazonaws.ses#RuleDoesNotExistException":
       response = {
         ...(await deserializeAws_queryRuleDoesNotExistExceptionResponse(parsedOutput, context)),
@@ -2107,7 +2107,7 @@ const deserializeAws_queryCreateReceiptRuleCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "RuleSetDoesNotExist":
+    case "RuleSetDoesNotExistException":
     case "com.amazonaws.ses#RuleSetDoesNotExistException":
       response = {
         ...(await deserializeAws_queryRuleSetDoesNotExistExceptionResponse(parsedOutput, context)),
@@ -2161,7 +2161,7 @@ const deserializeAws_queryCreateReceiptRuleSetCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "AlreadyExists":
+    case "AlreadyExistsException":
     case "com.amazonaws.ses#AlreadyExistsException":
       response = {
         ...(await deserializeAws_queryAlreadyExistsExceptionResponse(parsedOutput, context)),
@@ -2169,7 +2169,7 @@ const deserializeAws_queryCreateReceiptRuleSetCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "LimitExceeded":
+    case "LimitExceededException":
     case "com.amazonaws.ses#LimitExceededException":
       response = {
         ...(await deserializeAws_queryLimitExceededExceptionResponse(parsedOutput, context)),
@@ -2223,7 +2223,7 @@ const deserializeAws_queryCreateTemplateCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "AlreadyExists":
+    case "AlreadyExistsException":
     case "com.amazonaws.ses#AlreadyExistsException":
       response = {
         ...(await deserializeAws_queryAlreadyExistsExceptionResponse(parsedOutput, context)),
@@ -2231,7 +2231,7 @@ const deserializeAws_queryCreateTemplateCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidTemplate":
+    case "InvalidTemplateException":
     case "com.amazonaws.ses#InvalidTemplateException":
       response = {
         ...(await deserializeAws_queryInvalidTemplateExceptionResponse(parsedOutput, context)),
@@ -2239,7 +2239,7 @@ const deserializeAws_queryCreateTemplateCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "LimitExceeded":
+    case "LimitExceededException":
     case "com.amazonaws.ses#LimitExceededException":
       response = {
         ...(await deserializeAws_queryLimitExceededExceptionResponse(parsedOutput, context)),
@@ -2293,7 +2293,7 @@ const deserializeAws_queryDeleteConfigurationSetCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "ConfigurationSetDoesNotExist":
+    case "ConfigurationSetDoesNotExistException":
     case "com.amazonaws.ses#ConfigurationSetDoesNotExistException":
       response = {
         ...(await deserializeAws_queryConfigurationSetDoesNotExistExceptionResponse(parsedOutput, context)),
@@ -2350,7 +2350,7 @@ const deserializeAws_queryDeleteConfigurationSetEventDestinationCommandError = a
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "ConfigurationSetDoesNotExist":
+    case "ConfigurationSetDoesNotExistException":
     case "com.amazonaws.ses#ConfigurationSetDoesNotExistException":
       response = {
         ...(await deserializeAws_queryConfigurationSetDoesNotExistExceptionResponse(parsedOutput, context)),
@@ -2358,7 +2358,7 @@ const deserializeAws_queryDeleteConfigurationSetEventDestinationCommandError = a
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "EventDestinationDoesNotExist":
+    case "EventDestinationDoesNotExistException":
     case "com.amazonaws.ses#EventDestinationDoesNotExistException":
       response = {
         ...(await deserializeAws_queryEventDestinationDoesNotExistExceptionResponse(parsedOutput, context)),
@@ -2415,7 +2415,7 @@ const deserializeAws_queryDeleteConfigurationSetTrackingOptionsCommandError = as
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "ConfigurationSetDoesNotExist":
+    case "ConfigurationSetDoesNotExistException":
     case "com.amazonaws.ses#ConfigurationSetDoesNotExistException":
       response = {
         ...(await deserializeAws_queryConfigurationSetDoesNotExistExceptionResponse(parsedOutput, context)),
@@ -2658,7 +2658,7 @@ const deserializeAws_queryDeleteReceiptRuleCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "RuleSetDoesNotExist":
+    case "RuleSetDoesNotExistException":
     case "com.amazonaws.ses#RuleSetDoesNotExistException":
       response = {
         ...(await deserializeAws_queryRuleSetDoesNotExistExceptionResponse(parsedOutput, context)),
@@ -2712,7 +2712,7 @@ const deserializeAws_queryDeleteReceiptRuleSetCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "CannotDelete":
+    case "CannotDeleteException":
     case "com.amazonaws.ses#CannotDeleteException":
       response = {
         ...(await deserializeAws_queryCannotDeleteExceptionResponse(parsedOutput, context)),
@@ -2901,7 +2901,7 @@ const deserializeAws_queryDescribeConfigurationSetCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "ConfigurationSetDoesNotExist":
+    case "ConfigurationSetDoesNotExistException":
     case "com.amazonaws.ses#ConfigurationSetDoesNotExistException":
       response = {
         ...(await deserializeAws_queryConfigurationSetDoesNotExistExceptionResponse(parsedOutput, context)),
@@ -2955,7 +2955,7 @@ const deserializeAws_queryDescribeReceiptRuleCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "RuleDoesNotExist":
+    case "RuleDoesNotExistException":
     case "com.amazonaws.ses#RuleDoesNotExistException":
       response = {
         ...(await deserializeAws_queryRuleDoesNotExistExceptionResponse(parsedOutput, context)),
@@ -2963,7 +2963,7 @@ const deserializeAws_queryDescribeReceiptRuleCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "RuleSetDoesNotExist":
+    case "RuleSetDoesNotExistException":
     case "com.amazonaws.ses#RuleSetDoesNotExistException":
       response = {
         ...(await deserializeAws_queryRuleSetDoesNotExistExceptionResponse(parsedOutput, context)),
@@ -3017,7 +3017,7 @@ const deserializeAws_queryDescribeReceiptRuleSetCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "RuleSetDoesNotExist":
+    case "RuleSetDoesNotExistException":
     case "com.amazonaws.ses#RuleSetDoesNotExistException":
       response = {
         ...(await deserializeAws_queryRuleSetDoesNotExistExceptionResponse(parsedOutput, context)),
@@ -3120,7 +3120,7 @@ const deserializeAws_queryGetCustomVerificationEmailTemplateCommandError = async
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "CustomVerificationEmailTemplateDoesNotExist":
+    case "CustomVerificationEmailTemplateDoesNotExistException":
     case "com.amazonaws.ses#CustomVerificationEmailTemplateDoesNotExistException":
       response = {
         ...(await deserializeAws_queryCustomVerificationEmailTemplateDoesNotExistExceptionResponse(
@@ -3508,7 +3508,7 @@ const deserializeAws_queryGetTemplateCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "TemplateDoesNotExist":
+    case "TemplateDoesNotExistException":
     case "com.amazonaws.ses#TemplateDoesNotExistException":
       response = {
         ...(await deserializeAws_queryTemplateDoesNotExistExceptionResponse(parsedOutput, context)),
@@ -3936,7 +3936,7 @@ const deserializeAws_queryPutConfigurationSetDeliveryOptionsCommandError = async
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "ConfigurationSetDoesNotExist":
+    case "ConfigurationSetDoesNotExistException":
     case "com.amazonaws.ses#ConfigurationSetDoesNotExistException":
       response = {
         ...(await deserializeAws_queryConfigurationSetDoesNotExistExceptionResponse(parsedOutput, context)),
@@ -3944,7 +3944,7 @@ const deserializeAws_queryPutConfigurationSetDeliveryOptionsCommandError = async
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidDeliveryOptions":
+    case "InvalidDeliveryOptionsException":
     case "com.amazonaws.ses#InvalidDeliveryOptionsException":
       response = {
         ...(await deserializeAws_queryInvalidDeliveryOptionsExceptionResponse(parsedOutput, context)),
@@ -3998,7 +3998,7 @@ const deserializeAws_queryPutIdentityPolicyCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "InvalidPolicy":
+    case "InvalidPolicyException":
     case "com.amazonaws.ses#InvalidPolicyException":
       response = {
         ...(await deserializeAws_queryInvalidPolicyExceptionResponse(parsedOutput, context)),
@@ -4052,7 +4052,7 @@ const deserializeAws_queryReorderReceiptRuleSetCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "RuleDoesNotExist":
+    case "RuleDoesNotExistException":
     case "com.amazonaws.ses#RuleDoesNotExistException":
       response = {
         ...(await deserializeAws_queryRuleDoesNotExistExceptionResponse(parsedOutput, context)),
@@ -4060,7 +4060,7 @@ const deserializeAws_queryReorderReceiptRuleSetCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "RuleSetDoesNotExist":
+    case "RuleSetDoesNotExistException":
     case "com.amazonaws.ses#RuleSetDoesNotExistException":
       response = {
         ...(await deserializeAws_queryRuleSetDoesNotExistExceptionResponse(parsedOutput, context)),
@@ -4176,7 +4176,7 @@ const deserializeAws_querySendBulkTemplatedEmailCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ConfigurationSetDoesNotExist":
+    case "ConfigurationSetDoesNotExistException":
     case "com.amazonaws.ses#ConfigurationSetDoesNotExistException":
       response = {
         ...(await deserializeAws_queryConfigurationSetDoesNotExistExceptionResponse(parsedOutput, context)),
@@ -4208,7 +4208,7 @@ const deserializeAws_querySendBulkTemplatedEmailCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "TemplateDoesNotExist":
+    case "TemplateDoesNotExistException":
     case "com.amazonaws.ses#TemplateDoesNotExistException":
       response = {
         ...(await deserializeAws_queryTemplateDoesNotExistExceptionResponse(parsedOutput, context)),
@@ -4262,7 +4262,7 @@ const deserializeAws_querySendCustomVerificationEmailCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "ConfigurationSetDoesNotExist":
+    case "ConfigurationSetDoesNotExistException":
     case "com.amazonaws.ses#ConfigurationSetDoesNotExistException":
       response = {
         ...(await deserializeAws_queryConfigurationSetDoesNotExistExceptionResponse(parsedOutput, context)),
@@ -4270,7 +4270,7 @@ const deserializeAws_querySendCustomVerificationEmailCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "CustomVerificationEmailTemplateDoesNotExist":
+    case "CustomVerificationEmailTemplateDoesNotExistException":
     case "com.amazonaws.ses#CustomVerificationEmailTemplateDoesNotExistException":
       response = {
         ...(await deserializeAws_queryCustomVerificationEmailTemplateDoesNotExistExceptionResponse(
@@ -4281,7 +4281,7 @@ const deserializeAws_querySendCustomVerificationEmailCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "FromEmailAddressNotVerified":
+    case "FromEmailAddressNotVerifiedException":
     case "com.amazonaws.ses#FromEmailAddressNotVerifiedException":
       response = {
         ...(await deserializeAws_queryFromEmailAddressNotVerifiedExceptionResponse(parsedOutput, context)),
@@ -4297,7 +4297,7 @@ const deserializeAws_querySendCustomVerificationEmailCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ProductionAccessNotGranted":
+    case "ProductionAccessNotGrantedException":
     case "com.amazonaws.ses#ProductionAccessNotGrantedException":
       response = {
         ...(await deserializeAws_queryProductionAccessNotGrantedExceptionResponse(parsedOutput, context)),
@@ -4359,7 +4359,7 @@ const deserializeAws_querySendEmailCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ConfigurationSetDoesNotExist":
+    case "ConfigurationSetDoesNotExistException":
     case "com.amazonaws.ses#ConfigurationSetDoesNotExistException":
       response = {
         ...(await deserializeAws_queryConfigurationSetDoesNotExistExceptionResponse(parsedOutput, context)),
@@ -4445,7 +4445,7 @@ const deserializeAws_querySendRawEmailCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ConfigurationSetDoesNotExist":
+    case "ConfigurationSetDoesNotExistException":
     case "com.amazonaws.ses#ConfigurationSetDoesNotExistException":
       response = {
         ...(await deserializeAws_queryConfigurationSetDoesNotExistExceptionResponse(parsedOutput, context)),
@@ -4531,7 +4531,7 @@ const deserializeAws_querySendTemplatedEmailCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ConfigurationSetDoesNotExist":
+    case "ConfigurationSetDoesNotExistException":
     case "com.amazonaws.ses#ConfigurationSetDoesNotExistException":
       response = {
         ...(await deserializeAws_queryConfigurationSetDoesNotExistExceptionResponse(parsedOutput, context)),
@@ -4563,7 +4563,7 @@ const deserializeAws_querySendTemplatedEmailCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "TemplateDoesNotExist":
+    case "TemplateDoesNotExistException":
     case "com.amazonaws.ses#TemplateDoesNotExistException":
       response = {
         ...(await deserializeAws_queryTemplateDoesNotExistExceptionResponse(parsedOutput, context)),
@@ -4617,7 +4617,7 @@ const deserializeAws_querySetActiveReceiptRuleSetCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "RuleSetDoesNotExist":
+    case "RuleSetDoesNotExistException":
     case "com.amazonaws.ses#RuleSetDoesNotExistException":
       response = {
         ...(await deserializeAws_queryRuleSetDoesNotExistExceptionResponse(parsedOutput, context)),
@@ -4907,7 +4907,7 @@ const deserializeAws_querySetReceiptRulePositionCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "RuleDoesNotExist":
+    case "RuleDoesNotExistException":
     case "com.amazonaws.ses#RuleDoesNotExistException":
       response = {
         ...(await deserializeAws_queryRuleDoesNotExistExceptionResponse(parsedOutput, context)),
@@ -4915,7 +4915,7 @@ const deserializeAws_querySetReceiptRulePositionCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "RuleSetDoesNotExist":
+    case "RuleSetDoesNotExistException":
     case "com.amazonaws.ses#RuleSetDoesNotExistException":
       response = {
         ...(await deserializeAws_queryRuleSetDoesNotExistExceptionResponse(parsedOutput, context)),
@@ -4969,7 +4969,7 @@ const deserializeAws_queryTestRenderTemplateCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "InvalidRenderingParameter":
+    case "InvalidRenderingParameterException":
     case "com.amazonaws.ses#InvalidRenderingParameterException":
       response = {
         ...(await deserializeAws_queryInvalidRenderingParameterExceptionResponse(parsedOutput, context)),
@@ -4977,7 +4977,7 @@ const deserializeAws_queryTestRenderTemplateCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "MissingRenderingAttribute":
+    case "MissingRenderingAttributeException":
     case "com.amazonaws.ses#MissingRenderingAttributeException":
       response = {
         ...(await deserializeAws_queryMissingRenderingAttributeExceptionResponse(parsedOutput, context)),
@@ -4985,7 +4985,7 @@ const deserializeAws_queryTestRenderTemplateCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "TemplateDoesNotExist":
+    case "TemplateDoesNotExistException":
     case "com.amazonaws.ses#TemplateDoesNotExistException":
       response = {
         ...(await deserializeAws_queryTemplateDoesNotExistExceptionResponse(parsedOutput, context)),
@@ -5085,7 +5085,7 @@ const deserializeAws_queryUpdateConfigurationSetEventDestinationCommandError = a
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "ConfigurationSetDoesNotExist":
+    case "ConfigurationSetDoesNotExistException":
     case "com.amazonaws.ses#ConfigurationSetDoesNotExistException":
       response = {
         ...(await deserializeAws_queryConfigurationSetDoesNotExistExceptionResponse(parsedOutput, context)),
@@ -5093,7 +5093,7 @@ const deserializeAws_queryUpdateConfigurationSetEventDestinationCommandError = a
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "EventDestinationDoesNotExist":
+    case "EventDestinationDoesNotExistException":
     case "com.amazonaws.ses#EventDestinationDoesNotExistException":
       response = {
         ...(await deserializeAws_queryEventDestinationDoesNotExistExceptionResponse(parsedOutput, context)),
@@ -5101,7 +5101,7 @@ const deserializeAws_queryUpdateConfigurationSetEventDestinationCommandError = a
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidCloudWatchDestination":
+    case "InvalidCloudWatchDestinationException":
     case "com.amazonaws.ses#InvalidCloudWatchDestinationException":
       response = {
         ...(await deserializeAws_queryInvalidCloudWatchDestinationExceptionResponse(parsedOutput, context)),
@@ -5109,7 +5109,7 @@ const deserializeAws_queryUpdateConfigurationSetEventDestinationCommandError = a
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidFirehoseDestination":
+    case "InvalidFirehoseDestinationException":
     case "com.amazonaws.ses#InvalidFirehoseDestinationException":
       response = {
         ...(await deserializeAws_queryInvalidFirehoseDestinationExceptionResponse(parsedOutput, context)),
@@ -5117,7 +5117,7 @@ const deserializeAws_queryUpdateConfigurationSetEventDestinationCommandError = a
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidSNSDestination":
+    case "InvalidSNSDestinationException":
     case "com.amazonaws.ses#InvalidSNSDestinationException":
       response = {
         ...(await deserializeAws_queryInvalidSNSDestinationExceptionResponse(parsedOutput, context)),
@@ -5168,7 +5168,7 @@ const deserializeAws_queryUpdateConfigurationSetReputationMetricsEnabledCommandE
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "ConfigurationSetDoesNotExist":
+    case "ConfigurationSetDoesNotExistException":
     case "com.amazonaws.ses#ConfigurationSetDoesNotExistException":
       response = {
         ...(await deserializeAws_queryConfigurationSetDoesNotExistExceptionResponse(parsedOutput, context)),
@@ -5219,7 +5219,7 @@ const deserializeAws_queryUpdateConfigurationSetSendingEnabledCommandError = asy
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "ConfigurationSetDoesNotExist":
+    case "ConfigurationSetDoesNotExistException":
     case "com.amazonaws.ses#ConfigurationSetDoesNotExistException":
       response = {
         ...(await deserializeAws_queryConfigurationSetDoesNotExistExceptionResponse(parsedOutput, context)),
@@ -5276,7 +5276,7 @@ const deserializeAws_queryUpdateConfigurationSetTrackingOptionsCommandError = as
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "ConfigurationSetDoesNotExist":
+    case "ConfigurationSetDoesNotExistException":
     case "com.amazonaws.ses#ConfigurationSetDoesNotExistException":
       response = {
         ...(await deserializeAws_queryConfigurationSetDoesNotExistExceptionResponse(parsedOutput, context)),
@@ -5284,7 +5284,7 @@ const deserializeAws_queryUpdateConfigurationSetTrackingOptionsCommandError = as
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidTrackingOptions":
+    case "InvalidTrackingOptionsException":
     case "com.amazonaws.ses#InvalidTrackingOptionsException":
       response = {
         ...(await deserializeAws_queryInvalidTrackingOptionsExceptionResponse(parsedOutput, context)),
@@ -5343,7 +5343,7 @@ const deserializeAws_queryUpdateCustomVerificationEmailTemplateCommandError = as
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "CustomVerificationEmailInvalidContent":
+    case "CustomVerificationEmailInvalidContentException":
     case "com.amazonaws.ses#CustomVerificationEmailInvalidContentException":
       response = {
         ...(await deserializeAws_queryCustomVerificationEmailInvalidContentExceptionResponse(parsedOutput, context)),
@@ -5351,7 +5351,7 @@ const deserializeAws_queryUpdateCustomVerificationEmailTemplateCommandError = as
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "CustomVerificationEmailTemplateDoesNotExist":
+    case "CustomVerificationEmailTemplateDoesNotExistException":
     case "com.amazonaws.ses#CustomVerificationEmailTemplateDoesNotExistException":
       response = {
         ...(await deserializeAws_queryCustomVerificationEmailTemplateDoesNotExistExceptionResponse(
@@ -5362,7 +5362,7 @@ const deserializeAws_queryUpdateCustomVerificationEmailTemplateCommandError = as
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "FromEmailAddressNotVerified":
+    case "FromEmailAddressNotVerifiedException":
     case "com.amazonaws.ses#FromEmailAddressNotVerifiedException":
       response = {
         ...(await deserializeAws_queryFromEmailAddressNotVerifiedExceptionResponse(parsedOutput, context)),
@@ -5416,7 +5416,7 @@ const deserializeAws_queryUpdateReceiptRuleCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "InvalidLambdaFunction":
+    case "InvalidLambdaFunctionException":
     case "com.amazonaws.ses#InvalidLambdaFunctionException":
       response = {
         ...(await deserializeAws_queryInvalidLambdaFunctionExceptionResponse(parsedOutput, context)),
@@ -5424,7 +5424,7 @@ const deserializeAws_queryUpdateReceiptRuleCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidS3Configuration":
+    case "InvalidS3ConfigurationException":
     case "com.amazonaws.ses#InvalidS3ConfigurationException":
       response = {
         ...(await deserializeAws_queryInvalidS3ConfigurationExceptionResponse(parsedOutput, context)),
@@ -5432,7 +5432,7 @@ const deserializeAws_queryUpdateReceiptRuleCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidSnsTopic":
+    case "InvalidSnsTopicException":
     case "com.amazonaws.ses#InvalidSnsTopicException":
       response = {
         ...(await deserializeAws_queryInvalidSnsTopicExceptionResponse(parsedOutput, context)),
@@ -5440,7 +5440,7 @@ const deserializeAws_queryUpdateReceiptRuleCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "LimitExceeded":
+    case "LimitExceededException":
     case "com.amazonaws.ses#LimitExceededException":
       response = {
         ...(await deserializeAws_queryLimitExceededExceptionResponse(parsedOutput, context)),
@@ -5448,7 +5448,7 @@ const deserializeAws_queryUpdateReceiptRuleCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "RuleDoesNotExist":
+    case "RuleDoesNotExistException":
     case "com.amazonaws.ses#RuleDoesNotExistException":
       response = {
         ...(await deserializeAws_queryRuleDoesNotExistExceptionResponse(parsedOutput, context)),
@@ -5456,7 +5456,7 @@ const deserializeAws_queryUpdateReceiptRuleCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "RuleSetDoesNotExist":
+    case "RuleSetDoesNotExistException":
     case "com.amazonaws.ses#RuleSetDoesNotExistException":
       response = {
         ...(await deserializeAws_queryRuleSetDoesNotExistExceptionResponse(parsedOutput, context)),
@@ -5510,7 +5510,7 @@ const deserializeAws_queryUpdateTemplateCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "InvalidTemplate":
+    case "InvalidTemplateException":
     case "com.amazonaws.ses#InvalidTemplateException":
       response = {
         ...(await deserializeAws_queryInvalidTemplateExceptionResponse(parsedOutput, context)),
@@ -5518,7 +5518,7 @@ const deserializeAws_queryUpdateTemplateCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "TemplateDoesNotExist":
+    case "TemplateDoesNotExistException":
     case "com.amazonaws.ses#TemplateDoesNotExistException":
       response = {
         ...(await deserializeAws_queryTemplateDoesNotExistExceptionResponse(parsedOutput, context)),

--- a/clients/client-sns/src/protocols/Aws_query.ts
+++ b/clients/client-sns/src/protocols/Aws_query.ts
@@ -908,7 +908,7 @@ const deserializeAws_queryAddPermissionCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "AuthorizationError":
+    case "AuthorizationErrorException":
     case "com.amazonaws.sns#AuthorizationErrorException":
       response = {
         ...(await deserializeAws_queryAuthorizationErrorExceptionResponse(parsedOutput, context)),
@@ -916,7 +916,7 @@ const deserializeAws_queryAddPermissionCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InternalError":
+    case "InternalErrorException":
     case "com.amazonaws.sns#InternalErrorException":
       response = {
         ...(await deserializeAws_queryInternalErrorExceptionResponse(parsedOutput, context)),
@@ -924,7 +924,7 @@ const deserializeAws_queryAddPermissionCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidParameter":
+    case "InvalidParameterException":
     case "com.amazonaws.sns#InvalidParameterException":
       response = {
         ...(await deserializeAws_queryInvalidParameterExceptionResponse(parsedOutput, context)),
@@ -932,7 +932,7 @@ const deserializeAws_queryAddPermissionCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "NotFound":
+    case "NotFoundException":
     case "com.amazonaws.sns#NotFoundException":
       response = {
         ...(await deserializeAws_queryNotFoundExceptionResponse(parsedOutput, context)),
@@ -986,7 +986,7 @@ const deserializeAws_queryCheckIfPhoneNumberIsOptedOutCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "AuthorizationError":
+    case "AuthorizationErrorException":
     case "com.amazonaws.sns#AuthorizationErrorException":
       response = {
         ...(await deserializeAws_queryAuthorizationErrorExceptionResponse(parsedOutput, context)),
@@ -994,7 +994,7 @@ const deserializeAws_queryCheckIfPhoneNumberIsOptedOutCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InternalError":
+    case "InternalErrorException":
     case "com.amazonaws.sns#InternalErrorException":
       response = {
         ...(await deserializeAws_queryInternalErrorExceptionResponse(parsedOutput, context)),
@@ -1002,7 +1002,7 @@ const deserializeAws_queryCheckIfPhoneNumberIsOptedOutCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidParameter":
+    case "InvalidParameterException":
     case "com.amazonaws.sns#InvalidParameterException":
       response = {
         ...(await deserializeAws_queryInvalidParameterExceptionResponse(parsedOutput, context)),
@@ -1010,7 +1010,7 @@ const deserializeAws_queryCheckIfPhoneNumberIsOptedOutCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "Throttled":
+    case "ThrottledException":
     case "com.amazonaws.sns#ThrottledException":
       response = {
         ...(await deserializeAws_queryThrottledExceptionResponse(parsedOutput, context)),
@@ -1064,7 +1064,7 @@ const deserializeAws_queryConfirmSubscriptionCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "AuthorizationError":
+    case "AuthorizationErrorException":
     case "com.amazonaws.sns#AuthorizationErrorException":
       response = {
         ...(await deserializeAws_queryAuthorizationErrorExceptionResponse(parsedOutput, context)),
@@ -1072,7 +1072,7 @@ const deserializeAws_queryConfirmSubscriptionCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "FilterPolicyLimitExceeded":
+    case "FilterPolicyLimitExceededException":
     case "com.amazonaws.sns#FilterPolicyLimitExceededException":
       response = {
         ...(await deserializeAws_queryFilterPolicyLimitExceededExceptionResponse(parsedOutput, context)),
@@ -1080,7 +1080,7 @@ const deserializeAws_queryConfirmSubscriptionCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InternalError":
+    case "InternalErrorException":
     case "com.amazonaws.sns#InternalErrorException":
       response = {
         ...(await deserializeAws_queryInternalErrorExceptionResponse(parsedOutput, context)),
@@ -1088,7 +1088,7 @@ const deserializeAws_queryConfirmSubscriptionCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidParameter":
+    case "InvalidParameterException":
     case "com.amazonaws.sns#InvalidParameterException":
       response = {
         ...(await deserializeAws_queryInvalidParameterExceptionResponse(parsedOutput, context)),
@@ -1096,7 +1096,7 @@ const deserializeAws_queryConfirmSubscriptionCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "NotFound":
+    case "NotFoundException":
     case "com.amazonaws.sns#NotFoundException":
       response = {
         ...(await deserializeAws_queryNotFoundExceptionResponse(parsedOutput, context)),
@@ -1104,7 +1104,7 @@ const deserializeAws_queryConfirmSubscriptionCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "SubscriptionLimitExceeded":
+    case "SubscriptionLimitExceededException":
     case "com.amazonaws.sns#SubscriptionLimitExceededException":
       response = {
         ...(await deserializeAws_querySubscriptionLimitExceededExceptionResponse(parsedOutput, context)),
@@ -1158,7 +1158,7 @@ const deserializeAws_queryCreatePlatformApplicationCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "AuthorizationError":
+    case "AuthorizationErrorException":
     case "com.amazonaws.sns#AuthorizationErrorException":
       response = {
         ...(await deserializeAws_queryAuthorizationErrorExceptionResponse(parsedOutput, context)),
@@ -1166,7 +1166,7 @@ const deserializeAws_queryCreatePlatformApplicationCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InternalError":
+    case "InternalErrorException":
     case "com.amazonaws.sns#InternalErrorException":
       response = {
         ...(await deserializeAws_queryInternalErrorExceptionResponse(parsedOutput, context)),
@@ -1174,7 +1174,7 @@ const deserializeAws_queryCreatePlatformApplicationCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidParameter":
+    case "InvalidParameterException":
     case "com.amazonaws.sns#InvalidParameterException":
       response = {
         ...(await deserializeAws_queryInvalidParameterExceptionResponse(parsedOutput, context)),
@@ -1228,7 +1228,7 @@ const deserializeAws_queryCreatePlatformEndpointCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "AuthorizationError":
+    case "AuthorizationErrorException":
     case "com.amazonaws.sns#AuthorizationErrorException":
       response = {
         ...(await deserializeAws_queryAuthorizationErrorExceptionResponse(parsedOutput, context)),
@@ -1236,7 +1236,7 @@ const deserializeAws_queryCreatePlatformEndpointCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InternalError":
+    case "InternalErrorException":
     case "com.amazonaws.sns#InternalErrorException":
       response = {
         ...(await deserializeAws_queryInternalErrorExceptionResponse(parsedOutput, context)),
@@ -1244,7 +1244,7 @@ const deserializeAws_queryCreatePlatformEndpointCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidParameter":
+    case "InvalidParameterException":
     case "com.amazonaws.sns#InvalidParameterException":
       response = {
         ...(await deserializeAws_queryInvalidParameterExceptionResponse(parsedOutput, context)),
@@ -1252,7 +1252,7 @@ const deserializeAws_queryCreatePlatformEndpointCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "NotFound":
+    case "NotFoundException":
     case "com.amazonaws.sns#NotFoundException":
       response = {
         ...(await deserializeAws_queryNotFoundExceptionResponse(parsedOutput, context)),
@@ -1306,7 +1306,7 @@ const deserializeAws_queryCreateSMSSandboxPhoneNumberCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "AuthorizationError":
+    case "AuthorizationErrorException":
     case "com.amazonaws.sns#AuthorizationErrorException":
       response = {
         ...(await deserializeAws_queryAuthorizationErrorExceptionResponse(parsedOutput, context)),
@@ -1314,7 +1314,7 @@ const deserializeAws_queryCreateSMSSandboxPhoneNumberCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InternalError":
+    case "InternalErrorException":
     case "com.amazonaws.sns#InternalErrorException":
       response = {
         ...(await deserializeAws_queryInternalErrorExceptionResponse(parsedOutput, context)),
@@ -1322,7 +1322,7 @@ const deserializeAws_queryCreateSMSSandboxPhoneNumberCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidParameter":
+    case "InvalidParameterException":
     case "com.amazonaws.sns#InvalidParameterException":
       response = {
         ...(await deserializeAws_queryInvalidParameterExceptionResponse(parsedOutput, context)),
@@ -1330,7 +1330,7 @@ const deserializeAws_queryCreateSMSSandboxPhoneNumberCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "OptedOut":
+    case "OptedOutException":
     case "com.amazonaws.sns#OptedOutException":
       response = {
         ...(await deserializeAws_queryOptedOutExceptionResponse(parsedOutput, context)),
@@ -1338,7 +1338,7 @@ const deserializeAws_queryCreateSMSSandboxPhoneNumberCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "Throttled":
+    case "ThrottledException":
     case "com.amazonaws.sns#ThrottledException":
       response = {
         ...(await deserializeAws_queryThrottledExceptionResponse(parsedOutput, context)),
@@ -1346,7 +1346,7 @@ const deserializeAws_queryCreateSMSSandboxPhoneNumberCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "UserError":
+    case "UserErrorException":
     case "com.amazonaws.sns#UserErrorException":
       response = {
         ...(await deserializeAws_queryUserErrorExceptionResponse(parsedOutput, context)),
@@ -1400,7 +1400,7 @@ const deserializeAws_queryCreateTopicCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "AuthorizationError":
+    case "AuthorizationErrorException":
     case "com.amazonaws.sns#AuthorizationErrorException":
       response = {
         ...(await deserializeAws_queryAuthorizationErrorExceptionResponse(parsedOutput, context)),
@@ -1408,7 +1408,7 @@ const deserializeAws_queryCreateTopicCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ConcurrentAccess":
+    case "ConcurrentAccessException":
     case "com.amazonaws.sns#ConcurrentAccessException":
       response = {
         ...(await deserializeAws_queryConcurrentAccessExceptionResponse(parsedOutput, context)),
@@ -1416,7 +1416,7 @@ const deserializeAws_queryCreateTopicCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InternalError":
+    case "InternalErrorException":
     case "com.amazonaws.sns#InternalErrorException":
       response = {
         ...(await deserializeAws_queryInternalErrorExceptionResponse(parsedOutput, context)),
@@ -1424,7 +1424,7 @@ const deserializeAws_queryCreateTopicCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidParameter":
+    case "InvalidParameterException":
     case "com.amazonaws.sns#InvalidParameterException":
       response = {
         ...(await deserializeAws_queryInvalidParameterExceptionResponse(parsedOutput, context)),
@@ -1432,7 +1432,7 @@ const deserializeAws_queryCreateTopicCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidSecurity":
+    case "InvalidSecurityException":
     case "com.amazonaws.sns#InvalidSecurityException":
       response = {
         ...(await deserializeAws_queryInvalidSecurityExceptionResponse(parsedOutput, context)),
@@ -1440,7 +1440,7 @@ const deserializeAws_queryCreateTopicCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "StaleTag":
+    case "StaleTagException":
     case "com.amazonaws.sns#StaleTagException":
       response = {
         ...(await deserializeAws_queryStaleTagExceptionResponse(parsedOutput, context)),
@@ -1448,7 +1448,7 @@ const deserializeAws_queryCreateTopicCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "TagLimitExceeded":
+    case "TagLimitExceededException":
     case "com.amazonaws.sns#TagLimitExceededException":
       response = {
         ...(await deserializeAws_queryTagLimitExceededExceptionResponse(parsedOutput, context)),
@@ -1456,7 +1456,7 @@ const deserializeAws_queryCreateTopicCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "TagPolicy":
+    case "TagPolicyException":
     case "com.amazonaws.sns#TagPolicyException":
       response = {
         ...(await deserializeAws_queryTagPolicyExceptionResponse(parsedOutput, context)),
@@ -1464,7 +1464,7 @@ const deserializeAws_queryCreateTopicCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "TopicLimitExceeded":
+    case "TopicLimitExceededException":
     case "com.amazonaws.sns#TopicLimitExceededException":
       response = {
         ...(await deserializeAws_queryTopicLimitExceededExceptionResponse(parsedOutput, context)),
@@ -1515,7 +1515,7 @@ const deserializeAws_queryDeleteEndpointCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "AuthorizationError":
+    case "AuthorizationErrorException":
     case "com.amazonaws.sns#AuthorizationErrorException":
       response = {
         ...(await deserializeAws_queryAuthorizationErrorExceptionResponse(parsedOutput, context)),
@@ -1523,7 +1523,7 @@ const deserializeAws_queryDeleteEndpointCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InternalError":
+    case "InternalErrorException":
     case "com.amazonaws.sns#InternalErrorException":
       response = {
         ...(await deserializeAws_queryInternalErrorExceptionResponse(parsedOutput, context)),
@@ -1531,7 +1531,7 @@ const deserializeAws_queryDeleteEndpointCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidParameter":
+    case "InvalidParameterException":
     case "com.amazonaws.sns#InvalidParameterException":
       response = {
         ...(await deserializeAws_queryInvalidParameterExceptionResponse(parsedOutput, context)),
@@ -1582,7 +1582,7 @@ const deserializeAws_queryDeletePlatformApplicationCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "AuthorizationError":
+    case "AuthorizationErrorException":
     case "com.amazonaws.sns#AuthorizationErrorException":
       response = {
         ...(await deserializeAws_queryAuthorizationErrorExceptionResponse(parsedOutput, context)),
@@ -1590,7 +1590,7 @@ const deserializeAws_queryDeletePlatformApplicationCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InternalError":
+    case "InternalErrorException":
     case "com.amazonaws.sns#InternalErrorException":
       response = {
         ...(await deserializeAws_queryInternalErrorExceptionResponse(parsedOutput, context)),
@@ -1598,7 +1598,7 @@ const deserializeAws_queryDeletePlatformApplicationCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidParameter":
+    case "InvalidParameterException":
     case "com.amazonaws.sns#InvalidParameterException":
       response = {
         ...(await deserializeAws_queryInvalidParameterExceptionResponse(parsedOutput, context)),
@@ -1652,7 +1652,7 @@ const deserializeAws_queryDeleteSMSSandboxPhoneNumberCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "AuthorizationError":
+    case "AuthorizationErrorException":
     case "com.amazonaws.sns#AuthorizationErrorException":
       response = {
         ...(await deserializeAws_queryAuthorizationErrorExceptionResponse(parsedOutput, context)),
@@ -1660,7 +1660,7 @@ const deserializeAws_queryDeleteSMSSandboxPhoneNumberCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InternalError":
+    case "InternalErrorException":
     case "com.amazonaws.sns#InternalErrorException":
       response = {
         ...(await deserializeAws_queryInternalErrorExceptionResponse(parsedOutput, context)),
@@ -1668,7 +1668,7 @@ const deserializeAws_queryDeleteSMSSandboxPhoneNumberCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidParameter":
+    case "InvalidParameterException":
     case "com.amazonaws.sns#InvalidParameterException":
       response = {
         ...(await deserializeAws_queryInvalidParameterExceptionResponse(parsedOutput, context)),
@@ -1676,7 +1676,7 @@ const deserializeAws_queryDeleteSMSSandboxPhoneNumberCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ResourceNotFound":
+    case "ResourceNotFoundException":
     case "com.amazonaws.sns#ResourceNotFoundException":
       response = {
         ...(await deserializeAws_queryResourceNotFoundExceptionResponse(parsedOutput, context)),
@@ -1684,7 +1684,7 @@ const deserializeAws_queryDeleteSMSSandboxPhoneNumberCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "Throttled":
+    case "ThrottledException":
     case "com.amazonaws.sns#ThrottledException":
       response = {
         ...(await deserializeAws_queryThrottledExceptionResponse(parsedOutput, context)),
@@ -1692,7 +1692,7 @@ const deserializeAws_queryDeleteSMSSandboxPhoneNumberCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "UserError":
+    case "UserErrorException":
     case "com.amazonaws.sns#UserErrorException":
       response = {
         ...(await deserializeAws_queryUserErrorExceptionResponse(parsedOutput, context)),
@@ -1743,7 +1743,7 @@ const deserializeAws_queryDeleteTopicCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "AuthorizationError":
+    case "AuthorizationErrorException":
     case "com.amazonaws.sns#AuthorizationErrorException":
       response = {
         ...(await deserializeAws_queryAuthorizationErrorExceptionResponse(parsedOutput, context)),
@@ -1751,7 +1751,7 @@ const deserializeAws_queryDeleteTopicCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ConcurrentAccess":
+    case "ConcurrentAccessException":
     case "com.amazonaws.sns#ConcurrentAccessException":
       response = {
         ...(await deserializeAws_queryConcurrentAccessExceptionResponse(parsedOutput, context)),
@@ -1759,7 +1759,7 @@ const deserializeAws_queryDeleteTopicCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InternalError":
+    case "InternalErrorException":
     case "com.amazonaws.sns#InternalErrorException":
       response = {
         ...(await deserializeAws_queryInternalErrorExceptionResponse(parsedOutput, context)),
@@ -1767,7 +1767,7 @@ const deserializeAws_queryDeleteTopicCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidParameter":
+    case "InvalidParameterException":
     case "com.amazonaws.sns#InvalidParameterException":
       response = {
         ...(await deserializeAws_queryInvalidParameterExceptionResponse(parsedOutput, context)),
@@ -1775,7 +1775,7 @@ const deserializeAws_queryDeleteTopicCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "NotFound":
+    case "NotFoundException":
     case "com.amazonaws.sns#NotFoundException":
       response = {
         ...(await deserializeAws_queryNotFoundExceptionResponse(parsedOutput, context)),
@@ -1783,7 +1783,7 @@ const deserializeAws_queryDeleteTopicCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "StaleTag":
+    case "StaleTagException":
     case "com.amazonaws.sns#StaleTagException":
       response = {
         ...(await deserializeAws_queryStaleTagExceptionResponse(parsedOutput, context)),
@@ -1791,7 +1791,7 @@ const deserializeAws_queryDeleteTopicCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "TagPolicy":
+    case "TagPolicyException":
     case "com.amazonaws.sns#TagPolicyException":
       response = {
         ...(await deserializeAws_queryTagPolicyExceptionResponse(parsedOutput, context)),
@@ -1845,7 +1845,7 @@ const deserializeAws_queryGetEndpointAttributesCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "AuthorizationError":
+    case "AuthorizationErrorException":
     case "com.amazonaws.sns#AuthorizationErrorException":
       response = {
         ...(await deserializeAws_queryAuthorizationErrorExceptionResponse(parsedOutput, context)),
@@ -1853,7 +1853,7 @@ const deserializeAws_queryGetEndpointAttributesCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InternalError":
+    case "InternalErrorException":
     case "com.amazonaws.sns#InternalErrorException":
       response = {
         ...(await deserializeAws_queryInternalErrorExceptionResponse(parsedOutput, context)),
@@ -1861,7 +1861,7 @@ const deserializeAws_queryGetEndpointAttributesCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidParameter":
+    case "InvalidParameterException":
     case "com.amazonaws.sns#InvalidParameterException":
       response = {
         ...(await deserializeAws_queryInvalidParameterExceptionResponse(parsedOutput, context)),
@@ -1869,7 +1869,7 @@ const deserializeAws_queryGetEndpointAttributesCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "NotFound":
+    case "NotFoundException":
     case "com.amazonaws.sns#NotFoundException":
       response = {
         ...(await deserializeAws_queryNotFoundExceptionResponse(parsedOutput, context)),
@@ -1926,7 +1926,7 @@ const deserializeAws_queryGetPlatformApplicationAttributesCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "AuthorizationError":
+    case "AuthorizationErrorException":
     case "com.amazonaws.sns#AuthorizationErrorException":
       response = {
         ...(await deserializeAws_queryAuthorizationErrorExceptionResponse(parsedOutput, context)),
@@ -1934,7 +1934,7 @@ const deserializeAws_queryGetPlatformApplicationAttributesCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InternalError":
+    case "InternalErrorException":
     case "com.amazonaws.sns#InternalErrorException":
       response = {
         ...(await deserializeAws_queryInternalErrorExceptionResponse(parsedOutput, context)),
@@ -1942,7 +1942,7 @@ const deserializeAws_queryGetPlatformApplicationAttributesCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidParameter":
+    case "InvalidParameterException":
     case "com.amazonaws.sns#InvalidParameterException":
       response = {
         ...(await deserializeAws_queryInvalidParameterExceptionResponse(parsedOutput, context)),
@@ -1950,7 +1950,7 @@ const deserializeAws_queryGetPlatformApplicationAttributesCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "NotFound":
+    case "NotFoundException":
     case "com.amazonaws.sns#NotFoundException":
       response = {
         ...(await deserializeAws_queryNotFoundExceptionResponse(parsedOutput, context)),
@@ -2004,7 +2004,7 @@ const deserializeAws_queryGetSMSAttributesCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "AuthorizationError":
+    case "AuthorizationErrorException":
     case "com.amazonaws.sns#AuthorizationErrorException":
       response = {
         ...(await deserializeAws_queryAuthorizationErrorExceptionResponse(parsedOutput, context)),
@@ -2012,7 +2012,7 @@ const deserializeAws_queryGetSMSAttributesCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InternalError":
+    case "InternalErrorException":
     case "com.amazonaws.sns#InternalErrorException":
       response = {
         ...(await deserializeAws_queryInternalErrorExceptionResponse(parsedOutput, context)),
@@ -2020,7 +2020,7 @@ const deserializeAws_queryGetSMSAttributesCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidParameter":
+    case "InvalidParameterException":
     case "com.amazonaws.sns#InvalidParameterException":
       response = {
         ...(await deserializeAws_queryInvalidParameterExceptionResponse(parsedOutput, context)),
@@ -2028,7 +2028,7 @@ const deserializeAws_queryGetSMSAttributesCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "Throttled":
+    case "ThrottledException":
     case "com.amazonaws.sns#ThrottledException":
       response = {
         ...(await deserializeAws_queryThrottledExceptionResponse(parsedOutput, context)),
@@ -2082,7 +2082,7 @@ const deserializeAws_queryGetSMSSandboxAccountStatusCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "AuthorizationError":
+    case "AuthorizationErrorException":
     case "com.amazonaws.sns#AuthorizationErrorException":
       response = {
         ...(await deserializeAws_queryAuthorizationErrorExceptionResponse(parsedOutput, context)),
@@ -2090,7 +2090,7 @@ const deserializeAws_queryGetSMSSandboxAccountStatusCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InternalError":
+    case "InternalErrorException":
     case "com.amazonaws.sns#InternalErrorException":
       response = {
         ...(await deserializeAws_queryInternalErrorExceptionResponse(parsedOutput, context)),
@@ -2098,7 +2098,7 @@ const deserializeAws_queryGetSMSSandboxAccountStatusCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "Throttled":
+    case "ThrottledException":
     case "com.amazonaws.sns#ThrottledException":
       response = {
         ...(await deserializeAws_queryThrottledExceptionResponse(parsedOutput, context)),
@@ -2152,7 +2152,7 @@ const deserializeAws_queryGetSubscriptionAttributesCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "AuthorizationError":
+    case "AuthorizationErrorException":
     case "com.amazonaws.sns#AuthorizationErrorException":
       response = {
         ...(await deserializeAws_queryAuthorizationErrorExceptionResponse(parsedOutput, context)),
@@ -2160,7 +2160,7 @@ const deserializeAws_queryGetSubscriptionAttributesCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InternalError":
+    case "InternalErrorException":
     case "com.amazonaws.sns#InternalErrorException":
       response = {
         ...(await deserializeAws_queryInternalErrorExceptionResponse(parsedOutput, context)),
@@ -2168,7 +2168,7 @@ const deserializeAws_queryGetSubscriptionAttributesCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidParameter":
+    case "InvalidParameterException":
     case "com.amazonaws.sns#InvalidParameterException":
       response = {
         ...(await deserializeAws_queryInvalidParameterExceptionResponse(parsedOutput, context)),
@@ -2176,7 +2176,7 @@ const deserializeAws_queryGetSubscriptionAttributesCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "NotFound":
+    case "NotFoundException":
     case "com.amazonaws.sns#NotFoundException":
       response = {
         ...(await deserializeAws_queryNotFoundExceptionResponse(parsedOutput, context)),
@@ -2230,7 +2230,7 @@ const deserializeAws_queryGetTopicAttributesCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "AuthorizationError":
+    case "AuthorizationErrorException":
     case "com.amazonaws.sns#AuthorizationErrorException":
       response = {
         ...(await deserializeAws_queryAuthorizationErrorExceptionResponse(parsedOutput, context)),
@@ -2238,7 +2238,7 @@ const deserializeAws_queryGetTopicAttributesCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InternalError":
+    case "InternalErrorException":
     case "com.amazonaws.sns#InternalErrorException":
       response = {
         ...(await deserializeAws_queryInternalErrorExceptionResponse(parsedOutput, context)),
@@ -2246,7 +2246,7 @@ const deserializeAws_queryGetTopicAttributesCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidParameter":
+    case "InvalidParameterException":
     case "com.amazonaws.sns#InvalidParameterException":
       response = {
         ...(await deserializeAws_queryInvalidParameterExceptionResponse(parsedOutput, context)),
@@ -2254,7 +2254,7 @@ const deserializeAws_queryGetTopicAttributesCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidSecurity":
+    case "InvalidSecurityException":
     case "com.amazonaws.sns#InvalidSecurityException":
       response = {
         ...(await deserializeAws_queryInvalidSecurityExceptionResponse(parsedOutput, context)),
@@ -2262,7 +2262,7 @@ const deserializeAws_queryGetTopicAttributesCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "NotFound":
+    case "NotFoundException":
     case "com.amazonaws.sns#NotFoundException":
       response = {
         ...(await deserializeAws_queryNotFoundExceptionResponse(parsedOutput, context)),
@@ -2319,7 +2319,7 @@ const deserializeAws_queryListEndpointsByPlatformApplicationCommandError = async
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "AuthorizationError":
+    case "AuthorizationErrorException":
     case "com.amazonaws.sns#AuthorizationErrorException":
       response = {
         ...(await deserializeAws_queryAuthorizationErrorExceptionResponse(parsedOutput, context)),
@@ -2327,7 +2327,7 @@ const deserializeAws_queryListEndpointsByPlatformApplicationCommandError = async
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InternalError":
+    case "InternalErrorException":
     case "com.amazonaws.sns#InternalErrorException":
       response = {
         ...(await deserializeAws_queryInternalErrorExceptionResponse(parsedOutput, context)),
@@ -2335,7 +2335,7 @@ const deserializeAws_queryListEndpointsByPlatformApplicationCommandError = async
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidParameter":
+    case "InvalidParameterException":
     case "com.amazonaws.sns#InvalidParameterException":
       response = {
         ...(await deserializeAws_queryInvalidParameterExceptionResponse(parsedOutput, context)),
@@ -2343,7 +2343,7 @@ const deserializeAws_queryListEndpointsByPlatformApplicationCommandError = async
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "NotFound":
+    case "NotFoundException":
     case "com.amazonaws.sns#NotFoundException":
       response = {
         ...(await deserializeAws_queryNotFoundExceptionResponse(parsedOutput, context)),
@@ -2397,7 +2397,7 @@ const deserializeAws_queryListOriginationNumbersCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "AuthorizationError":
+    case "AuthorizationErrorException":
     case "com.amazonaws.sns#AuthorizationErrorException":
       response = {
         ...(await deserializeAws_queryAuthorizationErrorExceptionResponse(parsedOutput, context)),
@@ -2405,7 +2405,7 @@ const deserializeAws_queryListOriginationNumbersCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InternalError":
+    case "InternalErrorException":
     case "com.amazonaws.sns#InternalErrorException":
       response = {
         ...(await deserializeAws_queryInternalErrorExceptionResponse(parsedOutput, context)),
@@ -2413,7 +2413,7 @@ const deserializeAws_queryListOriginationNumbersCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidParameter":
+    case "InvalidParameterException":
     case "com.amazonaws.sns#InvalidParameterException":
       response = {
         ...(await deserializeAws_queryInvalidParameterExceptionResponse(parsedOutput, context)),
@@ -2421,7 +2421,7 @@ const deserializeAws_queryListOriginationNumbersCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "Throttled":
+    case "ThrottledException":
     case "com.amazonaws.sns#ThrottledException":
       response = {
         ...(await deserializeAws_queryThrottledExceptionResponse(parsedOutput, context)),
@@ -2483,7 +2483,7 @@ const deserializeAws_queryListPhoneNumbersOptedOutCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "AuthorizationError":
+    case "AuthorizationErrorException":
     case "com.amazonaws.sns#AuthorizationErrorException":
       response = {
         ...(await deserializeAws_queryAuthorizationErrorExceptionResponse(parsedOutput, context)),
@@ -2491,7 +2491,7 @@ const deserializeAws_queryListPhoneNumbersOptedOutCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InternalError":
+    case "InternalErrorException":
     case "com.amazonaws.sns#InternalErrorException":
       response = {
         ...(await deserializeAws_queryInternalErrorExceptionResponse(parsedOutput, context)),
@@ -2499,7 +2499,7 @@ const deserializeAws_queryListPhoneNumbersOptedOutCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidParameter":
+    case "InvalidParameterException":
     case "com.amazonaws.sns#InvalidParameterException":
       response = {
         ...(await deserializeAws_queryInvalidParameterExceptionResponse(parsedOutput, context)),
@@ -2507,7 +2507,7 @@ const deserializeAws_queryListPhoneNumbersOptedOutCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "Throttled":
+    case "ThrottledException":
     case "com.amazonaws.sns#ThrottledException":
       response = {
         ...(await deserializeAws_queryThrottledExceptionResponse(parsedOutput, context)),
@@ -2561,7 +2561,7 @@ const deserializeAws_queryListPlatformApplicationsCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "AuthorizationError":
+    case "AuthorizationErrorException":
     case "com.amazonaws.sns#AuthorizationErrorException":
       response = {
         ...(await deserializeAws_queryAuthorizationErrorExceptionResponse(parsedOutput, context)),
@@ -2569,7 +2569,7 @@ const deserializeAws_queryListPlatformApplicationsCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InternalError":
+    case "InternalErrorException":
     case "com.amazonaws.sns#InternalErrorException":
       response = {
         ...(await deserializeAws_queryInternalErrorExceptionResponse(parsedOutput, context)),
@@ -2577,7 +2577,7 @@ const deserializeAws_queryListPlatformApplicationsCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidParameter":
+    case "InvalidParameterException":
     case "com.amazonaws.sns#InvalidParameterException":
       response = {
         ...(await deserializeAws_queryInvalidParameterExceptionResponse(parsedOutput, context)),
@@ -2631,7 +2631,7 @@ const deserializeAws_queryListSMSSandboxPhoneNumbersCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "AuthorizationError":
+    case "AuthorizationErrorException":
     case "com.amazonaws.sns#AuthorizationErrorException":
       response = {
         ...(await deserializeAws_queryAuthorizationErrorExceptionResponse(parsedOutput, context)),
@@ -2639,7 +2639,7 @@ const deserializeAws_queryListSMSSandboxPhoneNumbersCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InternalError":
+    case "InternalErrorException":
     case "com.amazonaws.sns#InternalErrorException":
       response = {
         ...(await deserializeAws_queryInternalErrorExceptionResponse(parsedOutput, context)),
@@ -2647,7 +2647,7 @@ const deserializeAws_queryListSMSSandboxPhoneNumbersCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidParameter":
+    case "InvalidParameterException":
     case "com.amazonaws.sns#InvalidParameterException":
       response = {
         ...(await deserializeAws_queryInvalidParameterExceptionResponse(parsedOutput, context)),
@@ -2655,7 +2655,7 @@ const deserializeAws_queryListSMSSandboxPhoneNumbersCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ResourceNotFound":
+    case "ResourceNotFoundException":
     case "com.amazonaws.sns#ResourceNotFoundException":
       response = {
         ...(await deserializeAws_queryResourceNotFoundExceptionResponse(parsedOutput, context)),
@@ -2663,7 +2663,7 @@ const deserializeAws_queryListSMSSandboxPhoneNumbersCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "Throttled":
+    case "ThrottledException":
     case "com.amazonaws.sns#ThrottledException":
       response = {
         ...(await deserializeAws_queryThrottledExceptionResponse(parsedOutput, context)),
@@ -2717,7 +2717,7 @@ const deserializeAws_queryListSubscriptionsCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "AuthorizationError":
+    case "AuthorizationErrorException":
     case "com.amazonaws.sns#AuthorizationErrorException":
       response = {
         ...(await deserializeAws_queryAuthorizationErrorExceptionResponse(parsedOutput, context)),
@@ -2725,7 +2725,7 @@ const deserializeAws_queryListSubscriptionsCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InternalError":
+    case "InternalErrorException":
     case "com.amazonaws.sns#InternalErrorException":
       response = {
         ...(await deserializeAws_queryInternalErrorExceptionResponse(parsedOutput, context)),
@@ -2733,7 +2733,7 @@ const deserializeAws_queryListSubscriptionsCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidParameter":
+    case "InvalidParameterException":
     case "com.amazonaws.sns#InvalidParameterException":
       response = {
         ...(await deserializeAws_queryInvalidParameterExceptionResponse(parsedOutput, context)),
@@ -2787,7 +2787,7 @@ const deserializeAws_queryListSubscriptionsByTopicCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "AuthorizationError":
+    case "AuthorizationErrorException":
     case "com.amazonaws.sns#AuthorizationErrorException":
       response = {
         ...(await deserializeAws_queryAuthorizationErrorExceptionResponse(parsedOutput, context)),
@@ -2795,7 +2795,7 @@ const deserializeAws_queryListSubscriptionsByTopicCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InternalError":
+    case "InternalErrorException":
     case "com.amazonaws.sns#InternalErrorException":
       response = {
         ...(await deserializeAws_queryInternalErrorExceptionResponse(parsedOutput, context)),
@@ -2803,7 +2803,7 @@ const deserializeAws_queryListSubscriptionsByTopicCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidParameter":
+    case "InvalidParameterException":
     case "com.amazonaws.sns#InvalidParameterException":
       response = {
         ...(await deserializeAws_queryInvalidParameterExceptionResponse(parsedOutput, context)),
@@ -2811,7 +2811,7 @@ const deserializeAws_queryListSubscriptionsByTopicCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "NotFound":
+    case "NotFoundException":
     case "com.amazonaws.sns#NotFoundException":
       response = {
         ...(await deserializeAws_queryNotFoundExceptionResponse(parsedOutput, context)),
@@ -2865,7 +2865,7 @@ const deserializeAws_queryListTagsForResourceCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "AuthorizationError":
+    case "AuthorizationErrorException":
     case "com.amazonaws.sns#AuthorizationErrorException":
       response = {
         ...(await deserializeAws_queryAuthorizationErrorExceptionResponse(parsedOutput, context)),
@@ -2873,7 +2873,7 @@ const deserializeAws_queryListTagsForResourceCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ConcurrentAccess":
+    case "ConcurrentAccessException":
     case "com.amazonaws.sns#ConcurrentAccessException":
       response = {
         ...(await deserializeAws_queryConcurrentAccessExceptionResponse(parsedOutput, context)),
@@ -2881,7 +2881,7 @@ const deserializeAws_queryListTagsForResourceCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidParameter":
+    case "InvalidParameterException":
     case "com.amazonaws.sns#InvalidParameterException":
       response = {
         ...(await deserializeAws_queryInvalidParameterExceptionResponse(parsedOutput, context)),
@@ -2889,7 +2889,7 @@ const deserializeAws_queryListTagsForResourceCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ResourceNotFound":
+    case "ResourceNotFoundException":
     case "com.amazonaws.sns#ResourceNotFoundException":
       response = {
         ...(await deserializeAws_queryResourceNotFoundExceptionResponse(parsedOutput, context)),
@@ -2897,7 +2897,7 @@ const deserializeAws_queryListTagsForResourceCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "TagPolicy":
+    case "TagPolicyException":
     case "com.amazonaws.sns#TagPolicyException":
       response = {
         ...(await deserializeAws_queryTagPolicyExceptionResponse(parsedOutput, context)),
@@ -2951,7 +2951,7 @@ const deserializeAws_queryListTopicsCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "AuthorizationError":
+    case "AuthorizationErrorException":
     case "com.amazonaws.sns#AuthorizationErrorException":
       response = {
         ...(await deserializeAws_queryAuthorizationErrorExceptionResponse(parsedOutput, context)),
@@ -2959,7 +2959,7 @@ const deserializeAws_queryListTopicsCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InternalError":
+    case "InternalErrorException":
     case "com.amazonaws.sns#InternalErrorException":
       response = {
         ...(await deserializeAws_queryInternalErrorExceptionResponse(parsedOutput, context)),
@@ -2967,7 +2967,7 @@ const deserializeAws_queryListTopicsCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidParameter":
+    case "InvalidParameterException":
     case "com.amazonaws.sns#InvalidParameterException":
       response = {
         ...(await deserializeAws_queryInvalidParameterExceptionResponse(parsedOutput, context)),
@@ -3021,7 +3021,7 @@ const deserializeAws_queryOptInPhoneNumberCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "AuthorizationError":
+    case "AuthorizationErrorException":
     case "com.amazonaws.sns#AuthorizationErrorException":
       response = {
         ...(await deserializeAws_queryAuthorizationErrorExceptionResponse(parsedOutput, context)),
@@ -3029,7 +3029,7 @@ const deserializeAws_queryOptInPhoneNumberCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InternalError":
+    case "InternalErrorException":
     case "com.amazonaws.sns#InternalErrorException":
       response = {
         ...(await deserializeAws_queryInternalErrorExceptionResponse(parsedOutput, context)),
@@ -3037,7 +3037,7 @@ const deserializeAws_queryOptInPhoneNumberCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidParameter":
+    case "InvalidParameterException":
     case "com.amazonaws.sns#InvalidParameterException":
       response = {
         ...(await deserializeAws_queryInvalidParameterExceptionResponse(parsedOutput, context)),
@@ -3045,7 +3045,7 @@ const deserializeAws_queryOptInPhoneNumberCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "Throttled":
+    case "ThrottledException":
     case "com.amazonaws.sns#ThrottledException":
       response = {
         ...(await deserializeAws_queryThrottledExceptionResponse(parsedOutput, context)),
@@ -3099,7 +3099,7 @@ const deserializeAws_queryPublishCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "AuthorizationError":
+    case "AuthorizationErrorException":
     case "com.amazonaws.sns#AuthorizationErrorException":
       response = {
         ...(await deserializeAws_queryAuthorizationErrorExceptionResponse(parsedOutput, context)),
@@ -3107,7 +3107,7 @@ const deserializeAws_queryPublishCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "EndpointDisabled":
+    case "EndpointDisabledException":
     case "com.amazonaws.sns#EndpointDisabledException":
       response = {
         ...(await deserializeAws_queryEndpointDisabledExceptionResponse(parsedOutput, context)),
@@ -3115,7 +3115,7 @@ const deserializeAws_queryPublishCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InternalError":
+    case "InternalErrorException":
     case "com.amazonaws.sns#InternalErrorException":
       response = {
         ...(await deserializeAws_queryInternalErrorExceptionResponse(parsedOutput, context)),
@@ -3123,7 +3123,7 @@ const deserializeAws_queryPublishCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidParameter":
+    case "InvalidParameterException":
     case "com.amazonaws.sns#InvalidParameterException":
       response = {
         ...(await deserializeAws_queryInvalidParameterExceptionResponse(parsedOutput, context)),
@@ -3131,7 +3131,15 @@ const deserializeAws_queryPublishCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidSecurity":
+    case "InvalidParameterValueException":
+    case "com.amazonaws.sns#InvalidParameterValueException":
+      response = {
+        ...(await deserializeAws_queryInvalidParameterValueExceptionResponse(parsedOutput, context)),
+        name: errorCode,
+        $metadata: deserializeMetadata(output),
+      };
+      break;
+    case "InvalidSecurityException":
     case "com.amazonaws.sns#InvalidSecurityException":
       response = {
         ...(await deserializeAws_queryInvalidSecurityExceptionResponse(parsedOutput, context)),
@@ -3139,7 +3147,7 @@ const deserializeAws_queryPublishCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "KMSAccessDenied":
+    case "KMSAccessDeniedException":
     case "com.amazonaws.sns#KMSAccessDeniedException":
       response = {
         ...(await deserializeAws_queryKMSAccessDeniedExceptionResponse(parsedOutput, context)),
@@ -3147,7 +3155,7 @@ const deserializeAws_queryPublishCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "KMSDisabled":
+    case "KMSDisabledException":
     case "com.amazonaws.sns#KMSDisabledException":
       response = {
         ...(await deserializeAws_queryKMSDisabledExceptionResponse(parsedOutput, context)),
@@ -3155,7 +3163,7 @@ const deserializeAws_queryPublishCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "KMSInvalidState":
+    case "KMSInvalidStateException":
     case "com.amazonaws.sns#KMSInvalidStateException":
       response = {
         ...(await deserializeAws_queryKMSInvalidStateExceptionResponse(parsedOutput, context)),
@@ -3163,7 +3171,7 @@ const deserializeAws_queryPublishCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "KMSNotFound":
+    case "KMSNotFoundException":
     case "com.amazonaws.sns#KMSNotFoundException":
       response = {
         ...(await deserializeAws_queryKMSNotFoundExceptionResponse(parsedOutput, context)),
@@ -3179,7 +3187,7 @@ const deserializeAws_queryPublishCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "KMSThrottling":
+    case "KMSThrottlingException":
     case "com.amazonaws.sns#KMSThrottlingException":
       response = {
         ...(await deserializeAws_queryKMSThrottlingExceptionResponse(parsedOutput, context)),
@@ -3187,7 +3195,7 @@ const deserializeAws_queryPublishCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "NotFound":
+    case "NotFoundException":
     case "com.amazonaws.sns#NotFoundException":
       response = {
         ...(await deserializeAws_queryNotFoundExceptionResponse(parsedOutput, context)),
@@ -3195,15 +3203,7 @@ const deserializeAws_queryPublishCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ParameterValueInvalid":
-    case "com.amazonaws.sns#InvalidParameterValueException":
-      response = {
-        ...(await deserializeAws_queryInvalidParameterValueExceptionResponse(parsedOutput, context)),
-        name: errorCode,
-        $metadata: deserializeMetadata(output),
-      };
-      break;
-    case "PlatformApplicationDisabled":
+    case "PlatformApplicationDisabledException":
     case "com.amazonaws.sns#PlatformApplicationDisabledException":
       response = {
         ...(await deserializeAws_queryPlatformApplicationDisabledExceptionResponse(parsedOutput, context)),
@@ -3257,7 +3257,7 @@ const deserializeAws_queryPublishBatchCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "AuthorizationError":
+    case "AuthorizationErrorException":
     case "com.amazonaws.sns#AuthorizationErrorException":
       response = {
         ...(await deserializeAws_queryAuthorizationErrorExceptionResponse(parsedOutput, context)),
@@ -3265,7 +3265,7 @@ const deserializeAws_queryPublishBatchCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "BatchEntryIdsNotDistinct":
+    case "BatchEntryIdsNotDistinctException":
     case "com.amazonaws.sns#BatchEntryIdsNotDistinctException":
       response = {
         ...(await deserializeAws_queryBatchEntryIdsNotDistinctExceptionResponse(parsedOutput, context)),
@@ -3273,7 +3273,7 @@ const deserializeAws_queryPublishBatchCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "BatchRequestTooLong":
+    case "BatchRequestTooLongException":
     case "com.amazonaws.sns#BatchRequestTooLongException":
       response = {
         ...(await deserializeAws_queryBatchRequestTooLongExceptionResponse(parsedOutput, context)),
@@ -3281,7 +3281,7 @@ const deserializeAws_queryPublishBatchCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "EmptyBatchRequest":
+    case "EmptyBatchRequestException":
     case "com.amazonaws.sns#EmptyBatchRequestException":
       response = {
         ...(await deserializeAws_queryEmptyBatchRequestExceptionResponse(parsedOutput, context)),
@@ -3289,7 +3289,7 @@ const deserializeAws_queryPublishBatchCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "EndpointDisabled":
+    case "EndpointDisabledException":
     case "com.amazonaws.sns#EndpointDisabledException":
       response = {
         ...(await deserializeAws_queryEndpointDisabledExceptionResponse(parsedOutput, context)),
@@ -3297,7 +3297,7 @@ const deserializeAws_queryPublishBatchCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InternalError":
+    case "InternalErrorException":
     case "com.amazonaws.sns#InternalErrorException":
       response = {
         ...(await deserializeAws_queryInternalErrorExceptionResponse(parsedOutput, context)),
@@ -3305,7 +3305,7 @@ const deserializeAws_queryPublishBatchCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidBatchEntryId":
+    case "InvalidBatchEntryIdException":
     case "com.amazonaws.sns#InvalidBatchEntryIdException":
       response = {
         ...(await deserializeAws_queryInvalidBatchEntryIdExceptionResponse(parsedOutput, context)),
@@ -3313,7 +3313,7 @@ const deserializeAws_queryPublishBatchCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidParameter":
+    case "InvalidParameterException":
     case "com.amazonaws.sns#InvalidParameterException":
       response = {
         ...(await deserializeAws_queryInvalidParameterExceptionResponse(parsedOutput, context)),
@@ -3321,7 +3321,15 @@ const deserializeAws_queryPublishBatchCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidSecurity":
+    case "InvalidParameterValueException":
+    case "com.amazonaws.sns#InvalidParameterValueException":
+      response = {
+        ...(await deserializeAws_queryInvalidParameterValueExceptionResponse(parsedOutput, context)),
+        name: errorCode,
+        $metadata: deserializeMetadata(output),
+      };
+      break;
+    case "InvalidSecurityException":
     case "com.amazonaws.sns#InvalidSecurityException":
       response = {
         ...(await deserializeAws_queryInvalidSecurityExceptionResponse(parsedOutput, context)),
@@ -3329,7 +3337,7 @@ const deserializeAws_queryPublishBatchCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "KMSAccessDenied":
+    case "KMSAccessDeniedException":
     case "com.amazonaws.sns#KMSAccessDeniedException":
       response = {
         ...(await deserializeAws_queryKMSAccessDeniedExceptionResponse(parsedOutput, context)),
@@ -3337,7 +3345,7 @@ const deserializeAws_queryPublishBatchCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "KMSDisabled":
+    case "KMSDisabledException":
     case "com.amazonaws.sns#KMSDisabledException":
       response = {
         ...(await deserializeAws_queryKMSDisabledExceptionResponse(parsedOutput, context)),
@@ -3345,7 +3353,7 @@ const deserializeAws_queryPublishBatchCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "KMSInvalidState":
+    case "KMSInvalidStateException":
     case "com.amazonaws.sns#KMSInvalidStateException":
       response = {
         ...(await deserializeAws_queryKMSInvalidStateExceptionResponse(parsedOutput, context)),
@@ -3353,7 +3361,7 @@ const deserializeAws_queryPublishBatchCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "KMSNotFound":
+    case "KMSNotFoundException":
     case "com.amazonaws.sns#KMSNotFoundException":
       response = {
         ...(await deserializeAws_queryKMSNotFoundExceptionResponse(parsedOutput, context)),
@@ -3369,7 +3377,7 @@ const deserializeAws_queryPublishBatchCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "KMSThrottling":
+    case "KMSThrottlingException":
     case "com.amazonaws.sns#KMSThrottlingException":
       response = {
         ...(await deserializeAws_queryKMSThrottlingExceptionResponse(parsedOutput, context)),
@@ -3377,7 +3385,7 @@ const deserializeAws_queryPublishBatchCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "NotFound":
+    case "NotFoundException":
     case "com.amazonaws.sns#NotFoundException":
       response = {
         ...(await deserializeAws_queryNotFoundExceptionResponse(parsedOutput, context)),
@@ -3385,15 +3393,7 @@ const deserializeAws_queryPublishBatchCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ParameterValueInvalid":
-    case "com.amazonaws.sns#InvalidParameterValueException":
-      response = {
-        ...(await deserializeAws_queryInvalidParameterValueExceptionResponse(parsedOutput, context)),
-        name: errorCode,
-        $metadata: deserializeMetadata(output),
-      };
-      break;
-    case "PlatformApplicationDisabled":
+    case "PlatformApplicationDisabledException":
     case "com.amazonaws.sns#PlatformApplicationDisabledException":
       response = {
         ...(await deserializeAws_queryPlatformApplicationDisabledExceptionResponse(parsedOutput, context)),
@@ -3401,7 +3401,7 @@ const deserializeAws_queryPublishBatchCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "TooManyEntriesInBatchRequest":
+    case "TooManyEntriesInBatchRequestException":
     case "com.amazonaws.sns#TooManyEntriesInBatchRequestException":
       response = {
         ...(await deserializeAws_queryTooManyEntriesInBatchRequestExceptionResponse(parsedOutput, context)),
@@ -3452,7 +3452,7 @@ const deserializeAws_queryRemovePermissionCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "AuthorizationError":
+    case "AuthorizationErrorException":
     case "com.amazonaws.sns#AuthorizationErrorException":
       response = {
         ...(await deserializeAws_queryAuthorizationErrorExceptionResponse(parsedOutput, context)),
@@ -3460,7 +3460,7 @@ const deserializeAws_queryRemovePermissionCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InternalError":
+    case "InternalErrorException":
     case "com.amazonaws.sns#InternalErrorException":
       response = {
         ...(await deserializeAws_queryInternalErrorExceptionResponse(parsedOutput, context)),
@@ -3468,7 +3468,7 @@ const deserializeAws_queryRemovePermissionCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidParameter":
+    case "InvalidParameterException":
     case "com.amazonaws.sns#InvalidParameterException":
       response = {
         ...(await deserializeAws_queryInvalidParameterExceptionResponse(parsedOutput, context)),
@@ -3476,7 +3476,7 @@ const deserializeAws_queryRemovePermissionCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "NotFound":
+    case "NotFoundException":
     case "com.amazonaws.sns#NotFoundException":
       response = {
         ...(await deserializeAws_queryNotFoundExceptionResponse(parsedOutput, context)),
@@ -3527,7 +3527,7 @@ const deserializeAws_querySetEndpointAttributesCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "AuthorizationError":
+    case "AuthorizationErrorException":
     case "com.amazonaws.sns#AuthorizationErrorException":
       response = {
         ...(await deserializeAws_queryAuthorizationErrorExceptionResponse(parsedOutput, context)),
@@ -3535,7 +3535,7 @@ const deserializeAws_querySetEndpointAttributesCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InternalError":
+    case "InternalErrorException":
     case "com.amazonaws.sns#InternalErrorException":
       response = {
         ...(await deserializeAws_queryInternalErrorExceptionResponse(parsedOutput, context)),
@@ -3543,7 +3543,7 @@ const deserializeAws_querySetEndpointAttributesCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidParameter":
+    case "InvalidParameterException":
     case "com.amazonaws.sns#InvalidParameterException":
       response = {
         ...(await deserializeAws_queryInvalidParameterExceptionResponse(parsedOutput, context)),
@@ -3551,7 +3551,7 @@ const deserializeAws_querySetEndpointAttributesCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "NotFound":
+    case "NotFoundException":
     case "com.amazonaws.sns#NotFoundException":
       response = {
         ...(await deserializeAws_queryNotFoundExceptionResponse(parsedOutput, context)),
@@ -3602,7 +3602,7 @@ const deserializeAws_querySetPlatformApplicationAttributesCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "AuthorizationError":
+    case "AuthorizationErrorException":
     case "com.amazonaws.sns#AuthorizationErrorException":
       response = {
         ...(await deserializeAws_queryAuthorizationErrorExceptionResponse(parsedOutput, context)),
@@ -3610,7 +3610,7 @@ const deserializeAws_querySetPlatformApplicationAttributesCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InternalError":
+    case "InternalErrorException":
     case "com.amazonaws.sns#InternalErrorException":
       response = {
         ...(await deserializeAws_queryInternalErrorExceptionResponse(parsedOutput, context)),
@@ -3618,7 +3618,7 @@ const deserializeAws_querySetPlatformApplicationAttributesCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidParameter":
+    case "InvalidParameterException":
     case "com.amazonaws.sns#InvalidParameterException":
       response = {
         ...(await deserializeAws_queryInvalidParameterExceptionResponse(parsedOutput, context)),
@@ -3626,7 +3626,7 @@ const deserializeAws_querySetPlatformApplicationAttributesCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "NotFound":
+    case "NotFoundException":
     case "com.amazonaws.sns#NotFoundException":
       response = {
         ...(await deserializeAws_queryNotFoundExceptionResponse(parsedOutput, context)),
@@ -3680,7 +3680,7 @@ const deserializeAws_querySetSMSAttributesCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "AuthorizationError":
+    case "AuthorizationErrorException":
     case "com.amazonaws.sns#AuthorizationErrorException":
       response = {
         ...(await deserializeAws_queryAuthorizationErrorExceptionResponse(parsedOutput, context)),
@@ -3688,7 +3688,7 @@ const deserializeAws_querySetSMSAttributesCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InternalError":
+    case "InternalErrorException":
     case "com.amazonaws.sns#InternalErrorException":
       response = {
         ...(await deserializeAws_queryInternalErrorExceptionResponse(parsedOutput, context)),
@@ -3696,7 +3696,7 @@ const deserializeAws_querySetSMSAttributesCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidParameter":
+    case "InvalidParameterException":
     case "com.amazonaws.sns#InvalidParameterException":
       response = {
         ...(await deserializeAws_queryInvalidParameterExceptionResponse(parsedOutput, context)),
@@ -3704,7 +3704,7 @@ const deserializeAws_querySetSMSAttributesCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "Throttled":
+    case "ThrottledException":
     case "com.amazonaws.sns#ThrottledException":
       response = {
         ...(await deserializeAws_queryThrottledExceptionResponse(parsedOutput, context)),
@@ -3755,7 +3755,7 @@ const deserializeAws_querySetSubscriptionAttributesCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "AuthorizationError":
+    case "AuthorizationErrorException":
     case "com.amazonaws.sns#AuthorizationErrorException":
       response = {
         ...(await deserializeAws_queryAuthorizationErrorExceptionResponse(parsedOutput, context)),
@@ -3763,7 +3763,7 @@ const deserializeAws_querySetSubscriptionAttributesCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "FilterPolicyLimitExceeded":
+    case "FilterPolicyLimitExceededException":
     case "com.amazonaws.sns#FilterPolicyLimitExceededException":
       response = {
         ...(await deserializeAws_queryFilterPolicyLimitExceededExceptionResponse(parsedOutput, context)),
@@ -3771,7 +3771,7 @@ const deserializeAws_querySetSubscriptionAttributesCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InternalError":
+    case "InternalErrorException":
     case "com.amazonaws.sns#InternalErrorException":
       response = {
         ...(await deserializeAws_queryInternalErrorExceptionResponse(parsedOutput, context)),
@@ -3779,7 +3779,7 @@ const deserializeAws_querySetSubscriptionAttributesCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidParameter":
+    case "InvalidParameterException":
     case "com.amazonaws.sns#InvalidParameterException":
       response = {
         ...(await deserializeAws_queryInvalidParameterExceptionResponse(parsedOutput, context)),
@@ -3787,7 +3787,7 @@ const deserializeAws_querySetSubscriptionAttributesCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "NotFound":
+    case "NotFoundException":
     case "com.amazonaws.sns#NotFoundException":
       response = {
         ...(await deserializeAws_queryNotFoundExceptionResponse(parsedOutput, context)),
@@ -3838,7 +3838,7 @@ const deserializeAws_querySetTopicAttributesCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "AuthorizationError":
+    case "AuthorizationErrorException":
     case "com.amazonaws.sns#AuthorizationErrorException":
       response = {
         ...(await deserializeAws_queryAuthorizationErrorExceptionResponse(parsedOutput, context)),
@@ -3846,7 +3846,7 @@ const deserializeAws_querySetTopicAttributesCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InternalError":
+    case "InternalErrorException":
     case "com.amazonaws.sns#InternalErrorException":
       response = {
         ...(await deserializeAws_queryInternalErrorExceptionResponse(parsedOutput, context)),
@@ -3854,7 +3854,7 @@ const deserializeAws_querySetTopicAttributesCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidParameter":
+    case "InvalidParameterException":
     case "com.amazonaws.sns#InvalidParameterException":
       response = {
         ...(await deserializeAws_queryInvalidParameterExceptionResponse(parsedOutput, context)),
@@ -3862,7 +3862,7 @@ const deserializeAws_querySetTopicAttributesCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidSecurity":
+    case "InvalidSecurityException":
     case "com.amazonaws.sns#InvalidSecurityException":
       response = {
         ...(await deserializeAws_queryInvalidSecurityExceptionResponse(parsedOutput, context)),
@@ -3870,7 +3870,7 @@ const deserializeAws_querySetTopicAttributesCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "NotFound":
+    case "NotFoundException":
     case "com.amazonaws.sns#NotFoundException":
       response = {
         ...(await deserializeAws_queryNotFoundExceptionResponse(parsedOutput, context)),
@@ -3924,7 +3924,7 @@ const deserializeAws_querySubscribeCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "AuthorizationError":
+    case "AuthorizationErrorException":
     case "com.amazonaws.sns#AuthorizationErrorException":
       response = {
         ...(await deserializeAws_queryAuthorizationErrorExceptionResponse(parsedOutput, context)),
@@ -3932,7 +3932,7 @@ const deserializeAws_querySubscribeCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "FilterPolicyLimitExceeded":
+    case "FilterPolicyLimitExceededException":
     case "com.amazonaws.sns#FilterPolicyLimitExceededException":
       response = {
         ...(await deserializeAws_queryFilterPolicyLimitExceededExceptionResponse(parsedOutput, context)),
@@ -3940,7 +3940,7 @@ const deserializeAws_querySubscribeCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InternalError":
+    case "InternalErrorException":
     case "com.amazonaws.sns#InternalErrorException":
       response = {
         ...(await deserializeAws_queryInternalErrorExceptionResponse(parsedOutput, context)),
@@ -3948,7 +3948,7 @@ const deserializeAws_querySubscribeCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidParameter":
+    case "InvalidParameterException":
     case "com.amazonaws.sns#InvalidParameterException":
       response = {
         ...(await deserializeAws_queryInvalidParameterExceptionResponse(parsedOutput, context)),
@@ -3956,7 +3956,7 @@ const deserializeAws_querySubscribeCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidSecurity":
+    case "InvalidSecurityException":
     case "com.amazonaws.sns#InvalidSecurityException":
       response = {
         ...(await deserializeAws_queryInvalidSecurityExceptionResponse(parsedOutput, context)),
@@ -3964,7 +3964,7 @@ const deserializeAws_querySubscribeCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "NotFound":
+    case "NotFoundException":
     case "com.amazonaws.sns#NotFoundException":
       response = {
         ...(await deserializeAws_queryNotFoundExceptionResponse(parsedOutput, context)),
@@ -3972,7 +3972,7 @@ const deserializeAws_querySubscribeCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "SubscriptionLimitExceeded":
+    case "SubscriptionLimitExceededException":
     case "com.amazonaws.sns#SubscriptionLimitExceededException":
       response = {
         ...(await deserializeAws_querySubscriptionLimitExceededExceptionResponse(parsedOutput, context)),
@@ -4026,7 +4026,7 @@ const deserializeAws_queryTagResourceCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "AuthorizationError":
+    case "AuthorizationErrorException":
     case "com.amazonaws.sns#AuthorizationErrorException":
       response = {
         ...(await deserializeAws_queryAuthorizationErrorExceptionResponse(parsedOutput, context)),
@@ -4034,7 +4034,7 @@ const deserializeAws_queryTagResourceCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ConcurrentAccess":
+    case "ConcurrentAccessException":
     case "com.amazonaws.sns#ConcurrentAccessException":
       response = {
         ...(await deserializeAws_queryConcurrentAccessExceptionResponse(parsedOutput, context)),
@@ -4042,7 +4042,7 @@ const deserializeAws_queryTagResourceCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidParameter":
+    case "InvalidParameterException":
     case "com.amazonaws.sns#InvalidParameterException":
       response = {
         ...(await deserializeAws_queryInvalidParameterExceptionResponse(parsedOutput, context)),
@@ -4050,7 +4050,7 @@ const deserializeAws_queryTagResourceCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ResourceNotFound":
+    case "ResourceNotFoundException":
     case "com.amazonaws.sns#ResourceNotFoundException":
       response = {
         ...(await deserializeAws_queryResourceNotFoundExceptionResponse(parsedOutput, context)),
@@ -4058,7 +4058,7 @@ const deserializeAws_queryTagResourceCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "StaleTag":
+    case "StaleTagException":
     case "com.amazonaws.sns#StaleTagException":
       response = {
         ...(await deserializeAws_queryStaleTagExceptionResponse(parsedOutput, context)),
@@ -4066,7 +4066,7 @@ const deserializeAws_queryTagResourceCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "TagLimitExceeded":
+    case "TagLimitExceededException":
     case "com.amazonaws.sns#TagLimitExceededException":
       response = {
         ...(await deserializeAws_queryTagLimitExceededExceptionResponse(parsedOutput, context)),
@@ -4074,7 +4074,7 @@ const deserializeAws_queryTagResourceCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "TagPolicy":
+    case "TagPolicyException":
     case "com.amazonaws.sns#TagPolicyException":
       response = {
         ...(await deserializeAws_queryTagPolicyExceptionResponse(parsedOutput, context)),
@@ -4125,7 +4125,7 @@ const deserializeAws_queryUnsubscribeCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "AuthorizationError":
+    case "AuthorizationErrorException":
     case "com.amazonaws.sns#AuthorizationErrorException":
       response = {
         ...(await deserializeAws_queryAuthorizationErrorExceptionResponse(parsedOutput, context)),
@@ -4133,7 +4133,7 @@ const deserializeAws_queryUnsubscribeCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InternalError":
+    case "InternalErrorException":
     case "com.amazonaws.sns#InternalErrorException":
       response = {
         ...(await deserializeAws_queryInternalErrorExceptionResponse(parsedOutput, context)),
@@ -4141,7 +4141,7 @@ const deserializeAws_queryUnsubscribeCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidParameter":
+    case "InvalidParameterException":
     case "com.amazonaws.sns#InvalidParameterException":
       response = {
         ...(await deserializeAws_queryInvalidParameterExceptionResponse(parsedOutput, context)),
@@ -4149,7 +4149,7 @@ const deserializeAws_queryUnsubscribeCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidSecurity":
+    case "InvalidSecurityException":
     case "com.amazonaws.sns#InvalidSecurityException":
       response = {
         ...(await deserializeAws_queryInvalidSecurityExceptionResponse(parsedOutput, context)),
@@ -4157,7 +4157,7 @@ const deserializeAws_queryUnsubscribeCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "NotFound":
+    case "NotFoundException":
     case "com.amazonaws.sns#NotFoundException":
       response = {
         ...(await deserializeAws_queryNotFoundExceptionResponse(parsedOutput, context)),
@@ -4211,7 +4211,7 @@ const deserializeAws_queryUntagResourceCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "AuthorizationError":
+    case "AuthorizationErrorException":
     case "com.amazonaws.sns#AuthorizationErrorException":
       response = {
         ...(await deserializeAws_queryAuthorizationErrorExceptionResponse(parsedOutput, context)),
@@ -4219,7 +4219,7 @@ const deserializeAws_queryUntagResourceCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ConcurrentAccess":
+    case "ConcurrentAccessException":
     case "com.amazonaws.sns#ConcurrentAccessException":
       response = {
         ...(await deserializeAws_queryConcurrentAccessExceptionResponse(parsedOutput, context)),
@@ -4227,7 +4227,7 @@ const deserializeAws_queryUntagResourceCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidParameter":
+    case "InvalidParameterException":
     case "com.amazonaws.sns#InvalidParameterException":
       response = {
         ...(await deserializeAws_queryInvalidParameterExceptionResponse(parsedOutput, context)),
@@ -4235,7 +4235,7 @@ const deserializeAws_queryUntagResourceCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ResourceNotFound":
+    case "ResourceNotFoundException":
     case "com.amazonaws.sns#ResourceNotFoundException":
       response = {
         ...(await deserializeAws_queryResourceNotFoundExceptionResponse(parsedOutput, context)),
@@ -4243,7 +4243,7 @@ const deserializeAws_queryUntagResourceCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "StaleTag":
+    case "StaleTagException":
     case "com.amazonaws.sns#StaleTagException":
       response = {
         ...(await deserializeAws_queryStaleTagExceptionResponse(parsedOutput, context)),
@@ -4251,7 +4251,7 @@ const deserializeAws_queryUntagResourceCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "TagLimitExceeded":
+    case "TagLimitExceededException":
     case "com.amazonaws.sns#TagLimitExceededException":
       response = {
         ...(await deserializeAws_queryTagLimitExceededExceptionResponse(parsedOutput, context)),
@@ -4259,7 +4259,7 @@ const deserializeAws_queryUntagResourceCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "TagPolicy":
+    case "TagPolicyException":
     case "com.amazonaws.sns#TagPolicyException":
       response = {
         ...(await deserializeAws_queryTagPolicyExceptionResponse(parsedOutput, context)),
@@ -4313,7 +4313,7 @@ const deserializeAws_queryVerifySMSSandboxPhoneNumberCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "AuthorizationError":
+    case "AuthorizationErrorException":
     case "com.amazonaws.sns#AuthorizationErrorException":
       response = {
         ...(await deserializeAws_queryAuthorizationErrorExceptionResponse(parsedOutput, context)),
@@ -4321,7 +4321,7 @@ const deserializeAws_queryVerifySMSSandboxPhoneNumberCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InternalError":
+    case "InternalErrorException":
     case "com.amazonaws.sns#InternalErrorException":
       response = {
         ...(await deserializeAws_queryInternalErrorExceptionResponse(parsedOutput, context)),
@@ -4329,7 +4329,7 @@ const deserializeAws_queryVerifySMSSandboxPhoneNumberCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidParameter":
+    case "InvalidParameterException":
     case "com.amazonaws.sns#InvalidParameterException":
       response = {
         ...(await deserializeAws_queryInvalidParameterExceptionResponse(parsedOutput, context)),
@@ -4337,7 +4337,7 @@ const deserializeAws_queryVerifySMSSandboxPhoneNumberCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "ResourceNotFound":
+    case "ResourceNotFoundException":
     case "com.amazonaws.sns#ResourceNotFoundException":
       response = {
         ...(await deserializeAws_queryResourceNotFoundExceptionResponse(parsedOutput, context)),
@@ -4345,7 +4345,7 @@ const deserializeAws_queryVerifySMSSandboxPhoneNumberCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "Throttled":
+    case "ThrottledException":
     case "com.amazonaws.sns#ThrottledException":
       response = {
         ...(await deserializeAws_queryThrottledExceptionResponse(parsedOutput, context)),

--- a/clients/client-sqs/src/protocols/Aws_query.ts
+++ b/clients/client-sqs/src/protocols/Aws_query.ts
@@ -504,7 +504,7 @@ const deserializeAws_queryChangeMessageVisibilityCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "AWS.SimpleQueueService.MessageNotInflight":
+    case "MessageNotInflight":
     case "com.amazonaws.sqs#MessageNotInflight":
       response = {
         ...(await deserializeAws_queryMessageNotInflightResponse(parsedOutput, context)),
@@ -566,7 +566,7 @@ const deserializeAws_queryChangeMessageVisibilityBatchCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "AWS.SimpleQueueService.BatchEntryIdsNotDistinct":
+    case "BatchEntryIdsNotDistinct":
     case "com.amazonaws.sqs#BatchEntryIdsNotDistinct":
       response = {
         ...(await deserializeAws_queryBatchEntryIdsNotDistinctResponse(parsedOutput, context)),
@@ -574,7 +574,7 @@ const deserializeAws_queryChangeMessageVisibilityBatchCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "AWS.SimpleQueueService.EmptyBatchRequest":
+    case "EmptyBatchRequest":
     case "com.amazonaws.sqs#EmptyBatchRequest":
       response = {
         ...(await deserializeAws_queryEmptyBatchRequestResponse(parsedOutput, context)),
@@ -582,7 +582,7 @@ const deserializeAws_queryChangeMessageVisibilityBatchCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "AWS.SimpleQueueService.InvalidBatchEntryId":
+    case "InvalidBatchEntryId":
     case "com.amazonaws.sqs#InvalidBatchEntryId":
       response = {
         ...(await deserializeAws_queryInvalidBatchEntryIdResponse(parsedOutput, context)),
@@ -590,7 +590,7 @@ const deserializeAws_queryChangeMessageVisibilityBatchCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "AWS.SimpleQueueService.TooManyEntriesInBatchRequest":
+    case "TooManyEntriesInBatchRequest":
     case "com.amazonaws.sqs#TooManyEntriesInBatchRequest":
       response = {
         ...(await deserializeAws_queryTooManyEntriesInBatchRequestResponse(parsedOutput, context)),
@@ -644,7 +644,7 @@ const deserializeAws_queryCreateQueueCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "AWS.SimpleQueueService.QueueDeletedRecently":
+    case "QueueDeletedRecently":
     case "com.amazonaws.sqs#QueueDeletedRecently":
       response = {
         ...(await deserializeAws_queryQueueDeletedRecentlyResponse(parsedOutput, context)),
@@ -652,7 +652,7 @@ const deserializeAws_queryCreateQueueCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "QueueAlreadyExists":
+    case "QueueNameExists":
     case "com.amazonaws.sqs#QueueNameExists":
       response = {
         ...(await deserializeAws_queryQueueNameExistsResponse(parsedOutput, context)),
@@ -765,7 +765,7 @@ const deserializeAws_queryDeleteMessageBatchCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "AWS.SimpleQueueService.BatchEntryIdsNotDistinct":
+    case "BatchEntryIdsNotDistinct":
     case "com.amazonaws.sqs#BatchEntryIdsNotDistinct":
       response = {
         ...(await deserializeAws_queryBatchEntryIdsNotDistinctResponse(parsedOutput, context)),
@@ -773,7 +773,7 @@ const deserializeAws_queryDeleteMessageBatchCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "AWS.SimpleQueueService.EmptyBatchRequest":
+    case "EmptyBatchRequest":
     case "com.amazonaws.sqs#EmptyBatchRequest":
       response = {
         ...(await deserializeAws_queryEmptyBatchRequestResponse(parsedOutput, context)),
@@ -781,7 +781,7 @@ const deserializeAws_queryDeleteMessageBatchCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "AWS.SimpleQueueService.InvalidBatchEntryId":
+    case "InvalidBatchEntryId":
     case "com.amazonaws.sqs#InvalidBatchEntryId":
       response = {
         ...(await deserializeAws_queryInvalidBatchEntryIdResponse(parsedOutput, context)),
@@ -789,7 +789,7 @@ const deserializeAws_queryDeleteMessageBatchCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "AWS.SimpleQueueService.TooManyEntriesInBatchRequest":
+    case "TooManyEntriesInBatchRequest":
     case "com.amazonaws.sqs#TooManyEntriesInBatchRequest":
       response = {
         ...(await deserializeAws_queryTooManyEntriesInBatchRequestResponse(parsedOutput, context)),
@@ -940,7 +940,7 @@ const deserializeAws_queryGetQueueUrlCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "AWS.SimpleQueueService.NonExistentQueue":
+    case "QueueDoesNotExist":
     case "com.amazonaws.sqs#QueueDoesNotExist":
       response = {
         ...(await deserializeAws_queryQueueDoesNotExistResponse(parsedOutput, context)),
@@ -994,7 +994,7 @@ const deserializeAws_queryListDeadLetterSourceQueuesCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "AWS.SimpleQueueService.NonExistentQueue":
+    case "QueueDoesNotExist":
     case "com.amazonaws.sqs#QueueDoesNotExist":
       response = {
         ...(await deserializeAws_queryQueueDoesNotExistResponse(parsedOutput, context)),
@@ -1137,18 +1137,18 @@ const deserializeAws_queryPurgeQueueCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "AWS.SimpleQueueService.NonExistentQueue":
-    case "com.amazonaws.sqs#QueueDoesNotExist":
+    case "PurgeQueueInProgress":
+    case "com.amazonaws.sqs#PurgeQueueInProgress":
       response = {
-        ...(await deserializeAws_queryQueueDoesNotExistResponse(parsedOutput, context)),
+        ...(await deserializeAws_queryPurgeQueueInProgressResponse(parsedOutput, context)),
         name: errorCode,
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "AWS.SimpleQueueService.PurgeQueueInProgress":
-    case "com.amazonaws.sqs#PurgeQueueInProgress":
+    case "QueueDoesNotExist":
+    case "com.amazonaws.sqs#QueueDoesNotExist":
       response = {
-        ...(await deserializeAws_queryPurgeQueueInProgressResponse(parsedOutput, context)),
+        ...(await deserializeAws_queryQueueDoesNotExistResponse(parsedOutput, context)),
         name: errorCode,
         $metadata: deserializeMetadata(output),
       };
@@ -1296,18 +1296,18 @@ const deserializeAws_querySendMessageCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "AWS.SimpleQueueService.UnsupportedOperation":
-    case "com.amazonaws.sqs#UnsupportedOperation":
-      response = {
-        ...(await deserializeAws_queryUnsupportedOperationResponse(parsedOutput, context)),
-        name: errorCode,
-        $metadata: deserializeMetadata(output),
-      };
-      break;
     case "InvalidMessageContents":
     case "com.amazonaws.sqs#InvalidMessageContents":
       response = {
         ...(await deserializeAws_queryInvalidMessageContentsResponse(parsedOutput, context)),
+        name: errorCode,
+        $metadata: deserializeMetadata(output),
+      };
+      break;
+    case "UnsupportedOperation":
+    case "com.amazonaws.sqs#UnsupportedOperation":
+      response = {
+        ...(await deserializeAws_queryUnsupportedOperationResponse(parsedOutput, context)),
         name: errorCode,
         $metadata: deserializeMetadata(output),
       };
@@ -1358,7 +1358,7 @@ const deserializeAws_querySendMessageBatchCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "AWS.SimpleQueueService.BatchEntryIdsNotDistinct":
+    case "BatchEntryIdsNotDistinct":
     case "com.amazonaws.sqs#BatchEntryIdsNotDistinct":
       response = {
         ...(await deserializeAws_queryBatchEntryIdsNotDistinctResponse(parsedOutput, context)),
@@ -1366,7 +1366,7 @@ const deserializeAws_querySendMessageBatchCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "AWS.SimpleQueueService.BatchRequestTooLong":
+    case "BatchRequestTooLong":
     case "com.amazonaws.sqs#BatchRequestTooLong":
       response = {
         ...(await deserializeAws_queryBatchRequestTooLongResponse(parsedOutput, context)),
@@ -1374,7 +1374,7 @@ const deserializeAws_querySendMessageBatchCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "AWS.SimpleQueueService.EmptyBatchRequest":
+    case "EmptyBatchRequest":
     case "com.amazonaws.sqs#EmptyBatchRequest":
       response = {
         ...(await deserializeAws_queryEmptyBatchRequestResponse(parsedOutput, context)),
@@ -1382,7 +1382,7 @@ const deserializeAws_querySendMessageBatchCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "AWS.SimpleQueueService.InvalidBatchEntryId":
+    case "InvalidBatchEntryId":
     case "com.amazonaws.sqs#InvalidBatchEntryId":
       response = {
         ...(await deserializeAws_queryInvalidBatchEntryIdResponse(parsedOutput, context)),
@@ -1390,7 +1390,7 @@ const deserializeAws_querySendMessageBatchCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "AWS.SimpleQueueService.TooManyEntriesInBatchRequest":
+    case "TooManyEntriesInBatchRequest":
     case "com.amazonaws.sqs#TooManyEntriesInBatchRequest":
       response = {
         ...(await deserializeAws_queryTooManyEntriesInBatchRequestResponse(parsedOutput, context)),
@@ -1398,7 +1398,7 @@ const deserializeAws_querySendMessageBatchCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "AWS.SimpleQueueService.UnsupportedOperation":
+    case "UnsupportedOperation":
     case "com.amazonaws.sqs#UnsupportedOperation":
       response = {
         ...(await deserializeAws_queryUnsupportedOperationResponse(parsedOutput, context)),

--- a/clients/client-sts/src/protocols/Aws_query.ts
+++ b/clients/client-sts/src/protocols/Aws_query.ts
@@ -229,7 +229,7 @@ const deserializeAws_queryAssumeRoleCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "MalformedPolicyDocument":
+    case "MalformedPolicyDocumentException":
     case "com.amazonaws.sts#MalformedPolicyDocumentException":
       response = {
         ...(await deserializeAws_queryMalformedPolicyDocumentExceptionResponse(parsedOutput, context)),
@@ -237,7 +237,7 @@ const deserializeAws_queryAssumeRoleCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "PackedPolicyTooLarge":
+    case "PackedPolicyTooLargeException":
     case "com.amazonaws.sts#PackedPolicyTooLargeException":
       response = {
         ...(await deserializeAws_queryPackedPolicyTooLargeExceptionResponse(parsedOutput, context)),
@@ -307,7 +307,7 @@ const deserializeAws_queryAssumeRoleWithSAMLCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "IDPRejectedClaim":
+    case "IDPRejectedClaimException":
     case "com.amazonaws.sts#IDPRejectedClaimException":
       response = {
         ...(await deserializeAws_queryIDPRejectedClaimExceptionResponse(parsedOutput, context)),
@@ -315,7 +315,7 @@ const deserializeAws_queryAssumeRoleWithSAMLCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidIdentityToken":
+    case "InvalidIdentityTokenException":
     case "com.amazonaws.sts#InvalidIdentityTokenException":
       response = {
         ...(await deserializeAws_queryInvalidIdentityTokenExceptionResponse(parsedOutput, context)),
@@ -323,7 +323,7 @@ const deserializeAws_queryAssumeRoleWithSAMLCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "MalformedPolicyDocument":
+    case "MalformedPolicyDocumentException":
     case "com.amazonaws.sts#MalformedPolicyDocumentException":
       response = {
         ...(await deserializeAws_queryMalformedPolicyDocumentExceptionResponse(parsedOutput, context)),
@@ -331,7 +331,7 @@ const deserializeAws_queryAssumeRoleWithSAMLCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "PackedPolicyTooLarge":
+    case "PackedPolicyTooLargeException":
     case "com.amazonaws.sts#PackedPolicyTooLargeException":
       response = {
         ...(await deserializeAws_queryPackedPolicyTooLargeExceptionResponse(parsedOutput, context)),
@@ -401,7 +401,7 @@ const deserializeAws_queryAssumeRoleWithWebIdentityCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "IDPCommunicationError":
+    case "IDPCommunicationErrorException":
     case "com.amazonaws.sts#IDPCommunicationErrorException":
       response = {
         ...(await deserializeAws_queryIDPCommunicationErrorExceptionResponse(parsedOutput, context)),
@@ -409,7 +409,7 @@ const deserializeAws_queryAssumeRoleWithWebIdentityCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "IDPRejectedClaim":
+    case "IDPRejectedClaimException":
     case "com.amazonaws.sts#IDPRejectedClaimException":
       response = {
         ...(await deserializeAws_queryIDPRejectedClaimExceptionResponse(parsedOutput, context)),
@@ -417,7 +417,7 @@ const deserializeAws_queryAssumeRoleWithWebIdentityCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "InvalidIdentityToken":
+    case "InvalidIdentityTokenException":
     case "com.amazonaws.sts#InvalidIdentityTokenException":
       response = {
         ...(await deserializeAws_queryInvalidIdentityTokenExceptionResponse(parsedOutput, context)),
@@ -425,7 +425,7 @@ const deserializeAws_queryAssumeRoleWithWebIdentityCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "MalformedPolicyDocument":
+    case "MalformedPolicyDocumentException":
     case "com.amazonaws.sts#MalformedPolicyDocumentException":
       response = {
         ...(await deserializeAws_queryMalformedPolicyDocumentExceptionResponse(parsedOutput, context)),
@@ -433,7 +433,7 @@ const deserializeAws_queryAssumeRoleWithWebIdentityCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "PackedPolicyTooLarge":
+    case "PackedPolicyTooLargeException":
     case "com.amazonaws.sts#PackedPolicyTooLargeException":
       response = {
         ...(await deserializeAws_queryPackedPolicyTooLargeExceptionResponse(parsedOutput, context)),
@@ -641,7 +641,7 @@ const deserializeAws_queryGetFederationTokenCommandError = async (
   let errorCode = "UnknownError";
   errorCode = loadQueryErrorCode(output, parsedOutput.body);
   switch (errorCode) {
-    case "MalformedPolicyDocument":
+    case "MalformedPolicyDocumentException":
     case "com.amazonaws.sts#MalformedPolicyDocumentException":
       response = {
         ...(await deserializeAws_queryMalformedPolicyDocumentExceptionResponse(parsedOutput, context)),
@@ -649,7 +649,7 @@ const deserializeAws_queryGetFederationTokenCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "PackedPolicyTooLarge":
+    case "PackedPolicyTooLargeException":
     case "com.amazonaws.sts#PackedPolicyTooLargeException":
       response = {
         ...(await deserializeAws_queryPackedPolicyTooLargeExceptionResponse(parsedOutput, context)),

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsProtocolUtils.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsProtocolUtils.java
@@ -294,7 +294,7 @@ final class AwsProtocolUtils {
             HttpMessageTestCase testCase,
             TypeScriptSettings settings
     ) {
-        // TODO: Enable when protocol test setup allows passing error names.
+        // TODO: Consume AWSQueryError trait as a follow-up.
         if (testCase.getId().equals("QueryCustomizedError")) {
             return true;
         }

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsQuery.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsQuery.java
@@ -15,11 +15,7 @@
 
 package software.amazon.smithy.aws.typescript.codegen;
 
-import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
-import java.util.TreeMap;
-import software.amazon.smithy.aws.traits.protocols.AwsQueryErrorTrait;
 import software.amazon.smithy.aws.traits.protocols.AwsQueryTrait;
 import software.amazon.smithy.codegen.core.SymbolReference;
 import software.amazon.smithy.model.shapes.OperationShape;
@@ -176,24 +172,5 @@ final class AwsQuery extends HttpRpcProtocolGenerator {
     @Override
     public void generateProtocolTests(GenerationContext context) {
         AwsProtocolUtils.generateProtocolTests(this, context);
-    }
-
-    @Override
-    public Map<String, ShapeId> getOperationErrors(GenerationContext context, OperationShape operation) {
-        Map<String, ShapeId> errors = new TreeMap<>();
-
-        operation.getErrors().forEach(shapeId -> {
-            Shape errorShape = context.getModel().expectShape(shapeId);
-            String errorName = shapeId.getName(context.getService());
-
-            Optional<AwsQueryErrorTrait> errorShapeTrait = errorShape.getTrait(AwsQueryErrorTrait.class);
-            if (errorShapeTrait.isPresent()) {
-                errors.put(errorShapeTrait.get().getCode(), shapeId);
-            } else {
-                errors.put(errorName, shapeId);
-            }
-        });
-
-        return errors;
     }
 }

--- a/private/aws-protocoltests-query/src/protocols/Aws_query.ts
+++ b/private/aws-protocoltests-query/src/protocols/Aws_query.ts
@@ -877,7 +877,7 @@ const deserializeAws_queryGreetingWithErrorsCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
-    case "Customized":
+    case "CustomCodeError":
     case "aws.protocoltests.query#CustomCodeError":
       response = {
         ...(await deserializeAws_queryCustomCodeErrorResponse(parsedOutput, context)),


### PR DESCRIPTION
### Issue
Internal JS-3027

This code change surfaced a bug in our error deserializer, where the error message is modeled to be in key `message` but the actual message is response payload with key `Message`.

### Description
This reverts commit 351bd3a40ad37be79d823d6a0e4e48304728ea6f added in https://github.com/aws/aws-sdk-js-v3/pull/3174.

### Testing
Integration tests were successful.
```
$ yarn test:integration:legacy
yarn run v1.22.17
$ cucumber-js --fail-fast
.......................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................

150 scenarios (150 passed)
523 steps (523 passed)
1m43.243s
Done in 104.70s.
```

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
