### PR TITLE
chore(clients): run builds concurrently

### DIFF
--- a/clients/client-accessanalyzer/package.json
+++ b/clients/client-accessanalyzer/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Accessanalyzer Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-account/package.json
+++ b/clients/client-account/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Account Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-acm-pca/package.json
+++ b/clients/client-acm-pca/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Acm Pca Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-acm/package.json
+++ b/clients/client-acm/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Acm Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-alexa-for-business/package.json
+++ b/clients/client-alexa-for-business/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Alexa For Business Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-amp/package.json
+++ b/clients/client-amp/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Amp Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-amplify/package.json
+++ b/clients/client-amplify/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Amplify Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-amplifybackend/package.json
+++ b/clients/client-amplifybackend/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Amplifybackend Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-amplifyuibuilder/package.json
+++ b/clients/client-amplifyuibuilder/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Amplifyuibuilder Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-api-gateway/package.json
+++ b/clients/client-api-gateway/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Api Gateway Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-apigatewaymanagementapi/package.json
+++ b/clients/client-apigatewaymanagementapi/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Apigatewaymanagementapi Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-apigatewayv2/package.json
+++ b/clients/client-apigatewayv2/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Apigatewayv2 Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-app-mesh/package.json
+++ b/clients/client-app-mesh/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript App Mesh Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-appconfig/package.json
+++ b/clients/client-appconfig/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Appconfig Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-appconfigdata/package.json
+++ b/clients/client-appconfigdata/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Appconfigdata Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-appflow/package.json
+++ b/clients/client-appflow/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Appflow Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-appintegrations/package.json
+++ b/clients/client-appintegrations/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Appintegrations Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-application-auto-scaling/package.json
+++ b/clients/client-application-auto-scaling/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Application Auto Scaling Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-application-discovery-service/package.json
+++ b/clients/client-application-discovery-service/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Application Discovery Service Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-application-insights/package.json
+++ b/clients/client-application-insights/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Application Insights Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-applicationcostprofiler/package.json
+++ b/clients/client-applicationcostprofiler/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Applicationcostprofiler Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-apprunner/package.json
+++ b/clients/client-apprunner/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Apprunner Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-appstream/package.json
+++ b/clients/client-appstream/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Appstream Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-appsync/package.json
+++ b/clients/client-appsync/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Appsync Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-athena/package.json
+++ b/clients/client-athena/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Athena Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-auditmanager/package.json
+++ b/clients/client-auditmanager/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Auditmanager Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-auto-scaling-plans/package.json
+++ b/clients/client-auto-scaling-plans/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Auto Scaling Plans Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-auto-scaling/package.json
+++ b/clients/client-auto-scaling/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Auto Scaling Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-backup-gateway/package.json
+++ b/clients/client-backup-gateway/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Backup Gateway Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-backup/package.json
+++ b/clients/client-backup/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Backup Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-batch/package.json
+++ b/clients/client-batch/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Batch Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-braket/package.json
+++ b/clients/client-braket/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Braket Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-budgets/package.json
+++ b/clients/client-budgets/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Budgets Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-chime-sdk-identity/package.json
+++ b/clients/client-chime-sdk-identity/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Chime Sdk Identity Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-chime-sdk-meetings/package.json
+++ b/clients/client-chime-sdk-meetings/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Chime Sdk Meetings Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-chime-sdk-messaging/package.json
+++ b/clients/client-chime-sdk-messaging/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Chime Sdk Messaging Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-chime/package.json
+++ b/clients/client-chime/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Chime Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-cloud9/package.json
+++ b/clients/client-cloud9/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Cloud9 Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-cloudcontrol/package.json
+++ b/clients/client-cloudcontrol/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Cloudcontrol Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-clouddirectory/package.json
+++ b/clients/client-clouddirectory/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Clouddirectory Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-cloudformation/package.json
+++ b/clients/client-cloudformation/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Cloudformation Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-cloudfront/package.json
+++ b/clients/client-cloudfront/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Cloudfront Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-cloudhsm-v2/package.json
+++ b/clients/client-cloudhsm-v2/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Cloudhsm V2 Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-cloudhsm/package.json
+++ b/clients/client-cloudhsm/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Cloudhsm Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-cloudsearch-domain/package.json
+++ b/clients/client-cloudsearch-domain/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Cloudsearch Domain Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-cloudsearch/package.json
+++ b/clients/client-cloudsearch/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Cloudsearch Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-cloudtrail/package.json
+++ b/clients/client-cloudtrail/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Cloudtrail Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-cloudwatch-events/package.json
+++ b/clients/client-cloudwatch-events/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Cloudwatch Events Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-cloudwatch-logs/package.json
+++ b/clients/client-cloudwatch-logs/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Cloudwatch Logs Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-cloudwatch/package.json
+++ b/clients/client-cloudwatch/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Cloudwatch Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-codeartifact/package.json
+++ b/clients/client-codeartifact/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Codeartifact Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-codebuild/package.json
+++ b/clients/client-codebuild/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Codebuild Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-codecommit/package.json
+++ b/clients/client-codecommit/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Codecommit Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-codedeploy/package.json
+++ b/clients/client-codedeploy/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Codedeploy Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-codeguru-reviewer/package.json
+++ b/clients/client-codeguru-reviewer/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Codeguru Reviewer Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-codeguruprofiler/package.json
+++ b/clients/client-codeguruprofiler/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Codeguruprofiler Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-codepipeline/package.json
+++ b/clients/client-codepipeline/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Codepipeline Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-codestar-connections/package.json
+++ b/clients/client-codestar-connections/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Codestar Connections Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-codestar-notifications/package.json
+++ b/clients/client-codestar-notifications/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Codestar Notifications Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-codestar/package.json
+++ b/clients/client-codestar/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Codestar Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-cognito-identity-provider/package.json
+++ b/clients/client-cognito-identity-provider/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Cognito Identity Provider Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-cognito-identity/package.json
+++ b/clients/client-cognito-identity/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Cognito Identity Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-cognito-sync/package.json
+++ b/clients/client-cognito-sync/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Cognito Sync Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-comprehend/package.json
+++ b/clients/client-comprehend/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Comprehend Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-comprehendmedical/package.json
+++ b/clients/client-comprehendmedical/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Comprehendmedical Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-compute-optimizer/package.json
+++ b/clients/client-compute-optimizer/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Compute Optimizer Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-config-service/package.json
+++ b/clients/client-config-service/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Config Service Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-connect-contact-lens/package.json
+++ b/clients/client-connect-contact-lens/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Connect Contact Lens Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-connect/package.json
+++ b/clients/client-connect/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Connect Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-connectparticipant/package.json
+++ b/clients/client-connectparticipant/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Connectparticipant Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-cost-and-usage-report-service/package.json
+++ b/clients/client-cost-and-usage-report-service/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Cost And Usage Report Service Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-cost-explorer/package.json
+++ b/clients/client-cost-explorer/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Cost Explorer Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-customer-profiles/package.json
+++ b/clients/client-customer-profiles/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Customer Profiles Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-data-pipeline/package.json
+++ b/clients/client-data-pipeline/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Data Pipeline Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-database-migration-service/package.json
+++ b/clients/client-database-migration-service/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Database Migration Service Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-databrew/package.json
+++ b/clients/client-databrew/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Databrew Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-dataexchange/package.json
+++ b/clients/client-dataexchange/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Dataexchange Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-datasync/package.json
+++ b/clients/client-datasync/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Datasync Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-dax/package.json
+++ b/clients/client-dax/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Dax Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-detective/package.json
+++ b/clients/client-detective/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Detective Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-device-farm/package.json
+++ b/clients/client-device-farm/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Device Farm Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-devops-guru/package.json
+++ b/clients/client-devops-guru/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Devops Guru Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-direct-connect/package.json
+++ b/clients/client-direct-connect/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Direct Connect Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-directory-service/package.json
+++ b/clients/client-directory-service/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Directory Service Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-dlm/package.json
+++ b/clients/client-dlm/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Dlm Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-docdb/package.json
+++ b/clients/client-docdb/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Docdb Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-drs/package.json
+++ b/clients/client-drs/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Drs Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-dynamodb-streams/package.json
+++ b/clients/client-dynamodb-streams/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Dynamodb Streams Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-dynamodb/package.json
+++ b/clients/client-dynamodb/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Dynamodb Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-ebs/package.json
+++ b/clients/client-ebs/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Ebs Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-ec2-instance-connect/package.json
+++ b/clients/client-ec2-instance-connect/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Ec2 Instance Connect Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-ec2/package.json
+++ b/clients/client-ec2/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Ec2 Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-ecr-public/package.json
+++ b/clients/client-ecr-public/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Ecr Public Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-ecr/package.json
+++ b/clients/client-ecr/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Ecr Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-ecs/package.json
+++ b/clients/client-ecs/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Ecs Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-efs/package.json
+++ b/clients/client-efs/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Efs Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-eks/package.json
+++ b/clients/client-eks/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Eks Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-elastic-beanstalk/package.json
+++ b/clients/client-elastic-beanstalk/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Elastic Beanstalk Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-elastic-inference/package.json
+++ b/clients/client-elastic-inference/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Elastic Inference Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-elastic-load-balancing-v2/package.json
+++ b/clients/client-elastic-load-balancing-v2/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Elastic Load Balancing V2 Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-elastic-load-balancing/package.json
+++ b/clients/client-elastic-load-balancing/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Elastic Load Balancing Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-elastic-transcoder/package.json
+++ b/clients/client-elastic-transcoder/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Elastic Transcoder Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-elasticache/package.json
+++ b/clients/client-elasticache/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Elasticache Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-elasticsearch-service/package.json
+++ b/clients/client-elasticsearch-service/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Elasticsearch Service Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-emr-containers/package.json
+++ b/clients/client-emr-containers/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Emr Containers Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-emr/package.json
+++ b/clients/client-emr/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Emr Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-eventbridge/package.json
+++ b/clients/client-eventbridge/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Eventbridge Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-evidently/package.json
+++ b/clients/client-evidently/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Evidently Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-finspace-data/package.json
+++ b/clients/client-finspace-data/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Finspace Data Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-finspace/package.json
+++ b/clients/client-finspace/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Finspace Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-firehose/package.json
+++ b/clients/client-firehose/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Firehose Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-fis/package.json
+++ b/clients/client-fis/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Fis Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-fms/package.json
+++ b/clients/client-fms/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Fms Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-forecast/package.json
+++ b/clients/client-forecast/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Forecast Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-forecastquery/package.json
+++ b/clients/client-forecastquery/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Forecastquery Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-frauddetector/package.json
+++ b/clients/client-frauddetector/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Frauddetector Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-fsx/package.json
+++ b/clients/client-fsx/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Fsx Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-gamelift/package.json
+++ b/clients/client-gamelift/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Gamelift Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-glacier/package.json
+++ b/clients/client-glacier/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Glacier Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-global-accelerator/package.json
+++ b/clients/client-global-accelerator/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Global Accelerator Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-glue/package.json
+++ b/clients/client-glue/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Glue Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-grafana/package.json
+++ b/clients/client-grafana/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Grafana Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-greengrass/package.json
+++ b/clients/client-greengrass/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Greengrass Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-greengrassv2/package.json
+++ b/clients/client-greengrassv2/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Greengrassv2 Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-groundstation/package.json
+++ b/clients/client-groundstation/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Groundstation Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-guardduty/package.json
+++ b/clients/client-guardduty/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Guardduty Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-health/package.json
+++ b/clients/client-health/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Health Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-healthlake/package.json
+++ b/clients/client-healthlake/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Healthlake Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-honeycode/package.json
+++ b/clients/client-honeycode/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Honeycode Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-iam/package.json
+++ b/clients/client-iam/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Iam Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-identitystore/package.json
+++ b/clients/client-identitystore/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Identitystore Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-imagebuilder/package.json
+++ b/clients/client-imagebuilder/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Imagebuilder Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-inspector/package.json
+++ b/clients/client-inspector/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Inspector Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-inspector2/package.json
+++ b/clients/client-inspector2/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Inspector2 Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-iot-1click-devices-service/package.json
+++ b/clients/client-iot-1click-devices-service/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Iot 1click Devices Service Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-iot-1click-projects/package.json
+++ b/clients/client-iot-1click-projects/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Iot 1click Projects Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-iot-data-plane/package.json
+++ b/clients/client-iot-data-plane/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Iot Data Plane Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-iot-events-data/package.json
+++ b/clients/client-iot-events-data/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Iot Events Data Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-iot-events/package.json
+++ b/clients/client-iot-events/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Iot Events Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-iot-jobs-data-plane/package.json
+++ b/clients/client-iot-jobs-data-plane/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Iot Jobs Data Plane Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-iot-wireless/package.json
+++ b/clients/client-iot-wireless/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Iot Wireless Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-iot/package.json
+++ b/clients/client-iot/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Iot Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-iotanalytics/package.json
+++ b/clients/client-iotanalytics/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Iotanalytics Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-iotdeviceadvisor/package.json
+++ b/clients/client-iotdeviceadvisor/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Iotdeviceadvisor Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-iotfleethub/package.json
+++ b/clients/client-iotfleethub/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Iotfleethub Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-iotsecuretunneling/package.json
+++ b/clients/client-iotsecuretunneling/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Iotsecuretunneling Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-iotsitewise/package.json
+++ b/clients/client-iotsitewise/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Iotsitewise Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-iotthingsgraph/package.json
+++ b/clients/client-iotthingsgraph/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Iotthingsgraph Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-iottwinmaker/package.json
+++ b/clients/client-iottwinmaker/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Iottwinmaker Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-ivs/package.json
+++ b/clients/client-ivs/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Ivs Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-kafka/package.json
+++ b/clients/client-kafka/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Kafka Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-kafkaconnect/package.json
+++ b/clients/client-kafkaconnect/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Kafkaconnect Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-kendra/package.json
+++ b/clients/client-kendra/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Kendra Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-kinesis-analytics-v2/package.json
+++ b/clients/client-kinesis-analytics-v2/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Kinesis Analytics V2 Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-kinesis-analytics/package.json
+++ b/clients/client-kinesis-analytics/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Kinesis Analytics Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-kinesis-video-archived-media/package.json
+++ b/clients/client-kinesis-video-archived-media/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Kinesis Video Archived Media Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-kinesis-video-media/package.json
+++ b/clients/client-kinesis-video-media/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Kinesis Video Media Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-kinesis-video-signaling/package.json
+++ b/clients/client-kinesis-video-signaling/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Kinesis Video Signaling Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-kinesis-video/package.json
+++ b/clients/client-kinesis-video/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Kinesis Video Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-kinesis/package.json
+++ b/clients/client-kinesis/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Kinesis Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-kms/package.json
+++ b/clients/client-kms/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Kms Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-lakeformation/package.json
+++ b/clients/client-lakeformation/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Lakeformation Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-lambda/package.json
+++ b/clients/client-lambda/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Lambda Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-lex-model-building-service/package.json
+++ b/clients/client-lex-model-building-service/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Lex Model Building Service Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-lex-models-v2/package.json
+++ b/clients/client-lex-models-v2/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Lex Models V2 Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-lex-runtime-service/package.json
+++ b/clients/client-lex-runtime-service/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Lex Runtime Service Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-lex-runtime-v2/package.json
+++ b/clients/client-lex-runtime-v2/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Lex Runtime V2 Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-license-manager/package.json
+++ b/clients/client-license-manager/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript License Manager Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-lightsail/package.json
+++ b/clients/client-lightsail/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Lightsail Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-location/package.json
+++ b/clients/client-location/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Location Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-lookoutequipment/package.json
+++ b/clients/client-lookoutequipment/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Lookoutequipment Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-lookoutmetrics/package.json
+++ b/clients/client-lookoutmetrics/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Lookoutmetrics Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-lookoutvision/package.json
+++ b/clients/client-lookoutvision/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Lookoutvision Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-machine-learning/package.json
+++ b/clients/client-machine-learning/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Machine Learning Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-macie/package.json
+++ b/clients/client-macie/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Macie Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-macie2/package.json
+++ b/clients/client-macie2/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Macie2 Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-managedblockchain/package.json
+++ b/clients/client-managedblockchain/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Managedblockchain Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-marketplace-catalog/package.json
+++ b/clients/client-marketplace-catalog/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Marketplace Catalog Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-marketplace-commerce-analytics/package.json
+++ b/clients/client-marketplace-commerce-analytics/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Marketplace Commerce Analytics Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-marketplace-entitlement-service/package.json
+++ b/clients/client-marketplace-entitlement-service/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Marketplace Entitlement Service Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-marketplace-metering/package.json
+++ b/clients/client-marketplace-metering/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Marketplace Metering Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-mediaconnect/package.json
+++ b/clients/client-mediaconnect/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Mediaconnect Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-mediaconvert/package.json
+++ b/clients/client-mediaconvert/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Mediaconvert Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-medialive/package.json
+++ b/clients/client-medialive/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Medialive Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-mediapackage-vod/package.json
+++ b/clients/client-mediapackage-vod/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Mediapackage Vod Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-mediapackage/package.json
+++ b/clients/client-mediapackage/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Mediapackage Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-mediastore-data/package.json
+++ b/clients/client-mediastore-data/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Mediastore Data Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-mediastore/package.json
+++ b/clients/client-mediastore/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Mediastore Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-mediatailor/package.json
+++ b/clients/client-mediatailor/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Mediatailor Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-memorydb/package.json
+++ b/clients/client-memorydb/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Memorydb Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-mgn/package.json
+++ b/clients/client-mgn/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Mgn Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-migration-hub-refactor-spaces/package.json
+++ b/clients/client-migration-hub-refactor-spaces/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Migration Hub Refactor Spaces Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-migration-hub/package.json
+++ b/clients/client-migration-hub/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Migration Hub Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-migrationhub-config/package.json
+++ b/clients/client-migrationhub-config/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Migrationhub Config Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-migrationhubstrategy/package.json
+++ b/clients/client-migrationhubstrategy/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Migrationhubstrategy Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-mobile/package.json
+++ b/clients/client-mobile/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Mobile Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-mq/package.json
+++ b/clients/client-mq/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Mq Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-mturk/package.json
+++ b/clients/client-mturk/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Mturk Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-mwaa/package.json
+++ b/clients/client-mwaa/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Mwaa Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-neptune/package.json
+++ b/clients/client-neptune/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Neptune Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-network-firewall/package.json
+++ b/clients/client-network-firewall/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Network Firewall Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-networkmanager/package.json
+++ b/clients/client-networkmanager/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Networkmanager Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-nimble/package.json
+++ b/clients/client-nimble/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Nimble Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-opensearch/package.json
+++ b/clients/client-opensearch/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Opensearch Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-opsworks/package.json
+++ b/clients/client-opsworks/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Opsworks Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-opsworkscm/package.json
+++ b/clients/client-opsworkscm/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Opsworkscm Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-organizations/package.json
+++ b/clients/client-organizations/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Organizations Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-outposts/package.json
+++ b/clients/client-outposts/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Outposts Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-panorama/package.json
+++ b/clients/client-panorama/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Panorama Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-personalize-events/package.json
+++ b/clients/client-personalize-events/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Personalize Events Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-personalize-runtime/package.json
+++ b/clients/client-personalize-runtime/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Personalize Runtime Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-personalize/package.json
+++ b/clients/client-personalize/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Personalize Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-pi/package.json
+++ b/clients/client-pi/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Pi Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-pinpoint-email/package.json
+++ b/clients/client-pinpoint-email/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Pinpoint Email Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-pinpoint-sms-voice/package.json
+++ b/clients/client-pinpoint-sms-voice/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Pinpoint Sms Voice Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-pinpoint/package.json
+++ b/clients/client-pinpoint/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Pinpoint Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-polly/package.json
+++ b/clients/client-polly/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Polly Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-pricing/package.json
+++ b/clients/client-pricing/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Pricing Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-proton/package.json
+++ b/clients/client-proton/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Proton Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-qldb-session/package.json
+++ b/clients/client-qldb-session/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Qldb Session Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-qldb/package.json
+++ b/clients/client-qldb/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Qldb Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-quicksight/package.json
+++ b/clients/client-quicksight/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Quicksight Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-ram/package.json
+++ b/clients/client-ram/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Ram Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-rbin/package.json
+++ b/clients/client-rbin/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Rbin Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-rds-data/package.json
+++ b/clients/client-rds-data/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Rds Data Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-rds/package.json
+++ b/clients/client-rds/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Rds Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-redshift-data/package.json
+++ b/clients/client-redshift-data/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Redshift Data Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-redshift/package.json
+++ b/clients/client-redshift/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Redshift Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-rekognition/package.json
+++ b/clients/client-rekognition/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Rekognition Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-resiliencehub/package.json
+++ b/clients/client-resiliencehub/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Resiliencehub Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-resource-groups-tagging-api/package.json
+++ b/clients/client-resource-groups-tagging-api/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Resource Groups Tagging Api Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-resource-groups/package.json
+++ b/clients/client-resource-groups/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Resource Groups Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-robomaker/package.json
+++ b/clients/client-robomaker/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Robomaker Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-route-53-domains/package.json
+++ b/clients/client-route-53-domains/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Route 53 Domains Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-route-53/package.json
+++ b/clients/client-route-53/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Route 53 Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-route53-recovery-cluster/package.json
+++ b/clients/client-route53-recovery-cluster/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Route53 Recovery Cluster Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-route53-recovery-control-config/package.json
+++ b/clients/client-route53-recovery-control-config/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Route53 Recovery Control Config Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-route53-recovery-readiness/package.json
+++ b/clients/client-route53-recovery-readiness/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Route53 Recovery Readiness Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-route53resolver/package.json
+++ b/clients/client-route53resolver/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Route53resolver Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-rum/package.json
+++ b/clients/client-rum/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Rum Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-s3-control/package.json
+++ b/clients/client-s3-control/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript S3 Control Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-s3/package.json
+++ b/clients/client-s3/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript S3 Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-s3outposts/package.json
+++ b/clients/client-s3outposts/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript S3outposts Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-sagemaker-a2i-runtime/package.json
+++ b/clients/client-sagemaker-a2i-runtime/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Sagemaker A2i Runtime Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-sagemaker-edge/package.json
+++ b/clients/client-sagemaker-edge/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Sagemaker Edge Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-sagemaker-featurestore-runtime/package.json
+++ b/clients/client-sagemaker-featurestore-runtime/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Sagemaker Featurestore Runtime Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-sagemaker-runtime/package.json
+++ b/clients/client-sagemaker-runtime/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Sagemaker Runtime Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-sagemaker/package.json
+++ b/clients/client-sagemaker/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Sagemaker Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-savingsplans/package.json
+++ b/clients/client-savingsplans/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Savingsplans Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-schemas/package.json
+++ b/clients/client-schemas/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Schemas Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-secrets-manager/package.json
+++ b/clients/client-secrets-manager/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Secrets Manager Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-securityhub/package.json
+++ b/clients/client-securityhub/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Securityhub Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-serverlessapplicationrepository/package.json
+++ b/clients/client-serverlessapplicationrepository/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Serverlessapplicationrepository Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-service-catalog-appregistry/package.json
+++ b/clients/client-service-catalog-appregistry/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Service Catalog Appregistry Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-service-catalog/package.json
+++ b/clients/client-service-catalog/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Service Catalog Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-service-quotas/package.json
+++ b/clients/client-service-quotas/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Service Quotas Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-servicediscovery/package.json
+++ b/clients/client-servicediscovery/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Servicediscovery Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-ses/package.json
+++ b/clients/client-ses/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Ses Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-sesv2/package.json
+++ b/clients/client-sesv2/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Sesv2 Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-sfn/package.json
+++ b/clients/client-sfn/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Sfn Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-shield/package.json
+++ b/clients/client-shield/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Shield Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-signer/package.json
+++ b/clients/client-signer/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Signer Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-sms/package.json
+++ b/clients/client-sms/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Sms Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-snow-device-management/package.json
+++ b/clients/client-snow-device-management/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Snow Device Management Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-snowball/package.json
+++ b/clients/client-snowball/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Snowball Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-sns/package.json
+++ b/clients/client-sns/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Sns Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-sqs/package.json
+++ b/clients/client-sqs/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Sqs Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-ssm-contacts/package.json
+++ b/clients/client-ssm-contacts/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Ssm Contacts Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-ssm-incidents/package.json
+++ b/clients/client-ssm-incidents/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Ssm Incidents Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-ssm/package.json
+++ b/clients/client-ssm/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Ssm Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-sso-admin/package.json
+++ b/clients/client-sso-admin/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Sso Admin Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-sso-oidc/package.json
+++ b/clients/client-sso-oidc/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Sso Oidc Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-sso/package.json
+++ b/clients/client-sso/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Sso Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-storage-gateway/package.json
+++ b/clients/client-storage-gateway/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Storage Gateway Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-sts/package.json
+++ b/clients/client-sts/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Sts Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-support/package.json
+++ b/clients/client-support/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Support Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-swf/package.json
+++ b/clients/client-swf/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Swf Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-synthetics/package.json
+++ b/clients/client-synthetics/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Synthetics Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-textract/package.json
+++ b/clients/client-textract/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Textract Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-timestream-query/package.json
+++ b/clients/client-timestream-query/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Timestream Query Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-timestream-write/package.json
+++ b/clients/client-timestream-write/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Timestream Write Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-transcribe-streaming/package.json
+++ b/clients/client-transcribe-streaming/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Transcribe Streaming Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-transcribe/package.json
+++ b/clients/client-transcribe/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Transcribe Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-transfer/package.json
+++ b/clients/client-transfer/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Transfer Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-translate/package.json
+++ b/clients/client-translate/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Translate Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-voice-id/package.json
+++ b/clients/client-voice-id/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Voice Id Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-waf-regional/package.json
+++ b/clients/client-waf-regional/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Waf Regional Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-waf/package.json
+++ b/clients/client-waf/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Waf Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-wafv2/package.json
+++ b/clients/client-wafv2/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Wafv2 Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-wellarchitected/package.json
+++ b/clients/client-wellarchitected/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Wellarchitected Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-wisdom/package.json
+++ b/clients/client-wisdom/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Wisdom Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-workdocs/package.json
+++ b/clients/client-workdocs/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Workdocs Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-worklink/package.json
+++ b/clients/client-worklink/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Worklink Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-workmail/package.json
+++ b/clients/client-workmail/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Workmail Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-workmailmessageflow/package.json
+++ b/clients/client-workmailmessageflow/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Workmailmessageflow Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-workspaces-web/package.json
+++ b/clients/client-workspaces-web/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Workspaces Web Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-workspaces/package.json
+++ b/clients/client-workspaces/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Workspaces Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/clients/client-xray/package.json
+++ b/clients/client-xray/package.json
@@ -3,7 +3,7 @@
   "description": "AWS SDK for JavaScript Xray Client for Node.js, Browser and React Native",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/private/aws-echo-service/package.json
+++ b/private/aws-echo-service/package.json
@@ -3,7 +3,7 @@
   "description": "@aws-sdk/aws-echo-service client",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/private/aws-protocoltests-ec2/package.json
+++ b/private/aws-protocoltests-ec2/package.json
@@ -3,7 +3,7 @@
   "description": "@aws-sdk/aws-protocoltests-ec2 client",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/private/aws-protocoltests-json-10/package.json
+++ b/private/aws-protocoltests-json-10/package.json
@@ -3,7 +3,7 @@
   "description": "@aws-sdk/aws-protocoltests-json-10 client",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/private/aws-protocoltests-json/package.json
+++ b/private/aws-protocoltests-json/package.json
@@ -3,7 +3,7 @@
   "description": "@aws-sdk/aws-protocoltests-json client",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/private/aws-protocoltests-query/package.json
+++ b/private/aws-protocoltests-query/package.json
@@ -3,7 +3,7 @@
   "description": "@aws-sdk/aws-protocoltests-query client",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/private/aws-protocoltests-restjson/package.json
+++ b/private/aws-protocoltests-restjson/package.json
@@ -3,7 +3,7 @@
   "description": "@aws-sdk/aws-protocoltests-restjson client",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/private/aws-protocoltests-restxml/package.json
+++ b/private/aws-protocoltests-restxml/package.json
@@ -3,7 +3,7 @@
   "description": "@aws-sdk/aws-protocoltests-restxml client",
   "version": "3.47.0",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",

--- a/scripts/generate-clients/copy-to-clients.js
+++ b/scripts/generate-clients/copy-to-clients.js
@@ -37,7 +37,14 @@ const mergeManifest = (fromContent = {}, toContent = {}) => {
     if (fromContent[name].constructor.name === "Object") {
       if (name === "devDependencies") {
         // Remove devDeps defined in monorepo root
-        const devDepsInRoot = ["@tsconfig/recommended", "downlevel-dts", "rimraf", "typedoc", "typescript"];
+        const devDepsInRoot = [
+          "@tsconfig/recommended",
+          "concurrently",
+          "downlevel-dts",
+          "rimraf",
+          "typedoc",
+          "typescript",
+        ];
         devDepsInRoot.forEach((devDep) => delete fromContent[name][devDep]);
       }
       merged[name] = mergeManifest(fromContent[name], toContent[name]);


### PR DESCRIPTION
### Issue
Closes https://github.com/aws/aws-sdk-js-v3/issues/3196

### Description

### Testing
CI

There are no improvements in running `build:all` but definite improvements if individual packages need to be built during development.

<details>
<summary>build:all</summary>

Before:

```console
$ time ./node_modules/.bin/lerna run build
...
14235.33s user 385.16s system 3283% cpu 7:25.24 total
```

After:

```console
$ time ./node_modules/.bin/lerna run build
...
14577.44s user 396.23s system 3379% cpu 7:23.04 total
```

</details>

<details>
<summary>client-ec2</summary>

Before:
```console
$ client-ec2> yarn build
...
Done in 45.95s.
```

After:
```console
$ client-ec2> yarn build
...
Done in 17.19s.
```

</details>

### Additional context
~~This PR will be made ready once https://github.com/aws/aws-sdk-js-v3/pull/3197 is merged.~~ Ready!
Changes in smithy-ts https://github.com/awslabs/smithy-typescript/pull/498

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
