### PR TITLE
fix(util-defaults-mode-browser): import bowser by default export

### DIFF
--- a/packages/util-defaults-mode-browser/src/resolveDefaultsModeConfig.ts
+++ b/packages/util-defaults-mode-browser/src/resolveDefaultsModeConfig.ts
@@ -1,7 +1,7 @@
 import { memoize } from "@aws-sdk/property-provider";
 import type { DefaultsMode, ResolvedDefaultsMode } from "@aws-sdk/smithy-client";
 import type { Provider } from "@aws-sdk/types";
-import { parse } from "bowser";
+import bowser from "bowser";
 
 import { DEFAULTS_MODE_OPTIONS } from "./constants";
 
@@ -45,7 +45,9 @@ export const resolveDefaultsModeConfig = ({
 
 const isMobileBrowser = (): boolean => {
   const parsedUA =
-    typeof window !== "undefined" && window?.navigator?.userAgent ? parse(window.navigator.userAgent) : undefined;
+    typeof window !== "undefined" && window?.navigator?.userAgent
+      ? bowser.parse(window.navigator.userAgent)
+      : undefined;
   const platform = parsedUA?.platform?.type;
   // Reference: https://github.com/lancedikson/bowser/blob/master/src/constants.js#L86
   return platform === "tablet" || platform === "mobile";


### PR DESCRIPTION
### Issue
Resolves #3202 

### Description
Similar to https://github.com/aws/aws-sdk-js-v3/pull/1991, fix Vite build by importing `bowser` from default export

### Testing
```console
./node_modules/.bin/snowpack build
[24:35:27] [snowpack] Hint: run "snowpack init" to create a project config file. Using defaults...
[24:35:27] [snowpack] ! building files...
[24:35:27] [snowpack] ✔ files built. [0.05s]
[24:35:27] [snowpack] ! building dependencies...
[24:35:31] [snowpack] ✔ dependencies built. [3.26s]
[24:35:31] [snowpack] ! writing to disk...
[24:35:31] [snowpack] ✔ write complete. [0.02s]
[24:35:31] [snowpack] ▶ Build Complete!
```

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
