### PR TITLE
fix(aws-protocoltests-*): add emitDeclarationOnly for types

### DIFF
--- a/private/aws-protocoltests-ec2/tsconfig.types.json
+++ b/private/aws-protocoltests-ec2/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/private/aws-protocoltests-json-10/tsconfig.types.json
+++ b/private/aws-protocoltests-json-10/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/private/aws-protocoltests-json/tsconfig.types.json
+++ b/private/aws-protocoltests-json/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/private/aws-protocoltests-query/tsconfig.types.json
+++ b/private/aws-protocoltests-query/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/private/aws-protocoltests-restjson/tsconfig.types.json
+++ b/private/aws-protocoltests-restjson/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }

--- a/private/aws-protocoltests-restxml/tsconfig.types.json
+++ b/private/aws-protocoltests-restxml/tsconfig.types.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "removeComments": false,
     "declaration": true,
-    "declarationDir": "dist-types"
+    "declarationDir": "dist-types",
+    "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "dist-types/**/*"]
 }


### PR DESCRIPTION
### Issue
Fixes: https://github.com/aws/aws-sdk-js-v3/issues/3212

### Description
Add emitDeclarationOnly for types

### Testing
Verified that running `yarn build:protocols` does not emit tranpiled JS files in src folder.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
