### PR TITLE
chore(codegen): remove prepack script from clients

### DIFF
--- a/scripts/generate-clients/copy-to-clients.js
+++ b/scripts/generate-clients/copy-to-clients.js
@@ -140,6 +140,8 @@ const copyToClients = async (sourceDir, destinationDir) => {
             directory: `clients/${clientName}`,
           },
         };
+        // no need for the default prepack script
+        delete mergedManifest.scripts.prepack;
         writeFileSync(destSubPath, JSON.stringify(mergedManifest, null, 2).concat(`\n`));
       } else if (packageSub === "typedoc.json") {
         const typedocJson = {


### PR DESCRIPTION
### Description
This removes the prepack script from client package.json

### Testing
Tested as a part of the Smithy-1.16 update PR: https://github.com/aws/aws-sdk-js-v3/pull/3215 - I removed the unnecessary if check

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
