### PR TITLE
chore(deps-dev): add missing @types/uuid

### DIFF
--- a/packages/middleware-retry/package.json
+++ b/packages/middleware-retry/package.json
@@ -26,7 +26,8 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@aws-sdk/node-config-provider": "*"
+    "@aws-sdk/node-config-provider": "*",
+    "@types/uuid": "^8.3.0"
   },
   "engines": {
     "node": ">= 12.0.0"

--- a/packages/middleware-sdk-transcribe-streaming/package.json
+++ b/packages/middleware-sdk-transcribe-streaming/package.json
@@ -30,6 +30,7 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
+    "@types/uuid": "^8.3.0",
     "jest-websocket-mock": "^2.0.2",
     "mock-socket": "^9.0.3"
   },


### PR DESCRIPTION
### Issue
The missing `@types/uuid` was noticed while trying to bump yarn to berry in https://github.com/aws/aws-sdk-js-v3/pull/3235

### Description
Adds missing @types/uuid as devDependencies in impacted packages.

<details>
<summary>Script used</summary>

```js
// @ts-check

import { readFileSync, writeFileSync } from "fs";
import { join } from "path";

import { getWorkspacePaths } from "./update-versions/getWorkspacePaths.mjs";

getWorkspacePaths().forEach((workspacePath) => {
  const packageJsonPath = join(workspacePath, "package.json");
  const packageJson = JSON.parse(readFileSync(packageJsonPath).toString());
  if (packageJson.dependencies && packageJson.dependencies["uuid"]) {
    if (packageJson.devDependencies && packageJson.devDependencies["@types/uuid"] === undefined) {
      packageJson.devDependencies["@types/uuid"] = "^8.3.0";
      packageJson.devDependencies = Object.fromEntries(Object.entries(packageJson.devDependencies).sort());
      writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, 2).concat(`\n`));
    }
  }
});
```

</details>

### Testing
N/A

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
