### PR TITLE
fix(eventstream-handler-node): explicitly define type of err

### DIFF
--- a/packages/eventstream-handler-node/src/EventStreamPayloadHandler.ts
+++ b/packages/eventstream-handler-node/src/EventStreamPayloadHandler.ts
@@ -76,7 +76,7 @@ export class EventStreamPayloadHandler implements IEventStreamPayloadHandler {
       eventSigner: await this.eventSigner(),
     });
 
-    pipeline(payloadStream, signingStream, request.body, (err) => {
+    pipeline(payloadStream, signingStream, request.body, (err: NodeJS.ErrnoException | null) => {
       if (err) {
         throw err;
       }


### PR DESCRIPTION
### Issue
This issue surfaced when attempting to bump yarn version to berry in https://github.com/aws/aws-sdk-js-v3/pull/3235

### Description
Explicitly define type of err in eventstream-handler-node

### Testing
yarn build is successful.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
