### PR TITLE
feat(types): merge SmithyException and SdkError to SdkException interface

### DIFF
--- a/packages/middleware-retry/src/defaultRetryQuota.spec.ts
+++ b/packages/middleware-retry/src/defaultRetryQuota.spec.ts
@@ -1,18 +1,18 @@
-import { SdkError } from "@aws-sdk/types";
+import { SdkException } from "@aws-sdk/types";
 
 import { INITIAL_RETRY_TOKENS, NO_RETRY_INCREMENT, RETRY_COST, TIMEOUT_RETRY_COST } from "./constants";
 import { getDefaultRetryQuota } from "./defaultRetryQuota";
 
 describe("defaultRetryQuota", () => {
-  const getMockError = () => new Error() as SdkError;
+  const getMockError = () => new Error() as SdkException;
   const getMockTimeoutError = () =>
     Object.assign(new Error(), {
       name: "TimeoutError",
-    }) as SdkError;
+    }) as SdkException;
 
   const getDrainedRetryQuota = (
     targetCapacity: number,
-    error: SdkError,
+    error: SdkException,
     initialRetryTokens: number = INITIAL_RETRY_TOKENS
   ) => {
     const retryQuota = getDefaultRetryQuota(initialRetryTokens);

--- a/packages/middleware-retry/src/defaultRetryQuota.ts
+++ b/packages/middleware-retry/src/defaultRetryQuota.ts
@@ -1,4 +1,4 @@
-import { SdkError } from "@aws-sdk/types";
+import { SdkException } from "@aws-sdk/types";
 
 import { NO_RETRY_INCREMENT, RETRY_COST, TIMEOUT_RETRY_COST } from "./constants";
 import { RetryQuota } from "./types";
@@ -30,11 +30,11 @@ export const getDefaultRetryQuota = (initialRetryTokens: number, options?: Defau
 
   let availableCapacity = initialRetryTokens;
 
-  const getCapacityAmount = (error: SdkError) => (error.name === "TimeoutError" ? timeoutRetryCost : retryCost);
+  const getCapacityAmount = (error: SdkException) => (error.name === "TimeoutError" ? timeoutRetryCost : retryCost);
 
-  const hasRetryTokens = (error: SdkError) => getCapacityAmount(error) <= availableCapacity;
+  const hasRetryTokens = (error: SdkException) => getCapacityAmount(error) <= availableCapacity;
 
-  const retrieveRetryTokens = (error: SdkError) => {
+  const retrieveRetryTokens = (error: SdkException) => {
     if (!hasRetryTokens(error)) {
       // retryStrategy should stop retrying, and return last error
       throw new Error("No retry token available");

--- a/packages/middleware-retry/src/retryDecider.spec.ts
+++ b/packages/middleware-retry/src/retryDecider.spec.ts
@@ -4,14 +4,14 @@ import {
   isThrottlingError,
   isTransientError,
 } from "@aws-sdk/service-error-classification";
-import { SdkError } from "@aws-sdk/types";
+import { SdkException } from "@aws-sdk/types";
 
 import { defaultRetryDecider } from "./retryDecider";
 
 jest.mock("@aws-sdk/service-error-classification");
 
 describe("defaultRetryDecider", () => {
-  const createMockError = () => Object.assign(new Error(), { $metadata: {} }) as SdkError;
+  const createMockError = () => Object.assign(new Error(), { $metadata: {} }) as SdkException;
 
   beforeEach(() => {
     (isRetryableByTrait as jest.Mock).mockReturnValue(false);

--- a/packages/middleware-retry/src/retryDecider.ts
+++ b/packages/middleware-retry/src/retryDecider.ts
@@ -4,9 +4,9 @@ import {
   isThrottlingError,
   isTransientError,
 } from "@aws-sdk/service-error-classification";
-import { SdkError } from "@aws-sdk/types";
+import { SdkException } from "@aws-sdk/types";
 
-export const defaultRetryDecider = (error: SdkError) => {
+export const defaultRetryDecider = (error: SdkException) => {
   if (!error) {
     return false;
   }

--- a/packages/middleware-retry/src/types.ts
+++ b/packages/middleware-retry/src/types.ts
@@ -1,4 +1,4 @@
-import { SdkError } from "@aws-sdk/types";
+import { SdkException } from "@aws-sdk/types";
 
 /**
  * Determines whether an error is retryable based on the number of retries
@@ -7,7 +7,7 @@ import { SdkError } from "@aws-sdk/types";
  * @param error         The error encountered.
  */
 export interface RetryDecider {
-  (error: SdkError): boolean;
+  (error: SdkException): boolean;
 }
 
 /**
@@ -27,13 +27,13 @@ export interface RetryQuota {
   /**
    * returns true if retry tokens are available from the retry quota bucket.
    */
-  hasRetryTokens: (error: SdkError) => boolean;
+  hasRetryTokens: (error: SdkException) => boolean;
 
   /**
    * returns token amount from the retry quota bucket.
    * throws error is retry tokens are not available.
    */
-  retrieveRetryTokens: (error: SdkError) => number;
+  retrieveRetryTokens: (error: SdkException) => number;
 
   /**
    * releases tokens back to the retry quota.

--- a/packages/service-error-classification/src/index.spec.ts
+++ b/packages/service-error-classification/src/index.spec.ts
@@ -1,4 +1,4 @@
-import { RetryableTrait, SdkError } from "@aws-sdk/types";
+import { RetryableTrait, SdkException } from "@aws-sdk/types";
 
 import {
   CLOCK_SKEW_ERROR_CODES,
@@ -9,7 +9,7 @@ import {
 import { isClockSkewError, isRetryableByTrait, isThrottlingError, isTransientError } from "./index";
 
 const checkForErrorType = (
-  isErrorTypeFunc: (error: SdkError) => boolean,
+  isErrorTypeFunc: (error: SdkException) => boolean,
   options: {
     name?: string;
     httpStatusCode?: number;
@@ -23,7 +23,7 @@ const checkForErrorType = (
     $metadata: { httpStatusCode },
     $retryable,
   });
-  expect(isErrorTypeFunc(error as SdkError)).toBe(errorTypeResult);
+  expect(isErrorTypeFunc(error as SdkException)).toBe(errorTypeResult);
 };
 
 describe("isRetryableByTrait", () => {

--- a/packages/service-error-classification/src/index.ts
+++ b/packages/service-error-classification/src/index.ts
@@ -1,4 +1,4 @@
-import { SdkError } from "@aws-sdk/types";
+import { SdkException } from "@aws-sdk/types";
 
 import {
   CLOCK_SKEW_ERROR_CODES,
@@ -7,15 +7,15 @@ import {
   TRANSIENT_ERROR_STATUS_CODES,
 } from "./constants";
 
-export const isRetryableByTrait = (error: SdkError) => error.$retryable !== undefined;
+export const isRetryableByTrait = (error: SdkException) => error.$retryable !== undefined;
 
-export const isClockSkewError = (error: SdkError) => CLOCK_SKEW_ERROR_CODES.includes(error.name);
+export const isClockSkewError = (error: SdkException) => CLOCK_SKEW_ERROR_CODES.includes(error.name);
 
-export const isThrottlingError = (error: SdkError) =>
+export const isThrottlingError = (error: SdkException) =>
   error.$metadata?.httpStatusCode === 429 ||
   THROTTLING_ERROR_CODES.includes(error.name) ||
   error.$retryable?.throttling == true;
 
-export const isTransientError = (error: SdkError) =>
+export const isTransientError = (error: SdkException) =>
   TRANSIENT_ERROR_CODES.includes(error.name) ||
   TRANSIENT_ERROR_STATUS_CODES.includes(error.$metadata?.httpStatusCode || 0);

--- a/packages/types/src/shapes.ts
+++ b/packages/types/src/shapes.ts
@@ -24,7 +24,8 @@ export interface RetryableTrait {
 
 /**
  * Type that is implemented by all Smithy shapes marked with the
- * error trait.
+ * error trait. This interface has been renamed to {@link SdkException}
+ * @deprecated
  */
 export interface SmithyException {
   /**
@@ -53,4 +54,8 @@ export interface SmithyException {
   readonly $response?: HttpResponse;
 }
 
-export type SdkError = Error & Partial<SmithyException> & Partial<MetadataBearer>;
+/**
+ * Type that is implemented by all Smithy shapes marked with the
+ * error trait.
+ */
+export type SdkException = Error & Partial<SmithyException> & Partial<MetadataBearer>;

--- a/packages/types/src/shapes.ts
+++ b/packages/types/src/shapes.ts
@@ -55,7 +55,12 @@ export interface SmithyException {
 }
 
 /**
+ * @deprecated
+ */
+export type SdkError = Error & Partial<SmithyException> & Partial<MetadataBearer>;
+
+/**
  * Type that is implemented by all Smithy shapes marked with the
  * error trait.
  */
-export type SdkException = Error & Partial<SmithyException> & Partial<MetadataBearer>;
+export type SdkException = SdkError;


### PR DESCRIPTION
### Description

Prerequisite for generating SDK errors as concrete classes. The `SdkException` interface will be extended to concrete class in following PR.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
