### PR TITLE
chore(packages): define devDeps used in scripts

### DIFF
--- a/lib/lib-dynamodb/package.json
+++ b/lib/lib-dynamodb/package.json
@@ -35,7 +35,13 @@
     "@aws-sdk/client-dynamodb": "*",
     "@aws-sdk/smithy-client": "*",
     "@aws-sdk/types": "*",
-    "@types/node": "^14.11.2"
+    "@tsconfig/recommended": "1.0.1",
+    "@types/node": "^14.11.2",
+    "concurrently": "7.0.0",
+    "downlevel-dts": "0.7.0",
+    "rimraf": "3.0.2",
+    "typedoc": "0.19.2",
+    "typescript": "~4.3.5"
   },
   "typesVersions": {
     "<4.0": {

--- a/lib/lib-storage/package.json
+++ b/lib/lib-storage/package.json
@@ -35,13 +35,19 @@
   "devDependencies": {
     "@aws-sdk/abort-controller": "*",
     "@aws-sdk/client-s3": "*",
+    "@tsconfig/recommended": "1.0.1",
     "@types/node": "^14.11.2",
+    "concurrently": "7.0.0",
+    "downlevel-dts": "0.7.0",
     "jasmine-core": "^3.6.0",
     "karma": "^5.2.3",
     "karma-chrome-launcher": "^3.1.0",
     "karma-jasmine": "^4.0.1",
     "karma-spec-reporter": "^0.0.32",
     "karma-typescript": "^5.2.0",
+    "rimraf": "3.0.2",
+    "typedoc": "0.19.2",
+    "typescript": "~4.3.5",
     "web-streams-polyfill": "^3.0.0"
   },
   "typesVersions": {

--- a/packages/abort-controller/package.json
+++ b/packages/abort-controller/package.json
@@ -41,5 +41,13 @@
     "type": "git",
     "url": "https://github.com/aws/aws-sdk-js-v3.git",
     "directory": "packages/abort-controller"
+  },
+  "devDependencies": {
+    "@tsconfig/recommended": "1.0.1",
+    "concurrently": "7.0.0",
+    "downlevel-dts": "0.7.0",
+    "rimraf": "3.0.2",
+    "typedoc": "0.19.2",
+    "typescript": "~4.3.5"
   }
 }

--- a/packages/body-checksum-browser/package.json
+++ b/packages/body-checksum-browser/package.json
@@ -28,7 +28,13 @@
   },
   "devDependencies": {
     "@aws-crypto/sha256-js": "2.0.0",
-    "@aws-sdk/util-utf8-browser": "*"
+    "@aws-sdk/util-utf8-browser": "*",
+    "@tsconfig/recommended": "1.0.1",
+    "concurrently": "7.0.0",
+    "downlevel-dts": "0.7.0",
+    "rimraf": "3.0.2",
+    "typedoc": "0.19.2",
+    "typescript": "~4.3.5"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/body-checksum-node/package.json
+++ b/packages/body-checksum-node/package.json
@@ -29,7 +29,13 @@
   },
   "devDependencies": {
     "@aws-crypto/sha256-js": "2.0.0",
-    "@aws-sdk/util-utf8-node": "*"
+    "@aws-sdk/util-utf8-node": "*",
+    "@tsconfig/recommended": "1.0.1",
+    "concurrently": "7.0.0",
+    "downlevel-dts": "0.7.0",
+    "rimraf": "3.0.2",
+    "typedoc": "0.19.2",
+    "typescript": "~4.3.5"
   },
   "engines": {
     "node": ">= 12.0.0"

--- a/packages/chunked-blob-reader-native/package.json
+++ b/packages/chunked-blob-reader-native/package.json
@@ -37,5 +37,13 @@
     "type": "git",
     "url": "https://github.com/aws/aws-sdk-js-v3.git",
     "directory": "packages/chunked-blob-reader-native"
+  },
+  "devDependencies": {
+    "@tsconfig/recommended": "1.0.1",
+    "concurrently": "7.0.0",
+    "downlevel-dts": "0.7.0",
+    "rimraf": "3.0.2",
+    "typedoc": "0.19.2",
+    "typescript": "~4.3.5"
   }
 }

--- a/packages/chunked-blob-reader/package.json
+++ b/packages/chunked-blob-reader/package.json
@@ -36,5 +36,13 @@
     "type": "git",
     "url": "https://github.com/aws/aws-sdk-js-v3.git",
     "directory": "packages/chunked-blob-reader"
+  },
+  "devDependencies": {
+    "@tsconfig/recommended": "1.0.1",
+    "concurrently": "7.0.0",
+    "downlevel-dts": "0.7.0",
+    "rimraf": "3.0.2",
+    "typedoc": "0.19.2",
+    "typescript": "~4.3.5"
   }
 }

--- a/packages/chunked-stream-reader-node/package.json
+++ b/packages/chunked-stream-reader-node/package.json
@@ -22,7 +22,13 @@
     "tslib": "^2.3.0"
   },
   "devDependencies": {
-    "@types/node": "^10.0.0"
+    "@tsconfig/recommended": "1.0.1",
+    "@types/node": "^10.0.0",
+    "concurrently": "7.0.0",
+    "downlevel-dts": "0.7.0",
+    "rimraf": "3.0.2",
+    "typedoc": "0.19.2",
+    "typescript": "~4.3.5"
   },
   "engines": {
     "node": ">= 12.0.0"

--- a/packages/config-resolver/package.json
+++ b/packages/config-resolver/package.json
@@ -25,7 +25,13 @@
     "tslib": "^2.3.0"
   },
   "devDependencies": {
-    "@aws-sdk/node-config-provider": "*"
+    "@aws-sdk/node-config-provider": "*",
+    "@tsconfig/recommended": "1.0.1",
+    "concurrently": "7.0.0",
+    "downlevel-dts": "0.7.0",
+    "rimraf": "3.0.2",
+    "typedoc": "0.19.2",
+    "typescript": "~4.3.5"
   },
   "engines": {
     "node": ">= 12.0.0"

--- a/packages/core-packages-documentation-generator/package.json
+++ b/packages/core-packages-documentation-generator/package.json
@@ -25,7 +25,13 @@
     "tslib": "^2.3.0"
   },
   "devDependencies": {
-    "@types/node": "^10.0.0"
+    "@tsconfig/recommended": "1.0.1",
+    "@types/node": "^10.0.0",
+    "concurrently": "7.0.0",
+    "downlevel-dts": "0.7.0",
+    "rimraf": "3.0.2",
+    "typedoc": "0.19.2",
+    "typescript": "~4.3.5"
   },
   "private": true,
   "typesVersions": {

--- a/packages/credential-provider-cognito-identity/package.json
+++ b/packages/credential-provider-cognito-identity/package.json
@@ -43,5 +43,13 @@
     "type": "git",
     "url": "https://github.com/aws/aws-sdk-js-v3.git",
     "directory": "packages/credential-provider-cognito-identity"
+  },
+  "devDependencies": {
+    "@tsconfig/recommended": "1.0.1",
+    "concurrently": "7.0.0",
+    "downlevel-dts": "0.7.0",
+    "rimraf": "3.0.2",
+    "typedoc": "0.19.2",
+    "typescript": "~4.3.5"
   }
 }

--- a/packages/credential-provider-env/package.json
+++ b/packages/credential-provider-env/package.json
@@ -28,7 +28,13 @@
     "tslib": "^2.3.0"
   },
   "devDependencies": {
-    "@types/node": "^10.0.0"
+    "@tsconfig/recommended": "1.0.1",
+    "@types/node": "^10.0.0",
+    "concurrently": "7.0.0",
+    "downlevel-dts": "0.7.0",
+    "rimraf": "3.0.2",
+    "typedoc": "0.19.2",
+    "typescript": "~4.3.5"
   },
   "types": "./dist-types/index.d.ts",
   "engines": {

--- a/packages/credential-provider-imds/package.json
+++ b/packages/credential-provider-imds/package.json
@@ -30,8 +30,14 @@
     "tslib": "^2.3.0"
   },
   "devDependencies": {
+    "@tsconfig/recommended": "1.0.1",
     "@types/node": "^10.0.0",
-    "nock": "^13.0.2"
+    "concurrently": "7.0.0",
+    "downlevel-dts": "0.7.0",
+    "nock": "^13.0.2",
+    "rimraf": "3.0.2",
+    "typedoc": "0.19.2",
+    "typescript": "~4.3.5"
   },
   "types": "./dist-types/index.d.ts",
   "engines": {

--- a/packages/credential-provider-ini/package.json
+++ b/packages/credential-provider-ini/package.json
@@ -34,7 +34,13 @@
     "tslib": "^2.3.0"
   },
   "devDependencies": {
-    "@types/node": "^10.0.0"
+    "@tsconfig/recommended": "1.0.1",
+    "@types/node": "^10.0.0",
+    "concurrently": "7.0.0",
+    "downlevel-dts": "0.7.0",
+    "rimraf": "3.0.2",
+    "typedoc": "0.19.2",
+    "typescript": "~4.3.5"
   },
   "types": "./dist-types/index.d.ts",
   "engines": {

--- a/packages/credential-provider-node/package.json
+++ b/packages/credential-provider-node/package.json
@@ -39,7 +39,13 @@
     "tslib": "^2.3.0"
   },
   "devDependencies": {
-    "@types/node": "^10.0.0"
+    "@tsconfig/recommended": "1.0.1",
+    "@types/node": "^10.0.0",
+    "concurrently": "7.0.0",
+    "downlevel-dts": "0.7.0",
+    "rimraf": "3.0.2",
+    "typedoc": "0.19.2",
+    "typescript": "~4.3.5"
   },
   "types": "./dist-types/index.d.ts",
   "typesVersions": {

--- a/packages/credential-provider-process/package.json
+++ b/packages/credential-provider-process/package.json
@@ -30,7 +30,13 @@
     "tslib": "^2.3.0"
   },
   "devDependencies": {
-    "@types/node": "^10.0.0"
+    "@tsconfig/recommended": "1.0.1",
+    "@types/node": "^10.0.0",
+    "concurrently": "7.0.0",
+    "downlevel-dts": "0.7.0",
+    "rimraf": "3.0.2",
+    "typedoc": "0.19.2",
+    "typescript": "~4.3.5"
   },
   "types": "./dist-types/index.d.ts",
   "engines": {

--- a/packages/credential-provider-sso/package.json
+++ b/packages/credential-provider-sso/package.json
@@ -31,7 +31,13 @@
     "tslib": "^2.3.0"
   },
   "devDependencies": {
-    "@types/node": "^10.0.0"
+    "@tsconfig/recommended": "1.0.1",
+    "@types/node": "^10.0.0",
+    "concurrently": "7.0.0",
+    "downlevel-dts": "0.7.0",
+    "rimraf": "3.0.2",
+    "typedoc": "0.19.2",
+    "typescript": "~4.3.5"
   },
   "types": "./dist-types/index.d.ts",
   "engines": {

--- a/packages/credential-provider-web-identity/package.json
+++ b/packages/credential-provider-web-identity/package.json
@@ -36,7 +36,13 @@
     "tslib": "^2.3.0"
   },
   "devDependencies": {
-    "@types/node": "^10.0.0"
+    "@tsconfig/recommended": "1.0.1",
+    "@types/node": "^10.0.0",
+    "concurrently": "7.0.0",
+    "downlevel-dts": "0.7.0",
+    "rimraf": "3.0.2",
+    "typedoc": "0.19.2",
+    "typescript": "~4.3.5"
   },
   "types": "./dist-types/index.d.ts",
   "engines": {

--- a/packages/credential-providers/package.json
+++ b/packages/credential-providers/package.json
@@ -43,7 +43,13 @@
     "tslib": "^2.3.0"
   },
   "devDependencies": {
-    "@types/node": "^10.0.0"
+    "@tsconfig/recommended": "1.0.1",
+    "@types/node": "^10.0.0",
+    "concurrently": "7.0.0",
+    "downlevel-dts": "0.7.0",
+    "rimraf": "3.0.2",
+    "typedoc": "0.19.2",
+    "typescript": "~4.3.5"
   },
   "types": "./dist-types/index.d.ts",
   "engines": {

--- a/packages/endpoint-cache/package.json
+++ b/packages/endpoint-cache/package.json
@@ -23,7 +23,13 @@
     "tslib": "^2.3.0"
   },
   "devDependencies": {
-    "@types/node": "^10.0.0"
+    "@tsconfig/recommended": "1.0.1",
+    "@types/node": "^10.0.0",
+    "concurrently": "7.0.0",
+    "downlevel-dts": "0.7.0",
+    "rimraf": "3.0.2",
+    "typedoc": "0.19.2",
+    "typescript": "~4.3.5"
   },
   "engines": {
     "node": ">= 12.0.0"

--- a/packages/eventstream-handler-node/package.json
+++ b/packages/eventstream-handler-node/package.json
@@ -24,7 +24,13 @@
     "tslib": "^2.3.0"
   },
   "devDependencies": {
-    "@aws-sdk/util-utf8-node": "*"
+    "@aws-sdk/util-utf8-node": "*",
+    "@tsconfig/recommended": "1.0.1",
+    "concurrently": "7.0.0",
+    "downlevel-dts": "0.7.0",
+    "rimraf": "3.0.2",
+    "typedoc": "0.19.2",
+    "typescript": "~4.3.5"
   },
   "engines": {
     "node": ">= 12.0.0"

--- a/packages/eventstream-marshaller/package.json
+++ b/packages/eventstream-marshaller/package.json
@@ -27,7 +27,13 @@
   "devDependencies": {
     "@aws-sdk/util-utf8-browser": "*",
     "@aws-sdk/util-utf8-node": "*",
-    "@types/node": "^10.0.0"
+    "@tsconfig/recommended": "1.0.1",
+    "@types/node": "^10.0.0",
+    "concurrently": "7.0.0",
+    "downlevel-dts": "0.7.0",
+    "rimraf": "3.0.2",
+    "typedoc": "0.19.2",
+    "typescript": "~4.3.5"
   },
   "browser": {
     "@aws-sdk/util-utf8-node": "@aws-sdk/util-utf8-browser"

--- a/packages/eventstream-serde-browser/package.json
+++ b/packages/eventstream-serde-browser/package.json
@@ -42,5 +42,13 @@
     "type": "git",
     "url": "https://github.com/aws/aws-sdk-js-v3.git",
     "directory": "packages/eventstream-serde-browser"
+  },
+  "devDependencies": {
+    "@tsconfig/recommended": "1.0.1",
+    "concurrently": "7.0.0",
+    "downlevel-dts": "0.7.0",
+    "rimraf": "3.0.2",
+    "typedoc": "0.19.2",
+    "typescript": "~4.3.5"
   }
 }

--- a/packages/eventstream-serde-config-resolver/package.json
+++ b/packages/eventstream-serde-config-resolver/package.json
@@ -40,5 +40,13 @@
     "type": "git",
     "url": "https://github.com/aws/aws-sdk-js-v3.git",
     "directory": "packages/eventstream-serde-config-resolver"
+  },
+  "devDependencies": {
+    "@tsconfig/recommended": "1.0.1",
+    "concurrently": "7.0.0",
+    "downlevel-dts": "0.7.0",
+    "rimraf": "3.0.2",
+    "typedoc": "0.19.2",
+    "typescript": "~4.3.5"
   }
 }

--- a/packages/eventstream-serde-node/package.json
+++ b/packages/eventstream-serde-node/package.json
@@ -25,7 +25,13 @@
     "tslib": "^2.3.0"
   },
   "devDependencies": {
-    "@aws-sdk/util-utf8-node": "*"
+    "@aws-sdk/util-utf8-node": "*",
+    "@tsconfig/recommended": "1.0.1",
+    "concurrently": "7.0.0",
+    "downlevel-dts": "0.7.0",
+    "rimraf": "3.0.2",
+    "typedoc": "0.19.2",
+    "typescript": "~4.3.5"
   },
   "engines": {
     "node": ">= 12.0.0"

--- a/packages/eventstream-serde-universal/package.json
+++ b/packages/eventstream-serde-universal/package.json
@@ -24,7 +24,13 @@
     "tslib": "^2.3.0"
   },
   "devDependencies": {
-    "@aws-sdk/util-utf8-node": "*"
+    "@aws-sdk/util-utf8-node": "*",
+    "@tsconfig/recommended": "1.0.1",
+    "concurrently": "7.0.0",
+    "downlevel-dts": "0.7.0",
+    "rimraf": "3.0.2",
+    "typedoc": "0.19.2",
+    "typescript": "~4.3.5"
   },
   "engines": {
     "node": ">= 12.0.0"

--- a/packages/fetch-http-handler/package.json
+++ b/packages/fetch-http-handler/package.json
@@ -27,7 +27,13 @@
     "tslib": "^2.3.0"
   },
   "devDependencies": {
-    "@aws-sdk/abort-controller": "*"
+    "@aws-sdk/abort-controller": "*",
+    "@tsconfig/recommended": "1.0.1",
+    "concurrently": "7.0.0",
+    "downlevel-dts": "0.7.0",
+    "rimraf": "3.0.2",
+    "typedoc": "0.19.2",
+    "typescript": "~4.3.5"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/hash-blob-browser/package.json
+++ b/packages/hash-blob-browser/package.json
@@ -26,7 +26,13 @@
   },
   "devDependencies": {
     "@aws-crypto/sha256-js": "2.0.0",
-    "@aws-sdk/util-hex-encoding": "*"
+    "@aws-sdk/util-hex-encoding": "*",
+    "@tsconfig/recommended": "1.0.1",
+    "concurrently": "7.0.0",
+    "downlevel-dts": "0.7.0",
+    "rimraf": "3.0.2",
+    "typedoc": "0.19.2",
+    "typescript": "~4.3.5"
   },
   "react-native": {
     "@aws-sdk/chunked-blob-reader": "@aws-sdk/chunked-blob-reader-native"

--- a/packages/hash-node/package.json
+++ b/packages/hash-node/package.json
@@ -19,8 +19,14 @@
   },
   "license": "Apache-2.0",
   "devDependencies": {
+    "@tsconfig/recommended": "1.0.1",
     "@types/node": "^10.0.0",
-    "hash-test-vectors": "^1.3.2"
+    "concurrently": "7.0.0",
+    "downlevel-dts": "0.7.0",
+    "hash-test-vectors": "^1.3.2",
+    "rimraf": "3.0.2",
+    "typedoc": "0.19.2",
+    "typescript": "~4.3.5"
   },
   "dependencies": {
     "@aws-sdk/types": "*",

--- a/packages/hash-stream-node/package.json
+++ b/packages/hash-stream-node/package.json
@@ -25,7 +25,13 @@
   "devDependencies": {
     "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/util-hex-encoding": "*",
-    "@types/node": "^10.0.0"
+    "@tsconfig/recommended": "1.0.1",
+    "@types/node": "^10.0.0",
+    "concurrently": "7.0.0",
+    "downlevel-dts": "0.7.0",
+    "rimraf": "3.0.2",
+    "typedoc": "0.19.2",
+    "typescript": "~4.3.5"
   },
   "engines": {
     "node": ">= 12.0.0"

--- a/packages/invalid-dependency/package.json
+++ b/packages/invalid-dependency/package.json
@@ -37,5 +37,13 @@
     "type": "git",
     "url": "https://github.com/aws/aws-sdk-js-v3.git",
     "directory": "packages/invalid-dependency"
+  },
+  "devDependencies": {
+    "@tsconfig/recommended": "1.0.1",
+    "concurrently": "7.0.0",
+    "downlevel-dts": "0.7.0",
+    "rimraf": "3.0.2",
+    "typedoc": "0.19.2",
+    "typescript": "~4.3.5"
   }
 }

--- a/packages/is-array-buffer/package.json
+++ b/packages/is-array-buffer/package.json
@@ -40,5 +40,13 @@
     "type": "git",
     "url": "https://github.com/aws/aws-sdk-js-v3.git",
     "directory": "packages/is-array-buffer"
+  },
+  "devDependencies": {
+    "@tsconfig/recommended": "1.0.1",
+    "concurrently": "7.0.0",
+    "downlevel-dts": "0.7.0",
+    "rimraf": "3.0.2",
+    "typedoc": "0.19.2",
+    "typescript": "~4.3.5"
   }
 }

--- a/packages/karma-credential-loader/package.json
+++ b/packages/karma-credential-loader/package.json
@@ -25,7 +25,13 @@
     "tslib": "^2.3.0"
   },
   "devDependencies": {
-    "@types/node": "^10.0.0"
+    "@tsconfig/recommended": "1.0.1",
+    "@types/node": "^10.0.0",
+    "concurrently": "7.0.0",
+    "downlevel-dts": "0.7.0",
+    "rimraf": "3.0.2",
+    "typedoc": "0.19.2",
+    "typescript": "~4.3.5"
   },
   "engines": {
     "node": ">= 12.0.0"

--- a/packages/md5-js/package.json
+++ b/packages/md5-js/package.json
@@ -22,8 +22,14 @@
     "@aws-sdk/util-base64-browser": "*",
     "@aws-sdk/util-base64-node": "*",
     "@aws-sdk/util-hex-encoding": "*",
+    "@tsconfig/recommended": "1.0.1",
     "@types/node": "^10.0.0",
-    "hash-test-vectors": "^1.3.2"
+    "concurrently": "7.0.0",
+    "downlevel-dts": "0.7.0",
+    "hash-test-vectors": "^1.3.2",
+    "rimraf": "3.0.2",
+    "typedoc": "0.19.2",
+    "typescript": "~4.3.5"
   },
   "dependencies": {
     "@aws-sdk/types": "*",

--- a/packages/middleware-apply-body-checksum/package.json
+++ b/packages/middleware-apply-body-checksum/package.json
@@ -42,5 +42,13 @@
     "type": "git",
     "url": "https://github.com/aws/aws-sdk-js-v3.git",
     "directory": "packages/middleware-apply-body-checksum"
+  },
+  "devDependencies": {
+    "@tsconfig/recommended": "1.0.1",
+    "concurrently": "7.0.0",
+    "downlevel-dts": "0.7.0",
+    "rimraf": "3.0.2",
+    "typedoc": "0.19.2",
+    "typescript": "~4.3.5"
   }
 }

--- a/packages/middleware-bucket-endpoint/package.json
+++ b/packages/middleware-bucket-endpoint/package.json
@@ -27,7 +27,13 @@
   },
   "devDependencies": {
     "@aws-sdk/middleware-stack": "*",
-    "@aws-sdk/node-config-provider": "*"
+    "@aws-sdk/node-config-provider": "*",
+    "@tsconfig/recommended": "1.0.1",
+    "concurrently": "7.0.0",
+    "downlevel-dts": "0.7.0",
+    "rimraf": "3.0.2",
+    "typedoc": "0.19.2",
+    "typescript": "~4.3.5"
   },
   "engines": {
     "node": ">= 12.0.0"

--- a/packages/middleware-content-length/package.json
+++ b/packages/middleware-content-length/package.json
@@ -41,5 +41,13 @@
     "type": "git",
     "url": "https://github.com/aws/aws-sdk-js-v3.git",
     "directory": "packages/middleware-content-length"
+  },
+  "devDependencies": {
+    "@tsconfig/recommended": "1.0.1",
+    "concurrently": "7.0.0",
+    "downlevel-dts": "0.7.0",
+    "rimraf": "3.0.2",
+    "typedoc": "0.19.2",
+    "typescript": "~4.3.5"
   }
 }

--- a/packages/middleware-endpoint-discovery/package.json
+++ b/packages/middleware-endpoint-discovery/package.json
@@ -19,7 +19,13 @@
   },
   "license": "Apache-2.0",
   "devDependencies": {
-    "@aws-sdk/node-config-provider": "*"
+    "@aws-sdk/node-config-provider": "*",
+    "@tsconfig/recommended": "1.0.1",
+    "concurrently": "7.0.0",
+    "downlevel-dts": "0.7.0",
+    "rimraf": "3.0.2",
+    "typedoc": "0.19.2",
+    "typescript": "~4.3.5"
   },
   "dependencies": {
     "@aws-sdk/config-resolver": "*",

--- a/packages/middleware-eventstream/package.json
+++ b/packages/middleware-eventstream/package.json
@@ -41,5 +41,13 @@
     "type": "git",
     "url": "https://github.com/aws/aws-sdk-js-v3.git",
     "directory": "packages/middleware-eventstream"
+  },
+  "devDependencies": {
+    "@tsconfig/recommended": "1.0.1",
+    "concurrently": "7.0.0",
+    "downlevel-dts": "0.7.0",
+    "rimraf": "3.0.2",
+    "typedoc": "0.19.2",
+    "typescript": "~4.3.5"
   }
 }

--- a/packages/middleware-expect-continue/package.json
+++ b/packages/middleware-expect-continue/package.json
@@ -42,5 +42,13 @@
     "type": "git",
     "url": "https://github.com/aws/aws-sdk-js-v3.git",
     "directory": "packages/middleware-expect-continue"
+  },
+  "devDependencies": {
+    "@tsconfig/recommended": "1.0.1",
+    "concurrently": "7.0.0",
+    "downlevel-dts": "0.7.0",
+    "rimraf": "3.0.2",
+    "typedoc": "0.19.2",
+    "typescript": "~4.3.5"
   }
 }

--- a/packages/middleware-header-default/package.json
+++ b/packages/middleware-header-default/package.json
@@ -41,5 +41,13 @@
     "type": "git",
     "url": "https://github.com/aws/aws-sdk-js-v3.git",
     "directory": "packages/middleware-header-default"
+  },
+  "devDependencies": {
+    "@tsconfig/recommended": "1.0.1",
+    "concurrently": "7.0.0",
+    "downlevel-dts": "0.7.0",
+    "rimraf": "3.0.2",
+    "typedoc": "0.19.2",
+    "typescript": "~4.3.5"
   }
 }

--- a/packages/middleware-host-header/package.json
+++ b/packages/middleware-host-header/package.json
@@ -41,5 +41,13 @@
     "type": "git",
     "url": "https://github.com/aws/aws-sdk-js-v3.git",
     "directory": "packages/middleware-host-header"
+  },
+  "devDependencies": {
+    "@tsconfig/recommended": "1.0.1",
+    "concurrently": "7.0.0",
+    "downlevel-dts": "0.7.0",
+    "rimraf": "3.0.2",
+    "typedoc": "0.19.2",
+    "typescript": "~4.3.5"
   }
 }

--- a/packages/middleware-location-constraint/package.json
+++ b/packages/middleware-location-constraint/package.json
@@ -40,5 +40,13 @@
     "type": "git",
     "url": "https://github.com/aws/aws-sdk-js-v3.git",
     "directory": "packages/middleware-location-constraint"
+  },
+  "devDependencies": {
+    "@tsconfig/recommended": "1.0.1",
+    "concurrently": "7.0.0",
+    "downlevel-dts": "0.7.0",
+    "rimraf": "3.0.2",
+    "typedoc": "0.19.2",
+    "typescript": "~4.3.5"
   }
 }

--- a/packages/middleware-logger/package.json
+++ b/packages/middleware-logger/package.json
@@ -25,7 +25,13 @@
   },
   "devDependencies": {
     "@aws-sdk/protocol-http": "*",
-    "@types/node": "^10.0.0"
+    "@tsconfig/recommended": "1.0.1",
+    "@types/node": "^10.0.0",
+    "concurrently": "7.0.0",
+    "downlevel-dts": "0.7.0",
+    "rimraf": "3.0.2",
+    "typedoc": "0.19.2",
+    "typescript": "~4.3.5"
   },
   "engines": {
     "node": ">= 12.0.0"

--- a/packages/middleware-retry/package.json
+++ b/packages/middleware-retry/package.json
@@ -27,7 +27,13 @@
   },
   "devDependencies": {
     "@aws-sdk/node-config-provider": "*",
-    "@types/uuid": "^8.3.0"
+    "@tsconfig/recommended": "1.0.1",
+    "@types/uuid": "^8.3.0",
+    "concurrently": "7.0.0",
+    "downlevel-dts": "0.7.0",
+    "rimraf": "3.0.2",
+    "typedoc": "0.19.2",
+    "typescript": "~4.3.5"
   },
   "engines": {
     "node": ">= 12.0.0"

--- a/packages/middleware-sdk-api-gateway/package.json
+++ b/packages/middleware-sdk-api-gateway/package.json
@@ -41,5 +41,13 @@
     "type": "git",
     "url": "https://github.com/aws/aws-sdk-js-v3.git",
     "directory": "packages/middleware-sdk-api-gateway"
+  },
+  "devDependencies": {
+    "@tsconfig/recommended": "1.0.1",
+    "concurrently": "7.0.0",
+    "downlevel-dts": "0.7.0",
+    "rimraf": "3.0.2",
+    "typedoc": "0.19.2",
+    "typescript": "~4.3.5"
   }
 }

--- a/packages/middleware-sdk-ec2/package.json
+++ b/packages/middleware-sdk-ec2/package.json
@@ -43,5 +43,13 @@
     "type": "git",
     "url": "https://github.com/aws/aws-sdk-js-v3.git",
     "directory": "packages/middleware-sdk-ec2"
+  },
+  "devDependencies": {
+    "@tsconfig/recommended": "1.0.1",
+    "concurrently": "7.0.0",
+    "downlevel-dts": "0.7.0",
+    "rimraf": "3.0.2",
+    "typedoc": "0.19.2",
+    "typescript": "~4.3.5"
   }
 }

--- a/packages/middleware-sdk-glacier/package.json
+++ b/packages/middleware-sdk-glacier/package.json
@@ -41,5 +41,13 @@
     "type": "git",
     "url": "https://github.com/aws/aws-sdk-js-v3.git",
     "directory": "packages/middleware-sdk-glacier"
+  },
+  "devDependencies": {
+    "@tsconfig/recommended": "1.0.1",
+    "concurrently": "7.0.0",
+    "downlevel-dts": "0.7.0",
+    "rimraf": "3.0.2",
+    "typedoc": "0.19.2",
+    "typescript": "~4.3.5"
   }
 }

--- a/packages/middleware-sdk-machinelearning/package.json
+++ b/packages/middleware-sdk-machinelearning/package.json
@@ -41,5 +41,13 @@
     "type": "git",
     "url": "https://github.com/aws/aws-sdk-js-v3.git",
     "directory": "packages/middleware-sdk-machinelearning"
+  },
+  "devDependencies": {
+    "@tsconfig/recommended": "1.0.1",
+    "concurrently": "7.0.0",
+    "downlevel-dts": "0.7.0",
+    "rimraf": "3.0.2",
+    "typedoc": "0.19.2",
+    "typescript": "~4.3.5"
   }
 }

--- a/packages/middleware-sdk-rds/package.json
+++ b/packages/middleware-sdk-rds/package.json
@@ -43,5 +43,13 @@
     "type": "git",
     "url": "https://github.com/aws/aws-sdk-js-v3.git",
     "directory": "packages/middleware-sdk-rds"
+  },
+  "devDependencies": {
+    "@tsconfig/recommended": "1.0.1",
+    "concurrently": "7.0.0",
+    "downlevel-dts": "0.7.0",
+    "rimraf": "3.0.2",
+    "typedoc": "0.19.2",
+    "typescript": "~4.3.5"
   }
 }

--- a/packages/middleware-sdk-route53/package.json
+++ b/packages/middleware-sdk-route53/package.json
@@ -40,5 +40,13 @@
     "type": "git",
     "url": "https://github.com/aws/aws-sdk-js-v3.git",
     "directory": "packages/middleware-sdk-route53"
+  },
+  "devDependencies": {
+    "@tsconfig/recommended": "1.0.1",
+    "concurrently": "7.0.0",
+    "downlevel-dts": "0.7.0",
+    "rimraf": "3.0.2",
+    "typedoc": "0.19.2",
+    "typescript": "~4.3.5"
   }
 }

--- a/packages/middleware-sdk-s3-control/package.json
+++ b/packages/middleware-sdk-s3-control/package.json
@@ -26,7 +26,13 @@
     "tslib": "^2.3.0"
   },
   "devDependencies": {
-    "@aws-sdk/middleware-stack": "*"
+    "@aws-sdk/middleware-stack": "*",
+    "@tsconfig/recommended": "1.0.1",
+    "concurrently": "7.0.0",
+    "downlevel-dts": "0.7.0",
+    "rimraf": "3.0.2",
+    "typedoc": "0.19.2",
+    "typescript": "~4.3.5"
   },
   "engines": {
     "node": ">= 12.0.0"

--- a/packages/middleware-sdk-s3/package.json
+++ b/packages/middleware-sdk-s3/package.json
@@ -32,7 +32,13 @@
     "tslib": "^2.3.0"
   },
   "devDependencies": {
-    "@aws-sdk/signature-v4-crt": "*"
+    "@aws-sdk/signature-v4-crt": "*",
+    "@tsconfig/recommended": "1.0.1",
+    "concurrently": "7.0.0",
+    "downlevel-dts": "0.7.0",
+    "rimraf": "3.0.2",
+    "typedoc": "0.19.2",
+    "typescript": "~4.3.5"
   },
   "peerDependencies": {
     "@aws-sdk/signature-v4-crt": "^3.31.0"

--- a/packages/middleware-sdk-sqs/package.json
+++ b/packages/middleware-sdk-sqs/package.json
@@ -41,5 +41,13 @@
     "type": "git",
     "url": "https://github.com/aws/aws-sdk-js-v3.git",
     "directory": "packages/middleware-sdk-sqs"
+  },
+  "devDependencies": {
+    "@tsconfig/recommended": "1.0.1",
+    "concurrently": "7.0.0",
+    "downlevel-dts": "0.7.0",
+    "rimraf": "3.0.2",
+    "typedoc": "0.19.2",
+    "typescript": "~4.3.5"
   }
 }

--- a/packages/middleware-sdk-sts/package.json
+++ b/packages/middleware-sdk-sts/package.json
@@ -44,5 +44,13 @@
     "type": "git",
     "url": "https://github.com/aws/aws-sdk-js-v3.git",
     "directory": "packages/middleware-sdk-sts"
+  },
+  "devDependencies": {
+    "@tsconfig/recommended": "1.0.1",
+    "concurrently": "7.0.0",
+    "downlevel-dts": "0.7.0",
+    "rimraf": "3.0.2",
+    "typedoc": "0.19.2",
+    "typescript": "~4.3.5"
   }
 }

--- a/packages/middleware-sdk-transcribe-streaming/package.json
+++ b/packages/middleware-sdk-transcribe-streaming/package.json
@@ -30,9 +30,15 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
+    "@tsconfig/recommended": "1.0.1",
     "@types/uuid": "^8.3.0",
+    "concurrently": "7.0.0",
+    "downlevel-dts": "0.7.0",
     "jest-websocket-mock": "^2.0.2",
-    "mock-socket": "^9.0.3"
+    "mock-socket": "^9.0.3",
+    "rimraf": "3.0.2",
+    "typedoc": "0.19.2",
+    "typescript": "~4.3.5"
   },
   "engines": {
     "node": ">= 12.0.0"

--- a/packages/middleware-serde/package.json
+++ b/packages/middleware-serde/package.json
@@ -40,5 +40,13 @@
     "type": "git",
     "url": "https://github.com/aws/aws-sdk-js-v3.git",
     "directory": "packages/middleware-serde"
+  },
+  "devDependencies": {
+    "@tsconfig/recommended": "1.0.1",
+    "concurrently": "7.0.0",
+    "downlevel-dts": "0.7.0",
+    "rimraf": "3.0.2",
+    "typedoc": "0.19.2",
+    "typescript": "~4.3.5"
   }
 }

--- a/packages/middleware-signing/package.json
+++ b/packages/middleware-signing/package.json
@@ -43,5 +43,13 @@
     "type": "git",
     "url": "https://github.com/aws/aws-sdk-js-v3.git",
     "directory": "packages/middleware-signing"
+  },
+  "devDependencies": {
+    "@tsconfig/recommended": "1.0.1",
+    "concurrently": "7.0.0",
+    "downlevel-dts": "0.7.0",
+    "rimraf": "3.0.2",
+    "typedoc": "0.19.2",
+    "typescript": "~4.3.5"
   }
 }

--- a/packages/middleware-ssec/package.json
+++ b/packages/middleware-ssec/package.json
@@ -40,5 +40,13 @@
     "type": "git",
     "url": "https://github.com/aws/aws-sdk-js-v3.git",
     "directory": "packages/middleware-ssec"
+  },
+  "devDependencies": {
+    "@tsconfig/recommended": "1.0.1",
+    "concurrently": "7.0.0",
+    "downlevel-dts": "0.7.0",
+    "rimraf": "3.0.2",
+    "typedoc": "0.19.2",
+    "typescript": "~4.3.5"
   }
 }

--- a/packages/middleware-stack/package.json
+++ b/packages/middleware-stack/package.json
@@ -24,7 +24,13 @@
     "tslib": "^2.3.0"
   },
   "devDependencies": {
-    "@aws-sdk/types": "*"
+    "@aws-sdk/types": "*",
+    "@tsconfig/recommended": "1.0.1",
+    "concurrently": "7.0.0",
+    "downlevel-dts": "0.7.0",
+    "rimraf": "3.0.2",
+    "typedoc": "0.19.2",
+    "typescript": "~4.3.5"
   },
   "engines": {
     "node": ">= 12.0.0"

--- a/packages/middleware-user-agent/package.json
+++ b/packages/middleware-user-agent/package.json
@@ -24,7 +24,13 @@
     "tslib": "^2.3.0"
   },
   "devDependencies": {
-    "@aws-sdk/middleware-stack": "*"
+    "@aws-sdk/middleware-stack": "*",
+    "@tsconfig/recommended": "1.0.1",
+    "concurrently": "7.0.0",
+    "downlevel-dts": "0.7.0",
+    "rimraf": "3.0.2",
+    "typedoc": "0.19.2",
+    "typescript": "~4.3.5"
   },
   "engines": {
     "node": ">= 12.0.0"

--- a/packages/node-config-provider/package.json
+++ b/packages/node-config-provider/package.json
@@ -27,7 +27,13 @@
     "tslib": "^2.3.0"
   },
   "devDependencies": {
-    "@types/node": "^10.0.0"
+    "@tsconfig/recommended": "1.0.1",
+    "@types/node": "^10.0.0",
+    "concurrently": "7.0.0",
+    "downlevel-dts": "0.7.0",
+    "rimraf": "3.0.2",
+    "typedoc": "0.19.2",
+    "typescript": "~4.3.5"
   },
   "engines": {
     "node": ">= 12.0.0"

--- a/packages/node-http-handler/package.json
+++ b/packages/node-http-handler/package.json
@@ -28,7 +28,13 @@
     "tslib": "^2.3.0"
   },
   "devDependencies": {
-    "@types/node": "^10.0.0"
+    "@tsconfig/recommended": "1.0.1",
+    "@types/node": "^10.0.0",
+    "concurrently": "7.0.0",
+    "downlevel-dts": "0.7.0",
+    "rimraf": "3.0.2",
+    "typedoc": "0.19.2",
+    "typescript": "~4.3.5"
   },
   "jest": {
     "coveragePathIgnorePatterns": [

--- a/packages/polly-request-presigner/package.json
+++ b/packages/polly-request-presigner/package.json
@@ -29,7 +29,13 @@
   },
   "devDependencies": {
     "@aws-sdk/hash-node": "*",
-    "@types/node": "^12.0.2"
+    "@tsconfig/recommended": "1.0.1",
+    "@types/node": "^12.0.2",
+    "concurrently": "7.0.0",
+    "downlevel-dts": "0.7.0",
+    "rimraf": "3.0.2",
+    "typedoc": "0.19.2",
+    "typescript": "~4.3.5"
   },
   "engines": {
     "node": ">= 12.0.0"

--- a/packages/property-provider/package.json
+++ b/packages/property-provider/package.json
@@ -40,5 +40,13 @@
     "type": "git",
     "url": "https://github.com/aws/aws-sdk-js-v3.git",
     "directory": "packages/property-provider"
+  },
+  "devDependencies": {
+    "@tsconfig/recommended": "1.0.1",
+    "concurrently": "7.0.0",
+    "downlevel-dts": "0.7.0",
+    "rimraf": "3.0.2",
+    "typedoc": "0.19.2",
+    "typescript": "~4.3.5"
   }
 }

--- a/packages/protocol-http/package.json
+++ b/packages/protocol-http/package.json
@@ -41,5 +41,13 @@
     "type": "git",
     "url": "https://github.com/aws/aws-sdk-js-v3.git",
     "directory": "packages/protocol-http"
+  },
+  "devDependencies": {
+    "@tsconfig/recommended": "1.0.1",
+    "concurrently": "7.0.0",
+    "downlevel-dts": "0.7.0",
+    "rimraf": "3.0.2",
+    "typedoc": "0.19.2",
+    "typescript": "~4.3.5"
   }
 }

--- a/packages/querystring-builder/package.json
+++ b/packages/querystring-builder/package.json
@@ -41,5 +41,13 @@
     "type": "git",
     "url": "https://github.com/aws/aws-sdk-js-v3.git",
     "directory": "packages/querystring-builder"
+  },
+  "devDependencies": {
+    "@tsconfig/recommended": "1.0.1",
+    "concurrently": "7.0.0",
+    "downlevel-dts": "0.7.0",
+    "rimraf": "3.0.2",
+    "typedoc": "0.19.2",
+    "typescript": "~4.3.5"
   }
 }

--- a/packages/querystring-parser/package.json
+++ b/packages/querystring-parser/package.json
@@ -40,5 +40,13 @@
     "type": "git",
     "url": "https://github.com/aws/aws-sdk-js-v3.git",
     "directory": "packages/querystring-parser"
+  },
+  "devDependencies": {
+    "@tsconfig/recommended": "1.0.1",
+    "concurrently": "7.0.0",
+    "downlevel-dts": "0.7.0",
+    "rimraf": "3.0.2",
+    "typedoc": "0.19.2",
+    "typescript": "~4.3.5"
   }
 }

--- a/packages/s3-presigned-post/package.json
+++ b/packages/s3-presigned-post/package.json
@@ -29,7 +29,13 @@
     "@aws-sdk/client-s3": "*",
     "@aws-sdk/hash-node": "*",
     "@aws-sdk/protocol-http": "*",
-    "@types/node": "^12.0.2"
+    "@tsconfig/recommended": "1.0.1",
+    "@types/node": "^12.0.2",
+    "concurrently": "7.0.0",
+    "downlevel-dts": "0.7.0",
+    "rimraf": "3.0.2",
+    "typedoc": "0.19.2",
+    "typescript": "~4.3.5"
   },
   "engines": {
     "node": ">= 12.0.0"

--- a/packages/s3-request-presigner/package.json
+++ b/packages/s3-request-presigner/package.json
@@ -31,7 +31,13 @@
   "devDependencies": {
     "@aws-sdk/client-s3": "*",
     "@aws-sdk/hash-node": "*",
-    "@types/node": "^12.0.2"
+    "@tsconfig/recommended": "1.0.1",
+    "@types/node": "^12.0.2",
+    "concurrently": "7.0.0",
+    "downlevel-dts": "0.7.0",
+    "rimraf": "3.0.2",
+    "typedoc": "0.19.2",
+    "typescript": "~4.3.5"
   },
   "engines": {
     "node": ">= 12.0.0"

--- a/packages/service-client-documentation-generator/package.json
+++ b/packages/service-client-documentation-generator/package.json
@@ -25,7 +25,13 @@
     "tslib": "^2.3.0"
   },
   "devDependencies": {
-    "@types/node": "^10.0.0"
+    "@tsconfig/recommended": "1.0.1",
+    "@types/node": "^10.0.0",
+    "concurrently": "7.0.0",
+    "downlevel-dts": "0.7.0",
+    "rimraf": "3.0.2",
+    "typedoc": "0.19.2",
+    "typescript": "~4.3.5"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/service-error-classification/package.json
+++ b/packages/service-error-classification/package.json
@@ -19,7 +19,13 @@
   },
   "license": "Apache-2.0",
   "devDependencies": {
-    "@aws-sdk/types": "*"
+    "@aws-sdk/types": "*",
+    "@tsconfig/recommended": "1.0.1",
+    "concurrently": "7.0.0",
+    "downlevel-dts": "0.7.0",
+    "rimraf": "3.0.2",
+    "typedoc": "0.19.2",
+    "typescript": "~4.3.5"
   },
   "engines": {
     "node": ">= 12.0.0"

--- a/packages/sha256-tree-hash/package.json
+++ b/packages/sha256-tree-hash/package.json
@@ -25,7 +25,13 @@
   "devDependencies": {
     "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/util-hex-encoding": "*",
-    "@aws-sdk/util-utf8-node": "*"
+    "@aws-sdk/util-utf8-node": "*",
+    "@tsconfig/recommended": "1.0.1",
+    "concurrently": "7.0.0",
+    "downlevel-dts": "0.7.0",
+    "rimraf": "3.0.2",
+    "typedoc": "0.19.2",
+    "typescript": "~4.3.5"
   },
   "engines": {
     "node": ">= 12.0.0"

--- a/packages/shared-ini-file-loader/package.json
+++ b/packages/shared-ini-file-loader/package.json
@@ -5,7 +5,13 @@
     "tslib": "^2.3.0"
   },
   "devDependencies": {
-    "@types/node": "^10.0.0"
+    "@tsconfig/recommended": "1.0.1",
+    "@types/node": "^10.0.0",
+    "concurrently": "7.0.0",
+    "downlevel-dts": "0.7.0",
+    "rimraf": "3.0.2",
+    "typedoc": "0.19.2",
+    "typescript": "~4.3.5"
   },
   "scripts": {
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",

--- a/packages/signature-v4-crt/package.json
+++ b/packages/signature-v4-crt/package.json
@@ -32,7 +32,13 @@
     "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/protocol-http": "*",
     "@aws-sdk/types": "*",
-    "@aws-sdk/util-buffer-from": "*"
+    "@aws-sdk/util-buffer-from": "*",
+    "@tsconfig/recommended": "1.0.1",
+    "concurrently": "7.0.0",
+    "downlevel-dts": "0.7.0",
+    "rimraf": "3.0.2",
+    "typedoc": "0.19.2",
+    "typescript": "~4.3.5"
   },
   "engines": {
     "node": ">= 12.0.0"

--- a/packages/signature-v4/package.json
+++ b/packages/signature-v4/package.json
@@ -29,7 +29,13 @@
   "devDependencies": {
     "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/protocol-http": "*",
-    "@aws-sdk/util-buffer-from": "*"
+    "@aws-sdk/util-buffer-from": "*",
+    "@tsconfig/recommended": "1.0.1",
+    "concurrently": "7.0.0",
+    "downlevel-dts": "0.7.0",
+    "rimraf": "3.0.2",
+    "typedoc": "0.19.2",
+    "typescript": "~4.3.5"
   },
   "engines": {
     "node": ">= 12.0.0"

--- a/packages/smithy-client/package.json
+++ b/packages/smithy-client/package.json
@@ -41,5 +41,13 @@
     "type": "git",
     "url": "https://github.com/aws/aws-sdk-js-v3.git",
     "directory": "packages/smithy-client"
+  },
+  "devDependencies": {
+    "@tsconfig/recommended": "1.0.1",
+    "concurrently": "7.0.0",
+    "downlevel-dts": "0.7.0",
+    "rimraf": "3.0.2",
+    "typedoc": "0.19.2",
+    "typescript": "~4.3.5"
   }
 }

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -37,5 +37,13 @@
     "type": "git",
     "url": "https://github.com/aws/aws-sdk-js-v3.git",
     "directory": "packages/types"
+  },
+  "devDependencies": {
+    "@tsconfig/recommended": "1.0.1",
+    "concurrently": "7.0.0",
+    "downlevel-dts": "0.7.0",
+    "rimraf": "3.0.2",
+    "typedoc": "0.19.2",
+    "typescript": "~4.3.5"
   }
 }

--- a/packages/url-parser/package.json
+++ b/packages/url-parser/package.json
@@ -38,5 +38,13 @@
     "type": "git",
     "url": "https://github.com/aws/aws-sdk-js-v3.git",
     "directory": "packages/url-parser"
+  },
+  "devDependencies": {
+    "@tsconfig/recommended": "1.0.1",
+    "concurrently": "7.0.0",
+    "downlevel-dts": "0.7.0",
+    "rimraf": "3.0.2",
+    "typedoc": "0.19.2",
+    "typescript": "~4.3.5"
   }
 }

--- a/packages/util-arn-parser/package.json
+++ b/packages/util-arn-parser/package.json
@@ -22,7 +22,13 @@
     "tslib": "^2.3.0"
   },
   "devDependencies": {
-    "@types/node": "^10.0.0"
+    "@tsconfig/recommended": "1.0.1",
+    "@types/node": "^10.0.0",
+    "concurrently": "7.0.0",
+    "downlevel-dts": "0.7.0",
+    "rimraf": "3.0.2",
+    "typedoc": "0.19.2",
+    "typescript": "~4.3.5"
   },
   "types": "./dist-types/index.d.ts",
   "engines": {

--- a/packages/util-base64-browser/package.json
+++ b/packages/util-base64-browser/package.json
@@ -22,7 +22,13 @@
     "tslib": "^2.3.0"
   },
   "devDependencies": {
-    "@types/node": "^10.0.0"
+    "@tsconfig/recommended": "1.0.1",
+    "@types/node": "^10.0.0",
+    "concurrently": "7.0.0",
+    "downlevel-dts": "0.7.0",
+    "rimraf": "3.0.2",
+    "typedoc": "0.19.2",
+    "typescript": "~4.3.5"
   },
   "types": "./dist-types/index.d.ts",
   "typesVersions": {

--- a/packages/util-base64-node/package.json
+++ b/packages/util-base64-node/package.json
@@ -23,7 +23,13 @@
     "tslib": "^2.3.0"
   },
   "devDependencies": {
-    "@types/node": "^10.0.0"
+    "@tsconfig/recommended": "1.0.1",
+    "@types/node": "^10.0.0",
+    "concurrently": "7.0.0",
+    "downlevel-dts": "0.7.0",
+    "rimraf": "3.0.2",
+    "typedoc": "0.19.2",
+    "typescript": "~4.3.5"
   },
   "types": "./dist-types/index.d.ts",
   "engines": {

--- a/packages/util-body-length-browser/package.json
+++ b/packages/util-body-length-browser/package.json
@@ -37,5 +37,13 @@
     "type": "git",
     "url": "https://github.com/aws/aws-sdk-js-v3.git",
     "directory": "packages/util-body-length-browser"
+  },
+  "devDependencies": {
+    "@tsconfig/recommended": "1.0.1",
+    "concurrently": "7.0.0",
+    "downlevel-dts": "0.7.0",
+    "rimraf": "3.0.2",
+    "typedoc": "0.19.2",
+    "typescript": "~4.3.5"
   }
 }

--- a/packages/util-body-length-node/package.json
+++ b/packages/util-body-length-node/package.json
@@ -12,7 +12,13 @@
     "test": "jest"
   },
   "devDependencies": {
-    "@types/node": "^10.0.0"
+    "@tsconfig/recommended": "1.0.1",
+    "@types/node": "^10.0.0",
+    "concurrently": "7.0.0",
+    "downlevel-dts": "0.7.0",
+    "rimraf": "3.0.2",
+    "typedoc": "0.19.2",
+    "typescript": "~4.3.5"
   },
   "main": "./dist-cjs/index.js",
   "module": "./dist-es/index.js",

--- a/packages/util-buffer-from/package.json
+++ b/packages/util-buffer-from/package.json
@@ -20,7 +20,13 @@
     "tslib": "^2.3.0"
   },
   "devDependencies": {
-    "@types/node": "^10.0.0"
+    "@tsconfig/recommended": "1.0.1",
+    "@types/node": "^10.0.0",
+    "concurrently": "7.0.0",
+    "downlevel-dts": "0.7.0",
+    "rimraf": "3.0.2",
+    "typedoc": "0.19.2",
+    "typescript": "~4.3.5"
   },
   "main": "./dist-cjs/index.js",
   "module": "./dist-es/index.js",

--- a/packages/util-config-provider/package.json
+++ b/packages/util-config-provider/package.json
@@ -24,7 +24,13 @@
     "tslib": "^2.3.0"
   },
   "devDependencies": {
-    "@types/node": "^10.0.0"
+    "@tsconfig/recommended": "1.0.1",
+    "@types/node": "^10.0.0",
+    "concurrently": "7.0.0",
+    "downlevel-dts": "0.7.0",
+    "rimraf": "3.0.2",
+    "typedoc": "0.19.2",
+    "typescript": "~4.3.5"
   },
   "engines": {
     "node": ">= 12.0.0"

--- a/packages/util-create-request/package.json
+++ b/packages/util-create-request/package.json
@@ -26,7 +26,13 @@
   },
   "devDependencies": {
     "@aws-sdk/protocol-http": "*",
-    "@types/node": "^10.0.3"
+    "@tsconfig/recommended": "1.0.1",
+    "@types/node": "^10.0.3",
+    "concurrently": "7.0.0",
+    "downlevel-dts": "0.7.0",
+    "rimraf": "3.0.2",
+    "typedoc": "0.19.2",
+    "typescript": "~4.3.5"
   },
   "engines": {
     "node": ">= 12.0.0"

--- a/packages/util-credentials/package.json
+++ b/packages/util-credentials/package.json
@@ -27,7 +27,13 @@
     "tslib": "^2.3.0"
   },
   "devDependencies": {
-    "@types/node": "^10.0.0"
+    "@tsconfig/recommended": "1.0.1",
+    "@types/node": "^10.0.0",
+    "concurrently": "7.0.0",
+    "downlevel-dts": "0.7.0",
+    "rimraf": "3.0.2",
+    "typedoc": "0.19.2",
+    "typescript": "~4.3.5"
   },
   "types": "./dist-types/index.d.ts",
   "engines": {

--- a/packages/util-defaults-mode-browser/package.json
+++ b/packages/util-defaults-mode-browser/package.json
@@ -25,7 +25,12 @@
   },
   "devDependencies": {
     "@aws-sdk/smithy-client": "*",
+    "@tsconfig/recommended": "1.0.1",
     "@types/node": "^10.0.0",
+    "concurrently": "7.0.0",
+    "downlevel-dts": "0.7.0",
+    "rimraf": "3.0.2",
+    "typedoc": "0.19.2",
     "typescript": "~4.3.5"
   },
   "engines": {

--- a/packages/util-defaults-mode-node/package.json
+++ b/packages/util-defaults-mode-node/package.json
@@ -27,7 +27,12 @@
   },
   "devDependencies": {
     "@aws-sdk/smithy-client": "*",
+    "@tsconfig/recommended": "1.0.1",
     "@types/node": "^10.0.0",
+    "concurrently": "7.0.0",
+    "downlevel-dts": "0.7.0",
+    "rimraf": "3.0.2",
+    "typedoc": "0.19.2",
     "typescript": "~4.3.5"
   },
   "engines": {

--- a/packages/util-dynamodb/package.json
+++ b/packages/util-dynamodb/package.json
@@ -22,7 +22,13 @@
     "tslib": "^2.3.0"
   },
   "devDependencies": {
-    "@aws-sdk/client-dynamodb": "*"
+    "@aws-sdk/client-dynamodb": "*",
+    "@tsconfig/recommended": "1.0.1",
+    "concurrently": "7.0.0",
+    "downlevel-dts": "0.7.0",
+    "rimraf": "3.0.2",
+    "typedoc": "0.19.2",
+    "typescript": "~4.3.5"
   },
   "engines": {
     "node": ">= 12.0.0"

--- a/packages/util-format-url/package.json
+++ b/packages/util-format-url/package.json
@@ -41,5 +41,13 @@
     "type": "git",
     "url": "https://github.com/aws/aws-sdk-js-v3.git",
     "directory": "packages/util-format-url"
+  },
+  "devDependencies": {
+    "@tsconfig/recommended": "1.0.1",
+    "concurrently": "7.0.0",
+    "downlevel-dts": "0.7.0",
+    "rimraf": "3.0.2",
+    "typedoc": "0.19.2",
+    "typescript": "~4.3.5"
   }
 }

--- a/packages/util-hex-encoding/package.json
+++ b/packages/util-hex-encoding/package.json
@@ -40,5 +40,13 @@
     "type": "git",
     "url": "https://github.com/aws/aws-sdk-js-v3.git",
     "directory": "packages/util-hex-encoding"
+  },
+  "devDependencies": {
+    "@tsconfig/recommended": "1.0.1",
+    "concurrently": "7.0.0",
+    "downlevel-dts": "0.7.0",
+    "rimraf": "3.0.2",
+    "typedoc": "0.19.2",
+    "typescript": "~4.3.5"
   }
 }

--- a/packages/util-locate-window/package.json
+++ b/packages/util-locate-window/package.json
@@ -19,7 +19,13 @@
     "tslib": "^2.3.0"
   },
   "devDependencies": {
-    "@types/node": "^10.0.0"
+    "@tsconfig/recommended": "1.0.1",
+    "@types/node": "^10.0.0",
+    "concurrently": "7.0.0",
+    "downlevel-dts": "0.7.0",
+    "rimraf": "3.0.2",
+    "typedoc": "0.19.2",
+    "typescript": "~4.3.5"
   },
   "main": "./dist-cjs/index.js",
   "module": "./dist-es/index.js",

--- a/packages/util-uri-escape/package.json
+++ b/packages/util-uri-escape/package.json
@@ -39,5 +39,13 @@
     "type": "git",
     "url": "https://github.com/aws/aws-sdk-js-v3.git",
     "directory": "packages/util-uri-escape"
+  },
+  "devDependencies": {
+    "@tsconfig/recommended": "1.0.1",
+    "concurrently": "7.0.0",
+    "downlevel-dts": "0.7.0",
+    "rimraf": "3.0.2",
+    "typedoc": "0.19.2",
+    "typescript": "~4.3.5"
   }
 }

--- a/packages/util-user-agent-browser/package.json
+++ b/packages/util-user-agent-browser/package.json
@@ -25,7 +25,13 @@
     "tslib": "^2.3.0"
   },
   "devDependencies": {
-    "@aws-sdk/protocol-http": "*"
+    "@aws-sdk/protocol-http": "*",
+    "@tsconfig/recommended": "1.0.1",
+    "concurrently": "7.0.0",
+    "downlevel-dts": "0.7.0",
+    "rimraf": "3.0.2",
+    "typedoc": "0.19.2",
+    "typescript": "~4.3.5"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/util-user-agent-node/package.json
+++ b/packages/util-user-agent-node/package.json
@@ -25,7 +25,13 @@
   },
   "devDependencies": {
     "@aws-sdk/protocol-http": "*",
-    "@types/node": "^10.0.0"
+    "@tsconfig/recommended": "1.0.1",
+    "@types/node": "^10.0.0",
+    "concurrently": "7.0.0",
+    "downlevel-dts": "0.7.0",
+    "rimraf": "3.0.2",
+    "typedoc": "0.19.2",
+    "typescript": "~4.3.5"
   },
   "engines": {
     "node": ">= 12.0.0"

--- a/packages/util-utf8-browser/package.json
+++ b/packages/util-utf8-browser/package.json
@@ -37,5 +37,13 @@
     "type": "git",
     "url": "https://github.com/aws/aws-sdk-js-v3.git",
     "directory": "packages/util-utf8-browser"
+  },
+  "devDependencies": {
+    "@tsconfig/recommended": "1.0.1",
+    "concurrently": "7.0.0",
+    "downlevel-dts": "0.7.0",
+    "rimraf": "3.0.2",
+    "typedoc": "0.19.2",
+    "typescript": "~4.3.5"
   }
 }

--- a/packages/util-utf8-node/package.json
+++ b/packages/util-utf8-node/package.json
@@ -23,7 +23,13 @@
     "tslib": "^2.3.0"
   },
   "devDependencies": {
-    "@types/node": "^10.0.0"
+    "@tsconfig/recommended": "1.0.1",
+    "@types/node": "^10.0.0",
+    "concurrently": "7.0.0",
+    "downlevel-dts": "0.7.0",
+    "rimraf": "3.0.2",
+    "typedoc": "0.19.2",
+    "typescript": "~4.3.5"
   },
   "jest": {
     "testEnvironment": "node"

--- a/packages/util-waiter/package.json
+++ b/packages/util-waiter/package.json
@@ -42,5 +42,13 @@
     "type": "git",
     "url": "https://github.com/aws/aws-sdk-js-v3.git",
     "directory": "packages/util-waiter"
+  },
+  "devDependencies": {
+    "@tsconfig/recommended": "1.0.1",
+    "concurrently": "7.0.0",
+    "downlevel-dts": "0.7.0",
+    "rimraf": "3.0.2",
+    "typedoc": "0.19.2",
+    "typescript": "~4.3.5"
   }
 }

--- a/packages/xml-builder/package.json
+++ b/packages/xml-builder/package.json
@@ -40,5 +40,13 @@
     "type": "git",
     "url": "https://github.com/aws/aws-sdk-js-v3.git",
     "directory": "packages/xml-builder"
+  },
+  "devDependencies": {
+    "@tsconfig/recommended": "1.0.1",
+    "concurrently": "7.0.0",
+    "downlevel-dts": "0.7.0",
+    "rimraf": "3.0.2",
+    "typedoc": "0.19.2",
+    "typescript": "~4.3.5"
   }
 }


### PR DESCRIPTION
### Issue
Closes https://github.com/aws/aws-sdk-js-v3/issues/3243

### Description
Define devDeps used in scripts

<details>
<summary>Script used</summary>

```js
// @ts-check

import { readFileSync, writeFileSync } from "fs";
import { join } from "path";

import { getWorkspacePaths } from "./update-versions/getWorkspacePaths.mjs";

getWorkspacePaths().forEach((workspacePath) => {
  const packageJsonPath = join(workspacePath, "package.json");
  const packageJson = JSON.parse(readFileSync(packageJsonPath).toString());

  if (packageJson.devDependencies === undefined) {
    packageJson.devDependencies = {};
  }

  const devDepToVersionHash = {
    "@tsconfig/recommended": "1.0.1",
    concurrently: "7.0.0",
    "downlevel-dts": "0.7.0",
    rimraf: "3.0.2",
    typedoc: "0.19.2",
    typescript: "~4.3.5",
  };

  Object.entries(devDepToVersionHash).forEach(([dep, version]) => (packageJson.devDependencies[dep] = version));
  packageJson.devDependencies = Object.fromEntries(Object.entries(packageJson.devDependencies).sort());
  writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, 2).concat(`\n`));
});

```

</details>

### Testing
CI

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
