### PR TITLE
chore(middleware-sdk-transcribe-streaming): remove unused yarn build before test

### DIFF
--- a/packages/middleware-sdk-transcribe-streaming/package.json
+++ b/packages/middleware-sdk-transcribe-streaming/package.json
@@ -11,7 +11,6 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-*",
-    "pretest": "yarn build",
     "test": "jest --passWithNoTests"
   },
   "author": {


### PR DESCRIPTION
### Issue
Refs: https://github.com/aws/aws-sdk-js-v3/issues/3248

### Description
Removes unused yarn build before test, as it's no longer required.
We use ts-jest to run jest tests without compiling them to TypeScript.

### Testing
Verified that `yarn test` succeeds without building `middleware-sdk-transcribe-streaming` package:

```console
$ yarn test
yarn run v1.22.17
$ jest --passWithNoTests
 PASS  src/middleware-endpoint.spec.ts
 PASS  src/signer.spec.ts
 PASS  src/websocket-handler.spec.ts

Test Suites: 3 passed, 3 total
Tests:       15 passed, 15 total
Snapshots:   0 total
Time:        4.395 s
Ran all test suites.
Done in 5.46s.
```

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
