### PR TITLE
chore(codegen): increase JVM memory size

### DIFF
--- a/codegen/build.gradle.kts
+++ b/codegen/build.gradle.kts
@@ -90,10 +90,6 @@ subprojects {
             useJUnitPlatform()
         }
 
-        tasks.withType<JavaExec> {
-            jvmArgs = listOf<String>("-Xms4g", "-Xmx4g")
-        }
-
         // Apply junit 5 and hamcrest test dependencies to all java projects.
         dependencies {
             testImplementation("org.junit.jupiter:junit-jupiter-api:5.4.0")

--- a/codegen/sdk-codegen/gradle.properties
+++ b/codegen/sdk-codegen/gradle.properties
@@ -1,2 +1,3 @@
 modelsDirProp=aws-models
 defaultsModeConfigOutput=../../packages/smithy-client/src/defaults-mode.ts
+org.gradle.jvmargs=-Xmx4g -Xms4g


### PR DESCRIPTION
### Issue
JVM out of memory exception in the CI:
```console
Projection ec2.2016-11-15 failed: java.lang.OutOfMemoryError: Java heap space
java.base/java.util.Arrays.copyOf(Arrays.java:3745)
```

### Description
[Gradle build fails with Out of Memory: Java heap space error](https://stackoverflow.com/questions/63088123/gradle-build-fails-with-out-of-memory-java-heap-space-error)

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
