### PR TITLE
chore(package.json): add packageManager field with value `yarn@1.22.17`

### DIFF
--- a/package.json
+++ b/package.json
@@ -141,5 +141,6 @@
       "prettier --write"
     ],
     "**/*.{ts,js,md,json}": "prettier --write"
-  }
+  },
+  "packageManager": "yarn@1.22.17"
 }


### PR DESCRIPTION
### Issue
Fixes: https://github.com/aws/aws-sdk-js-v3/issues/3259

### Description
Adds packageManager value `yarn@1.22.17`

### Testing

<details>
<summary>Node.js 14.x (v14.18.3) without corepack</summary>

```console
$ aws-sdk-js-v3> node -v
v14.18.3

$ aws-sdk-js-v3> corepack -v
zsh: command not found: corepack

$ aws-sdk-js-v3> yarn -v
zsh: command not found: yarn
```

</details>

<details>
<summary>Node.js 14.x (v14.18.3) with corepack</summary>

```console
$ aws-sdk-js-v3> node -v
v14.18.3

$ aws-sdk-js-v3> corepack -v                                                 
zsh: command not found: corepack

$ aws-sdk-js-v3> yarn -v
zsh: command not found: yarn

$ aws-sdk-js-v3> npm install -g corepack
...
+ corepack@0.10.0
updated 1 package in 0.118s

$ aws-sdk-js-v3> yarn -v
1.22.17
```

</details>

<details>
<summary>Node.js >= 16.10</summary>

```console
$ aws-sdk-js-v3> node -v
v16.13.2

$ aws-sdk-js-v3> yarn -v
zsh: command not found: yarn

$ aws-sdk-js-v3> corepack enable

$ aws-sdk-js-v3> yarn -v
1.22.17
```

</details>

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
