### PR TITLE
feat(smithy-client): implement SdkException class

### DIFF
--- a/clients/client-accessanalyzer/src/models/models_0.ts
+++ b/clients/client-accessanalyzer/src/models/models_0.ts
@@ -1,32 +1,21 @@
-import { SdkException as __SdkException } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer, ResponseMetadata as __ResponseMetadata } from "@aws-sdk/types";
+import { MetadataBearer as $MetadataBearer, SmithyException as __SmithyException } from "@aws-sdk/types";
 
 /**
  * <p>You do not have sufficient access to perform this action.</p>
  */
-export interface AccessDeniedException extends __SdkException {
+export interface AccessDeniedException extends __SmithyException, $MetadataBearer {
   name: "AccessDeniedException";
   $fault: "client";
-}
-
-export class AccessDeniedException extends __SdkException {
-  constructor(responseMetadata: __ResponseMetadata, deserialized: any) {
-    super({
-      name: "AccessDeniedException",
-      $fault: "client",
-      $metadata: responseMetadata,
-    });
-    Object.setPrototypeOf(this, AccessDeniedException.prototype);
-    Object.assign(this, { ...deserialized });
-  }
+  message: string | undefined;
 }
 
 /**
  * <p>A conflict exception error.</p>
  */
-export interface ConflictException extends __SdkException {
+export interface ConflictException extends __SmithyException, $MetadataBearer {
   name: "ConflictException";
   $fault: "client";
+  message: string | undefined;
   /**
    * <p>The ID of the resource.</p>
    */
@@ -36,18 +25,6 @@ export interface ConflictException extends __SdkException {
    * <p>The resource type.</p>
    */
   resourceType: string | undefined;
-}
-
-export class ConflictException extends __SdkException {
-  constructor(responseMetadata: __ResponseMetadata, deserialized: any) {
-    super({
-      name: "ConflictException",
-      $fault: "client",
-      $metadata: responseMetadata,
-    });
-    Object.setPrototypeOf(this, ConflictException.prototype);
-    Object.assign(this, { ...deserialized });
-  }
 }
 
 /**
@@ -121,34 +98,24 @@ export namespace CreateArchiveRuleRequest {
 /**
  * <p>Internal server error.</p>
  */
-export interface InternalServerException extends __SdkException {
+export interface InternalServerException extends __SmithyException, $MetadataBearer {
   name: "InternalServerException";
   $fault: "server";
   $retryable: {};
+  message: string | undefined;
   /**
    * <p>The seconds to wait to retry.</p>
    */
   retryAfterSeconds?: number;
 }
 
-export class InternalServerException extends __SdkException {
-  constructor(responseMetadata: __ResponseMetadata, deserialized: any) {
-    super({
-      name: "InternalServerException",
-      $fault: "server",
-      $metadata: responseMetadata,
-    });
-    Object.setPrototypeOf(this, InternalServerException.prototype);
-    Object.assign(this, { ...deserialized });
-  }
-}
-
 /**
  * <p>The specified resource could not be found.</p>
  */
-export interface ResourceNotFoundException extends __SdkException {
+export interface ResourceNotFoundException extends __SmithyException, $MetadataBearer {
   name: "ResourceNotFoundException";
   $fault: "client";
+  message: string | undefined;
   /**
    * <p>The ID of the resource.</p>
    */
@@ -160,24 +127,13 @@ export interface ResourceNotFoundException extends __SdkException {
   resourceType: string | undefined;
 }
 
-export class ResourceNotFoundException extends __SdkException {
-  constructor(responseMetadata: __ResponseMetadata, deserialized: any) {
-    super({
-      name: "ResourceNotFoundException",
-      $fault: "client",
-      $metadata: responseMetadata,
-    });
-    Object.setPrototypeOf(this, ResourceNotFoundException.prototype);
-    Object.assign(this, { ...deserialized });
-  }
-}
-
 /**
  * <p>Service quote met error.</p>
  */
-export interface ServiceQuotaExceededException extends __SdkException {
+export interface ServiceQuotaExceededException extends __SmithyException, $MetadataBearer {
   name: "ServiceQuotaExceededException";
   $fault: "client";
+  message: string | undefined;
   /**
    * <p>The resource ID.</p>
    */
@@ -189,43 +145,20 @@ export interface ServiceQuotaExceededException extends __SdkException {
   resourceType: string | undefined;
 }
 
-export class ServiceQuotaExceededException extends __SdkException {
-  constructor(responseMetadata: __ResponseMetadata, deserialized: any) {
-    super({
-      name: "ServiceQuotaExceededException",
-      $fault: "client",
-      $metadata: responseMetadata,
-    });
-    Object.setPrototypeOf(this, ServiceQuotaExceededException.prototype);
-    Object.assign(this, { ...deserialized });
-  }
-}
-
 /**
  * <p>Throttling limit exceeded error.</p>
  */
-export interface ThrottlingException extends __SdkException {
+export interface ThrottlingException extends __SmithyException, $MetadataBearer {
   name: "ThrottlingException";
   $fault: "client";
   $retryable: {
     throttling: true;
   };
+  message: string | undefined;
   /**
    * <p>The seconds to wait to retry.</p>
    */
   retryAfterSeconds?: number;
-}
-
-export class ThrottlingException extends __SdkException {
-  constructor(responseMetadata: __ResponseMetadata, deserialized: any) {
-    super({
-      name: "ThrottlingException",
-      $fault: "client",
-      $metadata: responseMetadata,
-    });
-    Object.setPrototypeOf(this, ThrottlingException.prototype);
-    Object.assign(this, { ...deserialized });
-  }
 }
 
 /**
@@ -262,9 +195,10 @@ export enum ValidationExceptionReason {
 /**
  * <p>Validation exception error.</p>
  */
-export interface ValidationException extends __SdkException {
+export interface ValidationException extends __SmithyException, $MetadataBearer {
   name: "ValidationException";
   $fault: "client";
+  message: string | undefined;
   /**
    * <p>The reason for the exception.</p>
    */
@@ -274,18 +208,6 @@ export interface ValidationException extends __SdkException {
    * <p>A list of fields that didn't validate.</p>
    */
   fieldList?: ValidationExceptionField[];
-}
-
-export class ValidationException extends __SdkException {
-  constructor(responseMetadata: __ResponseMetadata, deserialized: any) {
-    super({
-      name: "ValidationException",
-      $fault: "client",
-      $metadata: responseMetadata,
-    });
-    Object.setPrototypeOf(this, ValidationException.prototype);
-    Object.assign(this, { ...deserialized });
-  }
 }
 
 /**

--- a/clients/client-accessanalyzer/src/models/models_0.ts
+++ b/clients/client-accessanalyzer/src/models/models_0.ts
@@ -1,21 +1,32 @@
-import { MetadataBearer as $MetadataBearer, SmithyException as __SmithyException } from "@aws-sdk/types";
+import { SdkException as __SdkException } from "@aws-sdk/smithy-client";
+import { MetadataBearer as $MetadataBearer, ResponseMetadata as __ResponseMetadata } from "@aws-sdk/types";
 
 /**
  * <p>You do not have sufficient access to perform this action.</p>
  */
-export interface AccessDeniedException extends __SmithyException, $MetadataBearer {
+export interface AccessDeniedException extends __SdkException {
   name: "AccessDeniedException";
   $fault: "client";
-  message: string | undefined;
+}
+
+export class AccessDeniedException extends __SdkException {
+  constructor(responseMetadata: __ResponseMetadata, deserialized: any) {
+    super({
+      name: "AccessDeniedException",
+      $fault: "client",
+      $metadata: responseMetadata,
+    });
+    Object.setPrototypeOf(this, AccessDeniedException.prototype);
+    Object.assign(this, { ...deserialized });
+  }
 }
 
 /**
  * <p>A conflict exception error.</p>
  */
-export interface ConflictException extends __SmithyException, $MetadataBearer {
+export interface ConflictException extends __SdkException {
   name: "ConflictException";
   $fault: "client";
-  message: string | undefined;
   /**
    * <p>The ID of the resource.</p>
    */
@@ -25,6 +36,18 @@ export interface ConflictException extends __SmithyException, $MetadataBearer {
    * <p>The resource type.</p>
    */
   resourceType: string | undefined;
+}
+
+export class ConflictException extends __SdkException {
+  constructor(responseMetadata: __ResponseMetadata, deserialized: any) {
+    super({
+      name: "ConflictException",
+      $fault: "client",
+      $metadata: responseMetadata,
+    });
+    Object.setPrototypeOf(this, ConflictException.prototype);
+    Object.assign(this, { ...deserialized });
+  }
 }
 
 /**
@@ -98,24 +121,34 @@ export namespace CreateArchiveRuleRequest {
 /**
  * <p>Internal server error.</p>
  */
-export interface InternalServerException extends __SmithyException, $MetadataBearer {
+export interface InternalServerException extends __SdkException {
   name: "InternalServerException";
   $fault: "server";
   $retryable: {};
-  message: string | undefined;
   /**
    * <p>The seconds to wait to retry.</p>
    */
   retryAfterSeconds?: number;
 }
 
+export class InternalServerException extends __SdkException {
+  constructor(responseMetadata: __ResponseMetadata, deserialized: any) {
+    super({
+      name: "InternalServerException",
+      $fault: "server",
+      $metadata: responseMetadata,
+    });
+    Object.setPrototypeOf(this, InternalServerException.prototype);
+    Object.assign(this, { ...deserialized });
+  }
+}
+
 /**
  * <p>The specified resource could not be found.</p>
  */
-export interface ResourceNotFoundException extends __SmithyException, $MetadataBearer {
+export interface ResourceNotFoundException extends __SdkException {
   name: "ResourceNotFoundException";
   $fault: "client";
-  message: string | undefined;
   /**
    * <p>The ID of the resource.</p>
    */
@@ -127,13 +160,24 @@ export interface ResourceNotFoundException extends __SmithyException, $MetadataB
   resourceType: string | undefined;
 }
 
+export class ResourceNotFoundException extends __SdkException {
+  constructor(responseMetadata: __ResponseMetadata, deserialized: any) {
+    super({
+      name: "ResourceNotFoundException",
+      $fault: "client",
+      $metadata: responseMetadata,
+    });
+    Object.setPrototypeOf(this, ResourceNotFoundException.prototype);
+    Object.assign(this, { ...deserialized });
+  }
+}
+
 /**
  * <p>Service quote met error.</p>
  */
-export interface ServiceQuotaExceededException extends __SmithyException, $MetadataBearer {
+export interface ServiceQuotaExceededException extends __SdkException {
   name: "ServiceQuotaExceededException";
   $fault: "client";
-  message: string | undefined;
   /**
    * <p>The resource ID.</p>
    */
@@ -145,20 +189,43 @@ export interface ServiceQuotaExceededException extends __SmithyException, $Metad
   resourceType: string | undefined;
 }
 
+export class ServiceQuotaExceededException extends __SdkException {
+  constructor(responseMetadata: __ResponseMetadata, deserialized: any) {
+    super({
+      name: "ServiceQuotaExceededException",
+      $fault: "client",
+      $metadata: responseMetadata,
+    });
+    Object.setPrototypeOf(this, ServiceQuotaExceededException.prototype);
+    Object.assign(this, { ...deserialized });
+  }
+}
+
 /**
  * <p>Throttling limit exceeded error.</p>
  */
-export interface ThrottlingException extends __SmithyException, $MetadataBearer {
+export interface ThrottlingException extends __SdkException {
   name: "ThrottlingException";
   $fault: "client";
   $retryable: {
     throttling: true;
   };
-  message: string | undefined;
   /**
    * <p>The seconds to wait to retry.</p>
    */
   retryAfterSeconds?: number;
+}
+
+export class ThrottlingException extends __SdkException {
+  constructor(responseMetadata: __ResponseMetadata, deserialized: any) {
+    super({
+      name: "ThrottlingException",
+      $fault: "client",
+      $metadata: responseMetadata,
+    });
+    Object.setPrototypeOf(this, ThrottlingException.prototype);
+    Object.assign(this, { ...deserialized });
+  }
 }
 
 /**
@@ -195,10 +262,9 @@ export enum ValidationExceptionReason {
 /**
  * <p>Validation exception error.</p>
  */
-export interface ValidationException extends __SmithyException, $MetadataBearer {
+export interface ValidationException extends __SdkException {
   name: "ValidationException";
   $fault: "client";
-  message: string | undefined;
   /**
    * <p>The reason for the exception.</p>
    */
@@ -208,6 +274,18 @@ export interface ValidationException extends __SmithyException, $MetadataBearer 
    * <p>A list of fields that didn't validate.</p>
    */
   fieldList?: ValidationExceptionField[];
+}
+
+export class ValidationException extends __SdkException {
+  constructor(responseMetadata: __ResponseMetadata, deserialized: any) {
+    super({
+      name: "ValidationException",
+      $fault: "client",
+      $metadata: responseMetadata,
+    });
+    Object.setPrototypeOf(this, ValidationException.prototype);
+    Object.assign(this, { ...deserialized });
+  }
 }
 
 /**

--- a/packages/smithy-client/src/exceptions.spec.ts
+++ b/packages/smithy-client/src/exceptions.spec.ts
@@ -1,0 +1,39 @@
+import { decorateServiceException, ServiceException } from "./exceptions";
+
+it("ServiceException extends from Error", () => {
+  expect(
+    new ServiceException({
+      name: "Error",
+      message: "",
+      $fault: "client",
+      $metadata: {},
+    })
+  ).toBeInstanceOf(Error);
+});
+
+describe("decorateServiceException", () => {
+  const exception = new ServiceException({
+    name: "Error",
+    message: "Error",
+    $fault: "client",
+    $metadata: {},
+  });
+
+  it("should inject unmodeled members to the exception", () => {
+    const decorated = decorateServiceException(exception, { foo: "foo" });
+    expect((decorated as any).foo).toBe("foo");
+  });
+
+  it("should not inject unmodeled members to the undefined", () => {
+    const decorated = decorateServiceException(exception, { message: undefined });
+    expect(decorated.message).toBe("Error");
+  });
+
+  it("should replace Message with message", () => {
+    const decorated = decorateServiceException({
+      name: "Error",
+      Message: "message",
+    } as any);
+    expect(decorated.message).toBe("message");
+  });
+});

--- a/packages/smithy-client/src/exceptions.ts
+++ b/packages/smithy-client/src/exceptions.ts
@@ -1,19 +1,19 @@
 import { HttpResponse, MetadataBearer, ResponseMetadata, RetryableTrait, SmithyException } from "@aws-sdk/types";
 
-export interface SdkExceptionOptions extends SmithyException, MetadataBearer {
+export interface ServiceExceptionOptions extends SmithyException, MetadataBearer {
   message?: string;
 }
 
-export class SdkException extends Error implements SmithyException, MetadataBearer {
+export class ServiceException extends Error implements SmithyException, MetadataBearer {
   readonly $fault: "client" | "server";
 
   $response?: HttpResponse;
   $retryable?: RetryableTrait;
   $metadata: ResponseMetadata;
 
-  constructor(options: SdkExceptionOptions) {
+  constructor(options: ServiceExceptionOptions) {
     super(options.message);
-    Object.setPrototypeOf(this, SdkException.prototype);
+    Object.setPrototypeOf(this, ServiceException.prototype);
     this.name = options.name;
     this.$fault = options.$fault;
     this.$metadata = options.$metadata;
@@ -27,11 +27,11 @@ export class SdkException extends Error implements SmithyException, MetadataBear
  *
  * @internal
  */
-export const decorateSdkException = <E extends SdkException>(
+export const decorateServiceException = <E extends ServiceException>(
   exception: E,
   additions: { [key: string]: any } = {}
 ): E => {
-  // apply additional properties to deserialized SdkException object
+  // apply additional properties to deserialized ServiceException object
   Object.entries(additions)
     .filter(([, v]) => v !== undefined)
     .forEach(([k, v]) => {

--- a/packages/smithy-client/src/exceptions.ts
+++ b/packages/smithy-client/src/exceptions.ts
@@ -4,6 +4,9 @@ export interface ServiceExceptionOptions extends SmithyException, MetadataBearer
   message?: string;
 }
 
+/**
+ * Base exception class for the exceptions from the server-side.
+ */
 export class ServiceException extends Error implements SmithyException, MetadataBearer {
   readonly $fault: "client" | "server";
 

--- a/packages/smithy-client/src/exceptions.ts
+++ b/packages/smithy-client/src/exceptions.ts
@@ -1,0 +1,65 @@
+import { HttpResponse, MetadataBearer, ResponseMetadata, RetryableTrait, SmithyException } from "@aws-sdk/types";
+
+export interface SdkExceptionOptions extends SmithyException, MetadataBearer {
+  message?: string;
+}
+
+export class SdkException extends Error implements SmithyException, MetadataBearer {
+  readonly $fault: "client" | "server";
+
+  $response?: HttpResponse;
+  $retryable?: RetryableTrait;
+  $metadata: ResponseMetadata;
+
+  constructor(options: SdkExceptionOptions) {
+    super(options.message);
+    Object.setPrototypeOf(this, SdkException.prototype);
+    this.name = options.name;
+    this.$fault = options.$fault;
+    this.$metadata = options.$metadata;
+  }
+}
+
+// const deserializeMetadata = (output: HttpResponse): ResponseMetadata => ({
+//   httpStatusCode: output.statusCode,
+//   requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+//   extendedRequestId: output.headers["x-amz-id-2"],
+//   cfId: output.headers["x-amz-cf-id"],
+// });
+
+// export interface InvalidSignatureException extends SmithyException {
+//   name: "InvalidSignatureException";
+//   $fault: "client";
+//   SomeTrait: string | undefined;
+// }
+
+// export class InvalidSignatureException extends SmithyException {
+//   constructor(parsedOutput: HttpResponse, deserialized: any) {
+//     super({
+//       name: "InvalidSignatureException",
+//       $fault: "client",
+//       $metadata: deserializeMetadata(parsedOutput),
+//     });
+//     Object.setPrototypeOf(this, InvalidSignatureException.prototype);
+//     Object.assign(this, { ...deserialized });
+//   }
+// }
+
+// (async () => {
+//   const error = new InvalidSignatureException(
+//     {
+//       statusCode: 400,
+//       headers: {
+//         "x-amzn-request-id": "124",
+//       },
+//     },
+//     await Promise.resolve({ SomeTrait: "trait_value" })
+//   );
+
+//   console.log(error);
+//   console.log(error instanceof InvalidSignatureException);
+//   console.log(error instanceof SdkException);
+//   console.log(error instanceof Error);
+//   console.log(new Error() instanceof InvalidSignatureException);
+//   console.log(new Error() instanceof Error);
+// })();

--- a/packages/smithy-client/src/index.ts
+++ b/packages/smithy-client/src/index.ts
@@ -4,6 +4,7 @@ export * from "./constants";
 export * from "./date-utils";
 export * from "./defaults-mode";
 export * from "./emitWarningIfUnsupportedVersion";
+export * from "./exceptions";
 export * from "./extended-encode-uri-component";
 export * from "./get-array-if-single-item";
 export * from "./get-value-from-text-node";

--- a/packages/types/src/shapes.ts
+++ b/packages/types/src/shapes.ts
@@ -25,6 +25,7 @@ export interface RetryableTrait {
 /**
  * Type that is implemented by all Smithy shapes marked with the
  * error trait.
+ * @deprecated
  */
 export interface SmithyException {
   /**
@@ -53,4 +54,7 @@ export interface SmithyException {
   readonly $response?: HttpResponse;
 }
 
+/**
+ * @deprecated
+ */
 export type SdkError = Error & Partial<SmithyException> & Partial<MetadataBearer>;


### PR DESCRIPTION
### Issue
https://github.com/aws/aws-sdk-js-v3/issues/1506
https://github.com/aws/aws-sdk-js-v3/issues/2007

### Description
* Create a new `ServiceException` class as a base class for all the server-side exception classes. The refactor to the deserializer will come next. It implements the mostly the same interface as `SdkError`.
* `SdkError` interface is **deprecated** because it is not used/enforced in actual exceptions thrown from the deserializer. It cannot be changed to `ServiceException` class because it declares every member as optional. However, the `SdkException` contains required members(`message`, `name`), simply keeping the name will cause breaking change to anyone consuming the `SdkError` interface.
* `SmithyExceptoin` interface is deprecated for the same reason.

### Testing
TBD

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
