### PR TITLE
fix(middleware-bucket-endpoint): do not override hostname when bucketEndpoint is set

### DIFF
--- a/packages/middleware-bucket-endpoint/src/bucketEndpointMiddleware.ts
+++ b/packages/middleware-bucket-endpoint/src/bucketEndpointMiddleware.ts
@@ -22,11 +22,11 @@ export const bucketEndpointMiddleware =
   ): BuildHandler<any, Output> =>
   async (args: BuildHandlerArguments<any>): Promise<BuildHandlerOutput<Output>> => {
     const { Bucket: bucketName } = args.input as { Bucket: string };
-    let replaceBucketInPath = options.bucketEndpoint;
+    let replaceBucketInPath = false;
     const request = args.request;
     if (HttpRequest.isInstance(request)) {
       if (options.bucketEndpoint) {
-        request.hostname = bucketName;
+        replaceBucketInPath = true;
       } else if (validateArn(bucketName)) {
         const bucketArn = parseArn(bucketName);
         const clientRegion = await options.region();


### PR DESCRIPTION
### Issue
Fixes: https://github.com/aws/aws-sdk-js-v3/issues/3031

### Description
Removes the override for hostname when bucketEndpoint is set

### Testing
Verified that hostname is not overridden using the following test code

<details>
<summary>Code</summary>

```js
import { S3 } from "../aws-sdk-js-v3/clients/client-s3/dist-cjs/index.js";

const region = "us-west-2";
const endpoint = "https://example.com";
const bucketEndpoint = true;
const client = new S3({ region, endpoint, bucketEndpoint });

client.middlewareStack.add(
  (next, context) => (args) => {
    console.log({ hostname: args.request.hostname, path: args.request.path });
    return next(args);
  },
  { step: "finalizeRequest" }
);

const Bucket = "test-bucket";
const Key = "test-key";

try {
  await client.getObject({ Bucket, Key });
} catch (error) {}

```

</details>

<details>
<summary>Output</summary>

```console
{ hostname: 'example.com', path: '/test-key' }
```

</details>

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
