### PR TITLE
feat(shared-ini-file-loader): remove concurrent/duplicate calls to readFile

### DIFF
--- a/packages/shared-ini-file-loader/src/index.ts
+++ b/packages/shared-ini-file-loader/src/index.ts
@@ -1,6 +1,7 @@
-import { readFile } from "fs";
 import { homedir } from "os";
 import { join, sep } from "path";
+
+import { slurpFile } from "./slurpFile";
 
 export const ENV_CREDENTIALS_PATH = "AWS_SHARED_CREDENTIALS_FILE";
 export const ENV_CONFIG_PATH = "AWS_CONFIG_FILE";
@@ -96,17 +97,6 @@ const parseIni = (iniData: string): ParsedIniData => {
 
   return map;
 };
-
-const slurpFile = (path: string): Promise<string> =>
-  new Promise((resolve, reject) => {
-    readFile(path, "utf8", (err, data) => {
-      if (err) {
-        reject(err);
-      } else {
-        resolve(data);
-      }
-    });
-  });
 
 /**
  * Get the HOME directory for the current runtime.

--- a/packages/shared-ini-file-loader/src/slurpFile.ts
+++ b/packages/shared-ini-file-loader/src/slurpFile.ts
@@ -1,12 +1,6 @@
-import { readFile } from "fs";
+// ToDo: Change to "fs/promises" when supporting nodejs>=14
+import { promises as fsPromises } from "fs";
 
-export const slurpFile = (path: string): Promise<string> =>
-  new Promise((resolve, reject) => {
-    readFile(path, "utf8", (err, data) => {
-      if (err) {
-        reject(err);
-      } else {
-        resolve(data);
-      }
-    });
-  });
+const { readFile } = fsPromises;
+
+export const slurpFile = async (path: string) => readFile(path, "utf8");

--- a/packages/shared-ini-file-loader/src/slurpFile.ts
+++ b/packages/shared-ini-file-loader/src/slurpFile.ts
@@ -37,17 +37,16 @@ const callReadFile = (path: string, cbs: callbacks) => {
 export const slurpFile = (path: string) =>
   new Promise<string>((resolve, reject) => {
     if (!fileReadHash[path]) {
-      // File not read yet, set file isReading to true.
+      // File not read yet, set file isReading to true and read file.
       fileReadHash[path] = { isReading: true, lastModified: new Date(0), contents: "", requestQueue: [] };
-      // Read file.
       callReadFile(path, { resolve, reject });
     } else if (fileReadHash[path].isReading) {
-      // File currently being read. Add to request queue.
+      // File currently being read. Add callbacks to the request queue.
       fileReadHash[path].requestQueue.push({ resolve, reject });
     } else {
-      // File already read, or read failed.
-      if (fileReadHash[path].lastModified === null) {
-        // Read failed. Read file again.
+      // File read was attempted in the past.
+      if (fileReadHash[path].lastModified.getTime() === 0) {
+        // Previous read attempt failed. Attempt read file again.
         callReadFile(path, { resolve, reject });
       } else {
         // Read file only if it's modified.

--- a/packages/shared-ini-file-loader/src/slurpFile.ts
+++ b/packages/shared-ini-file-loader/src/slurpFile.ts
@@ -1,0 +1,12 @@
+import { readFile } from "fs";
+
+export const slurpFile = (path: string): Promise<string> =>
+  new Promise((resolve, reject) => {
+    readFile(path, "utf8", (err, data) => {
+      if (err) {
+        reject(err);
+      } else {
+        resolve(data);
+      }
+    });
+  });

--- a/packages/shared-ini-file-loader/src/slurpFile.ts
+++ b/packages/shared-ini-file-loader/src/slurpFile.ts
@@ -1,6 +1,63 @@
 // ToDo: Change to "fs/promises" when supporting nodejs>=14
 import { promises as fsPromises } from "fs";
 
-const { readFile } = fsPromises;
+const { readFile, stat } = fsPromises;
 
-export const slurpFile = async (path: string) => readFile(path, "utf8");
+type callbacks = { resolve: Function; reject: Function };
+type fileStatus = {
+  contents: string;
+  isReading: boolean;
+  lastModified: Date;
+  requestQueue: callbacks[];
+};
+
+const fileReadHash: { [key: string]: fileStatus } = {};
+
+const callReadFile = (path: string, cbs: callbacks) => {
+  fileReadHash[path].requestQueue.push(cbs);
+  readFile(path, "utf8")
+    .then((data) => {
+      // File read successful
+      fileReadHash[path].contents = data;
+      fileReadHash[path].requestQueue.forEach(({ resolve }) => resolve(data));
+    })
+    .catch((err) => {
+      fileReadHash[path].requestQueue.forEach(({ reject }) => reject(err));
+    })
+    .finally(() => {
+      fileReadHash[path].isReading = false;
+      fileReadHash[path].requestQueue = [];
+      // Update last modified.
+      stat(path).then(({ mtime }) => {
+        fileReadHash[path].lastModified = mtime;
+      });
+    });
+};
+
+export const slurpFile = (path: string) =>
+  new Promise<string>((resolve, reject) => {
+    if (!fileReadHash[path]) {
+      // File not read yet, set file isReading to true.
+      fileReadHash[path] = { isReading: true, lastModified: new Date(0), contents: "", requestQueue: [] };
+      // Read file.
+      callReadFile(path, { resolve, reject });
+    } else if (fileReadHash[path].isReading) {
+      // File currently being read. Add to request queue.
+      fileReadHash[path].requestQueue.push({ resolve, reject });
+    } else {
+      // File already read, or read failed.
+      if (fileReadHash[path].lastModified === null) {
+        // Read failed. Read file again.
+        callReadFile(path, { resolve, reject });
+      } else {
+        // Read file only if it's modified.
+        stat(path).then(({ mtime }) => {
+          if (mtime === fileReadHash[path].lastModified) {
+            resolve(fileReadHash[path].contents);
+          } else {
+            callReadFile(path, { resolve, reject });
+          }
+        });
+      }
+    }
+  });


### PR DESCRIPTION
### Issue
Fixes: https://github.com/aws/aws-sdk-js-v3/issues/3019

### Description
Removes concurrent/duplicate calls to readFile by using a hash.

### Testing
ToDo: Unit testing

<details>
<summary>Single client</summary>

Refs: https://github.com/aws/aws-sdk-js-v3/issues/3019#issuecomment-1030258502
* Before: 4 calls to readFile
* After: 2 calls to readFile

</details>

<details>
<summary>Two clients</summary>

Refs: https://github.com/aws/aws-sdk-js-v3/issues/3019#issuecomment-1030265863
* Before: 8 calls to readFile
* After: 2 calls to readFile

</details>

<details>
<summary>Client with an operation</summary>

Refs: https://github.com/aws/aws-sdk-js-v3/issues/3019#issuecomment-1030283827
* Before: 16 calls to readFile
* After: 12 calls to readFile

</details>

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
