### PR TITLE
fix(node-http-handler): by default use 10 seconds as socketTimeout option, to prevent (#3279)

### DIFF
--- a/packages/node-http-handler/src/node-http-handler.ts
+++ b/packages/node-http-handler/src/node-http-handler.ts
@@ -59,7 +59,7 @@ export class NodeHttpHandler implements HttpHandler {
     const maxSockets = 50;
     return {
       connectionTimeout,
-      socketTimeout,
+      socketTimeout: socketTimeout === undefined ? 10000 : socketTimeout,
       httpAgent: httpAgent || new hAgent({ keepAlive, maxSockets }),
       httpsAgent: httpsAgent || new hsAgent({ keepAlive, maxSockets }),
     };

--- a/packages/node-http-handler/src/node-http2-handler.spec.ts
+++ b/packages/node-http-handler/src/node-http2-handler.spec.ts
@@ -374,7 +374,7 @@ describe(NodeHttp2Handler.name, () => {
   });
 
   it("will throw reasonable error when connection aborted abnormally", async () => {
-    nodeH2Handler = new NodeHttp2Handler();
+    nodeH2Handler = new NodeHttp2Handler({ requestTimeout: 0 });
     // Create a session by sending a request.
     await nodeH2Handler.handle(new HttpRequest(getMockReqOptions()), {});
     const authority = `${protocol}//${hostname}:${port}`;
@@ -399,7 +399,7 @@ describe(NodeHttp2Handler.name, () => {
   });
 
   it("will throw reasonable error when frameError is thrown", async () => {
-    nodeH2Handler = new NodeHttp2Handler();
+    nodeH2Handler = new NodeHttp2Handler({ requestTimeout: 0 });
     // Create a session by sending a request.
     await nodeH2Handler.handle(new HttpRequest(getMockReqOptions()), {});
     const authority = `${protocol}//${hostname}:${port}`;

--- a/packages/node-http-handler/src/node-http2-handler.ts
+++ b/packages/node-http-handler/src/node-http2-handler.ts
@@ -41,7 +41,7 @@ export class NodeHttp2Handler implements HttpHandler {
   private sessionCache: Map<string, ClientHttp2Session[]>;
 
   constructor({ requestTimeout, sessionTimeout, disableConcurrentStreams }: NodeHttp2HandlerOptions = {}) {
-    this.requestTimeout = requestTimeout;
+    this.requestTimeout = requestTimeout === undefined ? 10000 : requestTimeout;
     this.sessionTimeout = sessionTimeout;
     this.disableConcurrentStreams = disableConcurrentStreams;
     this.sessionCache = new Map<string, ClientHttp2Session[]>();


### PR DESCRIPTION
to prevent leaking file descriptors, like described in #3279

### Issue
Fixes: #3279

### Description
Sets a default socketTimeout for the node-http-handler to decrease the amount of open file descriptors (sockets)

### Testing
Was tested in user land described [here](https://github.com/aws/aws-sdk-js-v3/issues/3279) and [here](https://github.com/aws/aws-sdk-js-v3/issues/3019#issuecomment-1029287130)

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
