### PR TITLE
test(credential-provider-sso): mock getHomeDir from shared-ini-file-loader

### DIFF
--- a/packages/credential-provider-sso/src/index.spec.ts
+++ b/packages/credential-provider-sso/src/index.spec.ts
@@ -29,6 +29,8 @@ jest.mock("@aws-sdk/client-sso", () => ({
   GetRoleCredentialsCommand: mockGetRoleCredentialsCommand,
 }));
 
+jest.mock("@aws-sdk/shared-ini-file-loader", () => ({ getHomeDir: () => "/homedir" }));
+
 import { EXPIRE_WINDOW_MS, fromSSO } from "./index";
 
 const toRFC3339String = (date: number): string => {


### PR DESCRIPTION
### Issue
Refs: https://github.com/aws/aws-sdk-js-v3/pull/3285#issuecomment-1034240030

### Description
The existing mock for "fs" is failing unit tests for shared-ini-file-loader refactor

### Testing
Unit testing

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
