### PR TITLE
chore(benchmark-size): update current size of credential-provider-ini package

### DIFF
--- a/benchmark/size/report.md
+++ b/benchmark/size/report.md
@@ -38,7 +38,7 @@
 |@aws-sdk/credential-provider-cognito-identity|3.49.0|118.3 KB|✅(5.62.1)|✅(2.59.0)|✅(0.13.12)|
 |@aws-sdk/credential-provider-env|3.49.0|47.1 KB|N/A|N/A|N/A|
 |@aws-sdk/credential-provider-imds|3.49.0|79 KB|N/A|N/A|N/A|
-|@aws-sdk/credential-provider-ini|3.49.0|61.4 KB|N/A|N/A|N/A|
+|@aws-sdk/credential-provider-ini|3.49.0|69.7 KB|N/A|N/A|N/A|
 |@aws-sdk/credential-provider-node|3.49.0|61.5 KB|N/A|N/A|N/A|
 |@aws-sdk/credential-provider-process|3.49.0|48.1 KB|N/A|N/A|N/A|
 |@aws-sdk/credential-provider-sso|3.49.0|36.3 KB|N/A|N/A|N/A|

--- a/scripts/benchmark-size/runner/calculate-size/generate-project.ts
+++ b/scripts/benchmark-size/runner/calculate-size/generate-project.ts
@@ -12,13 +12,11 @@ export const generateProject = async (projectDir: string, options: PackageSizeRe
     ...options.packageContext,
     dependencies: [...peerDependencies, ...(options.packageContext?.dependencies ?? [])],
   };
-  // console.error("CONTEXT||||||||", contextWithPeerDep);
   for (const [name, template] of Object.entries(options.templates)) {
     const filePath = join(projectDir, name);
     const file = prettier.format(template(contextWithPeerDep), {
       filepath: filePath,
     });
-    // console.error("FILE|||||||, ", file);
     await fsPromise.writeFile(filePath, file);
   }
 

--- a/scripts/benchmark-size/runner/calculate-size/index.ts
+++ b/scripts/benchmark-size/runner/calculate-size/index.ts
@@ -25,43 +25,46 @@ export interface PackageSizeReportOutput {
 
 export const getPackageSizeReportRunner =
   (options: PackageSizeReportOptions) => async (context: ListrContext, task: ListrTaskWrapper<ListrContext, any>) => {
-    task.output = "preparing...";
-    const projectDir = join(options.tmpDir, options.packageName.replace("/", "_"));
-    await fsPromise.rmdir(projectDir, { recursive: true });
-    await fsPromise.mkdir(projectDir);
-    const entryPoint = join(projectDir, "index.js");
-    const bundlersContext = { ...options, entryPoint, projectDir };
+    try {
+      task.output = "preparing...";
+      const projectDir = join(options.tmpDir, options.packageName.replace("/", "_"));
+      await fsPromise.mkdir(projectDir);
+      const entryPoint = join(projectDir, "index.js");
+      const bundlersContext = { ...options, entryPoint, projectDir };
 
-    task.output = "generating project and installing dependencies";
-    await generateProject(projectDir, options);
+      task.output = "generating project and installing dependencies";
+      await generateProject(projectDir, options);
 
-    task.output = "calculating npm size";
-    const npmSizeResult = calculateNpmSize(projectDir, options.packageName);
+      task.output = "calculating npm size";
+      const npmSizeResult = calculateNpmSize(projectDir, options.packageName);
 
-    const skipBundlerTests = bundlersContext.packageContext.skipBundlerTests;
+      const skipBundlerTests = bundlersContext.packageContext.skipBundlerTests;
 
-    task.output = "calculating webpack 5 full bundle size";
-    const webpackSize = skipBundlerTests ? undefined : await getWebpackSize(bundlersContext);
+      task.output = "calculating webpack 5 full bundle size";
+      const webpackSize = skipBundlerTests ? undefined : await getWebpackSize(bundlersContext);
 
-    task.output = "calculating rollup full bundle size";
-    const rollupSize = skipBundlerTests ? undefined : await getRollupSize(bundlersContext);
+      task.output = "calculating rollup full bundle size";
+      const rollupSize = skipBundlerTests ? undefined : await getRollupSize(bundlersContext);
 
-    task.output = "calculating esbuild full bundle size";
-    const esbuildSize = skipBundlerTests ? undefined : await getEsbuildSize(bundlersContext);
+      task.output = "calculating esbuild full bundle size";
+      const esbuildSize = skipBundlerTests ? undefined : await getEsbuildSize(bundlersContext);
 
-    task.output = "output results";
-    const packageVersion = JSON.parse(
-      await fsPromise.readFile(
-        join(options.workspacePackages.filter((pkg) => pkg.name === options.packageName)[0].location, "package.json"),
-        "utf8"
-      )
-    ).version;
-    options.output.push({
-      name: options.packageName,
-      version: packageVersion,
-      ...npmSizeResult,
-      webpackSize,
-      esbuildSize,
-      rollupSize,
-    });
+      task.output = "output results";
+      const packageVersion = JSON.parse(
+        await fsPromise.readFile(
+          join(options.workspacePackages.filter((pkg) => pkg.name === options.packageName)[0].location, "package.json"),
+          "utf8"
+        )
+      ).version;
+      options.output.push({
+        name: options.packageName,
+        version: packageVersion,
+        ...npmSizeResult,
+        webpackSize,
+        esbuildSize,
+        rollupSize,
+      });
+    } catch (e) {
+      e.message = `[${options.packageName}]` + e.message;
+    }
   };

--- a/scripts/benchmark-size/runner/workspace.ts
+++ b/scripts/benchmark-size/runner/workspace.ts
@@ -87,12 +87,11 @@ export const validatePackagesAlreadyBuilt = async (packages: WorkspacePackage[])
     return true;
   };
 
-  const notBuilt: string[] = [];
-  for (const pkg of packages) {
-    if (!(await isBuilt(pkg.location))) {
-      notBuilt.push(pkg.name);
-    }
-  }
+  const notBuilt: string[] = await (
+    await Promise.all(packages.map(async (pkg) => ({ ...pkg, isBuilt: await isBuilt(pkg.location) })))
+  )
+    .filter((pkg) => !pkg.isBuilt)
+    .map((pkg) => pkg.name);
   if (notBuilt.length > 0) {
     throw new Error(`Please make sure these packages are fully built: ${notBuilt.join(", ")}`);
   }


### PR DESCRIPTION
### Issue
Ref: V517378088

The current size benchmark testing failed with:
```console
Updating 45 rows in the report /codebuild/output/src176440339/src/aws-sdk-js-v3/benchmark/size/report.md
Report is updated, validating the new result with the limit configurations.
Error: Limit validation has failed: 
@aws-sdk/credential-provider-ini package publishSize is 69734.4, increases by more than 10%
    at Object.updateReport (/codebuild/output/src176440339/src/aws-sdk-js-v3/scripts/benchmark-size/runner/reporter/index.ts:133:11)
    at /codebuild/output/src176440339/src/aws-sdk-js-v3/scripts/benchmark-size/runner/index.ts:119:3
    at step (/codebuild/output/src176440339/src/aws-sdk-js-v3/scripts/benchmark-size/runner/index.ts:44:23)
    at Object.next (/codebuild/output/src176440339/src/aws-sdk-js-v3/scripts/benchmark-size/runner/index.ts:25:53)
    at fulfilled (/codebuild/output/src176440339/src/aws-sdk-js-v3/scripts/benchmark-size/runner/index.ts:16:58)
error Command failed with exit code 1.
```

The size increase expected to introduced by https://github.com/aws/aws-sdk-js-v3/pull/3289

### Description
* Update the current size report to the latest size of `@aws-sdk/credential-provider-ini`.
* Show better log message of the `yarn test:size` script.

### Testing
<Details>
<Summary>Test Log</Summary>

```console
dev-dsk-zheallan-2c-2c672b83 % yarn test:size --since last_release
yarn run v1.22.17
$ cd scripts/benchmark-size/runner && yarn && ./cli.ts --since last_release
[1/4] Resolving packages...
success Already up-to-date.
starting generating size report for changed packages
publishing locally the changed package since last release.
the package versions will be the actual version up with a patch version and preid "ci".
published 397 packages
loading test scopes from /local/home/zheallan/workspace/aws-sdk-js-v3/scripts/benchmark-size/scope.json
loaded 55 local packages within test scope
Found 45 packages in the defined scope have size test scope.
✔ @aws-sdk/client-lambda
✔ @aws-sdk/client-dynamodb
✔ @aws-sdk/client-kinesis
✔ @aws-sdk/client-firehose
✔ @aws-sdk/client-cognito-identity
✔ @aws-sdk/client-s3
✔ @aws-sdk/client-app-mesh
✔ @aws-sdk/client-pinpoint
✔ @aws-sdk/client-cognito-sync
✔ @aws-sdk/client-ssm
✔ @aws-sdk/client-ec2
✔ @aws-sdk/client-sts
✔ @aws-sdk/client-cloudformation
✔ @aws-sdk/client-codepipeline
✔ @aws-sdk/client-cloudwatch
✔ @aws-sdk/client-cognito-identity-provider
✔ @aws-sdk/client-sns
✔ @aws-sdk/client-iam
✔ @aws-sdk/client-kms
✔ @aws-sdk/client-codecommit
✔ @aws-sdk/client-application-insights
✔ @aws-sdk/client-auto-scaling
✔ @aws-sdk/client-resource-groups-tagging-api
✔ @aws-sdk/client-codebuild
✔ @aws-sdk/client-efs
✔ @aws-sdk/client-glue
✔ @aws-sdk/client-athena
✔ @aws-sdk/client-cloudhsm-v2
✔ @aws-sdk/client-ses
✔ @aws-sdk/client-xray
✔ @aws-sdk/client-codedeploy
✔ @aws-sdk/client-eventbridge
✔ @aws-sdk/client-cloudwatch-logs
✔ @aws-sdk/client-opsworks
✔ @aws-sdk/credential-providers
✔ @aws-sdk/credential-provider-cognito-identity
✔ @aws-sdk/credential-provider-ini
✔ @aws-sdk/credential-provider-node
✔ @aws-sdk/credential-provider-process
✔ @aws-sdk/credential-provider-sso
✔ @aws-sdk/polly-request-presigner
✔ @aws-sdk/s3-presigned-post
✔ @aws-sdk/s3-request-presigner
✔ @aws-sdk/lib-dynamodb
✔ @aws-sdk/lib-storage
Updating 45 rows in the report /local/home/zheallan/workspace/aws-sdk-js-v3/benchmark/size/report.md
Report is updated, validating the new result with the limit configurations.
Done in 473.06s.
```

</Details>

### Additional context
Add any other context about the PR here.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
