### PR TITLE
fix(package.json): update version to v3.50.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aws-sdk-js-v3",
   "private": true,
-  "version": "3.49.0",
+  "version": "3.50.0",
   "description": "AWS SDK for JavaScript from the future",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
### Issue
Discussed internally over Slack: The command `lerna:version` fails, and will block `v3.51.0` release.

```console
$ yarn lerna:version
yarn run v1.22.17
$ lerna version --exact --conventional-commits --no-push --no-git-tag-version --no-commit-hooks --loglevel silent --no-private --yes
node:events:368
      throw er; // Unhandled 'error' event
      ^

Error: warning: refname 'v3.50.0' is ambiguous.
    at DestroyableTransform._transform (/local/home/trivikr/workspace/aws-sdk-js-v3/node_modules/git-raw-commits/index.js:83:30)
    at DestroyableTransform.Transform._read (/local/home/trivikr/workspace/aws-sdk-js-v3/node_modules/readable-stream/lib/_stream_transform.js:184:10)
    at DestroyableTransform.Transform._write (/local/home/trivikr/workspace/aws-sdk-js-v3/node_modules/readable-stream/lib/_stream_transform.js:172:83)
    at doWrite (/local/home/trivikr/workspace/aws-sdk-js-v3/node_modules/readable-stream/lib/_stream_writable.js:428:64)
    at writeOrBuffer (/local/home/trivikr/workspace/aws-sdk-js-v3/node_modules/readable-stream/lib/_stream_writable.js:417:5)
    at DestroyableTransform.Writable.write (/local/home/trivikr/workspace/aws-sdk-js-v3/node_modules/readable-stream/lib/_stream_writable.js:334:11)
    at Socket.ondata (node:internal/streams/readable:754:22)
    at Socket.emit (node:events:402:35)
    at addChunk (node:internal/streams/readable:315:12)
    at readableAddChunk (node:internal/streams/readable:285:11)
Emitted 'error' event on Readable instance at:
    at DestroyableTransform._transform (/local/home/trivikr/workspace/aws-sdk-js-v3/node_modules/git-raw-commits/index.js:83:16)
    at DestroyableTransform.Transform._read (/local/home/trivikr/workspace/aws-sdk-js-v3/node_modules/readable-stream/lib/_stream_transform.js:184:10)
    [... lines matching original stack trace ...]
    at readableAddChunk (node:internal/streams/readable:285:11)
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

### Description
Manually update version to `v3.50.0` to unblock the release, while we debug the release scripts.

### Testing
Verified that `lerna:version` command is successful.

```console
$ yarn lerna:version
yarn run v1.22.17
$ lerna version --exact --conventional-commits --no-push --no-git-tag-version --no-commit-hooks --loglevel silent --no-private --yes

Changes:
 - @aws-sdk/client-accessanalyzer: 3.50.0 => 3.51.0
 ...
 - @aws-sdk/util-user-agent-node: 3.50.0 => 3.51.0

Done in 56.19s.
```

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
