### PR TITLE
fix(scripts): disable downleveling for private workspaces

### DIFF
--- a/scripts/downlevel-dts/index.mjs
+++ b/scripts/downlevel-dts/index.mjs
@@ -5,6 +5,7 @@ import yargs from "yargs";
 
 import { downlevelWorkspace } from "./downlevelWorkspace.mjs";
 import { getWorkspaces } from "./getWorkspaces.mjs";
+import { isPrivateWorkspace } from "./isPrivateWorkspace.mjs";
 
 // ToDo: Write downlevel-dts as a yargs command, and import yargs in scripts instead.
 yargs
@@ -16,7 +17,9 @@ yargs
   .help()
   .alias("h", "help").argv;
 
-const workspaces = getWorkspaces(process.cwd());
+const workspaces = getWorkspaces(process.cwd()).filter(
+  ({ workspacesDir, workspaceName }) => !isPrivateWorkspace(workspacesDir, workspaceName)
+);
 const tasks = workspaces.map(({ workspacesDir, workspaceName }) => async () => {
   await downlevelWorkspace(workspacesDir, workspaceName);
 });

--- a/scripts/downlevel-dts/isPrivateWorkspace.mjs
+++ b/scripts/downlevel-dts/isPrivateWorkspace.mjs
@@ -1,0 +1,8 @@
+import { readFileSync } from "fs";
+import { join } from "path";
+
+export const isPrivateWorkspace = (workspacesDir, workspaceName) => {
+  const packageJsonPath = join(workspacesDir, workspaceName, "package.json");
+  const packageJson = JSON.parse(readFileSync(packageJsonPath).toString());
+  return packageJson.private && packageJson.private === true;
+};


### PR DESCRIPTION
### Issue
Attempt to fix JS-3107

### Description
Skips downleveling for private packages

### Testing
Verified that downleveling happens in non-private package (say `client-s3`) and not in private package (say `client-echo-service`):

<details>
<summary>Before</summary>

```console
$ aws-echo-service> ls dist-types          
commands                EchoService.d.ts  models     runtimeConfig.browser.d.ts  runtimeConfig.native.d.ts
EchoServiceClient.d.ts  index.d.ts        protocols  runtimeConfig.d.ts          runtimeConfig.shared.d.ts

$ client-s3> ls dist-types 
commands        models      runtimeConfig.browser.d.ts  runtimeConfig.shared.d.ts  waiters
endpoints.d.ts  pagination  runtimeConfig.d.ts          S3Client.d.ts
index.d.ts      protocols   runtimeConfig.native.d.ts   S3.d.ts
```

</details>

<details>
<summary>After</summary>

```console
$ aws-echo-service> ls dist-types          
commands                EchoService.d.ts  models     runtimeConfig.browser.d.ts  runtimeConfig.native.d.ts
EchoServiceClient.d.ts  index.d.ts        protocols  runtimeConfig.d.ts          runtimeConfig.shared.d.ts

$ client-s3> ls dist-types
commands        models      runtimeConfig.browser.d.ts  runtimeConfig.shared.d.ts  ts3.4
endpoints.d.ts  pagination  runtimeConfig.d.ts          S3Client.d.ts              waiters
index.d.ts      protocols   runtimeConfig.native.d.ts   S3.d.ts
```

</details>

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
