### PR TITLE
fix(scripts): log when types not present in downlevel script

### DIFF
--- a/scripts/downlevel-dts/downlevelWorkspace.mjs
+++ b/scripts/downlevel-dts/downlevelWorkspace.mjs
@@ -20,10 +20,8 @@ export const downlevelWorkspace = async (workspacesDir, workspaceName) => {
   try {
     await access(declarationDir);
   } catch (error) {
-    throw new Error(
-      `The types for "${workspaceName}" do not exist.\n` +
-        `Please build types for workspace "${workspaceDir}" before running downlevel-dts script.`
-    );
+    console.log(`The types for "${workspaceName}" do not exist.\n`);
+    return;
   }
 
   const downlevelDir = join(declarationDir, downlevelDirname);


### PR DESCRIPTION
### Issue
Internal JS-3107
Follow-up in JS-3106

### Description
Los instead of throwing error in downlevel script.

Reason for the change: We only build the packages to be published in new release automation scripts. Making this change to ignore when types are not available for any package. We'll run downlevel only for the changed packages as a follow-up.

### Testing

```console
$ cd private/aws-echo-service

$ rm -rf dist-types

$ cd ../../

$ yarn build:types:downlevel                                            
yarn run v1.22.17
$ node --es-module-specifier-resolution=node ./scripts/downlevel-dts
The types for "aws-echo-service" do not exist.

Done in 5.22s.
```

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
