### PR TITLE
feat(smithy-client): add ExceptionOptionType type

### DIFF
--- a/packages/smithy-client/src/exceptions.ts
+++ b/packages/smithy-client/src/exceptions.ts
@@ -1,5 +1,16 @@
 import { HttpResponse, MetadataBearer, ResponseMetadata, RetryableTrait, SmithyException } from "@aws-sdk/types";
 
+/**
+ * The type of the exception class constructor parameter. The returned type contains the properties
+ * in the `ExceptionType` but not in the `BaseExceptionType`. If the `BaseExceptionType` contains
+ * `$metadata` property, it's also included in the returned type.
+ * @internal
+ */
+export type ExceptionOptionType<ExceptionType extends Error, BaseExceptionType extends Error> = Omit<
+  ExceptionType,
+  Exclude<keyof BaseExceptionType, "$metadata">
+>;
+
 export interface ServiceExceptionOptions extends SmithyException, MetadataBearer {
   message?: string;
 }


### PR DESCRIPTION
### Description
Add an exception class constructor parameter type. It infers the exception class's contructor parameter from the exception interface and the base exception interface. It's used by client-side SDK and server-side SDK. 

Required by:
#3267 
#3310 

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
