### PR TITLE
chore(codegen): generate heap dump on OutOfMemory error

### DIFF
--- a/codegen/sdk-codegen/gradle.properties
+++ b/codegen/sdk-codegen/gradle.properties
@@ -1,3 +1,3 @@
 modelsDirProp=aws-models
 defaultsModeConfigOutput=../../packages/smithy-client/src/defaults-mode.ts
-org.gradle.jvmargs=-Xmx4g -Xms4g
+org.gradle.jvmargs=-XX:+HeapDumpOnOutOfMemoryError


### PR DESCRIPTION
### Issue
The OutOfMemory error appears even after we increased maximum size of memory allocation pool to `4g` in https://github.com/aws/aws-sdk-js-v3/pull/3253 

### Description
Temporarily disable manual increase of maximum memory size of memory allocation pool in Java, and generate heap dump on OutOfMemory.

### Testing
The command `yarn generate-clients` is successful in the workspace hosted on `c5.9xlarge`

### Additional context
Java docs: https://docs.oracle.com/javase/7/docs/webnotes/tsg/TSG-VM/html/clopts.html

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
