### PR TITLE
fix(scripts): generate clients in batches

### DIFF
--- a/scripts/generate-clients/code-gen-dir.js
+++ b/scripts/generate-clients/code-gen-dir.js
@@ -8,6 +8,7 @@ const CODE_GEN_SDK_ROOT = getCodeGenDirRoot("sdk-codegen");
 const CODE_GEN_PROTOCOL_TESTS_ROOT = getCodeGenDirRoot("protocol-test-codegen");
 
 const TEMP_CODE_GEN_INPUT_DIR = normalize(join(__dirname, ".aws-models"));
+const DEFAULT_CODE_GEN_INPUT_DIR = normalize(join(CODE_GEN_SDK_ROOT, "aws-models"));
 
 const getCodeGenOutputDir = (dir) =>
   normalize(join(__dirname, "..", "..", "codegen", dir, "build", "smithyprojections", dir));
@@ -22,5 +23,6 @@ module.exports = {
   CODE_GEN_SDK_OUTPUT_DIR,
   CODE_GEN_PROTOCOL_TESTS_OUTPUT_DIR,
   CODE_GEN_GENERIC_CLIENT_OUTPUT_DIR,
+  DEFAULT_CODE_GEN_INPUT_DIR,
   TEMP_CODE_GEN_INPUT_DIR,
 };

--- a/scripts/generate-clients/code-gen.js
+++ b/scripts/generate-clients/code-gen.js
@@ -3,29 +3,17 @@ const { basename, join, relative } = require("path");
 const { emptyDirSync } = require("fs-extra");
 const { copyFileSync } = require("fs");
 const { spawnProcess } = require("../utils/spawn-process");
-const {
-  CODE_GEN_ROOT,
-  CODE_GEN_SDK_ROOT,
-  DEFAULT_CODE_GEN_INPUT_DIR,
-  TEMP_CODE_GEN_INPUT_DIR,
-} = require("./code-gen-dir");
+const { CODE_GEN_ROOT, CODE_GEN_SDK_ROOT, TEMP_CODE_GEN_INPUT_DIR } = require("./code-gen-dir");
 const { getModelFilepaths } = require("./get-model-filepaths");
 
-const generateClients = async (models) => {
-  if (!models) {
-    // Models not defined. Choose default input directory
-    models = DEFAULT_CODE_GEN_INPUT_DIR;
-  }
-
+const generateClients = async (models, batchSize) => {
   const filepaths = getModelFilepaths(models);
-
   const options = [
     ":sdk-codegen:clean",
     ":sdk-codegen:build",
     `-PmodelsDirProp=${relative(CODE_GEN_SDK_ROOT, TEMP_CODE_GEN_INPUT_DIR)}`,
   ];
 
-  const batchSize = 50;
   while (filepaths.length > 0) {
     emptyDirSync(TEMP_CODE_GEN_INPUT_DIR);
     const filepathsToCopy = filepaths.splice(0, batchSize);

--- a/scripts/generate-clients/code-gen.js
+++ b/scripts/generate-clients/code-gen.js
@@ -1,51 +1,40 @@
 // @ts-check
-const path = require("path");
+const { basename, join, relative } = require("path");
 const { emptyDirSync } = require("fs-extra");
-const { copyFileSync, readdirSync, lstatSync } = require("fs");
+const { copyFileSync } = require("fs");
 const { spawnProcess } = require("../utils/spawn-process");
-const { CODE_GEN_ROOT, CODE_GEN_SDK_ROOT, TEMP_CODE_GEN_INPUT_DIR } = require("./code-gen-dir");
-const Glob = require("glob");
+const {
+  CODE_GEN_ROOT,
+  CODE_GEN_SDK_ROOT,
+  DEFAULT_CODE_GEN_INPUT_DIR,
+  TEMP_CODE_GEN_INPUT_DIR,
+} = require("./code-gen-dir");
+const { getModelFilepaths } = require("./get-model-filepaths");
 
 const generateClients = async (models) => {
-  let designatedModels = false;
-  if (typeof models === "string") {
-    //`models` is a folder path
-    designatedModels = true;
-    emptyDirSync(TEMP_CODE_GEN_INPUT_DIR);
-    console.log(`preparing models from ${models}...`);
-    for (const modelFileName of readdirSync(models)) {
-      const modelPath = path.join(models, modelFileName);
-      if (!lstatSync(modelPath).isFile()) continue;
-      console.log(`copying model ${modelFileName}...`);
-      copyFileSync(modelPath, path.join(TEMP_CODE_GEN_INPUT_DIR, modelFileName));
-    }
-  } else if (Array.isArray(models)) {
-    //`models` is a list of globs
-    designatedModels = true;
-    emptyDirSync(TEMP_CODE_GEN_INPUT_DIR);
-    models.forEach((pattern) => {
-      const files = Glob.sync(pattern, {
-        realpath: true,
-        absolute: true,
-      });
-      files.forEach((file) => {
-        if (!lstatSync(file).isFile()) return;
-        const name = path.basename(file);
-        console.log(`copying model ${name}...`);
-        copyFileSync(file, path.join(TEMP_CODE_GEN_INPUT_DIR, name));
-      });
-    });
-  } else {
-    console.log("no model supplied, generating all AWS clients");
-  }
-  const options = [":sdk-codegen:clean", ":sdk-codegen:build"];
-  if (designatedModels) {
-    options.push(`-PmodelsDirProp=${path.relative(CODE_GEN_SDK_ROOT, TEMP_CODE_GEN_INPUT_DIR)}`);
+  if (!models) {
+    // Models not defined. Choose default input directory
+    models = DEFAULT_CODE_GEN_INPUT_DIR;
   }
 
-  await spawnProcess("./gradlew", options, {
-    cwd: CODE_GEN_ROOT,
-  });
+  const filepaths = getModelFilepaths(models);
+
+  const options = [
+    ":sdk-codegen:clean",
+    ":sdk-codegen:build",
+    `-PmodelsDirProp=${relative(CODE_GEN_SDK_ROOT, TEMP_CODE_GEN_INPUT_DIR)}`,
+  ];
+
+  const batchSize = 50;
+  while (filepaths.length > 0) {
+    emptyDirSync(TEMP_CODE_GEN_INPUT_DIR);
+    const filepathsToCopy = filepaths.splice(0, batchSize);
+    for (const filepath of filepathsToCopy) {
+      const filename = basename(filepath);
+      copyFileSync(filepath, join(TEMP_CODE_GEN_INPUT_DIR, filename));
+    }
+    await spawnProcess("./gradlew", options, { cwd: CODE_GEN_ROOT });
+  }
 };
 
 const generateProtocolTests = async () => {

--- a/scripts/generate-clients/get-model-filepaths.js
+++ b/scripts/generate-clients/get-model-filepaths.js
@@ -1,0 +1,27 @@
+const { readdirSync, lstatSync } = require("fs");
+const Glob = require("glob");
+const { join } = require("path");
+
+const getModelFilepaths = (models) => {
+  if (typeof models === "string") {
+    //`models` is a folder path
+    console.log(`preparing models from ${models}...`);
+    return readdirSync(models)
+      .map((modelFileName) => join(models, modelFileName))
+      .filter((modelFilepath) => lstatSync(modelFilepath).isFile());
+  } else if (Array.isArray(models)) {
+    //`models` is a list of globs
+    console.log(`preparing models from ${models}...`);
+    return models
+      .map((pattern) =>
+        Glob.sync(pattern, {
+          realpath: true,
+          absolute: true,
+        })
+      )
+      .flat()
+      .filter((modelFilepath) => lstatSync(modelFilepath).isFile());
+  }
+};
+
+module.exports = { getModelFilepaths };

--- a/scripts/generate-clients/index.js
+++ b/scripts/generate-clients/index.js
@@ -8,6 +8,7 @@ const {
   CODE_GEN_SDK_OUTPUT_DIR,
   CODE_GEN_GENERIC_CLIENT_OUTPUT_DIR,
   CODE_GEN_PROTOCOL_TESTS_OUTPUT_DIR,
+  DEFAULT_CODE_GEN_INPUT_DIR,
   TEMP_CODE_GEN_INPUT_DIR,
 } = require("./code-gen-dir");
 const { prettifyCode } = require("./code-prettify");
@@ -22,6 +23,7 @@ const {
   output: clientsDir,
   noPrivateClients,
   s: serverOnly,
+  batchSize,
 } = yargs
   .alias("m", "models")
   .string("m")
@@ -41,6 +43,10 @@ const {
   .boolean("s")
   .describe("s", "Generate server artifacts instead of client ones")
   .conflicts("s", ["m", "g", "n"])
+  .describe("b", "Batchsize for generating clients")
+  .number("b")
+  .alias("b", "batch-size")
+  .default("b", 50)
   .help().argv;
 
 (async () => {
@@ -58,7 +64,7 @@ const {
       return;
     }
 
-    await generateClients(models || globs);
+    await generateClients(models || globs || DEFAULT_CODE_GEN_INPUT_DIR, batchSize);
     if (!noPrivateClients) {
       await generateGenericClient();
       await generateProtocolTests();


### PR DESCRIPTION
### Issue
Internal JS-3071

### Description
Generate clients in batches. The default batch size is `50`, but a custom batch size can be specified using option `-b` or `--batch-size`

Time taken for building clients (the call for `generateClients`):

| Batch Size | Time taken |
| ---------- | ---------- |
| 100        | 21.06s     |
| 50         | 27.68s     |
| 25         | 38.30s     |
| 10         | 70.62s     |

### Testing
Verified that all clients are generated
* When neither models/globs are passed.
  * `yarn generate-clients`
  * Clients are generated in the batches of 50.
  * Log: [generate-clients-all-log.txt](https://github.com/aws/aws-sdk-js-v3/files/8077175/generate-clients-all-log.txt)
* When batch-size is set to 10:
  * `yarn generate-clients -b 10`
  * Clients are generated in the batches of 10.
  * Log: [generate-clients-batch-size-ten-log.txt](https://github.com/aws/aws-sdk-js-v3/files/8077190/generate-clients-batch-size-ten-log.txt)
* When models directory is passed:
  * `yarn generate-clients -m codegen/sdk-codegen/aws-models`
  * Log: [generate-clients-models-log.txt](https://github.com/aws/aws-sdk-js-v3/files/8077219/generate-clients-models-log.txt)
* When globs is passed: 
  * `yarn generate-clients -g codegen/sdk-codegen/aws-models/a*.json`
  * Log: [generate-clients-globs-log.txt](https://github.com/aws/aws-sdk-js-v3/files/8077231/generate-clients-globs-log.txt)

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
