### PR TITLE
fix(scripts): store clients generated in a batch in temp directory

### DIFF
--- a/scripts/generate-clients/.gitignore
+++ b/scripts/generate-clients/.gitignore
@@ -1,1 +1,2 @@
 .aws-models/
+.sdk-codegen/

--- a/scripts/generate-clients/code-gen-dir.js
+++ b/scripts/generate-clients/code-gen-dir.js
@@ -15,6 +15,7 @@ const getCodeGenOutputDir = (dir) =>
 const CODE_GEN_PROTOCOL_TESTS_OUTPUT_DIR = getCodeGenOutputDir("protocol-test-codegen");
 const CODE_GEN_GENERIC_CLIENT_OUTPUT_DIR = getCodeGenOutputDir("generic-client-test-codegen");
 const CODE_GEN_SDK_OUTPUT_DIR = getCodeGenOutputDir("sdk-codegen");
+const TEMP_CODE_GEN_SDK_OUTPUT_DIR = normalize(join(__dirname, ".sdk-codegen"));
 
 module.exports = {
   CODE_GEN_ROOT,
@@ -25,4 +26,5 @@ module.exports = {
   CODE_GEN_GENERIC_CLIENT_OUTPUT_DIR,
   DEFAULT_CODE_GEN_INPUT_DIR,
   TEMP_CODE_GEN_INPUT_DIR,
+  TEMP_CODE_GEN_SDK_OUTPUT_DIR,
 };


### PR DESCRIPTION
### Issue
Fixes: https://github.com/aws/aws-sdk-js-v3/issues/3321

### Description
* Copies clients generated in a batch in a temporary directory `TEMP_CODE_GEN_SDK_OUTPUT_DIR`.
* Copies the clients back to `CODE_GEN_SDK_OUTPUT_DIR` after all batches are done running.
* Cleans up `TEMP_CODE_GEN_SDK_OUTPUT_DIR` after copying is complete

### Testing
Followed steps to reproduce from https://github.com/aws/aws-sdk-js-v3/issues/3321 and verified that all `a*.json` clients are present in `sdk-codegen` folder although clients were generated in the batches of `5`

```console
$ ls /local/home/trivikr/workspace/aws-sdk-js-v3/codegen/sdk-codegen/build/smithyprojections/sdk-codegen
accessanalyzer.2019-11-01      apigatewaymanagementapi.2018-11-29        app-mesh.2019-01-25
account.2021-02-01             apigatewayv2.2018-11-29                   apprunner.2020-05-15
acm.2015-12-08                 appconfig.2019-10-09                      appstream.2016-12-01
acm-pca.2017-08-22             appconfigdata.2021-11-11                  appsync.2017-07-25
alexa-for-business.2017-11-09  appflow.2020-08-23                        athena.2017-05-18
amp.2020-08-01                 appintegrations.2020-07-29                auditmanager.2017-07-25
amplify.2017-07-25             application-auto-scaling.2016-02-06       auto-scaling.2011-01-01
amplifybackend.2020-08-11      applicationcostprofiler.2020-09-10        auto-scaling-plans.2018-01-06
amplifyuibuilder.2021-08-11    application-discovery-service.2015-11-01  source
api-gateway.2015-07-09         application-insights.2018-11-25
```

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
