### PR TITLE
chore(lerna): allow private in version command

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "generate-clients": "node ./scripts/generate-clients",
     "generate:clients:generic": "node ./scripts/generate-clients/generic",
     "generate:defaults-mode-provider": "./scripts/generate-defaults-mode-provider/index.js",
-    "lerna:version": "lerna version --exact --conventional-commits --no-push --no-git-tag-version --no-commit-hooks --loglevel silent --no-private --yes",
+    "lerna:version": "lerna version --exact --conventional-commits --no-push --no-git-tag-version --no-commit-hooks --loglevel silent --yes",
     "local-publish": "node ./scripts/verdaccio-publish/index.js",
     "test:all": "yarn build:all && jest --coverage --passWithNoTests && lerna run test --scope '@aws-sdk/{fetch-http-handler,hash-blob-browser}' && yarn test:versions",
     "test:e2e": "yarn build:e2e && node ./tests/e2e/index.js",


### PR DESCRIPTION
### Issue
Internal JS-3106

### Description
Allow private in lerna:version command

### Testing
Verified that private packages are bumped in lerna:version

```console
$ yarn lerna:version
yarn run v1.22.17
$ lerna version --exact --conventional-commits --no-push --no-git-tag-version --no-commit-hooks --loglevel silent --yes
...
 - @aws-sdk/aws-echo-service: 3.51.0 => 3.52.0 (private)
 - @aws-sdk/aws-protocoltests-ec2: 3.51.0 => 3.52.0 (private)
 - @aws-sdk/aws-protocoltests-json-10: 3.51.0 => 3.52.0 (private)
 - @aws-sdk/aws-protocoltests-json: 3.51.0 => 3.52.0 (private)
 - @aws-sdk/aws-protocoltests-query: 3.51.0 => 3.52.0 (private)
 - @aws-sdk/aws-protocoltests-restjson: 3.51.0 => 3.52.0 (private)
 - @aws-sdk/aws-protocoltests-restxml: 3.51.0 => 3.52.0 (private)

Done in 60.95s.
```


---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
