### PR TITLE
fix(s3-presigned-post): Bucket name added twice (#3120)

### DIFF
--- a/packages/s3-presigned-post/src/createPresignedPost.ts
+++ b/packages/s3-presigned-post/src/createPresignedPost.ts
@@ -81,12 +81,13 @@ export const createPresignedPost = async (
   const signature = await hmac(sha256, signingKey, encodedPolicy);
 
   const endpoint = await client.config.endpoint();
-  if (!client.config.bucketEndpoint) {
-    endpoint.path = `/${Bucket}`;
-  }
+  const url = formatUrl({
+    ...endpoint,
+    ...!client.config.bucketEndpoint && { path: `/${Bucket}` }
+  })
 
   return {
-    url: formatUrl(endpoint),
+    url,
     fields: {
       ...fields,
       key: Key,


### PR DESCRIPTION
### Issue
#3120 

### Description
Replace the global client mutation with a simple clone

### Testing
tested locally

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
