### PR TITLE
docs(upgrading): Typo in the agent import example for upgrades

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -59,7 +59,7 @@ might not have the same name either.
 
   ```javascript
   const { Agent } = require("https");
-  const { Agent: HttpAgnet } = require("http");
+  const { Agent: HttpAgent } = require("http");
   const { NodeHttpHandler } = require("@aws-sdk/node-http-handler");
   const dynamodbClient = new DynamoDBClient({
     requestHandler: new NodeHttpHandler({


### PR DESCRIPTION
### Issue

N/A

### Description

Updates the example code under the httpOptions for upgrades to use the correct import of httpAgent.

### Testing

N/A

### Additional context

N/A

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
