### PR TITLE
fix(hash-stream-node): support file stream in readableStreamHasher

### DIFF
--- a/packages/hash-stream-node/src/fileStreamHasher.ts
+++ b/packages/hash-stream-node/src/fileStreamHasher.ts
@@ -4,6 +4,7 @@ import { Readable } from "stream";
 
 import { HashCalculator } from "./HashCalculator";
 
+// ToDo: deprecate in favor of readableStreamHasher
 export const fileStreamHasher: StreamHasher<Readable> = (hashCtor: HashConstructor, fileStream: Readable) =>
   new Promise((resolve, reject) => {
     if (!isReadStream(fileStream)) {

--- a/packages/hash-stream-node/src/fsCreateReadStream.spec.ts
+++ b/packages/hash-stream-node/src/fsCreateReadStream.spec.ts
@@ -1,0 +1,46 @@
+import * as fs from "fs";
+
+import { fsCreateReadStream } from "./fsCreateReadStream";
+
+jest.setTimeout(30000);
+
+describe(fsCreateReadStream.name, () => {
+  const mockFileContents = fs.readFileSync(__filename, "utf8");
+
+  it("uses file descriptor if defined", (done) => {
+    fs.promises.open(__filename, "r").then((fd) => {
+      if ((fd as any).createReadStream) {
+        const readStream = (fd as any).createReadStream();
+        const readStreamCopy = fsCreateReadStream(readStream);
+
+        const chunks: Array<Buffer> = [];
+        readStreamCopy.on("data", (chunk) => {
+          chunks.push(chunk);
+        });
+        readStreamCopy.on("end", () => {
+          const outputFileContents = Buffer.concat(chunks).toString();
+          expect(outputFileContents).toEqual(mockFileContents);
+          done();
+        });
+      } else {
+        console.log(`Skipping createReadStream test as it's not available.`);
+        done();
+      }
+    });
+  });
+
+  it("uses start and end if file descriptor is not defined", (done) => {
+    const readStream = fs.createReadStream(__filename);
+    const readStreamCopy = fsCreateReadStream(readStream);
+
+    const chunks: Array<Buffer> = [];
+    readStreamCopy.on("data", (chunk) => {
+      chunks.push(chunk);
+    });
+    readStreamCopy.on("end", () => {
+      const outputFileContents = Buffer.concat(chunks).toString();
+      expect(outputFileContents).toEqual(mockFileContents);
+      done();
+    });
+  });
+});

--- a/packages/hash-stream-node/src/fsCreateReadStream.ts
+++ b/packages/hash-stream-node/src/fsCreateReadStream.ts
@@ -1,0 +1,8 @@
+import { createReadStream, ReadStream } from "fs";
+
+export const fsCreateReadStream = (readStream: ReadStream) =>
+  createReadStream(readStream.path, {
+    fd: (readStream as any).fd,
+    start: (readStream as any).start,
+    end: (readStream as any).end,
+  });

--- a/packages/hash-stream-node/src/isFileStream.spec.ts
+++ b/packages/hash-stream-node/src/isFileStream.spec.ts
@@ -14,6 +14,17 @@ describe(isFileStream.name, () => {
       const readStream = createReadStream(Buffer.from(__filename, "utf-8"));
       expect(isFileStream(readStream)).toStrictEqual(true);
     });
+
+    it("with filehandle", async () => {
+      const { promises } = await import("fs");
+      const fd = await promises.open(__filename, "r");
+      // @ts-expect-error createReadStream is added in v16.11.0
+      if (fd.createReadStream) {
+        // @ts-expect-error createReadStream is added in v16.11.0
+        const readStream = fd.createReadStream();
+        expect(isFileStream(readStream)).toStrictEqual(true);
+      }
+    });
   });
 
   it("returns false if readablestream is not an fs.ReadStream", () => {

--- a/packages/hash-stream-node/src/isFileStream.spec.ts
+++ b/packages/hash-stream-node/src/isFileStream.spec.ts
@@ -1,0 +1,16 @@
+import { createReadStream } from "fs";
+import { Readable } from "stream";
+
+import { isFileStream } from "./isFileStream";
+
+describe(isFileStream.name, () => {
+  it("returns true if readablestream is fs.ReadStream", () => {
+    const readStream = createReadStream(__filename);
+    expect(isFileStream(readStream)).toStrictEqual(true);
+  });
+
+  it("returns false if readablestream is not an fs.ReadStream", () => {
+    const readableStream = new Readable({ read: (size) => {} });
+    expect(isFileStream(readableStream)).toStrictEqual(false);
+  });
+});

--- a/packages/hash-stream-node/src/isFileStream.spec.ts
+++ b/packages/hash-stream-node/src/isFileStream.spec.ts
@@ -4,9 +4,16 @@ import { Readable } from "stream";
 import { isFileStream } from "./isFileStream";
 
 describe(isFileStream.name, () => {
-  it("returns true if readablestream is fs.ReadStream", () => {
-    const readStream = createReadStream(__filename);
-    expect(isFileStream(readStream)).toStrictEqual(true);
+  describe("returns true if readablestream is fs.ReadStream", () => {
+    it("with string path", () => {
+      const readStream = createReadStream(__filename);
+      expect(isFileStream(readStream)).toStrictEqual(true);
+    });
+
+    it("with buffer path", () => {
+      const readStream = createReadStream(Buffer.from(__filename, "utf-8"));
+      expect(isFileStream(readStream)).toStrictEqual(true);
+    });
   });
 
   it("returns false if readablestream is not an fs.ReadStream", () => {

--- a/packages/hash-stream-node/src/isFileStream.ts
+++ b/packages/hash-stream-node/src/isFileStream.ts
@@ -4,5 +4,4 @@ import { Readable } from "stream";
 export const isFileStream = (stream: Readable): stream is ReadStream =>
   typeof (stream as ReadStream).path === "string" ||
   Buffer.isBuffer((stream as ReadStream).path) ||
-  // @ts-expect-error fd is not defined in @types/node
-  typeof (stream as ReadStream).fd === "number";
+  typeof (stream as any).fd === "number";

--- a/packages/hash-stream-node/src/isFileStream.ts
+++ b/packages/hash-stream-node/src/isFileStream.ts
@@ -1,4 +1,5 @@
 import { ReadStream } from "fs";
 import { Readable } from "stream";
 
-export const isFileStream = (stream: Readable): stream is ReadStream => typeof (stream as ReadStream).path === "string";
+export const isFileStream = (stream: Readable): stream is ReadStream =>
+  typeof (stream as ReadStream).path === "string" || Buffer.isBuffer((stream as ReadStream).path);

--- a/packages/hash-stream-node/src/isFileStream.ts
+++ b/packages/hash-stream-node/src/isFileStream.ts
@@ -2,4 +2,7 @@ import { ReadStream } from "fs";
 import { Readable } from "stream";
 
 export const isFileStream = (stream: Readable): stream is ReadStream =>
-  typeof (stream as ReadStream).path === "string" || Buffer.isBuffer((stream as ReadStream).path);
+  typeof (stream as ReadStream).path === "string" ||
+  Buffer.isBuffer((stream as ReadStream).path) ||
+  // @ts-expect-error fd is not defined in @types/node
+  typeof (stream as ReadStream).fd === "number";

--- a/packages/hash-stream-node/src/isFileStream.ts
+++ b/packages/hash-stream-node/src/isFileStream.ts
@@ -1,0 +1,4 @@
+import { ReadStream } from "fs";
+import { Readable } from "stream";
+
+export const isFileStream = (stream: Readable): stream is ReadStream => typeof (stream as ReadStream).path === "string";

--- a/packages/hash-stream-node/src/readableStreamHasher.spec.ts
+++ b/packages/hash-stream-node/src/readableStreamHasher.spec.ts
@@ -2,10 +2,12 @@ import { Hash } from "@aws-sdk/types";
 import { createReadStream } from "fs";
 import { Readable, Writable } from "stream";
 
+import { fsCreateReadStream } from "./fsCreateReadStream";
 import { HashCalculator } from "./HashCalculator";
 import { isFileStream } from "./isFileStream";
 import { readableStreamHasher } from "./readableStreamHasher";
 
+jest.mock("./fsCreateReadStream");
 jest.mock("./HashCalculator");
 jest.mock("./isFileStream");
 jest.mock("fs");
@@ -51,7 +53,7 @@ describe(readableStreamHasher.name, () => {
   });
 
   it("creates a copy in case of fileStream", () => {
-    (createReadStream as jest.Mock).mockReturnValue(
+    (fsCreateReadStream as jest.Mock).mockReturnValue(
       new Readable({
         read: (size) => {},
       })
@@ -62,10 +64,7 @@ describe(readableStreamHasher.name, () => {
     readableStreamHasher(mockHashCtor, fsReadStream);
 
     expect(isFileStream).toHaveBeenCalledWith(fsReadStream);
-    expect(createReadStream).toHaveBeenCalledWith(fsReadStream.path, {
-      start: (fsReadStream as any).start,
-      end: (fsReadStream as any).end,
-    });
+    expect(fsCreateReadStream).toHaveBeenCalledWith(fsReadStream);
   });
 
   it("computes hash for a readable stream", async () => {

--- a/packages/hash-stream-node/src/readableStreamHasher.ts
+++ b/packages/hash-stream-node/src/readableStreamHasher.ts
@@ -6,6 +6,7 @@ import { HashCalculator } from "./HashCalculator";
 import { isFileStream } from "./isFileStream";
 
 export const readableStreamHasher: StreamHasher<Readable> = (hashCtor: HashConstructor, readableStream: Readable) => {
+  // ToDo: create accurate copy if filestream is created from file descriptor.
   const streamToPipe = isFileStream(readableStream)
     ? createReadStream(readableStream.path, {
         start: (readableStream as any).start,

--- a/packages/hash-stream-node/src/readableStreamHasher.ts
+++ b/packages/hash-stream-node/src/readableStreamHasher.ts
@@ -1,8 +1,9 @@
 import { HashConstructor, StreamHasher } from "@aws-sdk/types";
-import { createReadStream, ReadStream } from "fs";
+import { createReadStream } from "fs";
 import { Readable } from "stream";
 
 import { HashCalculator } from "./HashCalculator";
+import { isFileStream } from "./isFileStream";
 
 export const readableStreamHasher: StreamHasher<Readable> = (hashCtor: HashConstructor, readableStream: Readable) => {
   const streamToPipe = isFileStream(readableStream)
@@ -28,5 +29,3 @@ export const readableStreamHasher: StreamHasher<Readable> = (hashCtor: HashConst
     });
   });
 };
-
-const isFileStream = (stream: Readable): stream is ReadStream => typeof (stream as ReadStream).path === "string";

--- a/packages/hash-stream-node/src/readableStreamHasher.ts
+++ b/packages/hash-stream-node/src/readableStreamHasher.ts
@@ -6,6 +6,7 @@ import { HashCalculator } from "./HashCalculator";
 import { isFileStream } from "./isFileStream";
 
 export const readableStreamHasher: StreamHasher<Readable> = (hashCtor: HashConstructor, readableStream: Readable) => {
+  // ToDo: throw if readableStream is already flowing and it's copy can't be created.
   // ToDo: create accurate copy if filestream is created from file descriptor.
   const streamToPipe = isFileStream(readableStream)
     ? createReadStream(readableStream.path, {

--- a/packages/hash-stream-node/src/readableStreamHasher.ts
+++ b/packages/hash-stream-node/src/readableStreamHasher.ts
@@ -1,19 +1,13 @@
 import { HashConstructor, StreamHasher } from "@aws-sdk/types";
-import { createReadStream } from "fs";
 import { Readable } from "stream";
 
+import { fsCreateReadStream } from "./fsCreateReadStream";
 import { HashCalculator } from "./HashCalculator";
 import { isFileStream } from "./isFileStream";
 
 export const readableStreamHasher: StreamHasher<Readable> = (hashCtor: HashConstructor, readableStream: Readable) => {
   // ToDo: throw if readableStream is already flowing and it's copy can't be created.
-  // ToDo: create accurate copy if filestream is created from file descriptor.
-  const streamToPipe = isFileStream(readableStream)
-    ? createReadStream(readableStream.path, {
-        start: (readableStream as any).start,
-        end: (readableStream as any).end,
-      })
-    : readableStream;
+  const streamToPipe = isFileStream(readableStream) ? fsCreateReadStream(readableStream) : readableStream;
 
   const hash = new hashCtor();
   const hashCalculator = new HashCalculator(hash);


### PR DESCRIPTION
### Issue
Internal JS-2965

### Description
Adds support for file stream in readableStreamHasher

### Testing
Done in [private-aws-sdk-js-v3/pull/75](https://github.com/aws/private-aws-sdk-js-v3/pull/75)

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
