### PR TITLE
fix(hash-stream-node): throw error if non-file readableStream is flowing

### DIFF
--- a/packages/hash-stream-node/src/readableStreamHasher.ts
+++ b/packages/hash-stream-node/src/readableStreamHasher.ts
@@ -6,7 +6,11 @@ import { HashCalculator } from "./HashCalculator";
 import { isFileStream } from "./isFileStream";
 
 export const readableStreamHasher: StreamHasher<Readable> = (hashCtor: HashConstructor, readableStream: Readable) => {
-  // ToDo: throw if readableStream is already flowing and it's copy can't be created.
+  // Throw if readableStream is already flowing and it's not a file stream.
+  if (!isFileStream(readableStream) && readableStream.readableFlowing !== null) {
+    throw new Error("Unable to calculate hash for flowing readable stream");
+  }
+
   const streamToPipe = isFileStream(readableStream) ? fsCreateReadStream(readableStream) : readableStream;
 
   const hash = new hashCtor();


### PR DESCRIPTION
### Issue
Internal JS-2965

### Description
Throws error if non-file readableStream is flowing

### Testing
Unit testing

### Additional context
Will be made ready after https://github.com/aws/aws-sdk-js-v3/pull/3338 is merged.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
