### PR TITLE
fix(codegen): increase memory allocation pool maximum size

### DIFF
--- a/codegen/sdk-codegen/gradle.properties
+++ b/codegen/sdk-codegen/gradle.properties
@@ -1,3 +1,3 @@
 modelsDirProp=aws-models
 defaultsModeConfigOutput=../../packages/smithy-client/src/defaults-mode.ts
-org.gradle.jvmargs=-XX:+HeapDumpOnOutOfMemoryError
+org.gradle.jvmargs=-Xmx4g -XX:+HeapDumpOnOutOfMemoryError


### PR DESCRIPTION
### Issue
Internal JS-3123

### Description
Sets memory allocation pool maximum size to 4 gigabytes.
* This was removed while testing in https://github.com/aws/aws-sdk-js-v3/pull/3317
* Although we're generating clients in batches from https://github.com/aws/aws-sdk-js-v3/pull/3319, the OutOfMemory gets thrown in the workspace intermittently.

### Testing
Verified that `yarn generate-clients` is successful.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
