### PR TITLE
fix(client-s3): disable bucket endpoint plugin in WriteGetObjectResponseCommand

### DIFF
--- a/clients/client-s3/src/commands/WriteGetObjectResponseCommand.ts
+++ b/clients/client-s3/src/commands/WriteGetObjectResponseCommand.ts
@@ -1,4 +1,3 @@
-import { getBucketEndpointPlugin } from "@aws-sdk/middleware-bucket-endpoint";
 import { getSerdePlugin } from "@aws-sdk/middleware-serde";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { Command as $Command } from "@aws-sdk/smithy-client";
@@ -93,7 +92,6 @@ export class WriteGetObjectResponseCommand extends $Command<
     options?: __HttpHandlerOptions
   ): Handler<WriteGetObjectResponseCommandInput, WriteGetObjectResponseCommandOutput> {
     this.middlewareStack.use(getSerdePlugin(configuration, this.serialize, this.deserialize));
-    this.middlewareStack.use(getBucketEndpointPlugin(configuration));
 
     const stack = clientStack.concat(this.middlewareStack);
 

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddS3Config.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddS3Config.java
@@ -186,7 +186,8 @@ public final class AddS3Config implements TypeScriptIntegration {
                 RuntimeClientPlugin.builder()
                         .withConventions(AwsDependency.LOCATION_CONSTRAINT.dependency, "LocationConstraint",
                                          HAS_MIDDLEWARE)
-                        .operationPredicate((m, s, o) -> o.getId().getName(s).equals("CreateBucket") && testServiceId(s))
+                        .operationPredicate((m, s, o) -> o.getId().getName(s).equals("CreateBucket")
+                                && testServiceId(s))
                         .build(),
                  /**
                  * BUCKET_ENDPOINT_MIDDLEWARE needs two separate plugins. The first resolves the config in the client.


### PR DESCRIPTION
### Issue
Resolves #2476

### Description
We have a customization that will inspect the S3 request’s `Bucket` parameters. This customization should only be applied to operations with `Bucket` input parameter. However, it was incorrectly applied to the operation which doesn’t have such parameter

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
