### PR TITLE
fix(util-stream): remove jest from devDeps

### DIFF
--- a/packages/util-stream-browser/package.json
+++ b/packages/util-stream-browser/package.json
@@ -22,11 +22,9 @@
     "tslib": "^2.3.0"
   },
   "devDependencies": {
-    "@types/jest": "^26.0.4",
     "@types/node": "^10.0.0",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "typescript": "~4.3.5",
     "rimraf": "3.0.2"
   },

--- a/packages/util-stream-node/package.json
+++ b/packages/util-stream-node/package.json
@@ -23,11 +23,9 @@
     "tslib": "^2.3.0"
   },
   "devDependencies": {
-    "@types/jest": "^26.0.4",
     "@types/node": "^10.0.0",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
-    "jest": "^26.1.0",
     "typescript": "~4.3.5",
     "rimraf": "3.0.2"
   },


### PR DESCRIPTION
### Issue
Mistakenly added in https://github.com/aws/aws-sdk-js-v3/pull/3339

### Description
The jest dependencies were added during development in private.
We now have bumped Jest to v27 and declare jest dependency in root package.json

### Testing
N/A

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
