### PR TITLE
feat(codegen): add getAwsChunkedEncodingStream to config

### DIFF
--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddHttpChecksumDependency.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddHttpChecksumDependency.java
@@ -76,6 +76,11 @@ public class AddHttpChecksumDependency implements TypeScriptIntegration {
                 + "that computes SHA1 hashes.\n"
                 + "@internal");
         writer.write("sha1?: __HashConstructor;\n");
+
+        writer.addImport("GetAwsChunkedEncodingStream", "GetAwsChunkedEncodingStream", "@aws-sdk/types");
+        writer.writeDocs("A function that returns Readable Stream which follows aws-chunked encoding stream.\n"
+                + "@internal");
+        writer.write("getAwsChunkedEncodingStream?: GetAwsChunkedEncodingStream;\n");
     }
 
     @Override
@@ -93,9 +98,9 @@ public class AddHttpChecksumDependency implements TypeScriptIntegration {
             case NODE:
                 return MapUtils.of(
                     "streamHasher", writer -> {
-                        writer.addDependency(TypeScriptDependency.STREAM_HASHER_NODE);
+                        writer.addDependency(AwsDependency.STREAM_HASHER_NODE);
                         writer.addImport("readableStreamHasher", "streamHasher",
-                                TypeScriptDependency.STREAM_HASHER_NODE.packageName);
+                                AwsDependency.STREAM_HASHER_NODE.packageName);
                         writer.write("streamHasher");
                     },
                     "md5", writer -> {
@@ -109,19 +114,25 @@ public class AddHttpChecksumDependency implements TypeScriptIntegration {
                         writer.addImport("HashConstructor", "__HashConstructor",
                                 TypeScriptDependency.AWS_SDK_TYPES.packageName);
                         writer.write("Hash.bind(null, \"sha1\")");
+                    },
+                    "getAwsChunkedEncodingStream", writer -> {
+                        writer.addDependency(AwsDependency.UTIL_STREAM_NODE);
+                        writer.addImport("getAwsChunkedEncodingStream", "getAwsChunkedEncodingStream",
+                                AwsDependency.UTIL_STREAM_NODE.packageName);
+                        writer.write("getAwsChunkedEncodingStream");
                     }
                 );
             case BROWSER:
                 return MapUtils.of(
                     "streamHasher", writer -> {
-                        writer.addDependency(TypeScriptDependency.STREAM_HASHER_BROWSER);
+                        writer.addDependency(AwsDependency.STREAM_HASHER_BROWSER);
                         writer.addImport("blobHasher", "streamHasher",
-                                TypeScriptDependency.STREAM_HASHER_BROWSER.packageName);
+                                AwsDependency.STREAM_HASHER_BROWSER.packageName);
                         writer.write("streamHasher");
                     },
                     "md5", writer -> {
-                        writer.addDependency(TypeScriptDependency.MD5_BROWSER);
-                        writer.addImport("Md5", "Md5", TypeScriptDependency.MD5_BROWSER.packageName);
+                        writer.addDependency(AwsDependency.MD5_BROWSER);
+                        writer.addImport("Md5", "Md5", AwsDependency.MD5_BROWSER.packageName);
                         writer.write("Md5");
                     },
                     "sha1", writer -> {
@@ -129,6 +140,12 @@ public class AddHttpChecksumDependency implements TypeScriptIntegration {
                         writer.addImport("Sha1",
                             "Sha1", AwsDependency.AWS_CRYPTO_SHA1_BROWSER.packageName);
                         writer.write("Sha1");
+                    },
+                    "getAwsChunkedEncodingStream", writer -> {
+                        writer.addDependency(AwsDependency.UTIL_STREAM_BROWSER);
+                        writer.addImport("getAwsChunkedEncodingStream", "getAwsChunkedEncodingStream",
+                                AwsDependency.UTIL_STREAM_BROWSER.packageName);
+                        writer.write("getAwsChunkedEncodingStream");
                     }
                 );
             default:

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsDependency.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsDependency.java
@@ -72,6 +72,13 @@ public enum AwsDependency implements SymbolDependencyContainer {
     AWS_SDK_UTIL_USER_AGENT_NODE(NORMAL_DEPENDENCY, "@aws-sdk/util-user-agent-node"),
     MIDDLEWARE_ENDPOINT_DISCOVERY(NORMAL_DEPENDENCY, "@aws-sdk/middleware-endpoint-discovery"),
     AWS_CRYPTO_SHA1_BROWSER(NORMAL_DEPENDENCY, "@aws-crypto/sha1-browser", "2.0.0"),
+
+    // Conditionally added when httpChecksum trait exists
+    MD5_BROWSER(NORMAL_DEPENDENCY, "@aws-sdk/md5-js"),
+    STREAM_HASHER_NODE(NORMAL_DEPENDENCY, "@aws-sdk/hash-stream-node"),
+    STREAM_HASHER_BROWSER(NORMAL_DEPENDENCY, "@aws-sdk/hash-blob-browser"),
+    UTIL_STREAM_NODE(NORMAL_DEPENDENCY, "@aws-sdk/util-stream-node"),
+    UTIL_STREAM_BROWSER(NORMAL_DEPENDENCY, "@aws-sdk/util-stream-browser"),
     FLEXIBLE_CHECKSUMS_MIDDLEWARE(NORMAL_DEPENDENCY, "@aws-sdk/middleware-flexible-checksums");
 
     public final String packageName;


### PR DESCRIPTION
### Issue
Internal JS-3100

### Description
Adds getAwsChunkedEncodingStream to config

### Testing
Tested with model updates in https://github.com/aws/private-aws-sdk-js-v3/pull/106

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
