### PR TITLE
fix(util-stream): rename downlevel-dts to build:types:downlevel

### DIFF
--- a/packages/util-stream-browser/package.json
+++ b/packages/util-stream-browser/package.json
@@ -5,7 +5,7 @@
     "build": "concurrently 'yarn:build:es' 'yarn:build:types'",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
+    "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
     "test": "exit 0"
   },

--- a/packages/util-stream-node/package.json
+++ b/packages/util-stream-node/package.json
@@ -6,7 +6,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
+    "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
     "test": "jest"
   },


### PR DESCRIPTION
### Issue
Internal JS-3127

### Description
The util-stream packages contains the original script `downlevel-dts` added in private, which was renamed to `build:types:downlevel` in public

### Testing
Verified that running `build:types:downlevel` at top level was successful.

```console
$ yarn build:types:downlevel
yarn run v1.22.17
$ node --es-module-specifier-resolution=node ./scripts/downlevel-dts
Done in 67.61s.
```

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
