### PR TITLE
chore(middleware-flexible-checksums): call stringHasher from flexibleChecksumsMiddleware

### DIFF
--- a/packages/middleware-flexible-checksums/src/flexibleChecksumsMiddleware.ts
+++ b/packages/middleware-flexible-checksums/src/flexibleChecksumsMiddleware.ts
@@ -15,6 +15,7 @@ import { FlexibleChecksumsMiddlewareConfig } from "./getFlexibleChecksumsPlugin"
 import { hasHeader } from "./hasHeader";
 import { isStreaming } from "./isStreaming";
 import { selectChecksumAlgorithmFunction } from "./selectChecksumAlgorithmFunction";
+import { stringHasher } from "./stringHasher";
 import { validateChecksumFromResponse } from "./validateChecksumFromResponse";
 
 export const flexibleChecksumsMiddleware =
@@ -59,10 +60,10 @@ export const flexibleChecksumsMiddleware =
         };
         delete updatedHeaders["content-length"];
       } else if (!hasHeader(checksumLocationName, headers)) {
-        const checksum = await getChecksum(requestBody, { streamHasher, checksumAlgorithmFn, base64Encoder });
+        const rawChecksum = await stringHasher(checksumAlgorithmFn, requestBody);
         updatedHeaders = {
           ...headers,
-          [checksumLocationName]: checksum,
+          [checksumLocationName]: base64Encoder(rawChecksum),
         };
       }
     }

--- a/packages/middleware-flexible-checksums/src/flexibleChecksumsMiddleware.ts
+++ b/packages/middleware-flexible-checksums/src/flexibleChecksumsMiddleware.ts
@@ -8,7 +8,6 @@ import {
 } from "@aws-sdk/types";
 
 import { PreviouslyResolved } from "./configuration";
-import { getChecksum } from "./getChecksum";
 import { getChecksumAlgorithmForRequest } from "./getChecksumAlgorithmForRequest";
 import { getChecksumLocationName } from "./getChecksumLocationName";
 import { FlexibleChecksumsMiddlewareConfig } from "./getFlexibleChecksumsPlugin";


### PR DESCRIPTION
### Issue
Follow-up to:
* https://github.com/aws/aws-sdk-js-v3/pull/3340
* https://github.com/aws/aws-sdk-js-v3/pull/3347

### Description
The flexibleChecksumsMiddleware can compute the checksum directly from stringHasher, and doesn't need to call getChecksum which requires both stringHasher/streamHasher.

### Testing
Unit testing

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
