### PR TITLE
fix(hash-stream-node): disable createReadStream with file descriptor

### DIFF
--- a/packages/hash-stream-node/src/fsCreateReadStream.spec.ts
+++ b/packages/hash-stream-node/src/fsCreateReadStream.spec.ts
@@ -7,7 +7,7 @@ jest.setTimeout(30000);
 describe(fsCreateReadStream.name, () => {
   const mockFileContents = fs.readFileSync(__filename, "utf8");
 
-  it("uses file descriptor if defined", (done) => {
+  it.skip("uses file descriptor if defined", (done) => {
     fs.promises.open(__filename, "r").then((fd) => {
       if ((fd as any).createReadStream) {
         const readStream = (fd as any).createReadStream();

--- a/packages/hash-stream-node/src/fsCreateReadStream.ts
+++ b/packages/hash-stream-node/src/fsCreateReadStream.ts
@@ -2,7 +2,8 @@ import { createReadStream, ReadStream } from "fs";
 
 export const fsCreateReadStream = (readStream: ReadStream) =>
   createReadStream(readStream.path, {
-    fd: (readStream as any).fd,
+    // ToDo: Removed to fix https://github.com/aws/aws-sdk-js-v3/issues/3368
+    // fd: (readStream as any).fd,
     start: (readStream as any).start,
     end: (readStream as any).end,
   });


### PR DESCRIPTION
### Issue
Fixes: https://github.com/aws/aws-sdk-js-v3/issues/3368

### Description
Disables createReadStream with file descriptor

### Testing

<details>
<summary>PutObject</summary>

```js
import { S3 } from "../aws-sdk-js-v3/clients/client-s3/dist-cjs/index.js";
import { createReadStream } from "fs";

const region = "us-west-2";
const client = new S3({ region });

// File created with command "(for i in {1..10000}; do echo $i "hello world"; done) > hello-world.txt"
const fileName = "hello-world.txt";
const readableStream = createReadStream(fileName);

const Bucket = "aws-sdk-js-trivikr-flexible-checksums-testing";
const Key = fileName;
const Body = readableStream;
const ChecksumAlgorithm = "CRC32";

await client.putObject({ Bucket, Key, Body, ChecksumAlgorithm });
```

</details>

<details>
<summary>GetObject</summary>

```js
import { S3 } from "../aws-sdk-js-v3/clients/client-s3/dist-cjs/index.js";
import { createWriteStream } from "fs";

const region = "us-west-2";
const client = new S3({ region });

const fileName = "hello-world.txt";
const Bucket = "aws-sdk-js-trivikr-flexible-checksums-testing";
const Key = fileName;
const ChecksumMode = "ENABLED";

const { Body } = await client.getObject({ Bucket, Key, ChecksumMode });
const writeStream = createWriteStream("./hello-world-copy.txt");
Body.pipe(writeStream);

```

</details>

<details>
<summary>diff is empty</summary>

```console
$ diff hello-world.txt hello-world-copy.txt
```

</details>

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
