### PR TITLE
fix(hash-stream-node): support copying fs.ReadStream from file descriptor

### DIFF
--- a/packages/hash-stream-node/src/fsCreateReadStream.spec.ts
+++ b/packages/hash-stream-node/src/fsCreateReadStream.spec.ts
@@ -7,7 +7,7 @@ jest.setTimeout(30000);
 describe(fsCreateReadStream.name, () => {
   const mockFileContents = fs.readFileSync(__filename, "utf8");
 
-  it.skip("uses file descriptor if defined", (done) => {
+  it("uses file descriptor if defined", (done) => {
     fs.promises.open(__filename, "r").then((fd) => {
       if ((fd as any).createReadStream) {
         const readStream = (fd as any).createReadStream();

--- a/packages/hash-stream-node/src/fsCreateReadStream.ts
+++ b/packages/hash-stream-node/src/fsCreateReadStream.ts
@@ -1,9 +1,10 @@
 import { createReadStream, ReadStream } from "fs";
 
 export const fsCreateReadStream = (readStream: ReadStream) =>
-  createReadStream(readStream.path, {
-    // ToDo: Removed to fix https://github.com/aws/aws-sdk-js-v3/issues/3368
-    // fd: (readStream as any).fd,
-    start: (readStream as any).start,
-    end: (readStream as any).end,
-  });
+  typeof readStream.path !== "undefined"
+    ? createReadStream(readStream.path, {
+        start: (readStream as any).start,
+        end: (readStream as any).end,
+      })
+    : // if there is an fd option, filename is ignored by createReadStream
+      createReadStream("", { fd: (readStream as any).fd });


### PR DESCRIPTION
### Issue
Attempt to fix https://github.com/aws/aws-sdk-js-v3/issues/3378

### Description
Support copying fs.ReadStream from file descriptor

### Testing
ToDo: manual integration testing

### Additional context
* The generic PR with file descriptor needs to be fixed https://github.com/aws/aws-sdk-js-v3/issues/3377 before this can be tested.
* We should disable creating a copy of file stream instead as suggested in https://github.com/aws/aws-sdk-js-v3/issues/3378#issuecomment-1054506257

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
