### PR TITLE
chore(util-body-length-node): move calculateBodyLength to it's own file

### DIFF
--- a/packages/util-body-length-node/src/calculateBodyLength.spec.ts
+++ b/packages/util-body-length-node/src/calculateBodyLength.spec.ts
@@ -1,12 +1,23 @@
+import { lstatSync } from "fs";
+
 import { calculateBodyLength } from "./calculateBodyLength";
 
-const arrayBuffer = new ArrayBuffer(1);
-const typedArray = new Uint8Array(1);
-const view = new DataView(arrayBuffer);
+jest.mock("fs");
 
 describe(calculateBodyLength.name, () => {
-  it("should handle null/undefined objects", () => {
-    expect(calculateBodyLength(null)).toEqual(0);
+  const arrayBuffer = new ArrayBuffer(1);
+  const typedArray = new Uint8Array(1);
+  const view = new DataView(arrayBuffer);
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it.each([
+    [0, null],
+    [0, undefined],
+  ])("should return %s for %s", (output, input) => {
+    expect(calculateBodyLength(input)).toEqual(output);
   });
 
   it("should handle string inputs", () => {
@@ -27,5 +38,14 @@ describe(calculateBodyLength.name, () => {
 
   it("should handle DataView inputs", () => {
     expect(calculateBodyLength(view)).toEqual(1);
+  });
+
+  it("should handle stream created using fs.createReadStream", () => {
+    const mockSize = { size: 10 };
+    (lstatSync as jest.Mock).mockReturnValue(mockSize);
+
+    // Populate path as string to mock body created from fs.createReadStream
+    const mockBody = { path: "mockPath" };
+    expect(calculateBodyLength(mockBody)).toEqual(mockSize.size);
   });
 });

--- a/packages/util-body-length-node/src/calculateBodyLength.spec.ts
+++ b/packages/util-body-length-node/src/calculateBodyLength.spec.ts
@@ -1,10 +1,10 @@
-import { calculateBodyLength } from "./";
+import { calculateBodyLength } from "./calculateBodyLength";
 
 const arrayBuffer = new ArrayBuffer(1);
 const typedArray = new Uint8Array(1);
 const view = new DataView(arrayBuffer);
 
-describe("caclulateBodyLength", () => {
+describe(calculateBodyLength.name, () => {
   it("should handle null/undefined objects", () => {
     expect(calculateBodyLength(null)).toEqual(0);
   });

--- a/packages/util-body-length-node/src/calculateBodyLength.spec.ts
+++ b/packages/util-body-length-node/src/calculateBodyLength.spec.ts
@@ -1,8 +1,6 @@
-import { lstatSync } from "fs";
+import { createReadStream, lstatSync } from "fs";
 
 import { calculateBodyLength } from "./calculateBodyLength";
-
-jest.mock("fs");
 
 describe(calculateBodyLength.name, () => {
   const arrayBuffer = new ArrayBuffer(1);
@@ -41,11 +39,8 @@ describe(calculateBodyLength.name, () => {
   });
 
   it("should handle stream created using fs.createReadStream", () => {
-    const mockSize = { size: 10 };
-    (lstatSync as jest.Mock).mockReturnValue(mockSize);
-
-    // Populate path as string to mock body created from fs.createReadStream
-    const mockBody = { path: "mockPath" };
-    expect(calculateBodyLength(mockBody)).toEqual(mockSize.size);
+    const fileSize = lstatSync(__filename).size;
+    const fsReadStream = createReadStream(__filename);
+    expect(calculateBodyLength(fsReadStream)).toEqual(fileSize);
   });
 });

--- a/packages/util-body-length-node/src/calculateBodyLength.ts
+++ b/packages/util-body-length-node/src/calculateBodyLength.ts
@@ -1,0 +1,18 @@
+import { lstatSync } from "fs";
+
+export const calculateBodyLength = (body: any): number | undefined => {
+  if (!body) {
+    return 0;
+  }
+  if (typeof body === "string") {
+    return Buffer.from(body).length;
+  } else if (typeof body.byteLength === "number") {
+    // handles Uint8Array, ArrayBuffer, Buffer, and ArrayBufferView
+    return body.byteLength;
+  } else if (typeof body.size === "number") {
+    return body.size;
+  } else if (typeof body.path === "string") {
+    // handles fs readable streams
+    return lstatSync(body.path).size;
+  }
+};

--- a/packages/util-body-length-node/src/index.ts
+++ b/packages/util-body-length-node/src/index.ts
@@ -1,18 +1,1 @@
-import { lstatSync } from "fs";
-
-export function calculateBodyLength(body: any): number | undefined {
-  if (!body) {
-    return 0;
-  }
-  if (typeof body === "string") {
-    return Buffer.from(body).length;
-  } else if (typeof body.byteLength === "number") {
-    // handles Uint8Array, ArrayBuffer, Buffer, and ArrayBufferView
-    return body.byteLength;
-  } else if (typeof body.size === "number") {
-    return body.size;
-  } else if (typeof body.path === "string") {
-    // handles fs readable streams
-    return lstatSync(body.path).size;
-  }
-}
+export * from "./calculateBodyLength";


### PR DESCRIPTION
### Issue
Refactoring before fix for https://github.com/aws/aws-sdk-js-v3/issues/3377 is posted.

### Description
Moves calculateBodyLength to it's own file, and adds missing unit tests

### Testing
Unit testing

### Additional context
This PR will be rebased after https://github.com/aws/aws-sdk-js-v3/pull/3380 is merged.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
