### PR TITLE
fix(util-body-length-node): fs.ReadStream with path of Buffer type

### DIFF
--- a/packages/util-body-length-node/src/calculateBodyLength.spec.ts
+++ b/packages/util-body-length-node/src/calculateBodyLength.spec.ts
@@ -38,9 +38,17 @@ describe(calculateBodyLength.name, () => {
     expect(calculateBodyLength(view)).toEqual(1);
   });
 
-  it("should handle stream created using fs.createReadStream", () => {
+  describe("should handle stream created using fs.createReadStream", () => {
     const fileSize = lstatSync(__filename).size;
-    const fsReadStream = createReadStream(__filename);
-    expect(calculateBodyLength(fsReadStream)).toEqual(fileSize);
+
+    it("when path is a string", () => {
+      const fsReadStream = createReadStream(__filename);
+      expect(calculateBodyLength(fsReadStream)).toEqual(fileSize);
+    });
+
+    it("when path is a Buffer", () => {
+      const fsReadStream = createReadStream(Buffer.from(__filename));
+      expect(calculateBodyLength(fsReadStream)).toEqual(fileSize);
+    });
   });
 });

--- a/packages/util-body-length-node/src/calculateBodyLength.spec.ts
+++ b/packages/util-body-length-node/src/calculateBodyLength.spec.ts
@@ -1,12 +1,23 @@
+import { lstatSync } from "fs";
+
 import { calculateBodyLength } from "./calculateBodyLength";
 
-const arrayBuffer = new ArrayBuffer(1);
-const typedArray = new Uint8Array(1);
-const view = new DataView(arrayBuffer);
+jest.mock("fs");
 
 describe(calculateBodyLength.name, () => {
-  it("should handle null/undefined objects", () => {
-    expect(calculateBodyLength(null)).toEqual(0);
+  const arrayBuffer = new ArrayBuffer(1);
+  const typedArray = new Uint8Array(1);
+  const view = new DataView(arrayBuffer);
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it.each([
+    [0, null],
+    [0, undefined],
+  ])("should return %s for %s", (output, input) => {
+    expect(calculateBodyLength(input)).toEqual(output);
   });
 
   it("should handle string inputs", () => {
@@ -27,5 +38,14 @@ describe(calculateBodyLength.name, () => {
 
   it("should handle DataView inputs", () => {
     expect(calculateBodyLength(view)).toEqual(1);
+  });
+
+  it("should handle stream created using fs.createReadStream", () => {
+    const mockSize = { size: 10 };
+    (lstatSync as jest.Mock).mockReturnValue(mockSize);
+
+    // Populate path as string to mock body created from fs.createReadStream
+    const mockBody = { path: "mockPath" };
+    expect(calculateBodyLength(mockBody)).toEqual(mockSize.size);
   });
 });

--- a/packages/util-body-length-node/src/calculateBodyLength.spec.ts
+++ b/packages/util-body-length-node/src/calculateBodyLength.spec.ts
@@ -1,21 +1,12 @@
-import { createReadStream, lstatSync } from "fs";
-
 import { calculateBodyLength } from "./calculateBodyLength";
 
+const arrayBuffer = new ArrayBuffer(1);
+const typedArray = new Uint8Array(1);
+const view = new DataView(arrayBuffer);
+
 describe(calculateBodyLength.name, () => {
-  const arrayBuffer = new ArrayBuffer(1);
-  const typedArray = new Uint8Array(1);
-  const view = new DataView(arrayBuffer);
-
-  afterEach(() => {
-    jest.clearAllMocks();
-  });
-
-  it.each([
-    [0, null],
-    [0, undefined],
-  ])("should return %s for %s", (output, input) => {
-    expect(calculateBodyLength(input)).toEqual(output);
+  it("should handle null/undefined objects", () => {
+    expect(calculateBodyLength(null)).toEqual(0);
   });
 
   it("should handle string inputs", () => {
@@ -36,11 +27,5 @@ describe(calculateBodyLength.name, () => {
 
   it("should handle DataView inputs", () => {
     expect(calculateBodyLength(view)).toEqual(1);
-  });
-
-  it("should handle stream created using fs.createReadStream", () => {
-    const fileSize = lstatSync(__filename).size;
-    const fsReadStream = createReadStream(__filename);
-    expect(calculateBodyLength(fsReadStream)).toEqual(fileSize);
   });
 });

--- a/packages/util-body-length-node/src/calculateBodyLength.spec.ts
+++ b/packages/util-body-length-node/src/calculateBodyLength.spec.ts
@@ -1,8 +1,6 @@
-import { lstatSync } from "fs";
+import { createReadStream, lstatSync } from "fs";
 
 import { calculateBodyLength } from "./calculateBodyLength";
-
-jest.mock("fs");
 
 describe(calculateBodyLength.name, () => {
   const arrayBuffer = new ArrayBuffer(1);
@@ -41,11 +39,8 @@ describe(calculateBodyLength.name, () => {
   });
 
   it("should handle stream created using fs.createReadStream", () => {
-    const mockSize = { size: 10 };
-    (lstatSync as jest.Mock).mockReturnValue(mockSize);
-
-    // Populate path as string to mock body created from fs.createReadStream
-    const mockBody = { path: "mockPath" };
-    expect(calculateBodyLength(mockBody)).toEqual(mockSize.size);
+    const fileSize = lstatSync(__filename).size;
+    const fsReadStream = createReadStream(__filename);
+    expect(calculateBodyLength(fsReadStream)).toEqual(fileSize);
   });
 });

--- a/packages/util-body-length-node/src/calculateBodyLength.ts
+++ b/packages/util-body-length-node/src/calculateBodyLength.ts
@@ -11,7 +11,7 @@ export const calculateBodyLength = (body: any): number | undefined => {
     return body.byteLength;
   } else if (typeof body.size === "number") {
     return body.size;
-  } else if (typeof body.path === "string") {
+  } else if (typeof body.path === "string" || Buffer.isBuffer(body.path)) {
     // handles fs readable streams
     return lstatSync(body.path).size;
   }


### PR DESCRIPTION
### Issue
Fixes: https://github.com/aws/aws-sdk-js-v3/issues/3383

### Description
Supports computation of body length when fs.ReadStream is created with path of type Buffer.

### Testing
Verified that object is successfully uploaded

<details>
<summary>PutObject without Checksum</summary>

```js
import { S3 } from "../aws-sdk-js-v3/clients/client-s3/dist-cjs/index.js";
import { createReadStream } from "fs";

const region = "us-west-2";
const client = new S3({ region });

// File created with command "(for i in {1..1000}; do echo $i "hello world"; done) > hello-world.txt"
const fileName = "hello-world.txt";
const readableStream = createReadStream(Buffer.from(fileName));

const Bucket = "aws-sdk-js-trivikr";
const Key = fileName;
const Body = readableStream;

try {
  await client.putObject({ Bucket, Key, Body });
} catch (error) {
  console.log({ error });
}
```

</details>

<details>
<summary>PutObject with Checksum</summary>

```js
import { S3 } from "../aws-sdk-js-v3/clients/client-s3/dist-cjs/index.js";
import { createReadStream } from "fs";

const region = "us-west-2";
const client = new S3({ region });

// File created with command "(for i in {1..1000}; do echo $i "hello world"; done) > hello-world.txt"
const fileName = "hello-world.txt";
const readableStream = createReadStream(Buffer.from(fileName));

const Bucket = "aws-sdk-js-trivikr";
const Key = fileName;
const Body = readableStream;
const ChecksumAlgorithm = "CRC32";

try {
  await client.putObject({ Bucket, Key, Body, ChecksumAlgorithm });
} catch (error) {
  console.log({ error });
}
```

</details>

### Additional context
~~This PR will be made ready after https://github.com/aws/aws-sdk-js-v3/pull/3381 is merged.~~ Ready!

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
