### PR TITLE
fix(util-body-length-node): support fd.createReadStream

### DIFF
--- a/packages/util-body-length-node/src/calculateBodyLength.spec.ts
+++ b/packages/util-body-length-node/src/calculateBodyLength.spec.ts
@@ -1,12 +1,23 @@
+import { lstatSync } from "fs";
+
 import { calculateBodyLength } from "./calculateBodyLength";
 
-const arrayBuffer = new ArrayBuffer(1);
-const typedArray = new Uint8Array(1);
-const view = new DataView(arrayBuffer);
+jest.mock("fs");
 
 describe(calculateBodyLength.name, () => {
-  it("should handle null/undefined objects", () => {
-    expect(calculateBodyLength(null)).toEqual(0);
+  const arrayBuffer = new ArrayBuffer(1);
+  const typedArray = new Uint8Array(1);
+  const view = new DataView(arrayBuffer);
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it.each([
+    [0, null],
+    [0, undefined],
+  ])("should return %s for %s", (output, input) => {
+    expect(calculateBodyLength(input)).toEqual(output);
   });
 
   it("should handle string inputs", () => {
@@ -27,5 +38,14 @@ describe(calculateBodyLength.name, () => {
 
   it("should handle DataView inputs", () => {
     expect(calculateBodyLength(view)).toEqual(1);
+  });
+
+  it("should handle stream created using fs.createReadStream", () => {
+    const mockSize = { size: 10 };
+    (lstatSync as jest.Mock).mockReturnValue(mockSize);
+
+    // Populate path as string to mock body created from fs.createReadStream
+    const mockBody = { path: "mockPath" };
+    expect(calculateBodyLength(mockBody)).toEqual(mockSize.size);
   });
 });

--- a/packages/util-body-length-node/src/calculateBodyLength.spec.ts
+++ b/packages/util-body-length-node/src/calculateBodyLength.spec.ts
@@ -41,9 +41,16 @@ describe(calculateBodyLength.name, () => {
   describe("fs.ReadStream", () => {
     const fileSize = lstatSync(__filename).size;
 
-    it("should handle stream created using fs.createReadStream", () => {
-      const fsReadStream = createReadStream(__filename);
-      expect(calculateBodyLength(fsReadStream)).toEqual(fileSize);
+    describe("should handle stream created using fs.createReadStream", () => {
+      it("when path is a string", () => {
+        const fsReadStream = createReadStream(__filename);
+        expect(calculateBodyLength(fsReadStream)).toEqual(fileSize);
+      });
+
+      it("when path is a Buffer", () => {
+        const fsReadStream = createReadStream(Buffer.from(__filename));
+        expect(calculateBodyLength(fsReadStream)).toEqual(fileSize);
+      });
     });
 
     it("should handle stream created using fd.createReadStream", async () => {

--- a/packages/util-body-length-node/src/calculateBodyLength.spec.ts
+++ b/packages/util-body-length-node/src/calculateBodyLength.spec.ts
@@ -1,4 +1,4 @@
-import { createReadStream, lstatSync } from "fs";
+import { createReadStream, lstatSync, promises } from "fs";
 
 import { calculateBodyLength } from "./calculateBodyLength";
 
@@ -38,9 +38,20 @@ describe(calculateBodyLength.name, () => {
     expect(calculateBodyLength(view)).toEqual(1);
   });
 
-  it("should handle stream created using fs.createReadStream", () => {
+  describe("fs.ReadStream", () => {
     const fileSize = lstatSync(__filename).size;
-    const fsReadStream = createReadStream(__filename);
-    expect(calculateBodyLength(fsReadStream)).toEqual(fileSize);
+
+    it("should handle stream created using fs.createReadStream", () => {
+      const fsReadStream = createReadStream(__filename);
+      expect(calculateBodyLength(fsReadStream)).toEqual(fileSize);
+    });
+
+    it("should handle stream created using fd.createReadStream", async () => {
+      const fd = await promises.open(__filename, "r");
+      if ((fd as any).createReadStream) {
+        const fdReadStream = (fd as any).createReadStream();
+        expect(calculateBodyLength(fdReadStream)).toEqual(fileSize);
+      }
+    });
   });
 });

--- a/packages/util-body-length-node/src/calculateBodyLength.spec.ts
+++ b/packages/util-body-length-node/src/calculateBodyLength.spec.ts
@@ -1,21 +1,12 @@
-import { createReadStream, lstatSync } from "fs";
-
 import { calculateBodyLength } from "./calculateBodyLength";
 
+const arrayBuffer = new ArrayBuffer(1);
+const typedArray = new Uint8Array(1);
+const view = new DataView(arrayBuffer);
+
 describe(calculateBodyLength.name, () => {
-  const arrayBuffer = new ArrayBuffer(1);
-  const typedArray = new Uint8Array(1);
-  const view = new DataView(arrayBuffer);
-
-  afterEach(() => {
-    jest.clearAllMocks();
-  });
-
-  it.each([
-    [0, null],
-    [0, undefined],
-  ])("should return %s for %s", (output, input) => {
-    expect(calculateBodyLength(input)).toEqual(output);
+  it("should handle null/undefined objects", () => {
+    expect(calculateBodyLength(null)).toEqual(0);
   });
 
   it("should handle string inputs", () => {
@@ -36,19 +27,5 @@ describe(calculateBodyLength.name, () => {
 
   it("should handle DataView inputs", () => {
     expect(calculateBodyLength(view)).toEqual(1);
-  });
-
-  describe("should handle stream created using fs.createReadStream", () => {
-    const fileSize = lstatSync(__filename).size;
-
-    it("when path is a string", () => {
-      const fsReadStream = createReadStream(__filename);
-      expect(calculateBodyLength(fsReadStream)).toEqual(fileSize);
-    });
-
-    it("when path is a Buffer", () => {
-      const fsReadStream = createReadStream(Buffer.from(__filename));
-      expect(calculateBodyLength(fsReadStream)).toEqual(fileSize);
-    });
   });
 });

--- a/packages/util-body-length-node/src/calculateBodyLength.spec.ts
+++ b/packages/util-body-length-node/src/calculateBodyLength.spec.ts
@@ -1,8 +1,6 @@
-import { lstatSync } from "fs";
+import { createReadStream, lstatSync } from "fs";
 
 import { calculateBodyLength } from "./calculateBodyLength";
-
-jest.mock("fs");
 
 describe(calculateBodyLength.name, () => {
   const arrayBuffer = new ArrayBuffer(1);
@@ -41,11 +39,8 @@ describe(calculateBodyLength.name, () => {
   });
 
   it("should handle stream created using fs.createReadStream", () => {
-    const mockSize = { size: 10 };
-    (lstatSync as jest.Mock).mockReturnValue(mockSize);
-
-    // Populate path as string to mock body created from fs.createReadStream
-    const mockBody = { path: "mockPath" };
-    expect(calculateBodyLength(mockBody)).toEqual(mockSize.size);
+    const fileSize = lstatSync(__filename).size;
+    const fsReadStream = createReadStream(__filename);
+    expect(calculateBodyLength(fsReadStream)).toEqual(fileSize);
   });
 });

--- a/packages/util-body-length-node/src/calculateBodyLength.ts
+++ b/packages/util-body-length-node/src/calculateBodyLength.ts
@@ -1,4 +1,4 @@
-import { lstatSync } from "fs";
+import { fstatSync, lstatSync } from "fs";
 
 export const calculateBodyLength = (body: any): number | undefined => {
   if (!body) {
@@ -14,5 +14,8 @@ export const calculateBodyLength = (body: any): number | undefined => {
   } else if (typeof body.path === "string" || Buffer.isBuffer(body.path)) {
     // handles fs readable streams
     return lstatSync(body.path).size;
+  } else if (typeof body.fd === "number") {
+    // handles fd readable streams
+    return fstatSync(body.fd).size;
   }
 };


### PR DESCRIPTION
### Issue
Fixes: https://github.com/aws/aws-sdk-js-v3/issues/3377

### Description
Compute length when fs.ReadStream is created using fd.createReadStream

### Testing
Verified that object is successfully put in the following cases:

<details>
<summary>PutObject without Checksum</summary>

```js
import { S3 } from "../aws-sdk-js-v3/clients/client-s3/dist-cjs/index.js";
import { open } from "fs/promises";

const region = "us-west-2";
const client = new S3({ region });

// File created with command "(for i in {1..1000}; do echo $i "hello world"; done) > hello-world.txt"
const fileName = "hello-world.txt";
const fd = await open(fileName);
const readableStream = fd.createReadStream();

const Bucket = "aws-sdk-js-trivikr";
const Key = fileName;
const Body = readableStream;

try {
  await client.putObject({ Bucket, Key, Body });
} catch (error) {
  console.log({ error });
}
```

</details>

<details>
<summary>PutObject with Checksum</summary>

```js
import { S3 } from "../aws-sdk-js-v3/clients/client-s3/dist-cjs/index.js";
import { open } from "fs/promises";

const region = "us-west-2";
const client = new S3({ region });

// File created with command "(for i in {1..1000}; do echo $i "hello world"; done) > hello-world.txt"
const fileName = "hello-world.txt";
const fd = await open(fileName);
const readableStream = fd.createReadStream();

const Bucket = "aws-sdk-js-trivikr";
const Key = fileName;
const Body = readableStream;
const ChecksumAlgorithm = "CRC32";

try {
  await client.putObject({ Bucket, Key, Body, ChecksumAlgorithm });
} catch (error) {
  console.log({ error });
}
```

</details>

### Additional context
~~This PR will be rebased after https://github.com/aws/aws-sdk-js-v3/pull/3384 is merged.~~ Ready!

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
