### PR TITLE
chore(util-body-length): throw Error if body length can't be computed

### DIFF
--- a/packages/util-body-length-browser/src/calculateBodyLength.spec.ts
+++ b/packages/util-body-length-browser/src/calculateBodyLength.spec.ts
@@ -33,4 +33,10 @@ describe(calculateBodyLength.name, () => {
     };
     expect(calculateBodyLength(mockFileObject)).toEqual(mockFileObject.size);
   });
+
+  it.each([true, 1, {}, []])("throws error if Body Length computation fails for: %s", (body) => {
+    expect(() => {
+      expect(calculateBodyLength(body));
+    }).toThrowError(`Body Length computation failed for ${body}`);
+  });
 });

--- a/packages/util-body-length-browser/src/calculateBodyLength.ts
+++ b/packages/util-body-length-browser/src/calculateBodyLength.ts
@@ -16,4 +16,5 @@ export const calculateBodyLength = (body: any): number | undefined => {
     // handles browser File object
     return body.size;
   }
+  throw new Error(`Body Length computation failed for ${body}`);
 };

--- a/packages/util-body-length-node/src/calculateBodyLength.spec.ts
+++ b/packages/util-body-length-node/src/calculateBodyLength.spec.ts
@@ -61,4 +61,10 @@ describe(calculateBodyLength.name, () => {
       }
     });
   });
+
+  it.each([true, 1, {}, []])("throws error if Body Length computation fails for: %s", (body) => {
+    expect(() => {
+      expect(calculateBodyLength(body));
+    }).toThrowError(`Body Length computation failed for ${body}`);
+  });
 });

--- a/packages/util-body-length-node/src/calculateBodyLength.ts
+++ b/packages/util-body-length-node/src/calculateBodyLength.ts
@@ -18,4 +18,5 @@ export const calculateBodyLength = (body: any): number | undefined => {
     // handles fd readable streams
     return fstatSync(body.fd).size;
   }
+  throw new Error(`Body Length computation failed for ${body}`);
 };


### PR DESCRIPTION
### Issue
Refs: https://github.com/aws/aws-sdk-js-v3/issues/3400

### Description
Throw Error if body length can't be computed

### Testing
* Unit testing
* Integration testing

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
