### PR TITLE
feat(credential-provider-imds): support static stability

### DIFF
--- a/packages/credential-provider-imds/src/fromContainerMetadata.spec.ts
+++ b/packages/credential-provider-imds/src/fromContainerMetadata.spec.ts
@@ -8,7 +8,7 @@ import { httpRequest } from "./remoteProvider/httpRequest";
 import { fromImdsCredentials, ImdsCredentials } from "./remoteProvider/ImdsCredentials";
 
 const mockHttpRequest = <any>httpRequest;
-jest.mock("./remoteProvider/httpRequest", () => ({ httpRequest: jest.fn() }));
+jest.mock("./remoteProvider/httpRequest");
 
 const relativeUri = process.env[ENV_CMDS_RELATIVE_URI];
 const fullUri = process.env[ENV_CMDS_FULL_URI];

--- a/packages/credential-provider-imds/src/index.ts
+++ b/packages/credential-provider-imds/src/index.ts
@@ -1,5 +1,6 @@
 export * from "./fromContainerMetadata";
 export * from "./fromInstanceMetadata";
 export * from "./remoteProvider/RemoteProviderInit";
+export * from "./types";
 export { httpRequest } from "./remoteProvider/httpRequest";
 export { getInstanceMetadataEndpoint } from "./utils/getInstanceMetadataEndpoint";

--- a/packages/credential-provider-imds/src/types.ts
+++ b/packages/credential-provider-imds/src/types.ts
@@ -1,0 +1,5 @@
+import { Credentials } from "@aws-sdk/types";
+
+export interface InstanceMetadataCredentials extends Credentials {
+  readonly originalExpiration?: Date;
+}

--- a/packages/credential-provider-imds/src/utils/getExtendedInstanceMetadataCredentials.spec.ts
+++ b/packages/credential-provider-imds/src/utils/getExtendedInstanceMetadataCredentials.spec.ts
@@ -1,0 +1,37 @@
+import { getExtendedInstanceMetadataCredentials } from "./getExtendedInstanceMetadataCredentials";
+
+describe("getExtendedInstanceMetadataCredentials()", () => {
+  let nowMock: jest.SpyInstance;
+  const staticSecret = {
+    accessKeyId: "key",
+    secretAccessKey: "secret",
+  };
+
+  beforeEach(() => {
+    jest.spyOn(global.console, "warn").mockImplementation(() => {});
+    jest.spyOn(global.Math, "random");
+    nowMock = jest.spyOn(Date, "now").mockReturnValueOnce(new Date("2022-02-22T00:00:00Z").getTime());
+  });
+
+  afterEach(() => {
+    nowMock.mockRestore();
+  });
+
+  it("should extend the expiration random time(~15 mins) from now", () => {
+    const anyDate: Date = "any date" as unknown as Date;
+    (Math.random as jest.Mock).mockReturnValue(0.5);
+    expect(getExtendedInstanceMetadataCredentials({ ...staticSecret, expiration: anyDate })).toEqual({
+      ...staticSecret,
+      originalExpiration: anyDate,
+      expiration: new Date("2022-02-22T00:17:30Z"),
+    });
+    expect(Math.random).toBeCalledTimes(1);
+  });
+
+  it("should print warning message when extending the credentials", () => {
+    const anyDate: Date = "any date" as unknown as Date;
+    getExtendedInstanceMetadataCredentials({ ...staticSecret, expiration: anyDate });
+    // TODO: fill the doc link
+    expect(console.warn).toBeCalledWith(expect.stringContaining("cannot renew the credential"));
+  });
+});

--- a/packages/credential-provider-imds/src/utils/getExtendedInstanceMetadataCredentials.spec.ts
+++ b/packages/credential-provider-imds/src/utils/getExtendedInstanceMetadataCredentials.spec.ts
@@ -32,6 +32,6 @@ describe("getExtendedInstanceMetadataCredentials()", () => {
     const anyDate: Date = "any date" as unknown as Date;
     getExtendedInstanceMetadataCredentials({ ...staticSecret, expiration: anyDate });
     // TODO: fill the doc link
-    expect(console.warn).toBeCalledWith(expect.stringContaining("cannot renew the credential"));
+    expect(console.warn).toBeCalledWith(expect.stringContaining("Attempting credential expiration extension"));
   });
 });

--- a/packages/credential-provider-imds/src/utils/getExtendedInstanceMetadataCredentials.ts
+++ b/packages/credential-provider-imds/src/utils/getExtendedInstanceMetadataCredentials.ts
@@ -3,7 +3,7 @@ import { InstanceMetadataCredentials } from "../types";
 const STATIC_STABILITY_REFRESH_INTERVAL_SECONDS = 15 * 60;
 const STATIC_STABILITY_REFRESH_INTERVAL_JITTER_WINDOW_SECONDS = 5 * 60;
 // TODO
-const STATIC_STABILITY_DOC_URL = "TBD";
+const STATIC_STABILITY_DOC_URL = "https://docs.aws.amazon.com/sdkref/latest/guide/feature-static-credentials.html";
 
 export const getExtendedInstanceMetadataCredentials = (
   credentials: InstanceMetadataCredentials
@@ -14,8 +14,9 @@ export const getExtendedInstanceMetadataCredentials = (
   const newExpiration = new Date(Date.now() + refreshInterval * 1000);
   // ToDo: Call warn function on logger from configuration
   console.warn(
-    "SDK cannot renew the credential from IMDS service. Extending the expiration of existing credentials " +
-      `to ${new Date(newExpiration)}.\nFor more information, please visit: ${STATIC_STABILITY_DOC_URL}`
+    "Attempting credential expiration extension due to a credential service availability issue. A refresh of these " +
+      "credentials will be attempted after ${new Date(newExpiration)}.\nFor more information, please visit: " +
+      STATIC_STABILITY_DOC_URL
   );
   const originalExpiration = credentials.originalExpiration ?? credentials.expiration;
   return {

--- a/packages/credential-provider-imds/src/utils/getExtendedInstanceMetadataCredentials.ts
+++ b/packages/credential-provider-imds/src/utils/getExtendedInstanceMetadataCredentials.ts
@@ -1,0 +1,26 @@
+import { InstanceMetadataCredentials } from "../types";
+
+const STATIC_STABILITY_REFRESH_INTERVAL_SECONDS = 15 * 60;
+const STATIC_STABILITY_REFRESH_INTERVAL_JITTER_WINDOW_SECONDS = 5 * 60;
+// TODO
+const STATIC_STABILITY_DOC_URL = "TBD";
+
+export const getExtendedInstanceMetadataCredentials = (
+  credentials: InstanceMetadataCredentials
+): InstanceMetadataCredentials => {
+  const refreshInterval =
+    STATIC_STABILITY_REFRESH_INTERVAL_SECONDS +
+    Math.floor(Math.random() * STATIC_STABILITY_REFRESH_INTERVAL_JITTER_WINDOW_SECONDS);
+  const newExpiration = new Date(Date.now() + refreshInterval * 1000);
+  // ToDo: Call warn function on logger from configuration
+  console.warn(
+    "SDK cannot renew the credential from IMDS service. Extending the expiration of existing credentials " +
+      `to ${new Date(newExpiration)}.\nFor more information, please visit: ${STATIC_STABILITY_DOC_URL}`
+  );
+  const originalExpiration = credentials.originalExpiration ?? credentials.expiration;
+  return {
+    ...credentials,
+    ...(originalExpiration ? { originalExpiration } : {}),
+    expiration: newExpiration,
+  };
+};

--- a/packages/credential-provider-imds/src/utils/staticStabilityProvider.spec.ts
+++ b/packages/credential-provider-imds/src/utils/staticStabilityProvider.spec.ts
@@ -1,0 +1,87 @@
+import { getExtendedInstanceMetadataCredentials } from "./getExtendedInstanceMetadataCredentials";
+import { staticStabilityProvider } from "./staticStabilityProvider";
+
+jest.mock("./getExtendedInstanceMetadataCredentials");
+
+describe("staticStabilityProvider", () => {
+  const ONE_HOUR_IN_FUTURE = new Date(Date.now() + 60 * 60 * 1000);
+  const mockCreds = {
+    accessKeyId: "key",
+    secretAccessKey: "secret",
+    sessionToken: "settion",
+    expiration: ONE_HOUR_IN_FUTURE,
+  };
+
+  beforeEach(() => {
+    (getExtendedInstanceMetadataCredentials as jest.Mock).mockImplementation(
+      (() => {
+        let extensionCount = 0;
+        return (input) => {
+          extensionCount++;
+          return {
+            ...input,
+            expiration: `Extending expiration count: ${extensionCount}`,
+          };
+        };
+      })()
+    );
+    jest.spyOn(global.console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it("should refresh credentials if provider is functional", async () => {
+    const provider = jest.fn();
+    const stableProvider = staticStabilityProvider(provider);
+    const repeat = 3;
+    for (let i = 0; i < repeat; i++) {
+      const newCreds = { ...mockCreds, accessKeyId: String(i + 1) };
+      provider.mockReset().mockResolvedValue(newCreds);
+      expect(await stableProvider()).toEqual(newCreds);
+    }
+  });
+
+  it("should throw if cannot load credentials at 1st load", async () => {
+    const provider = jest.fn().mockRejectedValue("Error");
+    try {
+      await staticStabilityProvider(provider)();
+      fail("This provider should throw");
+    } catch (e) {
+      expect(getExtendedInstanceMetadataCredentials).not.toBeCalled();
+      expect(provider).toBeCalledTimes(1);
+      expect(e).toEqual("Error");
+    }
+  });
+
+  it("should extend expired credentials if refresh fails", async () => {
+    const provider = jest.fn().mockResolvedValueOnce(mockCreds).mockRejectedValue("Error");
+    const stableProvider = staticStabilityProvider(provider);
+    expect(await stableProvider()).toEqual(mockCreds);
+    const repeat = 3;
+    for (let i = 0; i < repeat; i++) {
+      const newCreds = await stableProvider();
+      expect(newCreds).toMatchObject({ ...mockCreds, expiration: expect.stringContaining(`count: ${i + 1}`) });
+      expect(console.warn).toHaveBeenLastCalledWith(
+        expect.stringContaining("Credential renew failed:"),
+        expect.anything()
+      );
+    }
+    expect(getExtendedInstanceMetadataCredentials).toBeCalledTimes(repeat);
+    expect(console.warn).toBeCalledTimes(repeat);
+  });
+
+  it("should extend expired credentials if loaded expired credentials", async () => {
+    const ONE_HOUR_AGO = new Date(Date.now() - 60 * 60 * 1000);
+    const provider = jest.fn().mockResolvedValue({ ...mockCreds, expiration: ONE_HOUR_AGO });
+    const stableProvider = staticStabilityProvider(provider);
+    const repeat = 3;
+    for (let i = 0; i < repeat; i++) {
+      const newCreds = await stableProvider();
+      expect(newCreds).toMatchObject({ ...mockCreds, expiration: expect.stringContaining(`count: ${i + 1}`) });
+    }
+    expect(getExtendedInstanceMetadataCredentials).toBeCalledTimes(repeat);
+    expect(console.warn).not.toBeCalled();
+  });
+});

--- a/packages/credential-provider-imds/src/utils/staticStabilityProvider.ts
+++ b/packages/credential-provider-imds/src/utils/staticStabilityProvider.ts
@@ -1,0 +1,38 @@
+import { Credentials, Provider } from "@aws-sdk/types";
+
+import { InstanceMetadataCredentials } from "../types";
+import { getExtendedInstanceMetadataCredentials } from "./getExtendedInstanceMetadataCredentials";
+
+/**
+ * IMDS credential supports static stability feature. When used, the expiration
+ * of recently issued credentials is extended. The server side allows using
+ * the recently expired credentials. This mitigates impact when clients using
+ * refreshable credentials are unable to retrieve updates.
+ *
+ * @param provider Credential provider
+ * @returns A credential provider that supports static stability
+ */
+export const staticStabilityProvider = (
+  provider: Provider<InstanceMetadataCredentials>
+): Provider<InstanceMetadataCredentials> => {
+  let pastCredentials: InstanceMetadataCredentials;
+  return async () => {
+    let credentials: InstanceMetadataCredentials;
+    try {
+      credentials = await provider();
+      if (credentials.expiration && credentials.expiration.getTime() < Date.now()) {
+        credentials = getExtendedInstanceMetadataCredentials(credentials);
+      }
+    } catch (e) {
+      if (pastCredentials) {
+        // ToDo: Call warn function on logger from configuration
+        console.warn("Credential renew failed: ", e);
+        credentials = getExtendedInstanceMetadataCredentials(pastCredentials);
+      } else {
+        throw e;
+      }
+    }
+    pastCredentials = credentials;
+    return credentials;
+  };
+};


### PR DESCRIPTION
### Description
Implement static stability strategy to support cases when IMDS is unable to refresh credentials.


---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
