### PR TITLE
chore(middleware-content-length): set transfer-encoding if content-length is not set

### DIFF
--- a/packages/middleware-content-length/src/index.ts
+++ b/packages/middleware-content-length/src/index.ts
@@ -11,6 +11,7 @@ import {
 } from "@aws-sdk/types";
 
 const CONTENT_LENGTH_HEADER = "content-length";
+const TRANSFER_ENCODING_HEADER = "transfer-encoding";
 
 export function contentLengthMiddleware(bodyLengthChecker: BodyLengthCalculator): BuildMiddleware<any, any> {
   return <Output extends MetadataBearer>(next: BuildHandler<any, Output>): BuildHandler<any, Output> =>
@@ -24,11 +25,16 @@ export function contentLengthMiddleware(bodyLengthChecker: BodyLengthCalculator)
             .map((str) => str.toLowerCase())
             .indexOf(CONTENT_LENGTH_HEADER) === -1
         ) {
-          const length = bodyLengthChecker(body);
-          if (length !== undefined) {
+          try {
+            const length = bodyLengthChecker(body);
             request.headers = {
               ...request.headers,
               [CONTENT_LENGTH_HEADER]: String(length),
+            };
+          } catch (error) {
+            request.headers = {
+              ...request.headers,
+              [TRANSFER_ENCODING_HEADER]: "chunked",
             };
           }
         }


### PR DESCRIPTION
### Issue
Refs: https://github.com/aws/aws-sdk-js-v3/issues/3400

### Description
Sets transfer-encoding if content-length is not set.
Refs: https://github.com/aws/aws-sdk-js-v3/issues/3400#issuecomment-1062366026

### Testing
* Integration testing
* Unit tests are not present for the middleware, and should be added in a separate PR.

Verified that `transfer-encoding` header is set to `chunked` in the following test case when we attempt to send ReadableStream to PutObject:

```js
import { S3 } from "../aws-sdk-js-v3/clients/client-s3/dist-cjs/index.js";
import { Readable } from "stream";

const region = "us-west-2";
const client = new S3({ region });

const readableStream = new Readable();

const mockDataChunks = ["Hello", "World"];
setTimeout(() => {
  mockDataChunks.forEach((chunk) => readableStream.emit("data", chunk));
  readableStream.emit("end");
}, 1000);

const Bucket = "aws-sdk-js-trivikr";
const Key = "hello-world.txt";
const Body = readableStream;

try {
  await client.putObject({ Bucket, Key, Body });
} catch (error) {
  console.log({ error });
}
```

Irrespective of whether `Transfer-Encoding` is set (in PR) or not (in v3.53.1 with flexible checksums, or v3.52.0 prior to flexible checksums), the code fails with error:

```console
NotImplemented: A header you provided implies functionality that is not implemented
      at deserializeAws_restXmlPutObjectCommandError (/local/home/trivikr/workspace/aws-sdk-js-v3/clients/client-s3/dist-cjs/protocols/Aws_restXml.js:8037:24)
      at processTicksAndRejections (node:internal/process/task_queues:96:5)
      at async /local/home/trivikr/workspace/aws-sdk-js-v3/packages/middleware-serde/dist-cjs/deserializerMiddleware.js:7:24
      at async /local/home/trivikr/workspace/aws-sdk-js-v3/packages/middleware-signing/dist-cjs/middleware.js:11:20
      at async StandardRetryStrategy.retry (/local/home/trivikr/workspace/aws-sdk-js-v3/packages/middleware-retry/dist-cjs/StandardRetryStrategy.js:51:46)
      at async /local/home/trivikr/workspace/aws-sdk-js-v3/packages/middleware-flexible-checksums/dist-cjs/flexibleChecksumsMiddleware.js:56:20
      at async /local/home/trivikr/workspace/aws-sdk-js-v3/packages/middleware-logger/dist-cjs/loggerMiddleware.js:6:22
      at async file:///local/home/trivikr/workspace/temp/putObject.fd.mjs:20:3 {
    '$fault': 'client',
    '$metadata': {
      httpStatusCode: 501,
      requestId: undefined,
      extendedRequestId: 'YUlBcbnai0WfSRASq95c8Kh06Jg1qFmJL1RJLLHFFHpQIY3pD8+LZry4nv1U6bOYlkFK3vcdYAk=',
      cfId: undefined,
      attempts: 1,
      totalRetryDelay: 0
    },
    Code: 'NotImplemented',
    Header: 'Transfer-Encoding',
    RequestId: 'FFVSGD9GE62NHY9T',
    HostId: 'YUlBcbnai0WfSRASq95c8Kh06Jg1qFmJL1RJLLHFFHpQIY3pD8+LZry4nv1U6bOYlkFK3vcdYAk=',
    '$response': HttpResponse {
      statusCode: 501,
      headers: [Object],
      body: [IncomingMessage]
    }
  }
```

</details>

The error should be discussed separately if needed. We're following RFC7230 spec, and the behavior in AWS SDK for Python.

### Additional context
~~This PR will be rebased and made ready once https://github.com/aws/aws-sdk-js-v3/pull/3401 is merged.~~ Ready

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.