### PR TITLE
chore(types): update BodyLengthCalculator to return number

### DIFF
--- a/packages/types/src/util.ts
+++ b/packages/types/src/util.ts
@@ -51,7 +51,7 @@ export interface Provider<T> {
  * the size of the file.
  */
 export interface BodyLengthCalculator {
-  (body: any): number | undefined;
+  (body: any): number;
 }
 
 /**


### PR DESCRIPTION
### Issue
Fixes: https://github.com/aws/aws-sdk-js-v3/issues/3400

### Description
BodyLengthCalculator need not return undefined, as we throw error in cases where body length can't be computed.

### Testing
CI

### Additional context
This PR will be made ready when https://github.com/aws/aws-sdk-js-v3/pull/3405 is merged.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.