### PR TITLE
chore(packages): set bodyLengthChecker type to BodyLengthCalculator

### DIFF
--- a/packages/middleware-flexible-checksums/src/configuration.ts
+++ b/packages/middleware-flexible-checksums/src/configuration.ts
@@ -1,4 +1,10 @@
-import { Encoder, GetAwsChunkedEncodingStream, HashConstructor, StreamHasher } from "@aws-sdk/types";
+import {
+  BodyLengthCalculator,
+  Encoder,
+  GetAwsChunkedEncodingStream,
+  HashConstructor,
+  StreamHasher,
+} from "@aws-sdk/types";
 
 export interface PreviouslyResolved {
   /**
@@ -10,7 +16,7 @@ export interface PreviouslyResolved {
   /**
    * A function that can calculate the length of a body.
    */
-  bodyLengthChecker: (body: any) => number | undefined;
+  bodyLengthChecker: BodyLengthCalculator;
 
   /**
    * A function that returns Readable Stream which follows aws-chunked encoding stream.

--- a/packages/types/src/stream.ts
+++ b/packages/types/src/stream.ts
@@ -1,9 +1,9 @@
 import { HashConstructor, StreamHasher } from "./crypto";
-import { Encoder } from "./util";
+import { BodyLengthCalculator, Encoder } from "./util";
 
 export interface GetAwsChunkedEncodingStreamOptions {
   base64Encoder?: Encoder;
-  bodyLengthChecker: (body: any) => number | undefined;
+  bodyLengthChecker: BodyLengthCalculator;
   checksumAlgorithmFn?: HashConstructor;
   checksumLocationName?: string;
   streamHasher?: StreamHasher;


### PR DESCRIPTION
### Issue
The packages equivalent of https://github.com/aws/aws-sdk-js-v3/pull/3405

### Description
Sets bodyLengthChecker type to BodyLengthCalculator in packages

### Testing
CI

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
