### PR TITLE
feat(property-provider): memoize() supports force refresh

### DIFF
--- a/packages/credential-provider-node/src/defaultProvider.ts
+++ b/packages/credential-provider-node/src/defaultProvider.ts
@@ -6,7 +6,7 @@ import { fromSSO, FromSSOInit } from "@aws-sdk/credential-provider-sso";
 import { fromTokenFile, FromTokenFileInit } from "@aws-sdk/credential-provider-web-identity";
 import { chain, CredentialsProviderError, memoize } from "@aws-sdk/property-provider";
 import { ENV_PROFILE, loadSharedConfigFiles } from "@aws-sdk/shared-ini-file-loader";
-import { CredentialProvider } from "@aws-sdk/types";
+import { Credentials, MemoizedProvider } from "@aws-sdk/types";
 
 import { remoteProvider } from "./remoteProvider";
 
@@ -46,7 +46,7 @@ import { remoteProvider } from "./remoteProvider";
  */
 export const defaultProvider = (
   init: FromIniInit & RemoteProviderInit & FromProcessInit & FromSSOInit & FromTokenFileInit = {}
-): CredentialProvider => {
+): MemoizedProvider<Credentials> => {
   const options = {
     profile: process.env[ENV_PROFILE],
     ...init,

--- a/packages/middleware-endpoint-discovery/src/resolveEndpointDiscoveryConfig.ts
+++ b/packages/middleware-endpoint-discovery/src/resolveEndpointDiscoveryConfig.ts
@@ -1,11 +1,11 @@
 import { EndpointCache } from "@aws-sdk/endpoint-cache";
-import { Credentials, Provider } from "@aws-sdk/types";
+import { Credentials, MemoizedProvider, Provider } from "@aws-sdk/types";
 
 export interface EndpointDiscoveryInputConfig {}
 
 export interface PreviouslyResolved {
   isCustomEndpoint: boolean;
-  credentials: Provider<Credentials>;
+  credentials: MemoizedProvider<Credentials>;
   endpointDiscoveryEnabledProvider: Provider<boolean | undefined>;
 }
 

--- a/packages/middleware-sdk-ec2/src/index.ts
+++ b/packages/middleware-sdk-ec2/src/index.ts
@@ -9,6 +9,7 @@ import {
   InitializeHandlerOptions,
   InitializeHandlerOutput,
   InitializeMiddleware,
+  MemoizedProvider,
   MetadataBearer,
   Pluggable,
   Provider,
@@ -16,7 +17,7 @@ import {
 import { formatUrl } from "@aws-sdk/util-format-url";
 
 interface PreviouslyResolved {
-  credentials: Provider<Credentials>;
+  credentials: MemoizedProvider<Credentials>;
   endpoint: Provider<Endpoint>;
   region: Provider<string>;
   sha256: HashConstructor;

--- a/packages/middleware-sdk-rds/src/index.ts
+++ b/packages/middleware-sdk-rds/src/index.ts
@@ -9,6 +9,7 @@ import {
   InitializeHandlerOptions,
   InitializeHandlerOutput,
   InitializeMiddleware,
+  MemoizedProvider,
   MetadataBearer,
   Pluggable,
   Provider,
@@ -28,7 +29,7 @@ const sourceIdToCommandKeyMap: { [key: string]: string } = {
 const version = "2014-10-31";
 
 interface PreviouslyResolved {
-  credentials: Provider<Credentials>;
+  credentials: MemoizedProvider<Credentials>;
   endpoint: Provider<Endpoint>;
   region: Provider<string>;
   sha256: HashConstructor;

--- a/packages/middleware-signing/src/configurations.ts
+++ b/packages/middleware-signing/src/configurations.ts
@@ -4,6 +4,7 @@ import {
   Credentials,
   HashConstructor,
   Logger,
+  MemoizedProvider,
   Provider,
   RegionInfo,
   RegionInfoProvider,
@@ -75,7 +76,7 @@ export interface SigV4AuthInputConfig {
 }
 
 interface PreviouslyResolved {
-  credentialDefaultProvider: (input: any) => Provider<Credentials>;
+  credentialDefaultProvider: (input: any) => MemoizedProvider<Credentials>;
   region: string | Provider<string>;
   regionInfoProvider: RegionInfoProvider;
   signingName?: string;
@@ -86,7 +87,7 @@ interface PreviouslyResolved {
 }
 
 interface SigV4PreviouslyResolved {
-  credentialDefaultProvider: (input: any) => Provider<Credentials>;
+  credentialDefaultProvider: (input: any) => MemoizedProvider<Credentials>;
   region: string | Provider<string>;
   signingName: string;
   sha256: HashConstructor;
@@ -96,8 +97,10 @@ interface SigV4PreviouslyResolved {
 export interface AwsAuthResolvedConfig {
   /**
    * Resolved value for input config {@link AwsAuthInputConfig.credentials}
+   * This provider MAY memoize the loaded credentials for certain period.
+   * See {@link MemoizedProvider} for more information.
    */
-  credentials: Provider<Credentials>;
+  credentials: MemoizedProvider<Credentials>;
   /**
    * Resolved value for input config {@link AwsAuthInputConfig.signer}
    */
@@ -211,7 +214,9 @@ const normalizeProvider = <T>(input: T | Provider<T>): Provider<T> => {
   return input as Provider<T>;
 };
 
-const normalizeCredentialProvider = (credentials: Credentials | Provider<Credentials>): Provider<Credentials> => {
+const normalizeCredentialProvider = (
+  credentials: Credentials | Provider<Credentials>
+): MemoizedProvider<Credentials> => {
   if (typeof credentials === "function") {
     return memoize(
       credentials,

--- a/packages/property-provider/src/memoize.ts
+++ b/packages/property-provider/src/memoize.ts
@@ -57,7 +57,7 @@ export const memoize: MemoizeOverload = <T>(
     try {
       resolved = await pending;
       hasResult = true;
-      isConstant = undefined;
+      isConstant = false;
     } finally {
       pending = undefined;
     }
@@ -66,7 +66,7 @@ export const memoize: MemoizeOverload = <T>(
 
   if (isExpired === undefined) {
     // This is a static memoization; no need to incorporate refreshing unless using forceRefresh;
-    return async (options?: { forceRefresh?: boolean }) => {
+    return async (options) => {
       if (!hasResult || options?.forceRefresh) {
         resolved = await coalesceProvider();
       }
@@ -74,7 +74,7 @@ export const memoize: MemoizeOverload = <T>(
     };
   }
 
-  return async (options?: { forceRefresh?: boolean }) => {
+  return async (options) => {
     if (!hasResult || options?.forceRefresh) {
       resolved = await coalesceProvider();
     }

--- a/packages/property-provider/src/memoize.ts
+++ b/packages/property-provider/src/memoize.ts
@@ -1,4 +1,4 @@
-import { Provider } from "@aws-sdk/types";
+import { MemoizedProvider, Provider } from "@aws-sdk/types";
 
 interface MemoizeOverload {
   /**
@@ -12,7 +12,7 @@ interface MemoizeOverload {
    *
    * @param provider The provider whose result should be cached indefinitely.
    */
-  <T>(provider: Provider<T>): Provider<T>;
+  <T>(provider: Provider<T>): MemoizedProvider<T>;
 
   /**
    * Decorates a provider function with refreshing memoization.
@@ -37,17 +37,18 @@ interface MemoizeOverload {
     provider: Provider<T>,
     isExpired: (resolved: T) => boolean,
     requiresRefresh?: (resolved: T) => boolean
-  ): Provider<T>;
+  ): MemoizedProvider<T>;
 }
 
 export const memoize: MemoizeOverload = <T>(
   provider: Provider<T>,
   isExpired?: (resolved: T) => boolean,
   requiresRefresh?: (resolved: T) => boolean
-): Provider<T> => {
+): MemoizedProvider<T> => {
   let resolved: T;
   let pending: Promise<T> | undefined;
   let hasResult: boolean;
+  let isConstant = false;
   // Wrapper over supplied provider with side effect to handle concurrent invocation.
   const coalesceProvider: Provider<T> = async () => {
     if (!pending) {
@@ -56,6 +57,7 @@ export const memoize: MemoizeOverload = <T>(
     try {
       resolved = await pending;
       hasResult = true;
+      isConstant = undefined;
     } finally {
       pending = undefined;
     }
@@ -63,19 +65,17 @@ export const memoize: MemoizeOverload = <T>(
   };
 
   if (isExpired === undefined) {
-    // This is a static memoization; no need to incorporate refreshing
-    return async () => {
-      if (!hasResult) {
+    // This is a static memoization; no need to incorporate refreshing unless using forceRefresh;
+    return async (options?: { forceRefresh?: boolean }) => {
+      if (!hasResult || options?.forceRefresh) {
         resolved = await coalesceProvider();
       }
       return resolved;
     };
   }
 
-  let isConstant = false;
-
-  return async () => {
-    if (!hasResult) {
+  return async (options?: { forceRefresh?: boolean }) => {
+    if (!hasResult || options?.forceRefresh) {
       resolved = await coalesceProvider();
     }
     if (isConstant) {

--- a/packages/types/src/util.ts
+++ b/packages/types/src/util.ts
@@ -43,6 +43,24 @@ export interface Provider<T> {
 }
 
 /**
+ * A function that, when invoked, returns a promise that will be fulfilled with
+ * a value of type T. It memoizes the result from the previous invocation
+ * instead of calling the underlying resources every time.
+ *
+ * You can force the provider to refresh the memoized value by invoke the
+ * function with optional parameter hash with `forceRefresh` boolean key and
+ * value `true`.
+ *
+ * @example A function that reads credentials from IMDS service that could
+ * return expired credentials. The SDK will keep using the expired credentials
+ * until an unretryable service error requiring a force refresh of the
+ * credentials.
+ */
+export interface MemoizedProvider<T> {
+  (options?: { forceRefresh?: boolean }): Promise<T>;
+}
+
+/**
  * A function that, given a request body, determines the
  * length of the body. This is used to determine the Content-Length
  * that should be sent with a request.


### PR DESCRIPTION
### Issue
The dynamic credentials are memoized for certain expiration. V3 SDK doesn't offer a way to force a refresh for credentials, however V2 supports it: in V2, one can simply do `cred.get(callback)` to force a refresh. 

### Description
This change provides a hash option with key `forceRefresh: boolean` in the resolved credentials provider function. By setting the key, the underlying credential provider will be invoked again in regardless of the current credentials' expiration. For example:

```typescript
const client = new FooClient({});
//... needs a force refresh...
await client.config.credentials({ forceRefresh: true });
//... make more API calls...
```

### Testing
Unit test

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
