### PR TITLE
chore(clients): set default parameter for ClientConfig

### DIFF
--- a/clients/client-accessanalyzer/src/AccessAnalyzerClient.ts
+++ b/clients/client-accessanalyzer/src/AccessAnalyzerClient.ts
@@ -362,7 +362,7 @@ export class AccessAnalyzerClient extends __Client<
    */
   readonly config: AccessAnalyzerClientResolvedConfig;
 
-  constructor(configuration: AccessAnalyzerClientConfig) {
+  constructor(configuration: AccessAnalyzerClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-account/src/AccountClient.ts
+++ b/clients/client-account/src/AccountClient.ts
@@ -288,7 +288,7 @@ export class AccountClient extends __Client<
    */
   readonly config: AccountClientResolvedConfig;
 
-  constructor(configuration: AccountClientConfig) {
+  constructor(configuration: AccountClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-acm-pca/src/ACMPCAClient.ts
+++ b/clients/client-acm-pca/src/ACMPCAClient.ts
@@ -369,7 +369,7 @@ export class ACMPCAClient extends __Client<
    */
   readonly config: ACMPCAClientResolvedConfig;
 
-  constructor(configuration: ACMPCAClientConfig) {
+  constructor(configuration: ACMPCAClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-acm/src/ACMClient.ts
+++ b/clients/client-acm/src/ACMClient.ts
@@ -317,7 +317,7 @@ export class ACMClient extends __Client<
    */
   readonly config: ACMClientResolvedConfig;
 
-  constructor(configuration: ACMClientConfig) {
+  constructor(configuration: ACMClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-alexa-for-business/src/AlexaForBusinessClient.ts
+++ b/clients/client-alexa-for-business/src/AlexaForBusinessClient.ts
@@ -644,7 +644,7 @@ export class AlexaForBusinessClient extends __Client<
    */
   readonly config: AlexaForBusinessClientResolvedConfig;
 
-  constructor(configuration: AlexaForBusinessClientConfig) {
+  constructor(configuration: AlexaForBusinessClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-amp/src/AmpClient.ts
+++ b/clients/client-amp/src/AmpClient.ts
@@ -354,7 +354,7 @@ export class AmpClient extends __Client<
    */
   readonly config: AmpClientResolvedConfig;
 
-  constructor(configuration: AmpClientConfig) {
+  constructor(configuration: AmpClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-amplify/src/AmplifyClient.ts
+++ b/clients/client-amplify/src/AmplifyClient.ts
@@ -392,7 +392,7 @@ export class AmplifyClient extends __Client<
    */
   readonly config: AmplifyClientResolvedConfig;
 
-  constructor(configuration: AmplifyClientConfig) {
+  constructor(configuration: AmplifyClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-amplifybackend/src/AmplifyBackendClient.ts
+++ b/clients/client-amplifybackend/src/AmplifyBackendClient.ts
@@ -366,7 +366,7 @@ export class AmplifyBackendClient extends __Client<
    */
   readonly config: AmplifyBackendClientResolvedConfig;
 
-  constructor(configuration: AmplifyBackendClientConfig) {
+  constructor(configuration: AmplifyBackendClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-amplifyuibuilder/src/AmplifyUIBuilderClient.ts
+++ b/clients/client-amplifyuibuilder/src/AmplifyUIBuilderClient.ts
@@ -332,7 +332,7 @@ export class AmplifyUIBuilderClient extends __Client<
    */
   readonly config: AmplifyUIBuilderClientResolvedConfig;
 
-  constructor(configuration: AmplifyUIBuilderClientConfig) {
+  constructor(configuration: AmplifyUIBuilderClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-api-gateway/src/APIGatewayClient.ts
+++ b/clients/client-api-gateway/src/APIGatewayClient.ts
@@ -716,7 +716,7 @@ export class APIGatewayClient extends __Client<
    */
   readonly config: APIGatewayClientResolvedConfig;
 
-  constructor(configuration: APIGatewayClientConfig) {
+  constructor(configuration: APIGatewayClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-apigatewaymanagementapi/src/ApiGatewayManagementApiClient.ts
+++ b/clients/client-apigatewaymanagementapi/src/ApiGatewayManagementApiClient.ts
@@ -252,7 +252,7 @@ export class ApiGatewayManagementApiClient extends __Client<
    */
   readonly config: ApiGatewayManagementApiClientResolvedConfig;
 
-  constructor(configuration: ApiGatewayManagementApiClientConfig) {
+  constructor(configuration: ApiGatewayManagementApiClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-apigatewayv2/src/ApiGatewayV2Client.ts
+++ b/clients/client-apigatewayv2/src/ApiGatewayV2Client.ts
@@ -501,7 +501,7 @@ export class ApiGatewayV2Client extends __Client<
    */
   readonly config: ApiGatewayV2ClientResolvedConfig;
 
-  constructor(configuration: ApiGatewayV2ClientConfig) {
+  constructor(configuration: ApiGatewayV2ClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-app-mesh/src/AppMeshClient.ts
+++ b/clients/client-app-mesh/src/AppMeshClient.ts
@@ -425,7 +425,7 @@ export class AppMeshClient extends __Client<
    */
   readonly config: AppMeshClientResolvedConfig;
 
-  constructor(configuration: AppMeshClientConfig) {
+  constructor(configuration: AppMeshClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-appconfig/src/AppConfigClient.ts
+++ b/clients/client-appconfig/src/AppConfigClient.ts
@@ -483,7 +483,7 @@ export class AppConfigClient extends __Client<
    */
   readonly config: AppConfigClientResolvedConfig;
 
-  constructor(configuration: AppConfigClientConfig) {
+  constructor(configuration: AppConfigClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-appconfigdata/src/AppConfigDataClient.ts
+++ b/clients/client-appconfigdata/src/AppConfigDataClient.ts
@@ -312,7 +312,7 @@ export class AppConfigDataClient extends __Client<
    */
   readonly config: AppConfigDataClientResolvedConfig;
 
-  constructor(configuration: AppConfigDataClientConfig) {
+  constructor(configuration: AppConfigDataClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-appfabric/src/AppFabricClient.ts
+++ b/clients/client-appfabric/src/AppFabricClient.ts
@@ -374,7 +374,7 @@ export class AppFabricClient extends __Client<
    */
   readonly config: AppFabricClientResolvedConfig;
 
-  constructor(configuration: AppFabricClientConfig) {
+  constructor(configuration: AppFabricClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-appflow/src/AppflowClient.ts
+++ b/clients/client-appflow/src/AppflowClient.ts
@@ -391,7 +391,7 @@ export class AppflowClient extends __Client<
    */
   readonly config: AppflowClientResolvedConfig;
 
-  constructor(configuration: AppflowClientConfig) {
+  constructor(configuration: AppflowClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-appintegrations/src/AppIntegrationsClient.ts
+++ b/clients/client-appintegrations/src/AppIntegrationsClient.ts
@@ -333,7 +333,7 @@ export class AppIntegrationsClient extends __Client<
    */
   readonly config: AppIntegrationsClientResolvedConfig;
 
-  constructor(configuration: AppIntegrationsClientConfig) {
+  constructor(configuration: AppIntegrationsClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-application-auto-scaling/src/ApplicationAutoScalingClient.ts
+++ b/clients/client-application-auto-scaling/src/ApplicationAutoScalingClient.ts
@@ -385,7 +385,7 @@ export class ApplicationAutoScalingClient extends __Client<
    */
   readonly config: ApplicationAutoScalingClientResolvedConfig;
 
-  constructor(configuration: ApplicationAutoScalingClientConfig) {
+  constructor(configuration: ApplicationAutoScalingClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-application-discovery-service/src/ApplicationDiscoveryServiceClient.ts
+++ b/clients/client-application-discovery-service/src/ApplicationDiscoveryServiceClient.ts
@@ -472,7 +472,7 @@ export class ApplicationDiscoveryServiceClient extends __Client<
    */
   readonly config: ApplicationDiscoveryServiceClientResolvedConfig;
 
-  constructor(configuration: ApplicationDiscoveryServiceClientConfig) {
+  constructor(configuration: ApplicationDiscoveryServiceClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-application-insights/src/ApplicationInsightsClient.ts
+++ b/clients/client-application-insights/src/ApplicationInsightsClient.ts
@@ -380,7 +380,7 @@ export class ApplicationInsightsClient extends __Client<
    */
   readonly config: ApplicationInsightsClientResolvedConfig;
 
-  constructor(configuration: ApplicationInsightsClientConfig) {
+  constructor(configuration: ApplicationInsightsClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-applicationcostprofiler/src/ApplicationCostProfilerClient.ts
+++ b/clients/client-applicationcostprofiler/src/ApplicationCostProfilerClient.ts
@@ -287,7 +287,7 @@ export class ApplicationCostProfilerClient extends __Client<
    */
   readonly config: ApplicationCostProfilerClientResolvedConfig;
 
-  constructor(configuration: ApplicationCostProfilerClientConfig) {
+  constructor(configuration: ApplicationCostProfilerClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-apprunner/src/AppRunnerClient.ts
+++ b/clients/client-apprunner/src/AppRunnerClient.ts
@@ -421,7 +421,7 @@ export class AppRunnerClient extends __Client<
    */
   readonly config: AppRunnerClientResolvedConfig;
 
-  constructor(configuration: AppRunnerClientConfig) {
+  constructor(configuration: AppRunnerClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-appstream/src/AppStreamClient.ts
+++ b/clients/client-appstream/src/AppStreamClient.ts
@@ -596,7 +596,7 @@ export class AppStreamClient extends __Client<
    */
   readonly config: AppStreamClientResolvedConfig;
 
-  constructor(configuration: AppStreamClientConfig) {
+  constructor(configuration: AppStreamClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-appsync/src/AppSyncClient.ts
+++ b/clients/client-appsync/src/AppSyncClient.ts
@@ -469,7 +469,7 @@ export class AppSyncClient extends __Client<
    */
   readonly config: AppSyncClientResolvedConfig;
 
-  constructor(configuration: AppSyncClientConfig) {
+  constructor(configuration: AppSyncClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-arc-zonal-shift/src/ARCZonalShiftClient.ts
+++ b/clients/client-arc-zonal-shift/src/ARCZonalShiftClient.ts
@@ -281,7 +281,7 @@ export class ARCZonalShiftClient extends __Client<
    */
   readonly config: ARCZonalShiftClientResolvedConfig;
 
-  constructor(configuration: ARCZonalShiftClientConfig) {
+  constructor(configuration: ARCZonalShiftClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-athena/src/AthenaClient.ts
+++ b/clients/client-athena/src/AthenaClient.ts
@@ -556,7 +556,7 @@ export class AthenaClient extends __Client<
    */
   readonly config: AthenaClientResolvedConfig;
 
-  constructor(configuration: AthenaClientConfig) {
+  constructor(configuration: AthenaClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-auditmanager/src/AuditManagerClient.ts
+++ b/clients/client-auditmanager/src/AuditManagerClient.ts
@@ -581,7 +581,7 @@ export class AuditManagerClient extends __Client<
    */
   readonly config: AuditManagerClientResolvedConfig;
 
-  constructor(configuration: AuditManagerClientConfig) {
+  constructor(configuration: AuditManagerClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-auto-scaling-plans/src/AutoScalingPlansClient.ts
+++ b/clients/client-auto-scaling-plans/src/AutoScalingPlansClient.ts
@@ -307,7 +307,7 @@ export class AutoScalingPlansClient extends __Client<
    */
   readonly config: AutoScalingPlansClientResolvedConfig;
 
-  constructor(configuration: AutoScalingPlansClientConfig) {
+  constructor(configuration: AutoScalingPlansClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-auto-scaling/src/AutoScalingClient.ts
+++ b/clients/client-auto-scaling/src/AutoScalingClient.ts
@@ -582,7 +582,7 @@ export class AutoScalingClient extends __Client<
    */
   readonly config: AutoScalingClientResolvedConfig;
 
-  constructor(configuration: AutoScalingClientConfig) {
+  constructor(configuration: AutoScalingClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-backup-gateway/src/BackupGatewayClient.ts
+++ b/clients/client-backup-gateway/src/BackupGatewayClient.ts
@@ -371,7 +371,7 @@ export class BackupGatewayClient extends __Client<
    */
   readonly config: BackupGatewayClientResolvedConfig;
 
-  constructor(configuration: BackupGatewayClientConfig) {
+  constructor(configuration: BackupGatewayClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-backup/src/BackupClient.ts
+++ b/clients/client-backup/src/BackupClient.ts
@@ -565,7 +565,7 @@ export class BackupClient extends __Client<
    */
   readonly config: BackupClientResolvedConfig;
 
-  constructor(configuration: BackupClientConfig) {
+  constructor(configuration: BackupClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-backupstorage/src/BackupStorageClient.ts
+++ b/clients/client-backupstorage/src/BackupStorageClient.ts
@@ -283,7 +283,7 @@ export class BackupStorageClient extends __Client<
    */
   readonly config: BackupStorageClientResolvedConfig;
 
-  constructor(configuration: BackupStorageClientConfig) {
+  constructor(configuration: BackupStorageClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-batch/src/BatchClient.ts
+++ b/clients/client-batch/src/BatchClient.ts
@@ -367,7 +367,7 @@ export class BatchClient extends __Client<
    */
   readonly config: BatchClientResolvedConfig;
 
-  constructor(configuration: BatchClientConfig) {
+  constructor(configuration: BatchClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-billingconductor/src/BillingconductorClient.ts
+++ b/clients/client-billingconductor/src/BillingconductorClient.ts
@@ -398,7 +398,7 @@ export class BillingconductorClient extends __Client<
    */
   readonly config: BillingconductorClientResolvedConfig;
 
-  constructor(configuration: BillingconductorClientConfig) {
+  constructor(configuration: BillingconductorClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-braket/src/BraketClient.ts
+++ b/clients/client-braket/src/BraketClient.ts
@@ -297,7 +297,7 @@ export class BraketClient extends __Client<
    */
   readonly config: BraketClientResolvedConfig;
 
-  constructor(configuration: BraketClientConfig) {
+  constructor(configuration: BraketClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-budgets/src/BudgetsClient.ts
+++ b/clients/client-budgets/src/BudgetsClient.ts
@@ -384,7 +384,7 @@ export class BudgetsClient extends __Client<
    */
   readonly config: BudgetsClientResolvedConfig;
 
-  constructor(configuration: BudgetsClientConfig) {
+  constructor(configuration: BudgetsClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-chime-sdk-identity/src/ChimeSDKIdentityClient.ts
+++ b/clients/client-chime-sdk-identity/src/ChimeSDKIdentityClient.ts
@@ -411,7 +411,7 @@ export class ChimeSDKIdentityClient extends __Client<
    */
   readonly config: ChimeSDKIdentityClientResolvedConfig;
 
-  constructor(configuration: ChimeSDKIdentityClientConfig) {
+  constructor(configuration: ChimeSDKIdentityClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-chime-sdk-media-pipelines/src/ChimeSDKMediaPipelinesClient.ts
+++ b/clients/client-chime-sdk-media-pipelines/src/ChimeSDKMediaPipelinesClient.ts
@@ -349,7 +349,7 @@ export class ChimeSDKMediaPipelinesClient extends __Client<
    */
   readonly config: ChimeSDKMediaPipelinesClientResolvedConfig;
 
-  constructor(configuration: ChimeSDKMediaPipelinesClientConfig) {
+  constructor(configuration: ChimeSDKMediaPipelinesClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-chime-sdk-meetings/src/ChimeSDKMeetingsClient.ts
+++ b/clients/client-chime-sdk-meetings/src/ChimeSDKMeetingsClient.ts
@@ -317,7 +317,7 @@ export class ChimeSDKMeetingsClient extends __Client<
    */
   readonly config: ChimeSDKMeetingsClientResolvedConfig;
 
-  constructor(configuration: ChimeSDKMeetingsClientConfig) {
+  constructor(configuration: ChimeSDKMeetingsClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-chime-sdk-messaging/src/ChimeSDKMessagingClient.ts
+++ b/clients/client-chime-sdk-messaging/src/ChimeSDKMessagingClient.ts
@@ -498,7 +498,7 @@ export class ChimeSDKMessagingClient extends __Client<
    */
   readonly config: ChimeSDKMessagingClientResolvedConfig;
 
-  constructor(configuration: ChimeSDKMessagingClientConfig) {
+  constructor(configuration: ChimeSDKMessagingClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-chime-sdk-voice/src/ChimeSDKVoiceClient.ts
+++ b/clients/client-chime-sdk-voice/src/ChimeSDKVoiceClient.ts
@@ -733,7 +733,7 @@ export class ChimeSDKVoiceClient extends __Client<
    */
   readonly config: ChimeSDKVoiceClientResolvedConfig;
 
-  constructor(configuration: ChimeSDKVoiceClientConfig) {
+  constructor(configuration: ChimeSDKVoiceClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-chime/src/ChimeClient.ts
+++ b/clients/client-chime/src/ChimeClient.ts
@@ -1208,7 +1208,7 @@ export class ChimeClient extends __Client<
    */
   readonly config: ChimeClientResolvedConfig;
 
-  constructor(configuration: ChimeClientConfig) {
+  constructor(configuration: ChimeClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-cleanrooms/src/CleanRoomsClient.ts
+++ b/clients/client-cleanrooms/src/CleanRoomsClient.ts
@@ -474,7 +474,7 @@ export class CleanRoomsClient extends __Client<
    */
   readonly config: CleanRoomsClientResolvedConfig;
 
-  constructor(configuration: CleanRoomsClientConfig) {
+  constructor(configuration: CleanRoomsClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-cloud9/src/Cloud9Client.ts
+++ b/clients/client-cloud9/src/Cloud9Client.ts
@@ -375,7 +375,7 @@ export class Cloud9Client extends __Client<
    */
   readonly config: Cloud9ClientResolvedConfig;
 
-  constructor(configuration: Cloud9ClientConfig) {
+  constructor(configuration: Cloud9ClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-cloudcontrol/src/CloudControlClient.ts
+++ b/clients/client-cloudcontrol/src/CloudControlClient.ts
@@ -280,7 +280,7 @@ export class CloudControlClient extends __Client<
    */
   readonly config: CloudControlClientResolvedConfig;
 
-  constructor(configuration: CloudControlClientConfig) {
+  constructor(configuration: CloudControlClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-clouddirectory/src/CloudDirectoryClient.ts
+++ b/clients/client-clouddirectory/src/CloudDirectoryClient.ts
@@ -527,7 +527,7 @@ export class CloudDirectoryClient extends __Client<
    */
   readonly config: CloudDirectoryClientResolvedConfig;
 
-  constructor(configuration: CloudDirectoryClientConfig) {
+  constructor(configuration: CloudDirectoryClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-cloudformation/src/CloudFormationClient.ts
+++ b/clients/client-cloudformation/src/CloudFormationClient.ts
@@ -558,7 +558,7 @@ export class CloudFormationClient extends __Client<
    */
   readonly config: CloudFormationClientResolvedConfig;
 
-  constructor(configuration: CloudFormationClientConfig) {
+  constructor(configuration: CloudFormationClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-cloudfront/src/CloudFrontClient.ts
+++ b/clients/client-cloudfront/src/CloudFrontClient.ts
@@ -775,7 +775,7 @@ export class CloudFrontClient extends __Client<
    */
   readonly config: CloudFrontClientResolvedConfig;
 
-  constructor(configuration: CloudFrontClientConfig) {
+  constructor(configuration: CloudFrontClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-cloudhsm-v2/src/CloudHSMV2Client.ts
+++ b/clients/client-cloudhsm-v2/src/CloudHSMV2Client.ts
@@ -295,7 +295,7 @@ export class CloudHSMV2Client extends __Client<
    */
   readonly config: CloudHSMV2ClientResolvedConfig;
 
-  constructor(configuration: CloudHSMV2ClientConfig) {
+  constructor(configuration: CloudHSMV2ClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-cloudhsm/src/CloudHSMClient.ts
+++ b/clients/client-cloudhsm/src/CloudHSMClient.ts
@@ -322,7 +322,7 @@ export class CloudHSMClient extends __Client<
    */
   readonly config: CloudHSMClientResolvedConfig;
 
-  constructor(configuration: CloudHSMClientConfig) {
+  constructor(configuration: CloudHSMClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-cloudsearch-domain/src/CloudSearchDomainClient.ts
+++ b/clients/client-cloudsearch-domain/src/CloudSearchDomainClient.ts
@@ -252,7 +252,7 @@ export class CloudSearchDomainClient extends __Client<
    */
   readonly config: CloudSearchDomainClientResolvedConfig;
 
-  constructor(configuration: CloudSearchDomainClientConfig) {
+  constructor(configuration: CloudSearchDomainClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-cloudsearch/src/CloudSearchClient.ts
+++ b/clients/client-cloudsearch/src/CloudSearchClient.ts
@@ -369,7 +369,7 @@ export class CloudSearchClient extends __Client<
    */
   readonly config: CloudSearchClientResolvedConfig;
 
-  constructor(configuration: CloudSearchClientConfig) {
+  constructor(configuration: CloudSearchClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-cloudtrail-data/src/CloudTrailDataClient.ts
+++ b/clients/client-cloudtrail-data/src/CloudTrailDataClient.ts
@@ -252,7 +252,7 @@ export class CloudTrailDataClient extends __Client<
    */
   readonly config: CloudTrailDataClientResolvedConfig;
 
-  constructor(configuration: CloudTrailDataClientConfig) {
+  constructor(configuration: CloudTrailDataClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-cloudtrail/src/CloudTrailClient.ts
+++ b/clients/client-cloudtrail/src/CloudTrailClient.ts
@@ -435,7 +435,7 @@ export class CloudTrailClient extends __Client<
    */
   readonly config: CloudTrailClientResolvedConfig;
 
-  constructor(configuration: CloudTrailClientConfig) {
+  constructor(configuration: CloudTrailClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-cloudwatch-events/src/CloudWatchEventsClient.ts
+++ b/clients/client-cloudwatch-events/src/CloudWatchEventsClient.ts
@@ -467,7 +467,7 @@ export class CloudWatchEventsClient extends __Client<
    */
   readonly config: CloudWatchEventsClientResolvedConfig;
 
-  constructor(configuration: CloudWatchEventsClientConfig) {
+  constructor(configuration: CloudWatchEventsClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-cloudwatch-logs/src/CloudWatchLogsClient.ts
+++ b/clients/client-cloudwatch-logs/src/CloudWatchLogsClient.ts
@@ -487,7 +487,7 @@ export class CloudWatchLogsClient extends __Client<
    */
   readonly config: CloudWatchLogsClientResolvedConfig;
 
-  constructor(configuration: CloudWatchLogsClientConfig) {
+  constructor(configuration: CloudWatchLogsClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-cloudwatch/src/CloudWatchClient.ts
+++ b/clients/client-cloudwatch/src/CloudWatchClient.ts
@@ -411,7 +411,7 @@ export class CloudWatchClient extends __Client<
    */
   readonly config: CloudWatchClientResolvedConfig;
 
-  constructor(configuration: CloudWatchClientConfig) {
+  constructor(configuration: CloudWatchClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-codeartifact/src/CodeartifactClient.ts
+++ b/clients/client-codeartifact/src/CodeartifactClient.ts
@@ -712,7 +712,7 @@ export class CodeartifactClient extends __Client<
    */
   readonly config: CodeartifactClientResolvedConfig;
 
-  constructor(configuration: CodeartifactClientConfig) {
+  constructor(configuration: CodeartifactClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-codebuild/src/CodeBuildClient.ts
+++ b/clients/client-codebuild/src/CodeBuildClient.ts
@@ -436,7 +436,7 @@ export class CodeBuildClient extends __Client<
    */
   readonly config: CodeBuildClientResolvedConfig;
 
-  constructor(configuration: CodeBuildClientConfig) {
+  constructor(configuration: CodeBuildClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-codecatalyst/src/CodeCatalystClient.ts
+++ b/clients/client-codecatalyst/src/CodeCatalystClient.ts
@@ -524,7 +524,7 @@ export class CodeCatalystClient extends __Client<
    */
   readonly config: CodeCatalystClientResolvedConfig;
 
-  constructor(configuration: CodeCatalystClientConfig) {
+  constructor(configuration: CodeCatalystClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-codecommit/src/CodeCommitClient.ts
+++ b/clients/client-codecommit/src/CodeCommitClient.ts
@@ -1017,7 +1017,7 @@ export class CodeCommitClient extends __Client<
    */
   readonly config: CodeCommitClientResolvedConfig;
 
-  constructor(configuration: CodeCommitClientConfig) {
+  constructor(configuration: CodeCommitClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-codedeploy/src/CodeDeployClient.ts
+++ b/clients/client-codedeploy/src/CodeDeployClient.ts
@@ -581,7 +581,7 @@ export class CodeDeployClient extends __Client<
    */
   readonly config: CodeDeployClientResolvedConfig;
 
-  constructor(configuration: CodeDeployClientConfig) {
+  constructor(configuration: CodeDeployClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-codeguru-reviewer/src/CodeGuruReviewerClient.ts
+++ b/clients/client-codeguru-reviewer/src/CodeGuruReviewerClient.ts
@@ -331,7 +331,7 @@ export class CodeGuruReviewerClient extends __Client<
    */
   readonly config: CodeGuruReviewerClientResolvedConfig;
 
-  constructor(configuration: CodeGuruReviewerClientConfig) {
+  constructor(configuration: CodeGuruReviewerClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-codeguru-security/src/CodeGuruSecurityClient.ts
+++ b/clients/client-codeguru-security/src/CodeGuruSecurityClient.ts
@@ -308,7 +308,7 @@ export class CodeGuruSecurityClient extends __Client<
    */
   readonly config: CodeGuruSecurityClientResolvedConfig;
 
-  constructor(configuration: CodeGuruSecurityClientConfig) {
+  constructor(configuration: CodeGuruSecurityClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-codeguruprofiler/src/CodeGuruProfilerClient.ts
+++ b/clients/client-codeguruprofiler/src/CodeGuruProfilerClient.ts
@@ -373,7 +373,7 @@ export class CodeGuruProfilerClient extends __Client<
    */
   readonly config: CodeGuruProfilerClientResolvedConfig;
 
-  constructor(configuration: CodeGuruProfilerClientConfig) {
+  constructor(configuration: CodeGuruProfilerClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-codepipeline/src/CodePipelineClient.ts
+++ b/clients/client-codepipeline/src/CodePipelineClient.ts
@@ -616,7 +616,7 @@ export class CodePipelineClient extends __Client<
    */
   readonly config: CodePipelineClientResolvedConfig;
 
-  constructor(configuration: CodePipelineClientConfig) {
+  constructor(configuration: CodePipelineClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-codestar-connections/src/CodeStarConnectionsClient.ts
+++ b/clients/client-codestar-connections/src/CodeStarConnectionsClient.ts
@@ -364,7 +364,7 @@ export class CodeStarConnectionsClient extends __Client<
    */
   readonly config: CodeStarConnectionsClientResolvedConfig;
 
-  constructor(configuration: CodeStarConnectionsClientConfig) {
+  constructor(configuration: CodeStarConnectionsClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-codestar-notifications/src/CodestarNotificationsClient.ts
+++ b/clients/client-codestar-notifications/src/CodestarNotificationsClient.ts
@@ -386,7 +386,7 @@ export class CodestarNotificationsClient extends __Client<
    */
   readonly config: CodestarNotificationsClientResolvedConfig;
 
-  constructor(configuration: CodestarNotificationsClientConfig) {
+  constructor(configuration: CodestarNotificationsClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-codestar/src/CodeStarClient.ts
+++ b/clients/client-codestar/src/CodeStarClient.ts
@@ -398,7 +398,7 @@ export class CodeStarClient extends __Client<
    */
   readonly config: CodeStarClientResolvedConfig;
 
-  constructor(configuration: CodeStarClientConfig) {
+  constructor(configuration: CodeStarClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-cognito-identity-provider/src/CognitoIdentityProviderClient.ts
+++ b/clients/client-cognito-identity-provider/src/CognitoIdentityProviderClient.ts
@@ -790,7 +790,7 @@ export class CognitoIdentityProviderClient extends __Client<
    */
   readonly config: CognitoIdentityProviderClientResolvedConfig;
 
-  constructor(configuration: CognitoIdentityProviderClientConfig) {
+  constructor(configuration: CognitoIdentityProviderClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-cognito-identity/src/CognitoIdentityClient.ts
+++ b/clients/client-cognito-identity/src/CognitoIdentityClient.ts
@@ -356,7 +356,7 @@ export class CognitoIdentityClient extends __Client<
    */
   readonly config: CognitoIdentityClientResolvedConfig;
 
-  constructor(configuration: CognitoIdentityClientConfig) {
+  constructor(configuration: CognitoIdentityClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-cognito-sync/src/CognitoSyncClient.ts
+++ b/clients/client-cognito-sync/src/CognitoSyncClient.ts
@@ -330,7 +330,7 @@ export class CognitoSyncClient extends __Client<
    */
   readonly config: CognitoSyncClientResolvedConfig;
 
-  constructor(configuration: CognitoSyncClientConfig) {
+  constructor(configuration: CognitoSyncClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-comprehend/src/ComprehendClient.ts
+++ b/clients/client-comprehend/src/ComprehendClient.ts
@@ -681,7 +681,7 @@ export class ComprehendClient extends __Client<
    */
   readonly config: ComprehendClientResolvedConfig;
 
-  constructor(configuration: ComprehendClientConfig) {
+  constructor(configuration: ComprehendClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-comprehendmedical/src/ComprehendMedicalClient.ts
+++ b/clients/client-comprehendmedical/src/ComprehendMedicalClient.ts
@@ -384,7 +384,7 @@ export class ComprehendMedicalClient extends __Client<
    */
   readonly config: ComprehendMedicalClientResolvedConfig;
 
-  constructor(configuration: ComprehendMedicalClientConfig) {
+  constructor(configuration: ComprehendMedicalClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-compute-optimizer/src/ComputeOptimizerClient.ts
+++ b/clients/client-compute-optimizer/src/ComputeOptimizerClient.ts
@@ -383,7 +383,7 @@ export class ComputeOptimizerClient extends __Client<
    */
   readonly config: ComputeOptimizerClientResolvedConfig;
 
-  constructor(configuration: ComputeOptimizerClientConfig) {
+  constructor(configuration: ComputeOptimizerClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-config-service/src/ConfigServiceClient.ts
+++ b/clients/client-config-service/src/ConfigServiceClient.ts
@@ -782,7 +782,7 @@ export class ConfigServiceClient extends __Client<
    */
   readonly config: ConfigServiceClientResolvedConfig;
 
-  constructor(configuration: ConfigServiceClientConfig) {
+  constructor(configuration: ConfigServiceClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-connect-contact-lens/src/ConnectContactLensClient.ts
+++ b/clients/client-connect-contact-lens/src/ConnectContactLensClient.ts
@@ -256,7 +256,7 @@ export class ConnectContactLensClient extends __Client<
    */
   readonly config: ConnectContactLensClientResolvedConfig;
 
-  constructor(configuration: ConnectContactLensClientConfig) {
+  constructor(configuration: ConnectContactLensClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-connect/src/ConnectClient.ts
+++ b/clients/client-connect/src/ConnectClient.ts
@@ -1201,7 +1201,7 @@ export class ConnectClient extends __Client<
    */
   readonly config: ConnectClientResolvedConfig;
 
-  constructor(configuration: ConnectClientConfig) {
+  constructor(configuration: ConnectClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-connectcampaigns/src/ConnectCampaignsClient.ts
+++ b/clients/client-connectcampaigns/src/ConnectCampaignsClient.ts
@@ -342,7 +342,7 @@ export class ConnectCampaignsClient extends __Client<
    */
   readonly config: ConnectCampaignsClientResolvedConfig;
 
-  constructor(configuration: ConnectCampaignsClientConfig) {
+  constructor(configuration: ConnectCampaignsClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-connectcases/src/ConnectCasesClient.ts
+++ b/clients/client-connectcases/src/ConnectCasesClient.ts
@@ -355,7 +355,7 @@ export class ConnectCasesClient extends __Client<
    */
   readonly config: ConnectCasesClientResolvedConfig;
 
-  constructor(configuration: ConnectCasesClientConfig) {
+  constructor(configuration: ConnectCasesClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-connectparticipant/src/ConnectParticipantClient.ts
+++ b/clients/client-connectparticipant/src/ConnectParticipantClient.ts
@@ -296,7 +296,7 @@ export class ConnectParticipantClient extends __Client<
    */
   readonly config: ConnectParticipantClientResolvedConfig;
 
-  constructor(configuration: ConnectParticipantClientConfig) {
+  constructor(configuration: ConnectParticipantClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-controltower/src/ControlTowerClient.ts
+++ b/clients/client-controltower/src/ControlTowerClient.ts
@@ -334,7 +334,7 @@ export class ControlTowerClient extends __Client<
    */
   readonly config: ControlTowerClientResolvedConfig;
 
-  constructor(configuration: ControlTowerClientConfig) {
+  constructor(configuration: ControlTowerClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-cost-and-usage-report-service/src/CostAndUsageReportServiceClient.ts
+++ b/clients/client-cost-and-usage-report-service/src/CostAndUsageReportServiceClient.ts
@@ -288,7 +288,7 @@ export class CostAndUsageReportServiceClient extends __Client<
    */
   readonly config: CostAndUsageReportServiceClientResolvedConfig;
 
-  constructor(configuration: CostAndUsageReportServiceClientConfig) {
+  constructor(configuration: CostAndUsageReportServiceClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-cost-explorer/src/CostExplorerClient.ts
+++ b/clients/client-cost-explorer/src/CostExplorerClient.ts
@@ -459,7 +459,7 @@ export class CostExplorerClient extends __Client<
    */
   readonly config: CostExplorerClientResolvedConfig;
 
-  constructor(configuration: CostExplorerClientConfig) {
+  constructor(configuration: CostExplorerClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-customer-profiles/src/CustomerProfilesClient.ts
+++ b/clients/client-customer-profiles/src/CustomerProfilesClient.ts
@@ -467,7 +467,7 @@ export class CustomerProfilesClient extends __Client<
    */
   readonly config: CustomerProfilesClientResolvedConfig;
 
-  constructor(configuration: CustomerProfilesClientConfig) {
+  constructor(configuration: CustomerProfilesClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-data-pipeline/src/DataPipelineClient.ts
+++ b/clients/client-data-pipeline/src/DataPipelineClient.ts
@@ -331,7 +331,7 @@ export class DataPipelineClient extends __Client<
    */
   readonly config: DataPipelineClientResolvedConfig;
 
-  constructor(configuration: DataPipelineClientConfig) {
+  constructor(configuration: DataPipelineClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-database-migration-service/src/DatabaseMigrationServiceClient.ts
+++ b/clients/client-database-migration-service/src/DatabaseMigrationServiceClient.ts
@@ -838,7 +838,7 @@ export class DatabaseMigrationServiceClient extends __Client<
    */
   readonly config: DatabaseMigrationServiceClientResolvedConfig;
 
-  constructor(configuration: DatabaseMigrationServiceClientConfig) {
+  constructor(configuration: DatabaseMigrationServiceClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-databrew/src/DataBrewClient.ts
+++ b/clients/client-databrew/src/DataBrewClient.ts
@@ -402,7 +402,7 @@ export class DataBrewClient extends __Client<
    */
   readonly config: DataBrewClientResolvedConfig;
 
-  constructor(configuration: DataBrewClientConfig) {
+  constructor(configuration: DataBrewClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-dataexchange/src/DataExchangeClient.ts
+++ b/clients/client-dataexchange/src/DataExchangeClient.ts
@@ -354,7 +354,7 @@ export class DataExchangeClient extends __Client<
    */
   readonly config: DataExchangeClientResolvedConfig;
 
-  constructor(configuration: DataExchangeClientConfig) {
+  constructor(configuration: DataExchangeClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-datasync/src/DataSyncClient.ts
+++ b/clients/client-datasync/src/DataSyncClient.ts
@@ -521,7 +521,7 @@ export class DataSyncClient extends __Client<
    */
   readonly config: DataSyncClientResolvedConfig;
 
-  constructor(configuration: DataSyncClientConfig) {
+  constructor(configuration: DataSyncClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-dax/src/DAXClient.ts
+++ b/clients/client-dax/src/DAXClient.ts
@@ -338,7 +338,7 @@ export class DAXClient extends __Client<
    */
   readonly config: DAXClientResolvedConfig;
 
-  constructor(configuration: DAXClientConfig) {
+  constructor(configuration: DAXClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-detective/src/DetectiveClient.ts
+++ b/clients/client-detective/src/DetectiveClient.ts
@@ -429,7 +429,7 @@ export class DetectiveClient extends __Client<
    */
   readonly config: DetectiveClientResolvedConfig;
 
-  constructor(configuration: DetectiveClientConfig) {
+  constructor(configuration: DetectiveClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-device-farm/src/DeviceFarmClient.ts
+++ b/clients/client-device-farm/src/DeviceFarmClient.ts
@@ -587,7 +587,7 @@ export class DeviceFarmClient extends __Client<
    */
   readonly config: DeviceFarmClientResolvedConfig;
 
-  constructor(configuration: DeviceFarmClientConfig) {
+  constructor(configuration: DeviceFarmClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-devops-guru/src/DevOpsGuruClient.ts
+++ b/clients/client-devops-guru/src/DevOpsGuruClient.ts
@@ -416,7 +416,7 @@ export class DevOpsGuruClient extends __Client<
    */
   readonly config: DevOpsGuruClientResolvedConfig;
 
-  constructor(configuration: DevOpsGuruClientConfig) {
+  constructor(configuration: DevOpsGuruClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-direct-connect/src/DirectConnectClient.ts
+++ b/clients/client-direct-connect/src/DirectConnectClient.ts
@@ -575,7 +575,7 @@ export class DirectConnectClient extends __Client<
    */
   readonly config: DirectConnectClientResolvedConfig;
 
-  constructor(configuration: DirectConnectClientConfig) {
+  constructor(configuration: DirectConnectClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-directory-service/src/DirectoryServiceClient.ts
+++ b/clients/client-directory-service/src/DirectoryServiceClient.ts
@@ -550,7 +550,7 @@ export class DirectoryServiceClient extends __Client<
    */
   readonly config: DirectoryServiceClientResolvedConfig;
 
-  constructor(configuration: DirectoryServiceClientConfig) {
+  constructor(configuration: DirectoryServiceClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-dlm/src/DLMClient.ts
+++ b/clients/client-dlm/src/DLMClient.ts
@@ -291,7 +291,7 @@ export class DLMClient extends __Client<
    */
   readonly config: DLMClientResolvedConfig;
 
-  constructor(configuration: DLMClientConfig) {
+  constructor(configuration: DLMClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-docdb-elastic/src/DocDBElasticClient.ts
+++ b/clients/client-docdb-elastic/src/DocDBElasticClient.ts
@@ -300,7 +300,7 @@ export class DocDBElasticClient extends __Client<
    */
   readonly config: DocDBElasticClientResolvedConfig;
 
-  constructor(configuration: DocDBElasticClientConfig) {
+  constructor(configuration: DocDBElasticClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-docdb/src/DocDBClient.ts
+++ b/clients/client-docdb/src/DocDBClient.ts
@@ -527,7 +527,7 @@ export class DocDBClient extends __Client<
    */
   readonly config: DocDBClientResolvedConfig;
 
-  constructor(configuration: DocDBClientConfig) {
+  constructor(configuration: DocDBClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-drs/src/DrsClient.ts
+++ b/clients/client-drs/src/DrsClient.ts
@@ -495,7 +495,7 @@ export class DrsClient extends __Client<
    */
   readonly config: DrsClientResolvedConfig;
 
-  constructor(configuration: DrsClientConfig) {
+  constructor(configuration: DrsClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-dynamodb-streams/src/DynamoDBStreamsClient.ts
+++ b/clients/client-dynamodb-streams/src/DynamoDBStreamsClient.ts
@@ -262,7 +262,7 @@ export class DynamoDBStreamsClient extends __Client<
    */
   readonly config: DynamoDBStreamsClientResolvedConfig;
 
-  constructor(configuration: DynamoDBStreamsClientConfig) {
+  constructor(configuration: DynamoDBStreamsClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-dynamodb/src/DynamoDBClient.ts
+++ b/clients/client-dynamodb/src/DynamoDBClient.ts
@@ -490,7 +490,7 @@ export class DynamoDBClient extends __Client<
    */
   readonly config: DynamoDBClientResolvedConfig;
 
-  constructor(configuration: DynamoDBClientConfig) {
+  constructor(configuration: DynamoDBClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-ebs/src/EBSClient.ts
+++ b/clients/client-ebs/src/EBSClient.ts
@@ -287,7 +287,7 @@ export class EBSClient extends __Client<
    */
   readonly config: EBSClientResolvedConfig;
 
-  constructor(configuration: EBSClientConfig) {
+  constructor(configuration: EBSClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-ec2-instance-connect/src/EC2InstanceConnectClient.ts
+++ b/clients/client-ec2-instance-connect/src/EC2InstanceConnectClient.ts
@@ -253,7 +253,7 @@ export class EC2InstanceConnectClient extends __Client<
    */
   readonly config: EC2InstanceConnectClientResolvedConfig;
 
-  constructor(configuration: EC2InstanceConnectClientConfig) {
+  constructor(configuration: EC2InstanceConnectClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-ec2/src/EC2Client.ts
+++ b/clients/client-ec2/src/EC2Client.ts
@@ -3469,7 +3469,7 @@ export class EC2Client extends __Client<
    */
   readonly config: EC2ClientResolvedConfig;
 
-  constructor(configuration: EC2ClientConfig) {
+  constructor(configuration: EC2ClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-ecr-public/src/ECRPUBLICClient.ts
+++ b/clients/client-ecr-public/src/ECRPUBLICClient.ts
@@ -360,7 +360,7 @@ export class ECRPUBLICClient extends __Client<
    */
   readonly config: ECRPUBLICClientResolvedConfig;
 
-  constructor(configuration: ECRPUBLICClientConfig) {
+  constructor(configuration: ECRPUBLICClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-ecr/src/ECRClient.ts
+++ b/clients/client-ecr/src/ECRClient.ts
@@ -452,7 +452,7 @@ export class ECRClient extends __Client<
    */
   readonly config: ECRClientResolvedConfig;
 
-  constructor(configuration: ECRClientConfig) {
+  constructor(configuration: ECRClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-ecs/src/ECSClient.ts
+++ b/clients/client-ecs/src/ECSClient.ts
@@ -513,7 +513,7 @@ export class ECSClient extends __Client<
    */
   readonly config: ECSClientResolvedConfig;
 
-  constructor(configuration: ECSClientConfig) {
+  constructor(configuration: ECSClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-efs/src/EFSClient.ts
+++ b/clients/client-efs/src/EFSClient.ts
@@ -391,7 +391,7 @@ export class EFSClient extends __Client<
    */
   readonly config: EFSClientResolvedConfig;
 
-  constructor(configuration: EFSClientConfig) {
+  constructor(configuration: EFSClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-eks/src/EKSClient.ts
+++ b/clients/client-eks/src/EKSClient.ts
@@ -408,7 +408,7 @@ export class EKSClient extends __Client<
    */
   readonly config: EKSClientResolvedConfig;
 
-  constructor(configuration: EKSClientConfig) {
+  constructor(configuration: EKSClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-elastic-beanstalk/src/ElasticBeanstalkClient.ts
+++ b/clients/client-elastic-beanstalk/src/ElasticBeanstalkClient.ts
@@ -516,7 +516,7 @@ export class ElasticBeanstalkClient extends __Client<
    */
   readonly config: ElasticBeanstalkClientResolvedConfig;
 
-  constructor(configuration: ElasticBeanstalkClientConfig) {
+  constructor(configuration: ElasticBeanstalkClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-elastic-inference/src/ElasticInferenceClient.ts
+++ b/clients/client-elastic-inference/src/ElasticInferenceClient.ts
@@ -283,7 +283,7 @@ export class ElasticInferenceClient extends __Client<
    */
   readonly config: ElasticInferenceClientResolvedConfig;
 
-  constructor(configuration: ElasticInferenceClientConfig) {
+  constructor(configuration: ElasticInferenceClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-elastic-load-balancing-v2/src/ElasticLoadBalancingV2Client.ts
+++ b/clients/client-elastic-load-balancing-v2/src/ElasticLoadBalancingV2Client.ts
@@ -412,7 +412,7 @@ export class ElasticLoadBalancingV2Client extends __Client<
    */
   readonly config: ElasticLoadBalancingV2ClientResolvedConfig;
 
-  constructor(configuration: ElasticLoadBalancingV2ClientConfig) {
+  constructor(configuration: ElasticLoadBalancingV2ClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-elastic-load-balancing/src/ElasticLoadBalancingClient.ts
+++ b/clients/client-elastic-load-balancing/src/ElasticLoadBalancingClient.ts
@@ -425,7 +425,7 @@ export class ElasticLoadBalancingClient extends __Client<
    */
   readonly config: ElasticLoadBalancingClientResolvedConfig;
 
-  constructor(configuration: ElasticLoadBalancingClientConfig) {
+  constructor(configuration: ElasticLoadBalancingClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-elastic-transcoder/src/ElasticTranscoderClient.ts
+++ b/clients/client-elastic-transcoder/src/ElasticTranscoderClient.ts
@@ -304,7 +304,7 @@ export class ElasticTranscoderClient extends __Client<
    */
   readonly config: ElasticTranscoderClientResolvedConfig;
 
-  constructor(configuration: ElasticTranscoderClientConfig) {
+  constructor(configuration: ElasticTranscoderClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-elasticache/src/ElastiCacheClient.ts
+++ b/clients/client-elasticache/src/ElastiCacheClient.ts
@@ -582,7 +582,7 @@ export class ElastiCacheClient extends __Client<
    */
   readonly config: ElastiCacheClientResolvedConfig;
 
-  constructor(configuration: ElastiCacheClientConfig) {
+  constructor(configuration: ElastiCacheClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-elasticsearch-service/src/ElasticsearchServiceClient.ts
+++ b/clients/client-elasticsearch-service/src/ElasticsearchServiceClient.ts
@@ -504,7 +504,7 @@ export class ElasticsearchServiceClient extends __Client<
    */
   readonly config: ElasticsearchServiceClientResolvedConfig;
 
-  constructor(configuration: ElasticsearchServiceClientConfig) {
+  constructor(configuration: ElasticsearchServiceClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-emr-containers/src/EMRContainersClient.ts
+++ b/clients/client-emr-containers/src/EMRContainersClient.ts
@@ -362,7 +362,7 @@ export class EMRContainersClient extends __Client<
    */
   readonly config: EMRContainersClientResolvedConfig;
 
-  constructor(configuration: EMRContainersClientConfig) {
+  constructor(configuration: EMRContainersClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-emr-serverless/src/EMRServerlessClient.ts
+++ b/clients/client-emr-serverless/src/EMRServerlessClient.ts
@@ -317,7 +317,7 @@ export class EMRServerlessClient extends __Client<
    */
   readonly config: EMRServerlessClientResolvedConfig;
 
-  constructor(configuration: EMRServerlessClientConfig) {
+  constructor(configuration: EMRServerlessClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-emr/src/EMRClient.ts
+++ b/clients/client-emr/src/EMRClient.ts
@@ -503,7 +503,7 @@ export class EMRClient extends __Client<
    */
   readonly config: EMRClientResolvedConfig;
 
-  constructor(configuration: EMRClientConfig) {
+  constructor(configuration: EMRClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-entityresolution/src/EntityResolutionClient.ts
+++ b/clients/client-entityresolution/src/EntityResolutionClient.ts
@@ -331,7 +331,7 @@ export class EntityResolutionClient extends __Client<
    */
   readonly config: EntityResolutionClientResolvedConfig;
 
-  constructor(configuration: EntityResolutionClientConfig) {
+  constructor(configuration: EntityResolutionClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-eventbridge/src/EventBridgeClient.ts
+++ b/clients/client-eventbridge/src/EventBridgeClient.ts
@@ -482,7 +482,7 @@ export class EventBridgeClient extends __Client<
    */
   readonly config: EventBridgeClientResolvedConfig;
 
-  constructor(configuration: EventBridgeClientConfig) {
+  constructor(configuration: EventBridgeClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-evidently/src/EvidentlyClient.ts
+++ b/clients/client-evidently/src/EvidentlyClient.ts
@@ -384,7 +384,7 @@ export class EvidentlyClient extends __Client<
    */
   readonly config: EvidentlyClientResolvedConfig;
 
-  constructor(configuration: EvidentlyClientConfig) {
+  constructor(configuration: EvidentlyClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-finspace-data/src/FinspaceDataClient.ts
+++ b/clients/client-finspace-data/src/FinspaceDataClient.ts
@@ -369,7 +369,7 @@ export class FinspaceDataClient extends __Client<
    */
   readonly config: FinspaceDataClientResolvedConfig;
 
-  constructor(configuration: FinspaceDataClientConfig) {
+  constructor(configuration: FinspaceDataClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-finspace/src/FinspaceClient.ts
+++ b/clients/client-finspace/src/FinspaceClient.ts
@@ -369,7 +369,7 @@ export class FinspaceClient extends __Client<
    */
   readonly config: FinspaceClientResolvedConfig;
 
-  constructor(configuration: FinspaceClientConfig) {
+  constructor(configuration: FinspaceClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-firehose/src/FirehoseClient.ts
+++ b/clients/client-firehose/src/FirehoseClient.ts
@@ -310,7 +310,7 @@ export class FirehoseClient extends __Client<
    */
   readonly config: FirehoseClientResolvedConfig;
 
-  constructor(configuration: FirehoseClientConfig) {
+  constructor(configuration: FirehoseClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-fis/src/FisClient.ts
+++ b/clients/client-fis/src/FisClient.ts
@@ -319,7 +319,7 @@ export class FisClient extends __Client<
    */
   readonly config: FisClientResolvedConfig;
 
-  constructor(configuration: FisClientConfig) {
+  constructor(configuration: FisClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-fms/src/FMSClient.ts
+++ b/clients/client-fms/src/FMSClient.ts
@@ -441,7 +441,7 @@ export class FMSClient extends __Client<
    */
   readonly config: FMSClientResolvedConfig;
 
-  constructor(configuration: FMSClientConfig) {
+  constructor(configuration: FMSClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-forecast/src/ForecastClient.ts
+++ b/clients/client-forecast/src/ForecastClient.ts
@@ -543,7 +543,7 @@ export class ForecastClient extends __Client<
    */
   readonly config: ForecastClientResolvedConfig;
 
-  constructor(configuration: ForecastClientConfig) {
+  constructor(configuration: ForecastClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-forecastquery/src/ForecastqueryClient.ts
+++ b/clients/client-forecastquery/src/ForecastqueryClient.ts
@@ -251,7 +251,7 @@ export class ForecastqueryClient extends __Client<
    */
   readonly config: ForecastqueryClientResolvedConfig;
 
-  constructor(configuration: ForecastqueryClientConfig) {
+  constructor(configuration: ForecastqueryClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-frauddetector/src/FraudDetectorClient.ts
+++ b/clients/client-frauddetector/src/FraudDetectorClient.ts
@@ -543,7 +543,7 @@ export class FraudDetectorClient extends __Client<
    */
   readonly config: FraudDetectorClientResolvedConfig;
 
-  constructor(configuration: FraudDetectorClientConfig) {
+  constructor(configuration: FraudDetectorClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-fsx/src/FSxClient.ts
+++ b/clients/client-fsx/src/FSxClient.ts
@@ -430,7 +430,7 @@ export class FSxClient extends __Client<
    */
   readonly config: FSxClientResolvedConfig;
 
-  constructor(configuration: FSxClientConfig) {
+  constructor(configuration: FSxClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-gamelift/src/GameLiftClient.ts
+++ b/clients/client-gamelift/src/GameLiftClient.ts
@@ -789,7 +789,7 @@ export class GameLiftClient extends __Client<
    */
   readonly config: GameLiftClientResolvedConfig;
 
-  constructor(configuration: GameLiftClientConfig) {
+  constructor(configuration: GameLiftClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-gamesparks/src/GameSparksClient.ts
+++ b/clients/client-gamesparks/src/GameSparksClient.ts
@@ -381,7 +381,7 @@ export class GameSparksClient extends __Client<
    */
   readonly config: GameSparksClientResolvedConfig;
 
-  constructor(configuration: GameSparksClientConfig) {
+  constructor(configuration: GameSparksClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-glacier/src/GlacierClient.ts
+++ b/clients/client-glacier/src/GlacierClient.ts
@@ -448,7 +448,7 @@ export class GlacierClient extends __Client<
    */
   readonly config: GlacierClientResolvedConfig;
 
-  constructor(configuration: GlacierClientConfig) {
+  constructor(configuration: GlacierClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-global-accelerator/src/GlobalAcceleratorClient.ts
+++ b/clients/client-global-accelerator/src/GlobalAcceleratorClient.ts
@@ -538,7 +538,7 @@ export class GlobalAcceleratorClient extends __Client<
    */
   readonly config: GlobalAcceleratorClientResolvedConfig;
 
-  constructor(configuration: GlobalAcceleratorClientConfig) {
+  constructor(configuration: GlobalAcceleratorClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-glue/src/GlueClient.ts
+++ b/clients/client-glue/src/GlueClient.ts
@@ -1072,7 +1072,7 @@ export class GlueClient extends __Client<
    */
   readonly config: GlueClientResolvedConfig;
 
-  constructor(configuration: GlueClientConfig) {
+  constructor(configuration: GlueClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-grafana/src/GrafanaClient.ts
+++ b/clients/client-grafana/src/GrafanaClient.ts
@@ -335,7 +335,7 @@ export class GrafanaClient extends __Client<
    */
   readonly config: GrafanaClientResolvedConfig;
 
-  constructor(configuration: GrafanaClientConfig) {
+  constructor(configuration: GrafanaClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-greengrass/src/GreengrassClient.ts
+++ b/clients/client-greengrass/src/GreengrassClient.ts
@@ -750,7 +750,7 @@ export class GreengrassClient extends __Client<
    */
   readonly config: GreengrassClientResolvedConfig;
 
-  constructor(configuration: GreengrassClientConfig) {
+  constructor(configuration: GreengrassClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-greengrassv2/src/GreengrassV2Client.ts
+++ b/clients/client-greengrassv2/src/GreengrassV2Client.ts
@@ -388,7 +388,7 @@ export class GreengrassV2Client extends __Client<
    */
   readonly config: GreengrassV2ClientResolvedConfig;
 
-  constructor(configuration: GreengrassV2ClientConfig) {
+  constructor(configuration: GreengrassV2ClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-groundstation/src/GroundStationClient.ts
+++ b/clients/client-groundstation/src/GroundStationClient.ts
@@ -378,7 +378,7 @@ export class GroundStationClient extends __Client<
    */
   readonly config: GroundStationClientResolvedConfig;
 
-  constructor(configuration: GroundStationClientConfig) {
+  constructor(configuration: GroundStationClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-guardduty/src/GuardDutyClient.ts
+++ b/clients/client-guardduty/src/GuardDutyClient.ts
@@ -564,7 +564,7 @@ export class GuardDutyClient extends __Client<
    */
   readonly config: GuardDutyClientResolvedConfig;
 
-  constructor(configuration: GuardDutyClientConfig) {
+  constructor(configuration: GuardDutyClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-health/src/HealthClient.ts
+++ b/clients/client-health/src/HealthClient.ts
@@ -360,7 +360,7 @@ export class HealthClient extends __Client<
    */
   readonly config: HealthClientResolvedConfig;
 
-  constructor(configuration: HealthClientConfig) {
+  constructor(configuration: HealthClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-healthlake/src/HealthLakeClient.ts
+++ b/clients/client-healthlake/src/HealthLakeClient.ts
@@ -304,7 +304,7 @@ export class HealthLakeClient extends __Client<
    */
   readonly config: HealthLakeClientResolvedConfig;
 
-  constructor(configuration: HealthLakeClientConfig) {
+  constructor(configuration: HealthLakeClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-honeycode/src/HoneycodeClient.ts
+++ b/clients/client-honeycode/src/HoneycodeClient.ts
@@ -319,7 +319,7 @@ export class HoneycodeClient extends __Client<
    */
   readonly config: HoneycodeClientResolvedConfig;
 
-  constructor(configuration: HoneycodeClientConfig) {
+  constructor(configuration: HoneycodeClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-iam/src/IAMClient.ts
+++ b/clients/client-iam/src/IAMClient.ts
@@ -952,7 +952,7 @@ export class IAMClient extends __Client<
    */
   readonly config: IAMClientResolvedConfig;
 
-  constructor(configuration: IAMClientConfig) {
+  constructor(configuration: IAMClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-identitystore/src/IdentitystoreClient.ts
+++ b/clients/client-identitystore/src/IdentitystoreClient.ts
@@ -332,7 +332,7 @@ export class IdentitystoreClient extends __Client<
    */
   readonly config: IdentitystoreClientResolvedConfig;
 
-  constructor(configuration: IdentitystoreClientConfig) {
+  constructor(configuration: IdentitystoreClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-imagebuilder/src/ImagebuilderClient.ts
+++ b/clients/client-imagebuilder/src/ImagebuilderClient.ts
@@ -513,7 +513,7 @@ export class ImagebuilderClient extends __Client<
    */
   readonly config: ImagebuilderClientResolvedConfig;
 
-  constructor(configuration: ImagebuilderClientConfig) {
+  constructor(configuration: ImagebuilderClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-inspector/src/InspectorClient.ts
+++ b/clients/client-inspector/src/InspectorClient.ts
@@ -438,7 +438,7 @@ export class InspectorClient extends __Client<
    */
   readonly config: InspectorClientResolvedConfig;
 
-  constructor(configuration: InspectorClientConfig) {
+  constructor(configuration: InspectorClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-inspector2/src/Inspector2Client.ts
+++ b/clients/client-inspector2/src/Inspector2Client.ts
@@ -460,7 +460,7 @@ export class Inspector2Client extends __Client<
    */
   readonly config: Inspector2ClientResolvedConfig;
 
-  constructor(configuration: Inspector2ClientConfig) {
+  constructor(configuration: Inspector2ClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-internetmonitor/src/InternetMonitorClient.ts
+++ b/clients/client-internetmonitor/src/InternetMonitorClient.ts
@@ -294,7 +294,7 @@ export class InternetMonitorClient extends __Client<
    */
   readonly config: InternetMonitorClientResolvedConfig;
 
-  constructor(configuration: InternetMonitorClientConfig) {
+  constructor(configuration: InternetMonitorClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-iot-1click-devices-service/src/IoT1ClickDevicesServiceClient.ts
+++ b/clients/client-iot-1click-devices-service/src/IoT1ClickDevicesServiceClient.ts
@@ -299,7 +299,7 @@ export class IoT1ClickDevicesServiceClient extends __Client<
    */
   readonly config: IoT1ClickDevicesServiceClientResolvedConfig;
 
-  constructor(configuration: IoT1ClickDevicesServiceClientConfig) {
+  constructor(configuration: IoT1ClickDevicesServiceClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-iot-1click-projects/src/IoT1ClickProjectsClient.ts
+++ b/clients/client-iot-1click-projects/src/IoT1ClickProjectsClient.ts
@@ -306,7 +306,7 @@ export class IoT1ClickProjectsClient extends __Client<
    */
   readonly config: IoT1ClickProjectsClientResolvedConfig;
 
-  constructor(configuration: IoT1ClickProjectsClientConfig) {
+  constructor(configuration: IoT1ClickProjectsClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-iot-data-plane/src/IoTDataPlaneClient.ts
+++ b/clients/client-iot-data-plane/src/IoTDataPlaneClient.ts
@@ -283,7 +283,7 @@ export class IoTDataPlaneClient extends __Client<
    */
   readonly config: IoTDataPlaneClientResolvedConfig;
 
-  constructor(configuration: IoTDataPlaneClientConfig) {
+  constructor(configuration: IoTDataPlaneClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-iot-events-data/src/IoTEventsDataClient.ts
+++ b/clients/client-iot-events-data/src/IoTEventsDataClient.ts
@@ -295,7 +295,7 @@ export class IoTEventsDataClient extends __Client<
    */
   readonly config: IoTEventsDataClientResolvedConfig;
 
-  constructor(configuration: IoTEventsDataClientConfig) {
+  constructor(configuration: IoTEventsDataClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-iot-events/src/IoTEventsClient.ts
+++ b/clients/client-iot-events/src/IoTEventsClient.ts
@@ -359,7 +359,7 @@ export class IoTEventsClient extends __Client<
    */
   readonly config: IoTEventsClientResolvedConfig;
 
-  constructor(configuration: IoTEventsClientConfig) {
+  constructor(configuration: IoTEventsClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-iot-jobs-data-plane/src/IoTJobsDataPlaneClient.ts
+++ b/clients/client-iot-jobs-data-plane/src/IoTJobsDataPlaneClient.ts
@@ -277,7 +277,7 @@ export class IoTJobsDataPlaneClient extends __Client<
    */
   readonly config: IoTJobsDataPlaneClientResolvedConfig;
 
-  constructor(configuration: IoTJobsDataPlaneClientConfig) {
+  constructor(configuration: IoTJobsDataPlaneClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-iot-roborunner/src/IoTRoboRunnerClient.ts
+++ b/clients/client-iot-roborunner/src/IoTRoboRunnerClient.ts
@@ -307,7 +307,7 @@ export class IoTRoboRunnerClient extends __Client<
    */
   readonly config: IoTRoboRunnerClientResolvedConfig;
 
-  constructor(configuration: IoTRoboRunnerClientConfig) {
+  constructor(configuration: IoTRoboRunnerClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-iot-wireless/src/IoTWirelessClient.ts
+++ b/clients/client-iot-wireless/src/IoTWirelessClient.ts
@@ -837,7 +837,7 @@ export class IoTWirelessClient extends __Client<
    */
   readonly config: IoTWirelessClientResolvedConfig;
 
-  constructor(configuration: IoTWirelessClientConfig) {
+  constructor(configuration: IoTWirelessClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-iot/src/IoTClient.ts
+++ b/clients/client-iot/src/IoTClient.ts
@@ -1446,7 +1446,7 @@ export class IoTClient extends __Client<
    */
   readonly config: IoTClientResolvedConfig;
 
-  constructor(configuration: IoTClientConfig) {
+  constructor(configuration: IoTClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-iotanalytics/src/IoTAnalyticsClient.ts
+++ b/clients/client-iotanalytics/src/IoTAnalyticsClient.ts
@@ -390,7 +390,7 @@ export class IoTAnalyticsClient extends __Client<
    */
   readonly config: IoTAnalyticsClientResolvedConfig;
 
-  constructor(configuration: IoTAnalyticsClientConfig) {
+  constructor(configuration: IoTAnalyticsClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-iotdeviceadvisor/src/IotDeviceAdvisorClient.ts
+++ b/clients/client-iotdeviceadvisor/src/IotDeviceAdvisorClient.ts
@@ -311,7 +311,7 @@ export class IotDeviceAdvisorClient extends __Client<
    */
   readonly config: IotDeviceAdvisorClientResolvedConfig;
 
-  constructor(configuration: IotDeviceAdvisorClientConfig) {
+  constructor(configuration: IotDeviceAdvisorClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-iotfleethub/src/IoTFleetHubClient.ts
+++ b/clients/client-iotfleethub/src/IoTFleetHubClient.ts
@@ -279,7 +279,7 @@ export class IoTFleetHubClient extends __Client<
    */
   readonly config: IoTFleetHubClientResolvedConfig;
 
-  constructor(configuration: IoTFleetHubClientConfig) {
+  constructor(configuration: IoTFleetHubClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-iotfleetwise/src/IoTFleetWiseClient.ts
+++ b/clients/client-iotfleetwise/src/IoTFleetWiseClient.ts
@@ -468,7 +468,7 @@ export class IoTFleetWiseClient extends __Client<
    */
   readonly config: IoTFleetWiseClientResolvedConfig;
 
-  constructor(configuration: IoTFleetWiseClientConfig) {
+  constructor(configuration: IoTFleetWiseClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-iotsecuretunneling/src/IoTSecureTunnelingClient.ts
+++ b/clients/client-iotsecuretunneling/src/IoTSecureTunnelingClient.ts
@@ -280,7 +280,7 @@ export class IoTSecureTunnelingClient extends __Client<
    */
   readonly config: IoTSecureTunnelingClientResolvedConfig;
 
-  constructor(configuration: IoTSecureTunnelingClientConfig) {
+  constructor(configuration: IoTSecureTunnelingClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-iotsitewise/src/IoTSiteWiseClient.ts
+++ b/clients/client-iotsitewise/src/IoTSiteWiseClient.ts
@@ -553,7 +553,7 @@ export class IoTSiteWiseClient extends __Client<
    */
   readonly config: IoTSiteWiseClientResolvedConfig;
 
-  constructor(configuration: IoTSiteWiseClientConfig) {
+  constructor(configuration: IoTSiteWiseClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-iotthingsgraph/src/IoTThingsGraphClient.ts
+++ b/clients/client-iotthingsgraph/src/IoTThingsGraphClient.ts
@@ -420,7 +420,7 @@ export class IoTThingsGraphClient extends __Client<
    */
   readonly config: IoTThingsGraphClientResolvedConfig;
 
-  constructor(configuration: IoTThingsGraphClientConfig) {
+  constructor(configuration: IoTThingsGraphClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-iottwinmaker/src/IoTTwinMakerClient.ts
+++ b/clients/client-iottwinmaker/src/IoTTwinMakerClient.ts
@@ -372,7 +372,7 @@ export class IoTTwinMakerClient extends __Client<
    */
   readonly config: IoTTwinMakerClientResolvedConfig;
 
-  constructor(configuration: IoTTwinMakerClientConfig) {
+  constructor(configuration: IoTTwinMakerClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-ivs-realtime/src/IVSRealTimeClient.ts
+++ b/clients/client-ivs-realtime/src/IVSRealTimeClient.ts
@@ -429,7 +429,7 @@ export class IVSRealTimeClient extends __Client<
    */
   readonly config: IVSRealTimeClientResolvedConfig;
 
-  constructor(configuration: IVSRealTimeClientConfig) {
+  constructor(configuration: IVSRealTimeClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-ivs/src/IvsClient.ts
+++ b/clients/client-ivs/src/IvsClient.ts
@@ -704,7 +704,7 @@ export class IvsClient extends __Client<
    */
   readonly config: IvsClientResolvedConfig;
 
-  constructor(configuration: IvsClientConfig) {
+  constructor(configuration: IvsClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-ivschat/src/IvschatClient.ts
+++ b/clients/client-ivschat/src/IvschatClient.ts
@@ -533,7 +533,7 @@ export class IvschatClient extends __Client<
    */
   readonly config: IvschatClientResolvedConfig;
 
-  constructor(configuration: IvschatClientConfig) {
+  constructor(configuration: IvschatClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-kafka/src/KafkaClient.ts
+++ b/clients/client-kafka/src/KafkaClient.ts
@@ -459,7 +459,7 @@ export class KafkaClient extends __Client<
    */
   readonly config: KafkaClientResolvedConfig;
 
-  constructor(configuration: KafkaClientConfig) {
+  constructor(configuration: KafkaClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-kafkaconnect/src/KafkaConnectClient.ts
+++ b/clients/client-kafkaconnect/src/KafkaConnectClient.ts
@@ -294,7 +294,7 @@ export class KafkaConnectClient extends __Client<
    */
   readonly config: KafkaConnectClientResolvedConfig;
 
-  constructor(configuration: KafkaConnectClientConfig) {
+  constructor(configuration: KafkaConnectClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-kendra-ranking/src/KendraRankingClient.ts
+++ b/clients/client-kendra-ranking/src/KendraRankingClient.ts
@@ -293,7 +293,7 @@ export class KendraRankingClient extends __Client<
    */
   readonly config: KendraRankingClientResolvedConfig;
 
-  constructor(configuration: KendraRankingClientConfig) {
+  constructor(configuration: KendraRankingClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-kendra/src/KendraClient.ts
+++ b/clients/client-kendra/src/KendraClient.ts
@@ -546,7 +546,7 @@ export class KendraClient extends __Client<
    */
   readonly config: KendraClientResolvedConfig;
 
-  constructor(configuration: KendraClientConfig) {
+  constructor(configuration: KendraClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-keyspaces/src/KeyspacesClient.ts
+++ b/clients/client-keyspaces/src/KeyspacesClient.ts
@@ -301,7 +301,7 @@ export class KeyspacesClient extends __Client<
    */
   readonly config: KeyspacesClientResolvedConfig;
 
-  constructor(configuration: KeyspacesClientConfig) {
+  constructor(configuration: KeyspacesClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-kinesis-analytics-v2/src/KinesisAnalyticsV2Client.ts
+++ b/clients/client-kinesis-analytics-v2/src/KinesisAnalyticsV2Client.ts
@@ -410,7 +410,7 @@ export class KinesisAnalyticsV2Client extends __Client<
    */
   readonly config: KinesisAnalyticsV2ClientResolvedConfig;
 
-  constructor(configuration: KinesisAnalyticsV2ClientConfig) {
+  constructor(configuration: KinesisAnalyticsV2ClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-kinesis-analytics/src/KinesisAnalyticsClient.ts
+++ b/clients/client-kinesis-analytics/src/KinesisAnalyticsClient.ts
@@ -351,7 +351,7 @@ export class KinesisAnalyticsClient extends __Client<
    */
   readonly config: KinesisAnalyticsClientResolvedConfig;
 
-  constructor(configuration: KinesisAnalyticsClientConfig) {
+  constructor(configuration: KinesisAnalyticsClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-kinesis-video-archived-media/src/KinesisVideoArchivedMediaClient.ts
+++ b/clients/client-kinesis-video-archived-media/src/KinesisVideoArchivedMediaClient.ts
@@ -281,7 +281,7 @@ export class KinesisVideoArchivedMediaClient extends __Client<
    */
   readonly config: KinesisVideoArchivedMediaClientResolvedConfig;
 
-  constructor(configuration: KinesisVideoArchivedMediaClientConfig) {
+  constructor(configuration: KinesisVideoArchivedMediaClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-kinesis-video-media/src/KinesisVideoMediaClient.ts
+++ b/clients/client-kinesis-video-media/src/KinesisVideoMediaClient.ts
@@ -254,7 +254,7 @@ export class KinesisVideoMediaClient extends __Client<
    */
   readonly config: KinesisVideoMediaClientResolvedConfig;
 
-  constructor(configuration: KinesisVideoMediaClientConfig) {
+  constructor(configuration: KinesisVideoMediaClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-kinesis-video-signaling/src/KinesisVideoSignalingClient.ts
+++ b/clients/client-kinesis-video-signaling/src/KinesisVideoSignalingClient.ts
@@ -259,7 +259,7 @@ export class KinesisVideoSignalingClient extends __Client<
    */
   readonly config: KinesisVideoSignalingClientResolvedConfig;
 
-  constructor(configuration: KinesisVideoSignalingClientConfig) {
+  constructor(configuration: KinesisVideoSignalingClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-kinesis-video-webrtc-storage/src/KinesisVideoWebRTCStorageClient.ts
+++ b/clients/client-kinesis-video-webrtc-storage/src/KinesisVideoWebRTCStorageClient.ts
@@ -249,7 +249,7 @@ export class KinesisVideoWebRTCStorageClient extends __Client<
    */
   readonly config: KinesisVideoWebRTCStorageClientResolvedConfig;
 
-  constructor(configuration: KinesisVideoWebRTCStorageClientConfig) {
+  constructor(configuration: KinesisVideoWebRTCStorageClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-kinesis-video/src/KinesisVideoClient.ts
+++ b/clients/client-kinesis-video/src/KinesisVideoClient.ts
@@ -393,7 +393,7 @@ export class KinesisVideoClient extends __Client<
    */
   readonly config: KinesisVideoClientResolvedConfig;
 
-  constructor(configuration: KinesisVideoClientConfig) {
+  constructor(configuration: KinesisVideoClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-kinesis/src/KinesisClient.ts
+++ b/clients/client-kinesis/src/KinesisClient.ts
@@ -384,7 +384,7 @@ export class KinesisClient extends __Client<
    */
   readonly config: KinesisClientResolvedConfig;
 
-  constructor(configuration: KinesisClientConfig) {
+  constructor(configuration: KinesisClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-kms/src/KMSClient.ts
+++ b/clients/client-kms/src/KMSClient.ts
@@ -538,7 +538,7 @@ export class KMSClient extends __Client<
    */
   readonly config: KMSClientResolvedConfig;
 
-  constructor(configuration: KMSClientConfig) {
+  constructor(configuration: KMSClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-lakeformation/src/LakeFormationClient.ts
+++ b/clients/client-lakeformation/src/LakeFormationClient.ts
@@ -455,7 +455,7 @@ export class LakeFormationClient extends __Client<
    */
   readonly config: LakeFormationClientResolvedConfig;
 
-  constructor(configuration: LakeFormationClientConfig) {
+  constructor(configuration: LakeFormationClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-lambda/src/LambdaClient.ts
+++ b/clients/client-lambda/src/LambdaClient.ts
@@ -647,7 +647,7 @@ export class LambdaClient extends __Client<
    */
   readonly config: LambdaClientResolvedConfig;
 
-  constructor(configuration: LambdaClientConfig) {
+  constructor(configuration: LambdaClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-lex-model-building-service/src/LexModelBuildingServiceClient.ts
+++ b/clients/client-lex-model-building-service/src/LexModelBuildingServiceClient.ts
@@ -405,7 +405,7 @@ export class LexModelBuildingServiceClient extends __Client<
    */
   readonly config: LexModelBuildingServiceClientResolvedConfig;
 
-  constructor(configuration: LexModelBuildingServiceClientConfig) {
+  constructor(configuration: LexModelBuildingServiceClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-lex-models-v2/src/LexModelsV2Client.ts
+++ b/clients/client-lex-models-v2/src/LexModelsV2Client.ts
@@ -621,7 +621,7 @@ export class LexModelsV2Client extends __Client<
    */
   readonly config: LexModelsV2ClientResolvedConfig;
 
-  constructor(configuration: LexModelsV2ClientConfig) {
+  constructor(configuration: LexModelsV2ClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-lex-runtime-service/src/LexRuntimeServiceClient.ts
+++ b/clients/client-lex-runtime-service/src/LexRuntimeServiceClient.ts
@@ -279,7 +279,7 @@ export class LexRuntimeServiceClient extends __Client<
    */
   readonly config: LexRuntimeServiceClientResolvedConfig;
 
-  constructor(configuration: LexRuntimeServiceClientConfig) {
+  constructor(configuration: LexRuntimeServiceClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-lex-runtime-v2/src/LexRuntimeV2Client.ts
+++ b/clients/client-lex-runtime-v2/src/LexRuntimeV2Client.ts
@@ -300,7 +300,7 @@ export class LexRuntimeV2Client extends __Client<
    */
   readonly config: LexRuntimeV2ClientResolvedConfig;
 
-  constructor(configuration: LexRuntimeV2ClientConfig) {
+  constructor(configuration: LexRuntimeV2ClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-license-manager-linux-subscriptions/src/LicenseManagerLinuxSubscriptionsClient.ts
+++ b/clients/client-license-manager-linux-subscriptions/src/LicenseManagerLinuxSubscriptionsClient.ts
@@ -271,7 +271,7 @@ export class LicenseManagerLinuxSubscriptionsClient extends __Client<
    */
   readonly config: LicenseManagerLinuxSubscriptionsClientResolvedConfig;
 
-  constructor(configuration: LicenseManagerLinuxSubscriptionsClientConfig) {
+  constructor(configuration: LicenseManagerLinuxSubscriptionsClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-license-manager-user-subscriptions/src/LicenseManagerUserSubscriptionsClient.ts
+++ b/clients/client-license-manager-user-subscriptions/src/LicenseManagerUserSubscriptionsClient.ts
@@ -306,7 +306,7 @@ export class LicenseManagerUserSubscriptionsClient extends __Client<
    */
   readonly config: LicenseManagerUserSubscriptionsClientResolvedConfig;
 
-  constructor(configuration: LicenseManagerUserSubscriptionsClientConfig) {
+  constructor(configuration: LicenseManagerUserSubscriptionsClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-license-manager/src/LicenseManagerClient.ts
+++ b/clients/client-license-manager/src/LicenseManagerClient.ts
@@ -484,7 +484,7 @@ export class LicenseManagerClient extends __Client<
    */
   readonly config: LicenseManagerClientResolvedConfig;
 
-  constructor(configuration: LicenseManagerClientConfig) {
+  constructor(configuration: LicenseManagerClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-lightsail/src/LightsailClient.ts
+++ b/clients/client-lightsail/src/LightsailClient.ts
@@ -970,7 +970,7 @@ export class LightsailClient extends __Client<
    */
   readonly config: LightsailClientResolvedConfig;
 
-  constructor(configuration: LightsailClientConfig) {
+  constructor(configuration: LightsailClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-location/src/LocationClient.ts
+++ b/clients/client-location/src/LocationClient.ts
@@ -498,7 +498,7 @@ export class LocationClient extends __Client<
    */
   readonly config: LocationClientResolvedConfig;
 
-  constructor(configuration: LocationClientConfig) {
+  constructor(configuration: LocationClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-lookoutequipment/src/LookoutEquipmentClient.ts
+++ b/clients/client-lookoutequipment/src/LookoutEquipmentClient.ts
@@ -424,7 +424,7 @@ export class LookoutEquipmentClient extends __Client<
    */
   readonly config: LookoutEquipmentClientResolvedConfig;
 
-  constructor(configuration: LookoutEquipmentClientConfig) {
+  constructor(configuration: LookoutEquipmentClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-lookoutmetrics/src/LookoutMetricsClient.ts
+++ b/clients/client-lookoutmetrics/src/LookoutMetricsClient.ts
@@ -383,7 +383,7 @@ export class LookoutMetricsClient extends __Client<
    */
   readonly config: LookoutMetricsClientResolvedConfig;
 
-  constructor(configuration: LookoutMetricsClientConfig) {
+  constructor(configuration: LookoutMetricsClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-lookoutvision/src/LookoutVisionClient.ts
+++ b/clients/client-lookoutvision/src/LookoutVisionClient.ts
@@ -333,7 +333,7 @@ export class LookoutVisionClient extends __Client<
    */
   readonly config: LookoutVisionClientResolvedConfig;
 
-  constructor(configuration: LookoutVisionClientConfig) {
+  constructor(configuration: LookoutVisionClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-m2/src/M2Client.ts
+++ b/clients/client-m2/src/M2Client.ts
@@ -385,7 +385,7 @@ export class M2Client extends __Client<
    */
   readonly config: M2ClientResolvedConfig;
 
-  constructor(configuration: M2ClientConfig) {
+  constructor(configuration: M2ClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-machine-learning/src/MachineLearningClient.ts
+++ b/clients/client-machine-learning/src/MachineLearningClient.ts
@@ -364,7 +364,7 @@ export class MachineLearningClient extends __Client<
    */
   readonly config: MachineLearningClientResolvedConfig;
 
-  constructor(configuration: MachineLearningClientConfig) {
+  constructor(configuration: MachineLearningClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-macie/src/MacieClient.ts
+++ b/clients/client-macie/src/MacieClient.ts
@@ -285,7 +285,7 @@ export class MacieClient extends __Client<
    */
   readonly config: MacieClientResolvedConfig;
 
-  constructor(configuration: MacieClientConfig) {
+  constructor(configuration: MacieClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-macie2/src/Macie2Client.ts
+++ b/clients/client-macie2/src/Macie2Client.ts
@@ -630,7 +630,7 @@ export class Macie2Client extends __Client<
    */
   readonly config: Macie2ClientResolvedConfig;
 
-  constructor(configuration: Macie2ClientConfig) {
+  constructor(configuration: Macie2ClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-managedblockchain-query/src/ManagedBlockchainQueryClient.ts
+++ b/clients/client-managedblockchain-query/src/ManagedBlockchainQueryClient.ts
@@ -276,7 +276,7 @@ export class ManagedBlockchainQueryClient extends __Client<
    */
   readonly config: ManagedBlockchainQueryClientResolvedConfig;
 
-  constructor(configuration: ManagedBlockchainQueryClientConfig) {
+  constructor(configuration: ManagedBlockchainQueryClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-managedblockchain/src/ManagedBlockchainClient.ts
+++ b/clients/client-managedblockchain/src/ManagedBlockchainClient.ts
@@ -333,7 +333,7 @@ export class ManagedBlockchainClient extends __Client<
    */
   readonly config: ManagedBlockchainClientResolvedConfig;
 
-  constructor(configuration: ManagedBlockchainClientConfig) {
+  constructor(configuration: ManagedBlockchainClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-marketplace-catalog/src/MarketplaceCatalogClient.ts
+++ b/clients/client-marketplace-catalog/src/MarketplaceCatalogClient.ts
@@ -293,7 +293,7 @@ export class MarketplaceCatalogClient extends __Client<
    */
   readonly config: MarketplaceCatalogClientResolvedConfig;
 
-  constructor(configuration: MarketplaceCatalogClientConfig) {
+  constructor(configuration: MarketplaceCatalogClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-marketplace-commerce-analytics/src/MarketplaceCommerceAnalyticsClient.ts
+++ b/clients/client-marketplace-commerce-analytics/src/MarketplaceCommerceAnalyticsClient.ts
@@ -252,7 +252,7 @@ export class MarketplaceCommerceAnalyticsClient extends __Client<
    */
   readonly config: MarketplaceCommerceAnalyticsClientResolvedConfig;
 
-  constructor(configuration: MarketplaceCommerceAnalyticsClientConfig) {
+  constructor(configuration: MarketplaceCommerceAnalyticsClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-marketplace-entitlement-service/src/MarketplaceEntitlementServiceClient.ts
+++ b/clients/client-marketplace-entitlement-service/src/MarketplaceEntitlementServiceClient.ts
@@ -265,7 +265,7 @@ export class MarketplaceEntitlementServiceClient extends __Client<
    */
   readonly config: MarketplaceEntitlementServiceClientResolvedConfig;
 
-  constructor(configuration: MarketplaceEntitlementServiceClientConfig) {
+  constructor(configuration: MarketplaceEntitlementServiceClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-marketplace-metering/src/MarketplaceMeteringClient.ts
+++ b/clients/client-marketplace-metering/src/MarketplaceMeteringClient.ts
@@ -320,7 +320,7 @@ export class MarketplaceMeteringClient extends __Client<
    */
   readonly config: MarketplaceMeteringClientResolvedConfig;
 
-  constructor(configuration: MarketplaceMeteringClientConfig) {
+  constructor(configuration: MarketplaceMeteringClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-mediaconnect/src/MediaConnectClient.ts
+++ b/clients/client-mediaconnect/src/MediaConnectClient.ts
@@ -438,7 +438,7 @@ export class MediaConnectClient extends __Client<
    */
   readonly config: MediaConnectClientResolvedConfig;
 
-  constructor(configuration: MediaConnectClientConfig) {
+  constructor(configuration: MediaConnectClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-mediaconvert/src/MediaConvertClient.ts
+++ b/clients/client-mediaconvert/src/MediaConvertClient.ts
@@ -339,7 +339,7 @@ export class MediaConvertClient extends __Client<
    */
   readonly config: MediaConvertClientResolvedConfig;
 
-  constructor(configuration: MediaConvertClientConfig) {
+  constructor(configuration: MediaConvertClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-medialive/src/MediaLiveClient.ts
+++ b/clients/client-medialive/src/MediaLiveClient.ts
@@ -508,7 +508,7 @@ export class MediaLiveClient extends __Client<
    */
   readonly config: MediaLiveClientResolvedConfig;
 
-  constructor(configuration: MediaLiveClientConfig) {
+  constructor(configuration: MediaLiveClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-mediapackage-vod/src/MediaPackageVodClient.ts
+++ b/clients/client-mediapackage-vod/src/MediaPackageVodClient.ts
@@ -327,7 +327,7 @@ export class MediaPackageVodClient extends __Client<
    */
   readonly config: MediaPackageVodClientResolvedConfig;
 
-  constructor(configuration: MediaPackageVodClientConfig) {
+  constructor(configuration: MediaPackageVodClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-mediapackage/src/MediaPackageClient.ts
+++ b/clients/client-mediapackage/src/MediaPackageClient.ts
@@ -327,7 +327,7 @@ export class MediaPackageClient extends __Client<
    */
   readonly config: MediaPackageClientResolvedConfig;
 
-  constructor(configuration: MediaPackageClientConfig) {
+  constructor(configuration: MediaPackageClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-mediapackagev2/src/MediaPackageV2Client.ts
+++ b/clients/client-mediapackagev2/src/MediaPackageV2Client.ts
@@ -356,7 +356,7 @@ export class MediaPackageV2Client extends __Client<
    */
   readonly config: MediaPackageV2ClientResolvedConfig;
 
-  constructor(configuration: MediaPackageV2ClientConfig) {
+  constructor(configuration: MediaPackageV2ClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-mediastore-data/src/MediaStoreDataClient.ts
+++ b/clients/client-mediastore-data/src/MediaStoreDataClient.ts
@@ -270,7 +270,7 @@ export class MediaStoreDataClient extends __Client<
    */
   readonly config: MediaStoreDataClientResolvedConfig;
 
-  constructor(configuration: MediaStoreDataClientConfig) {
+  constructor(configuration: MediaStoreDataClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-mediastore/src/MediaStoreClient.ts
+++ b/clients/client-mediastore/src/MediaStoreClient.ts
@@ -319,7 +319,7 @@ export class MediaStoreClient extends __Client<
    */
   readonly config: MediaStoreClientResolvedConfig;
 
-  constructor(configuration: MediaStoreClientConfig) {
+  constructor(configuration: MediaStoreClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-mediatailor/src/MediaTailorClient.ts
+++ b/clients/client-mediatailor/src/MediaTailorClient.ts
@@ -430,7 +430,7 @@ export class MediaTailorClient extends __Client<
    */
   readonly config: MediaTailorClientResolvedConfig;
 
-  constructor(configuration: MediaTailorClientConfig) {
+  constructor(configuration: MediaTailorClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-medical-imaging/src/MedicalImagingClient.ts
+++ b/clients/client-medical-imaging/src/MedicalImagingClient.ts
@@ -474,7 +474,7 @@ export class MedicalImagingClient extends __Client<
    */
   readonly config: MedicalImagingClientResolvedConfig;
 
-  constructor(configuration: MedicalImagingClientConfig) {
+  constructor(configuration: MedicalImagingClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-memorydb/src/MemoryDBClient.ts
+++ b/clients/client-memorydb/src/MemoryDBClient.ts
@@ -398,7 +398,7 @@ export class MemoryDBClient extends __Client<
    */
   readonly config: MemoryDBClientResolvedConfig;
 
-  constructor(configuration: MemoryDBClientConfig) {
+  constructor(configuration: MemoryDBClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-mgn/src/MgnClient.ts
+++ b/clients/client-mgn/src/MgnClient.ts
@@ -540,7 +540,7 @@ export class MgnClient extends __Client<
    */
   readonly config: MgnClientResolvedConfig;
 
-  constructor(configuration: MgnClientConfig) {
+  constructor(configuration: MgnClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-migration-hub-refactor-spaces/src/MigrationHubRefactorSpacesClient.ts
+++ b/clients/client-migration-hub-refactor-spaces/src/MigrationHubRefactorSpacesClient.ts
@@ -335,7 +335,7 @@ export class MigrationHubRefactorSpacesClient extends __Client<
    */
   readonly config: MigrationHubRefactorSpacesClientResolvedConfig;
 
-  constructor(configuration: MigrationHubRefactorSpacesClientConfig) {
+  constructor(configuration: MigrationHubRefactorSpacesClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-migration-hub/src/MigrationHubClient.ts
+++ b/clients/client-migration-hub/src/MigrationHubClient.ts
@@ -350,7 +350,7 @@ export class MigrationHubClient extends __Client<
    */
   readonly config: MigrationHubClientResolvedConfig;
 
-  constructor(configuration: MigrationHubClientConfig) {
+  constructor(configuration: MigrationHubClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-migrationhub-config/src/MigrationHubConfigClient.ts
+++ b/clients/client-migrationhub-config/src/MigrationHubConfigClient.ts
@@ -286,7 +286,7 @@ export class MigrationHubConfigClient extends __Client<
    */
   readonly config: MigrationHubConfigClientResolvedConfig;
 
-  constructor(configuration: MigrationHubConfigClientConfig) {
+  constructor(configuration: MigrationHubConfigClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-migrationhuborchestrator/src/MigrationHubOrchestratorClient.ts
+++ b/clients/client-migrationhuborchestrator/src/MigrationHubOrchestratorClient.ts
@@ -359,7 +359,7 @@ export class MigrationHubOrchestratorClient extends __Client<
    */
   readonly config: MigrationHubOrchestratorClientResolvedConfig;
 
-  constructor(configuration: MigrationHubOrchestratorClientConfig) {
+  constructor(configuration: MigrationHubOrchestratorClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-migrationhubstrategy/src/MigrationHubStrategyClient.ts
+++ b/clients/client-migrationhubstrategy/src/MigrationHubStrategyClient.ts
@@ -350,7 +350,7 @@ export class MigrationHubStrategyClient extends __Client<
    */
   readonly config: MigrationHubStrategyClientResolvedConfig;
 
-  constructor(configuration: MigrationHubStrategyClientConfig) {
+  constructor(configuration: MigrationHubStrategyClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-mobile/src/MobileClient.ts
+++ b/clients/client-mobile/src/MobileClient.ts
@@ -277,7 +277,7 @@ export class MobileClient extends __Client<
    */
   readonly config: MobileClientResolvedConfig;
 
-  constructor(configuration: MobileClientConfig) {
+  constructor(configuration: MobileClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-mq/src/MqClient.ts
+++ b/clients/client-mq/src/MqClient.ts
@@ -336,7 +336,7 @@ export class MqClient extends __Client<
    */
   readonly config: MqClientResolvedConfig;
 
-  constructor(configuration: MqClientConfig) {
+  constructor(configuration: MqClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-mturk/src/MTurkClient.ts
+++ b/clients/client-mturk/src/MTurkClient.ts
@@ -426,7 +426,7 @@ export class MTurkClient extends __Client<
    */
   readonly config: MTurkClientResolvedConfig;
 
-  constructor(configuration: MTurkClientConfig) {
+  constructor(configuration: MTurkClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-mwaa/src/MWAAClient.ts
+++ b/clients/client-mwaa/src/MWAAClient.ts
@@ -368,7 +368,7 @@ export class MWAAClient extends __Client<
    */
   readonly config: MWAAClientResolvedConfig;
 
-  constructor(configuration: MWAAClientConfig) {
+  constructor(configuration: MWAAClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-neptune/src/NeptuneClient.ts
+++ b/clients/client-neptune/src/NeptuneClient.ts
@@ -634,7 +634,7 @@ export class NeptuneClient extends __Client<
    */
   readonly config: NeptuneClientResolvedConfig;
 
-  constructor(configuration: NeptuneClientConfig) {
+  constructor(configuration: NeptuneClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-network-firewall/src/NetworkFirewallClient.ts
+++ b/clients/client-network-firewall/src/NetworkFirewallClient.ts
@@ -500,7 +500,7 @@ export class NetworkFirewallClient extends __Client<
    */
   readonly config: NetworkFirewallClientResolvedConfig;
 
-  constructor(configuration: NetworkFirewallClientConfig) {
+  constructor(configuration: NetworkFirewallClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-networkmanager/src/NetworkManagerClient.ts
+++ b/clients/client-networkmanager/src/NetworkManagerClient.ts
@@ -633,7 +633,7 @@ export class NetworkManagerClient extends __Client<
    */
   readonly config: NetworkManagerClientResolvedConfig;
 
-  constructor(configuration: NetworkManagerClientConfig) {
+  constructor(configuration: NetworkManagerClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-nimble/src/NimbleClient.ts
+++ b/clients/client-nimble/src/NimbleClient.ts
@@ -491,7 +491,7 @@ export class NimbleClient extends __Client<
    */
   readonly config: NimbleClientResolvedConfig;
 
-  constructor(configuration: NimbleClientConfig) {
+  constructor(configuration: NimbleClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-oam/src/OAMClient.ts
+++ b/clients/client-oam/src/OAMClient.ts
@@ -305,7 +305,7 @@ export class OAMClient extends __Client<
    */
   readonly config: OAMClientResolvedConfig;
 
-  constructor(configuration: OAMClientConfig) {
+  constructor(configuration: OAMClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-omics/src/OmicsClient.ts
+++ b/clients/client-omics/src/OmicsClient.ts
@@ -578,7 +578,7 @@ export class OmicsClient extends __Client<
    */
   readonly config: OmicsClientResolvedConfig;
 
-  constructor(configuration: OmicsClientConfig) {
+  constructor(configuration: OmicsClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-opensearch/src/OpenSearchClient.ts
+++ b/clients/client-opensearch/src/OpenSearchClient.ts
@@ -510,7 +510,7 @@ export class OpenSearchClient extends __Client<
    */
   readonly config: OpenSearchClientResolvedConfig;
 
-  constructor(configuration: OpenSearchClientConfig) {
+  constructor(configuration: OpenSearchClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-opensearchserverless/src/OpenSearchServerlessClient.ts
+++ b/clients/client-opensearchserverless/src/OpenSearchServerlessClient.ts
@@ -381,7 +381,7 @@ export class OpenSearchServerlessClient extends __Client<
    */
   readonly config: OpenSearchServerlessClientResolvedConfig;
 
-  constructor(configuration: OpenSearchServerlessClientConfig) {
+  constructor(configuration: OpenSearchServerlessClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-opsworks/src/OpsWorksClient.ts
+++ b/clients/client-opsworks/src/OpsWorksClient.ts
@@ -660,7 +660,7 @@ export class OpsWorksClient extends __Client<
    */
   readonly config: OpsWorksClientResolvedConfig;
 
-  constructor(configuration: OpsWorksClientConfig) {
+  constructor(configuration: OpsWorksClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-opsworkscm/src/OpsWorksCMClient.ts
+++ b/clients/client-opsworkscm/src/OpsWorksCMClient.ts
@@ -405,7 +405,7 @@ export class OpsWorksCMClient extends __Client<
    */
   readonly config: OpsWorksCMClientResolvedConfig;
 
-  constructor(configuration: OpsWorksCMClientConfig) {
+  constructor(configuration: OpsWorksCMClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-organizations/src/OrganizationsClient.ts
+++ b/clients/client-organizations/src/OrganizationsClient.ts
@@ -563,7 +563,7 @@ export class OrganizationsClient extends __Client<
    */
   readonly config: OrganizationsClientResolvedConfig;
 
-  constructor(configuration: OrganizationsClientConfig) {
+  constructor(configuration: OrganizationsClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-osis/src/OSISClient.ts
+++ b/clients/client-osis/src/OSISClient.ts
@@ -302,7 +302,7 @@ export class OSISClient extends __Client<
    */
   readonly config: OSISClientResolvedConfig;
 
-  constructor(configuration: OSISClientConfig) {
+  constructor(configuration: OSISClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-outposts/src/OutpostsClient.ts
+++ b/clients/client-outposts/src/OutpostsClient.ts
@@ -337,7 +337,7 @@ export class OutpostsClient extends __Client<
    */
   readonly config: OutpostsClientResolvedConfig;
 
-  constructor(configuration: OutpostsClientConfig) {
+  constructor(configuration: OutpostsClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-panorama/src/PanoramaClient.ts
+++ b/clients/client-panorama/src/PanoramaClient.ts
@@ -413,7 +413,7 @@ export class PanoramaClient extends __Client<
    */
   readonly config: PanoramaClientResolvedConfig;
 
-  constructor(configuration: PanoramaClientConfig) {
+  constructor(configuration: PanoramaClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-payment-cryptography-data/src/PaymentCryptographyDataClient.ts
+++ b/clients/client-payment-cryptography-data/src/PaymentCryptographyDataClient.ts
@@ -289,7 +289,7 @@ export class PaymentCryptographyDataClient extends __Client<
    */
   readonly config: PaymentCryptographyDataClientResolvedConfig;
 
-  constructor(configuration: PaymentCryptographyDataClientConfig) {
+  constructor(configuration: PaymentCryptographyDataClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-payment-cryptography/src/PaymentCryptographyClient.ts
+++ b/clients/client-payment-cryptography/src/PaymentCryptographyClient.ts
@@ -322,7 +322,7 @@ export class PaymentCryptographyClient extends __Client<
    */
   readonly config: PaymentCryptographyClientResolvedConfig;
 
-  constructor(configuration: PaymentCryptographyClientConfig) {
+  constructor(configuration: PaymentCryptographyClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-personalize-events/src/PersonalizeEventsClient.ts
+++ b/clients/client-personalize-events/src/PersonalizeEventsClient.ts
@@ -251,7 +251,7 @@ export class PersonalizeEventsClient extends __Client<
    */
   readonly config: PersonalizeEventsClientResolvedConfig;
 
-  constructor(configuration: PersonalizeEventsClientConfig) {
+  constructor(configuration: PersonalizeEventsClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-personalize-runtime/src/PersonalizeRuntimeClient.ts
+++ b/clients/client-personalize-runtime/src/PersonalizeRuntimeClient.ts
@@ -251,7 +251,7 @@ export class PersonalizeRuntimeClient extends __Client<
    */
   readonly config: PersonalizeRuntimeClientResolvedConfig;
 
-  constructor(configuration: PersonalizeRuntimeClientConfig) {
+  constructor(configuration: PersonalizeRuntimeClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-personalize/src/PersonalizeClient.ts
+++ b/clients/client-personalize/src/PersonalizeClient.ts
@@ -529,7 +529,7 @@ export class PersonalizeClient extends __Client<
    */
   readonly config: PersonalizeClientResolvedConfig;
 
-  constructor(configuration: PersonalizeClientConfig) {
+  constructor(configuration: PersonalizeClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-pi/src/PIClient.ts
+++ b/clients/client-pi/src/PIClient.ts
@@ -303,7 +303,7 @@ export class PIClient extends __Client<
    */
   readonly config: PIClientResolvedConfig;
 
-  constructor(configuration: PIClientConfig) {
+  constructor(configuration: PIClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-pinpoint-email/src/PinpointEmailClient.ts
+++ b/clients/client-pinpoint-email/src/PinpointEmailClient.ts
@@ -505,7 +505,7 @@ export class PinpointEmailClient extends __Client<
    */
   readonly config: PinpointEmailClientResolvedConfig;
 
-  constructor(configuration: PinpointEmailClientConfig) {
+  constructor(configuration: PinpointEmailClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-pinpoint-sms-voice-v2/src/PinpointSMSVoiceV2Client.ts
+++ b/clients/client-pinpoint-sms-voice-v2/src/PinpointSMSVoiceV2Client.ts
@@ -462,7 +462,7 @@ export class PinpointSMSVoiceV2Client extends __Client<
    */
   readonly config: PinpointSMSVoiceV2ClientResolvedConfig;
 
-  constructor(configuration: PinpointSMSVoiceV2ClientConfig) {
+  constructor(configuration: PinpointSMSVoiceV2ClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-pinpoint-sms-voice/src/PinpointSMSVoiceClient.ts
+++ b/clients/client-pinpoint-sms-voice/src/PinpointSMSVoiceClient.ts
@@ -291,7 +291,7 @@ export class PinpointSMSVoiceClient extends __Client<
    */
   readonly config: PinpointSMSVoiceClientResolvedConfig;
 
-  constructor(configuration: PinpointSMSVoiceClientConfig) {
+  constructor(configuration: PinpointSMSVoiceClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-pinpoint/src/PinpointClient.ts
+++ b/clients/client-pinpoint/src/PinpointClient.ts
@@ -735,7 +735,7 @@ export class PinpointClient extends __Client<
    */
   readonly config: PinpointClientResolvedConfig;
 
-  constructor(configuration: PinpointClientConfig) {
+  constructor(configuration: PinpointClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-pipes/src/PipesClient.ts
+++ b/clients/client-pipes/src/PipesClient.ts
@@ -281,7 +281,7 @@ export class PipesClient extends __Client<
    */
   readonly config: PipesClientResolvedConfig;
 
-  constructor(configuration: PipesClientConfig) {
+  constructor(configuration: PipesClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-polly/src/PollyClient.ts
+++ b/clients/client-polly/src/PollyClient.ts
@@ -294,7 +294,7 @@ export class PollyClient extends __Client<
    */
   readonly config: PollyClientResolvedConfig;
 
-  constructor(configuration: PollyClientConfig) {
+  constructor(configuration: PollyClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-pricing/src/PricingClient.ts
+++ b/clients/client-pricing/src/PricingClient.ts
@@ -298,7 +298,7 @@ export class PricingClient extends __Client<
    */
   readonly config: PricingClientResolvedConfig;
 
-  constructor(configuration: PricingClientConfig) {
+  constructor(configuration: PricingClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-privatenetworks/src/PrivateNetworksClient.ts
+++ b/clients/client-privatenetworks/src/PrivateNetworksClient.ts
@@ -360,7 +360,7 @@ export class PrivateNetworksClient extends __Client<
    */
   readonly config: PrivateNetworksClientResolvedConfig;
 
-  constructor(configuration: PrivateNetworksClientConfig) {
+  constructor(configuration: PrivateNetworksClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-proton/src/ProtonClient.ts
+++ b/clients/client-proton/src/ProtonClient.ts
@@ -815,7 +815,7 @@ export class ProtonClient extends __Client<
    */
   readonly config: ProtonClientResolvedConfig;
 
-  constructor(configuration: ProtonClientConfig) {
+  constructor(configuration: ProtonClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-qldb-session/src/QLDBSessionClient.ts
+++ b/clients/client-qldb-session/src/QLDBSessionClient.ts
@@ -267,7 +267,7 @@ export class QLDBSessionClient extends __Client<
    */
   readonly config: QLDBSessionClientResolvedConfig;
 
-  constructor(configuration: QLDBSessionClientConfig) {
+  constructor(configuration: QLDBSessionClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-qldb/src/QLDBClient.ts
+++ b/clients/client-qldb/src/QLDBClient.ts
@@ -333,7 +333,7 @@ export class QLDBClient extends __Client<
    */
   readonly config: QLDBClientResolvedConfig;
 
-  constructor(configuration: QLDBClientConfig) {
+  constructor(configuration: QLDBClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-quicksight/src/QuickSightClient.ts
+++ b/clients/client-quicksight/src/QuickSightClient.ts
@@ -985,7 +985,7 @@ export class QuickSightClient extends __Client<
    */
   readonly config: QuickSightClientResolvedConfig;
 
-  constructor(configuration: QuickSightClientConfig) {
+  constructor(configuration: QuickSightClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-ram/src/RAMClient.ts
+++ b/clients/client-ram/src/RAMClient.ts
@@ -439,7 +439,7 @@ export class RAMClient extends __Client<
    */
   readonly config: RAMClientResolvedConfig;
 
-  constructor(configuration: RAMClientConfig) {
+  constructor(configuration: RAMClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-rbin/src/RbinClient.ts
+++ b/clients/client-rbin/src/RbinClient.ts
@@ -292,7 +292,7 @@ export class RbinClient extends __Client<
    */
   readonly config: RbinClientResolvedConfig;
 
-  constructor(configuration: RbinClientConfig) {
+  constructor(configuration: RbinClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-rds-data/src/RDSDataClient.ts
+++ b/clients/client-rds-data/src/RDSDataClient.ts
@@ -278,7 +278,7 @@ export class RDSDataClient extends __Client<
    */
   readonly config: RDSDataClientResolvedConfig;
 
-  constructor(configuration: RDSDataClientConfig) {
+  constructor(configuration: RDSDataClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-rds/src/RDSClient.ts
+++ b/clients/client-rds/src/RDSClient.ts
@@ -1048,7 +1048,7 @@ export class RDSClient extends __Client<
    */
   readonly config: RDSClientResolvedConfig;
 
-  constructor(configuration: RDSClientConfig) {
+  constructor(configuration: RDSClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-redshift-data/src/RedshiftDataClient.ts
+++ b/clients/client-redshift-data/src/RedshiftDataClient.ts
@@ -283,7 +283,7 @@ export class RedshiftDataClient extends __Client<
    */
   readonly config: RedshiftDataClientResolvedConfig;
 
-  constructor(configuration: RedshiftDataClientConfig) {
+  constructor(configuration: RedshiftDataClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-redshift-serverless/src/RedshiftServerlessClient.ts
+++ b/clients/client-redshift-serverless/src/RedshiftServerlessClient.ts
@@ -410,7 +410,7 @@ export class RedshiftServerlessClient extends __Client<
    */
   readonly config: RedshiftServerlessClientResolvedConfig;
 
-  constructor(configuration: RedshiftServerlessClientConfig) {
+  constructor(configuration: RedshiftServerlessClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-redshift/src/RedshiftClient.ts
+++ b/clients/client-redshift/src/RedshiftClient.ts
@@ -923,7 +923,7 @@ export class RedshiftClient extends __Client<
    */
   readonly config: RedshiftClientResolvedConfig;
 
-  constructor(configuration: RedshiftClientConfig) {
+  constructor(configuration: RedshiftClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-rekognition/src/RekognitionClient.ts
+++ b/clients/client-rekognition/src/RekognitionClient.ts
@@ -907,7 +907,7 @@ export class RekognitionClient extends __Client<
    */
   readonly config: RekognitionClientResolvedConfig;
 
-  constructor(configuration: RekognitionClientConfig) {
+  constructor(configuration: RekognitionClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-rekognitionstreaming/src/RekognitionStreamingClient.ts
+++ b/clients/client-rekognitionstreaming/src/RekognitionStreamingClient.ts
@@ -303,7 +303,7 @@ export class RekognitionStreamingClient extends __Client<
    */
   readonly config: RekognitionStreamingClientResolvedConfig;
 
-  constructor(configuration: RekognitionStreamingClientConfig) {
+  constructor(configuration: RekognitionStreamingClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-resiliencehub/src/ResiliencehubClient.ts
+++ b/clients/client-resiliencehub/src/ResiliencehubClient.ts
@@ -535,7 +535,7 @@ export class ResiliencehubClient extends __Client<
    */
   readonly config: ResiliencehubClientResolvedConfig;
 
-  constructor(configuration: ResiliencehubClientConfig) {
+  constructor(configuration: ResiliencehubClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-resource-explorer-2/src/ResourceExplorer2Client.ts
+++ b/clients/client-resource-explorer-2/src/ResourceExplorer2Client.ts
@@ -335,7 +335,7 @@ export class ResourceExplorer2Client extends __Client<
    */
   readonly config: ResourceExplorer2ClientResolvedConfig;
 
-  constructor(configuration: ResourceExplorer2ClientConfig) {
+  constructor(configuration: ResourceExplorer2ClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-resource-groups-tagging-api/src/ResourceGroupsTaggingAPIClient.ts
+++ b/clients/client-resource-groups-tagging-api/src/ResourceGroupsTaggingAPIClient.ts
@@ -280,7 +280,7 @@ export class ResourceGroupsTaggingAPIClient extends __Client<
    */
   readonly config: ResourceGroupsTaggingAPIClientResolvedConfig;
 
-  constructor(configuration: ResourceGroupsTaggingAPIClientConfig) {
+  constructor(configuration: ResourceGroupsTaggingAPIClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-resource-groups/src/ResourceGroupsClient.ts
+++ b/clients/client-resource-groups/src/ResourceGroupsClient.ts
@@ -342,7 +342,7 @@ export class ResourceGroupsClient extends __Client<
    */
   readonly config: ResourceGroupsClientResolvedConfig;
 
-  constructor(configuration: ResourceGroupsClientConfig) {
+  constructor(configuration: ResourceGroupsClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-robomaker/src/RoboMakerClient.ts
+++ b/clients/client-robomaker/src/RoboMakerClient.ts
@@ -531,7 +531,7 @@ export class RoboMakerClient extends __Client<
    */
   readonly config: RoboMakerClientResolvedConfig;
 
-  constructor(configuration: RoboMakerClientConfig) {
+  constructor(configuration: RoboMakerClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-rolesanywhere/src/RolesAnywhereClient.ts
+++ b/clients/client-rolesanywhere/src/RolesAnywhereClient.ts
@@ -353,7 +353,7 @@ export class RolesAnywhereClient extends __Client<
    */
   readonly config: RolesAnywhereClientResolvedConfig;
 
-  constructor(configuration: RolesAnywhereClientConfig) {
+  constructor(configuration: RolesAnywhereClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-route-53-domains/src/Route53DomainsClient.ts
+++ b/clients/client-route-53-domains/src/Route53DomainsClient.ts
@@ -415,7 +415,7 @@ export class Route53DomainsClient extends __Client<
    */
   readonly config: Route53DomainsClientResolvedConfig;
 
-  constructor(configuration: Route53DomainsClientConfig) {
+  constructor(configuration: Route53DomainsClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-route-53/src/Route53Client.ts
+++ b/clients/client-route-53/src/Route53Client.ts
@@ -619,7 +619,7 @@ export class Route53Client extends __Client<
    */
   readonly config: Route53ClientResolvedConfig;
 
-  constructor(configuration: Route53ClientConfig) {
+  constructor(configuration: Route53ClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-route53-recovery-cluster/src/Route53RecoveryClusterClient.ts
+++ b/clients/client-route53-recovery-cluster/src/Route53RecoveryClusterClient.ts
@@ -309,7 +309,7 @@ export class Route53RecoveryClusterClient extends __Client<
    */
   readonly config: Route53RecoveryClusterClientResolvedConfig;
 
-  constructor(configuration: Route53RecoveryClusterClientConfig) {
+  constructor(configuration: Route53RecoveryClusterClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-route53-recovery-control-config/src/Route53RecoveryControlConfigClient.ts
+++ b/clients/client-route53-recovery-control-config/src/Route53RecoveryControlConfigClient.ts
@@ -340,7 +340,7 @@ export class Route53RecoveryControlConfigClient extends __Client<
    */
   readonly config: Route53RecoveryControlConfigClientResolvedConfig;
 
-  constructor(configuration: Route53RecoveryControlConfigClientConfig) {
+  constructor(configuration: Route53RecoveryControlConfigClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-route53-recovery-readiness/src/Route53RecoveryReadinessClient.ts
+++ b/clients/client-route53-recovery-readiness/src/Route53RecoveryReadinessClient.ts
@@ -391,7 +391,7 @@ export class Route53RecoveryReadinessClient extends __Client<
    */
   readonly config: Route53RecoveryReadinessClientResolvedConfig;
 
-  constructor(configuration: Route53RecoveryReadinessClientConfig) {
+  constructor(configuration: Route53RecoveryReadinessClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-route53resolver/src/Route53ResolverClient.ts
+++ b/clients/client-route53resolver/src/Route53ResolverClient.ts
@@ -638,7 +638,7 @@ export class Route53ResolverClient extends __Client<
    */
   readonly config: Route53ResolverClientResolvedConfig;
 
-  constructor(configuration: Route53ResolverClientConfig) {
+  constructor(configuration: Route53ResolverClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-rum/src/RUMClient.ts
+++ b/clients/client-rum/src/RUMClient.ts
@@ -328,7 +328,7 @@ export class RUMClient extends __Client<
    */
   readonly config: RUMClientResolvedConfig;
 
-  constructor(configuration: RUMClientConfig) {
+  constructor(configuration: RUMClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-s3-control/src/S3ControlClient.ts
+++ b/clients/client-s3-control/src/S3ControlClient.ts
@@ -594,7 +594,7 @@ export class S3ControlClient extends __Client<
    */
   readonly config: S3ControlClientResolvedConfig;
 
-  constructor(configuration: S3ControlClientConfig) {
+  constructor(configuration: S3ControlClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-s3/src/S3Client.ts
+++ b/clients/client-s3/src/S3Client.ts
@@ -748,7 +748,7 @@ export class S3Client extends __Client<
    */
   readonly config: S3ClientResolvedConfig;
 
-  constructor(configuration: S3ClientConfig) {
+  constructor(configuration: S3ClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-s3outposts/src/S3OutpostsClient.ts
+++ b/clients/client-s3outposts/src/S3OutpostsClient.ts
@@ -264,7 +264,7 @@ export class S3OutpostsClient extends __Client<
    */
   readonly config: S3OutpostsClientResolvedConfig;
 
-  constructor(configuration: S3OutpostsClientConfig) {
+  constructor(configuration: S3OutpostsClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-sagemaker-a2i-runtime/src/SageMakerA2IRuntimeClient.ts
+++ b/clients/client-sagemaker-a2i-runtime/src/SageMakerA2IRuntimeClient.ts
@@ -286,7 +286,7 @@ export class SageMakerA2IRuntimeClient extends __Client<
    */
   readonly config: SageMakerA2IRuntimeClientResolvedConfig;
 
-  constructor(configuration: SageMakerA2IRuntimeClientConfig) {
+  constructor(configuration: SageMakerA2IRuntimeClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-sagemaker-edge/src/SagemakerEdgeClient.ts
+++ b/clients/client-sagemaker-edge/src/SagemakerEdgeClient.ts
@@ -258,7 +258,7 @@ export class SagemakerEdgeClient extends __Client<
    */
   readonly config: SagemakerEdgeClientResolvedConfig;
 
-  constructor(configuration: SagemakerEdgeClientConfig) {
+  constructor(configuration: SagemakerEdgeClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-sagemaker-featurestore-runtime/src/SageMakerFeatureStoreRuntimeClient.ts
+++ b/clients/client-sagemaker-featurestore-runtime/src/SageMakerFeatureStoreRuntimeClient.ts
@@ -285,7 +285,7 @@ export class SageMakerFeatureStoreRuntimeClient extends __Client<
    */
   readonly config: SageMakerFeatureStoreRuntimeClientResolvedConfig;
 
-  constructor(configuration: SageMakerFeatureStoreRuntimeClientConfig) {
+  constructor(configuration: SageMakerFeatureStoreRuntimeClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-sagemaker-geospatial/src/SageMakerGeospatialClient.ts
+++ b/clients/client-sagemaker-geospatial/src/SageMakerGeospatialClient.ts
@@ -358,7 +358,7 @@ export class SageMakerGeospatialClient extends __Client<
    */
   readonly config: SageMakerGeospatialClientResolvedConfig;
 
-  constructor(configuration: SageMakerGeospatialClientConfig) {
+  constructor(configuration: SageMakerGeospatialClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-sagemaker-metrics/src/SageMakerMetricsClient.ts
+++ b/clients/client-sagemaker-metrics/src/SageMakerMetricsClient.ts
@@ -255,7 +255,7 @@ export class SageMakerMetricsClient extends __Client<
    */
   readonly config: SageMakerMetricsClientResolvedConfig;
 
-  constructor(configuration: SageMakerMetricsClientConfig) {
+  constructor(configuration: SageMakerMetricsClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-sagemaker-runtime/src/SageMakerRuntimeClient.ts
+++ b/clients/client-sagemaker-runtime/src/SageMakerRuntimeClient.ts
@@ -251,7 +251,7 @@ export class SageMakerRuntimeClient extends __Client<
    */
   readonly config: SageMakerRuntimeClientResolvedConfig;
 
-  constructor(configuration: SageMakerRuntimeClientConfig) {
+  constructor(configuration: SageMakerRuntimeClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-sagemaker/src/SageMakerClient.ts
+++ b/clients/client-sagemaker/src/SageMakerClient.ts
@@ -1635,7 +1635,7 @@ export class SageMakerClient extends __Client<
    */
   readonly config: SageMakerClientResolvedConfig;
 
-  constructor(configuration: SageMakerClientConfig) {
+  constructor(configuration: SageMakerClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-savingsplans/src/SavingsplansClient.ts
+++ b/clients/client-savingsplans/src/SavingsplansClient.ts
@@ -294,7 +294,7 @@ export class SavingsplansClient extends __Client<
    */
   readonly config: SavingsplansClientResolvedConfig;
 
-  constructor(configuration: SavingsplansClientConfig) {
+  constructor(configuration: SavingsplansClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-scheduler/src/SchedulerClient.ts
+++ b/clients/client-scheduler/src/SchedulerClient.ts
@@ -295,7 +295,7 @@ export class SchedulerClient extends __Client<
    */
   readonly config: SchedulerClientResolvedConfig;
 
-  constructor(configuration: SchedulerClientConfig) {
+  constructor(configuration: SchedulerClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-schemas/src/SchemasClient.ts
+++ b/clients/client-schemas/src/SchemasClient.ts
@@ -357,7 +357,7 @@ export class SchemasClient extends __Client<
    */
   readonly config: SchemasClientResolvedConfig;
 
-  constructor(configuration: SchemasClientConfig) {
+  constructor(configuration: SchemasClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-secrets-manager/src/SecretsManagerClient.ts
+++ b/clients/client-secrets-manager/src/SecretsManagerClient.ts
@@ -358,7 +358,7 @@ export class SecretsManagerClient extends __Client<
    */
   readonly config: SecretsManagerClientResolvedConfig;
 
-  constructor(configuration: SecretsManagerClientConfig) {
+  constructor(configuration: SecretsManagerClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-securityhub/src/SecurityHubClient.ts
+++ b/clients/client-securityhub/src/SecurityHubClient.ts
@@ -609,7 +609,7 @@ export class SecurityHubClient extends __Client<
    */
   readonly config: SecurityHubClientResolvedConfig;
 
-  constructor(configuration: SecurityHubClientConfig) {
+  constructor(configuration: SecurityHubClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-securitylake/src/SecurityLakeClient.ts
+++ b/clients/client-securitylake/src/SecurityLakeClient.ts
@@ -412,7 +412,7 @@ export class SecurityLakeClient extends __Client<
    */
   readonly config: SecurityLakeClientResolvedConfig;
 
-  constructor(configuration: SecurityLakeClientConfig) {
+  constructor(configuration: SecurityLakeClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-serverlessapplicationrepository/src/ServerlessApplicationRepositoryClient.ts
+++ b/clients/client-serverlessapplicationrepository/src/ServerlessApplicationRepositoryClient.ts
@@ -333,7 +333,7 @@ export class ServerlessApplicationRepositoryClient extends __Client<
    */
   readonly config: ServerlessApplicationRepositoryClientResolvedConfig;
 
-  constructor(configuration: ServerlessApplicationRepositoryClientConfig) {
+  constructor(configuration: ServerlessApplicationRepositoryClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-service-catalog-appregistry/src/ServiceCatalogAppRegistryClient.ts
+++ b/clients/client-service-catalog-appregistry/src/ServiceCatalogAppRegistryClient.ts
@@ -355,7 +355,7 @@ export class ServiceCatalogAppRegistryClient extends __Client<
    */
   readonly config: ServiceCatalogAppRegistryClientResolvedConfig;
 
-  constructor(configuration: ServiceCatalogAppRegistryClientConfig) {
+  constructor(configuration: ServiceCatalogAppRegistryClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-service-catalog/src/ServiceCatalogClient.ts
+++ b/clients/client-service-catalog/src/ServiceCatalogClient.ts
@@ -717,7 +717,7 @@ export class ServiceCatalogClient extends __Client<
    */
   readonly config: ServiceCatalogClientResolvedConfig;
 
-  constructor(configuration: ServiceCatalogClientConfig) {
+  constructor(configuration: ServiceCatalogClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-service-quotas/src/ServiceQuotasClient.ts
+++ b/clients/client-service-quotas/src/ServiceQuotasClient.ts
@@ -347,7 +347,7 @@ export class ServiceQuotasClient extends __Client<
    */
   readonly config: ServiceQuotasClientResolvedConfig;
 
-  constructor(configuration: ServiceQuotasClientConfig) {
+  constructor(configuration: ServiceQuotasClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-servicediscovery/src/ServiceDiscoveryClient.ts
+++ b/clients/client-servicediscovery/src/ServiceDiscoveryClient.ts
@@ -357,7 +357,7 @@ export class ServiceDiscoveryClient extends __Client<
    */
   readonly config: ServiceDiscoveryClientResolvedConfig;
 
-  constructor(configuration: ServiceDiscoveryClientConfig) {
+  constructor(configuration: ServiceDiscoveryClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-ses/src/SESClient.ts
+++ b/clients/client-ses/src/SESClient.ts
@@ -617,7 +617,7 @@ export class SESClient extends __Client<
    */
   readonly config: SESClientResolvedConfig;
 
-  constructor(configuration: SESClientConfig) {
+  constructor(configuration: SESClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-sesv2/src/SESv2Client.ts
+++ b/clients/client-sesv2/src/SESv2Client.ts
@@ -696,7 +696,7 @@ export class SESv2Client extends __Client<
    */
   readonly config: SESv2ClientResolvedConfig;
 
-  constructor(configuration: SESv2ClientConfig) {
+  constructor(configuration: SESv2ClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-sfn/src/SFNClient.ts
+++ b/clients/client-sfn/src/SFNClient.ts
@@ -399,7 +399,7 @@ export class SFNClient extends __Client<
    */
   readonly config: SFNClientResolvedConfig;
 
-  constructor(configuration: SFNClientConfig) {
+  constructor(configuration: SFNClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-shield/src/ShieldClient.ts
+++ b/clients/client-shield/src/ShieldClient.ts
@@ -426,7 +426,7 @@ export class ShieldClient extends __Client<
    */
   readonly config: ShieldClientResolvedConfig;
 
-  constructor(configuration: ShieldClientConfig) {
+  constructor(configuration: ShieldClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-signer/src/SignerClient.ts
+++ b/clients/client-signer/src/SignerClient.ts
@@ -344,7 +344,7 @@ export class SignerClient extends __Client<
    */
   readonly config: SignerClientResolvedConfig;
 
-  constructor(configuration: SignerClientConfig) {
+  constructor(configuration: SignerClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-simspaceweaver/src/SimSpaceWeaverClient.ts
+++ b/clients/client-simspaceweaver/src/SimSpaceWeaverClient.ts
@@ -308,7 +308,7 @@ export class SimSpaceWeaverClient extends __Client<
    */
   readonly config: SimSpaceWeaverClientResolvedConfig;
 
-  constructor(configuration: SimSpaceWeaverClientConfig) {
+  constructor(configuration: SimSpaceWeaverClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-sms/src/SMSClient.ts
+++ b/clients/client-sms/src/SMSClient.ts
@@ -437,7 +437,7 @@ export class SMSClient extends __Client<
    */
   readonly config: SMSClientResolvedConfig;
 
-  constructor(configuration: SMSClientConfig) {
+  constructor(configuration: SMSClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-snow-device-management/src/SnowDeviceManagementClient.ts
+++ b/clients/client-snow-device-management/src/SnowDeviceManagementClient.ts
@@ -294,7 +294,7 @@ export class SnowDeviceManagementClient extends __Client<
    */
   readonly config: SnowDeviceManagementClientResolvedConfig;
 
-  constructor(configuration: SnowDeviceManagementClientConfig) {
+  constructor(configuration: SnowDeviceManagementClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-snowball/src/SnowballClient.ts
+++ b/clients/client-snowball/src/SnowballClient.ts
@@ -359,7 +359,7 @@ export class SnowballClient extends __Client<
    */
   readonly config: SnowballClientResolvedConfig;
 
-  constructor(configuration: SnowballClientConfig) {
+  constructor(configuration: SnowballClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-sns/src/SNSClient.ts
+++ b/clients/client-sns/src/SNSClient.ts
@@ -456,7 +456,7 @@ export class SNSClient extends __Client<
    */
   readonly config: SNSClientResolvedConfig;
 
-  constructor(configuration: SNSClientConfig) {
+  constructor(configuration: SNSClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-sqs/src/SQSClient.ts
+++ b/clients/client-sqs/src/SQSClient.ts
@@ -411,7 +411,7 @@ export class SQSClient extends __Client<
    */
   readonly config: SQSClientResolvedConfig;
 
-  constructor(configuration: SQSClientConfig) {
+  constructor(configuration: SQSClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-ssm-contacts/src/SSMContactsClient.ts
+++ b/clients/client-ssm-contacts/src/SSMContactsClient.ts
@@ -412,7 +412,7 @@ export class SSMContactsClient extends __Client<
    */
   readonly config: SSMContactsClientResolvedConfig;
 
-  constructor(configuration: SSMContactsClientConfig) {
+  constructor(configuration: SSMContactsClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-ssm-incidents/src/SSMIncidentsClient.ts
+++ b/clients/client-ssm-incidents/src/SSMIncidentsClient.ts
@@ -382,7 +382,7 @@ export class SSMIncidentsClient extends __Client<
    */
   readonly config: SSMIncidentsClientResolvedConfig;
 
-  constructor(configuration: SSMIncidentsClientConfig) {
+  constructor(configuration: SSMIncidentsClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-ssm-sap/src/SsmSapClient.ts
+++ b/clients/client-ssm-sap/src/SsmSapClient.ts
@@ -326,7 +326,7 @@ export class SsmSapClient extends __Client<
    */
   readonly config: SsmSapClientResolvedConfig;
 
-  constructor(configuration: SsmSapClientConfig) {
+  constructor(configuration: SsmSapClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-ssm/src/SSMClient.ts
+++ b/clients/client-ssm/src/SSMClient.ts
@@ -971,7 +971,7 @@ export class SSMClient extends __Client<
    */
   readonly config: SSMClientResolvedConfig;
 
-  constructor(configuration: SSMClientConfig) {
+  constructor(configuration: SSMClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-sso-admin/src/SSOAdminClient.ts
+++ b/clients/client-sso-admin/src/SSOAdminClient.ts
@@ -477,7 +477,7 @@ export class SSOAdminClient extends __Client<
    */
   readonly config: SSOAdminClientResolvedConfig;
 
-  constructor(configuration: SSOAdminClientConfig) {
+  constructor(configuration: SSOAdminClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-sso-oidc/src/SSOOIDCClient.ts
+++ b/clients/client-sso-oidc/src/SSOOIDCClient.ts
@@ -282,7 +282,7 @@ export class SSOOIDCClient extends __Client<
    */
   readonly config: SSOOIDCClientResolvedConfig;
 
-  constructor(configuration: SSOOIDCClientConfig) {
+  constructor(configuration: SSOOIDCClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-sso/src/SSOClient.ts
+++ b/clients/client-sso/src/SSOClient.ts
@@ -261,7 +261,7 @@ export class SSOClient extends __Client<
    */
   readonly config: SSOClientResolvedConfig;
 
-  constructor(configuration: SSOClientConfig) {
+  constructor(configuration: SSOClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-storage-gateway/src/StorageGatewayClient.ts
+++ b/clients/client-storage-gateway/src/StorageGatewayClient.ts
@@ -736,7 +736,7 @@ export class StorageGatewayClient extends __Client<
    */
   readonly config: StorageGatewayClientResolvedConfig;
 
-  constructor(configuration: StorageGatewayClientConfig) {
+  constructor(configuration: StorageGatewayClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-sts/src/STSClient.ts
+++ b/clients/client-sts/src/STSClient.ts
@@ -274,7 +274,7 @@ export class STSClient extends __Client<
    */
   readonly config: STSClientResolvedConfig;
 
-  constructor(configuration: STSClientConfig) {
+  constructor(configuration: STSClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-support-app/src/SupportAppClient.ts
+++ b/clients/client-support-app/src/SupportAppClient.ts
@@ -350,7 +350,7 @@ export class SupportAppClient extends __Client<
    */
   readonly config: SupportAppClientResolvedConfig;
 
-  constructor(configuration: SupportAppClientConfig) {
+  constructor(configuration: SupportAppClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-support/src/SupportClient.ts
+++ b/clients/client-support/src/SupportClient.ts
@@ -370,7 +370,7 @@ export class SupportClient extends __Client<
    */
   readonly config: SupportClientResolvedConfig;
 
-  constructor(configuration: SupportClientConfig) {
+  constructor(configuration: SupportClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-swf/src/SWFClient.ts
+++ b/clients/client-swf/src/SWFClient.ts
@@ -453,7 +453,7 @@ export class SWFClient extends __Client<
    */
   readonly config: SWFClientResolvedConfig;
 
-  constructor(configuration: SWFClientConfig) {
+  constructor(configuration: SWFClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-synthetics/src/SyntheticsClient.ts
+++ b/clients/client-synthetics/src/SyntheticsClient.ts
@@ -339,7 +339,7 @@ export class SyntheticsClient extends __Client<
    */
   readonly config: SyntheticsClientResolvedConfig;
 
-  constructor(configuration: SyntheticsClientConfig) {
+  constructor(configuration: SyntheticsClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-textract/src/TextractClient.ts
+++ b/clients/client-textract/src/TextractClient.ts
@@ -308,7 +308,7 @@ export class TextractClient extends __Client<
    */
   readonly config: TextractClientResolvedConfig;
 
-  constructor(configuration: TextractClientConfig) {
+  constructor(configuration: TextractClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-timestream-query/src/TimestreamQueryClient.ts
+++ b/clients/client-timestream-query/src/TimestreamQueryClient.ts
@@ -326,7 +326,7 @@ export class TimestreamQueryClient extends __Client<
    */
   readonly config: TimestreamQueryClientResolvedConfig;
 
-  constructor(configuration: TimestreamQueryClientConfig) {
+  constructor(configuration: TimestreamQueryClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-timestream-write/src/TimestreamWriteClient.ts
+++ b/clients/client-timestream-write/src/TimestreamWriteClient.ts
@@ -345,7 +345,7 @@ export class TimestreamWriteClient extends __Client<
    */
   readonly config: TimestreamWriteClientResolvedConfig;
 
-  constructor(configuration: TimestreamWriteClientConfig) {
+  constructor(configuration: TimestreamWriteClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-tnb/src/TnbClient.ts
+++ b/clients/client-tnb/src/TnbClient.ts
@@ -438,7 +438,7 @@ export class TnbClient extends __Client<
    */
   readonly config: TnbClientResolvedConfig;
 
-  constructor(configuration: TnbClientConfig) {
+  constructor(configuration: TnbClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-transcribe-streaming/src/TranscribeStreamingClient.ts
+++ b/clients/client-transcribe-streaming/src/TranscribeStreamingClient.ts
@@ -319,7 +319,7 @@ export class TranscribeStreamingClient extends __Client<
    */
   readonly config: TranscribeStreamingClientResolvedConfig;
 
-  constructor(configuration: TranscribeStreamingClientConfig) {
+  constructor(configuration: TranscribeStreamingClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-transcribe/src/TranscribeClient.ts
+++ b/clients/client-transcribe/src/TranscribeClient.ts
@@ -477,7 +477,7 @@ export class TranscribeClient extends __Client<
    */
   readonly config: TranscribeClientResolvedConfig;
 
-  constructor(configuration: TranscribeClientConfig) {
+  constructor(configuration: TranscribeClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-transfer/src/TransferClient.ts
+++ b/clients/client-transfer/src/TransferClient.ts
@@ -450,7 +450,7 @@ export class TransferClient extends __Client<
    */
   readonly config: TransferClientResolvedConfig;
 
-  constructor(configuration: TransferClientConfig) {
+  constructor(configuration: TransferClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-translate/src/TranslateClient.ts
+++ b/clients/client-translate/src/TranslateClient.ts
@@ -318,7 +318,7 @@ export class TranslateClient extends __Client<
    */
   readonly config: TranslateClientResolvedConfig;
 
-  constructor(configuration: TranslateClientConfig) {
+  constructor(configuration: TranslateClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-verifiedpermissions/src/VerifiedPermissionsClient.ts
+++ b/clients/client-verifiedpermissions/src/VerifiedPermissionsClient.ts
@@ -409,7 +409,7 @@ export class VerifiedPermissionsClient extends __Client<
    */
   readonly config: VerifiedPermissionsClientResolvedConfig;
 
-  constructor(configuration: VerifiedPermissionsClientConfig) {
+  constructor(configuration: VerifiedPermissionsClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-voice-id/src/VoiceIDClient.ts
+++ b/clients/client-voice-id/src/VoiceIDClient.ts
@@ -358,7 +358,7 @@ export class VoiceIDClient extends __Client<
    */
   readonly config: VoiceIDClientResolvedConfig;
 
-  constructor(configuration: VoiceIDClientConfig) {
+  constructor(configuration: VoiceIDClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-vpc-lattice/src/VPCLatticeClient.ts
+++ b/clients/client-vpc-lattice/src/VPCLatticeClient.ts
@@ -466,7 +466,7 @@ export class VPCLatticeClient extends __Client<
    */
   readonly config: VPCLatticeClientResolvedConfig;
 
-  constructor(configuration: VPCLatticeClientConfig) {
+  constructor(configuration: VPCLatticeClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-waf-regional/src/WAFRegionalClient.ts
+++ b/clients/client-waf-regional/src/WAFRegionalClient.ts
@@ -604,7 +604,7 @@ export class WAFRegionalClient extends __Client<
    */
   readonly config: WAFRegionalClientResolvedConfig;
 
-  constructor(configuration: WAFRegionalClientConfig) {
+  constructor(configuration: WAFRegionalClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-waf/src/WAFClient.ts
+++ b/clients/client-waf/src/WAFClient.ts
@@ -586,7 +586,7 @@ export class WAFClient extends __Client<
    */
   readonly config: WAFClientResolvedConfig;
 
-  constructor(configuration: WAFClientConfig) {
+  constructor(configuration: WAFClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-wafv2/src/WAFV2Client.ts
+++ b/clients/client-wafv2/src/WAFV2Client.ts
@@ -543,7 +543,7 @@ export class WAFV2Client extends __Client<
    */
   readonly config: WAFV2ClientResolvedConfig;
 
-  constructor(configuration: WAFV2ClientConfig) {
+  constructor(configuration: WAFV2ClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-wellarchitected/src/WellArchitectedClient.ts
+++ b/clients/client-wellarchitected/src/WellArchitectedClient.ts
@@ -461,7 +461,7 @@ export class WellArchitectedClient extends __Client<
    */
   readonly config: WellArchitectedClientResolvedConfig;
 
-  constructor(configuration: WellArchitectedClientConfig) {
+  constructor(configuration: WellArchitectedClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-wisdom/src/WisdomClient.ts
+++ b/clients/client-wisdom/src/WisdomClient.ts
@@ -372,7 +372,7 @@ export class WisdomClient extends __Client<
    */
   readonly config: WisdomClientResolvedConfig;
 
-  constructor(configuration: WisdomClientConfig) {
+  constructor(configuration: WisdomClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-workdocs/src/WorkDocsClient.ts
+++ b/clients/client-workdocs/src/WorkDocsClient.ts
@@ -490,7 +490,7 @@ export class WorkDocsClient extends __Client<
    */
   readonly config: WorkDocsClientResolvedConfig;
 
-  constructor(configuration: WorkDocsClientConfig) {
+  constructor(configuration: WorkDocsClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-worklink/src/WorkLinkClient.ts
+++ b/clients/client-worklink/src/WorkLinkClient.ts
@@ -411,7 +411,7 @@ export class WorkLinkClient extends __Client<
    */
   readonly config: WorkLinkClientResolvedConfig;
 
-  constructor(configuration: WorkLinkClientConfig) {
+  constructor(configuration: WorkLinkClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-workmail/src/WorkMailClient.ts
+++ b/clients/client-workmail/src/WorkMailClient.ts
@@ -671,7 +671,7 @@ export class WorkMailClient extends __Client<
    */
   readonly config: WorkMailClientResolvedConfig;
 
-  constructor(configuration: WorkMailClientConfig) {
+  constructor(configuration: WorkMailClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-workmailmessageflow/src/WorkMailMessageFlowClient.ts
+++ b/clients/client-workmailmessageflow/src/WorkMailMessageFlowClient.ts
@@ -265,7 +265,7 @@ export class WorkMailMessageFlowClient extends __Client<
    */
   readonly config: WorkMailMessageFlowClientResolvedConfig;
 
-  constructor(configuration: WorkMailMessageFlowClientConfig) {
+  constructor(configuration: WorkMailMessageFlowClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-workspaces-web/src/WorkSpacesWebClient.ts
+++ b/clients/client-workspaces-web/src/WorkSpacesWebClient.ts
@@ -542,7 +542,7 @@ export class WorkSpacesWebClient extends __Client<
    */
   readonly config: WorkSpacesWebClientResolvedConfig;
 
-  constructor(configuration: WorkSpacesWebClientConfig) {
+  constructor(configuration: WorkSpacesWebClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-workspaces/src/WorkSpacesClient.ts
+++ b/clients/client-workspaces/src/WorkSpacesClient.ts
@@ -592,7 +592,7 @@ export class WorkSpacesClient extends __Client<
    */
   readonly config: WorkSpacesClientResolvedConfig;
 
-  constructor(configuration: WorkSpacesClientConfig) {
+  constructor(configuration: WorkSpacesClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/clients/client-xray/src/XRayClient.ts
+++ b/clients/client-xray/src/XRayClient.ts
@@ -367,7 +367,7 @@ export class XRayClient extends __Client<
    */
   readonly config: XRayClientResolvedConfig;
 
-  constructor(configuration: XRayClientConfig) {
+  constructor(configuration: XRayClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveClientEndpointParameters(_config_0);
     const _config_2 = resolveRegionConfig(_config_1);

--- a/private/aws-echo-service/src/EchoServiceClient.ts
+++ b/private/aws-echo-service/src/EchoServiceClient.ts
@@ -202,7 +202,7 @@ export class EchoServiceClient extends __Client<
    */
   readonly config: EchoServiceClientResolvedConfig;
 
-  constructor(configuration: EchoServiceClientConfig) {
+  constructor(configuration: EchoServiceClientConfig = {}) {
     let _config_0 = __getRuntimeConfig(configuration);
     let _config_1 = resolveCustomEndpointsConfig(_config_0);
     let _config_2 = resolveRetryConfig(_config_1);

--- a/private/aws-protocoltests-ec2/src/EC2ProtocolClient.ts
+++ b/private/aws-protocoltests-ec2/src/EC2ProtocolClient.ts
@@ -326,7 +326,7 @@ export class EC2ProtocolClient extends __Client<
    */
   readonly config: EC2ProtocolClientResolvedConfig;
 
-  constructor(configuration: EC2ProtocolClientConfig) {
+  constructor(configuration: EC2ProtocolClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveRegionConfig(_config_0);
     const _config_2 = resolveEndpointsConfig(_config_1);

--- a/private/aws-protocoltests-json-10/src/JSONRPC10Client.ts
+++ b/private/aws-protocoltests-json-10/src/JSONRPC10Client.ts
@@ -274,7 +274,7 @@ export class JSONRPC10Client extends __Client<
    */
   readonly config: JSONRPC10ClientResolvedConfig;
 
-  constructor(configuration: JSONRPC10ClientConfig) {
+  constructor(configuration: JSONRPC10ClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveRegionConfig(_config_0);
     const _config_2 = resolveEndpointsConfig(_config_1);

--- a/private/aws-protocoltests-json/src/JsonProtocolClient.ts
+++ b/private/aws-protocoltests-json/src/JsonProtocolClient.ts
@@ -315,7 +315,7 @@ export class JsonProtocolClient extends __Client<
    */
   readonly config: JsonProtocolClientResolvedConfig;
 
-  constructor(configuration: JsonProtocolClientConfig) {
+  constructor(configuration: JsonProtocolClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveRegionConfig(_config_0);
     const _config_2 = resolveEndpointsConfig(_config_1);

--- a/private/aws-protocoltests-query/src/QueryProtocolClient.ts
+++ b/private/aws-protocoltests-query/src/QueryProtocolClient.ts
@@ -356,7 +356,7 @@ export class QueryProtocolClient extends __Client<
    */
   readonly config: QueryProtocolClientResolvedConfig;
 
-  constructor(configuration: QueryProtocolClientConfig) {
+  constructor(configuration: QueryProtocolClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveRegionConfig(_config_0);
     const _config_2 = resolveEndpointsConfig(_config_1);

--- a/private/aws-protocoltests-restjson/src/RestJsonProtocolClient.ts
+++ b/private/aws-protocoltests-restjson/src/RestJsonProtocolClient.ts
@@ -679,7 +679,7 @@ export class RestJsonProtocolClient extends __Client<
    */
   readonly config: RestJsonProtocolClientResolvedConfig;
 
-  constructor(configuration: RestJsonProtocolClientConfig) {
+  constructor(configuration: RestJsonProtocolClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveRegionConfig(_config_0);
     const _config_2 = resolveEndpointsConfig(_config_1);

--- a/private/aws-protocoltests-restxml/src/RestXmlProtocolClient.ts
+++ b/private/aws-protocoltests-restxml/src/RestXmlProtocolClient.ts
@@ -488,7 +488,7 @@ export class RestXmlProtocolClient extends __Client<
    */
   readonly config: RestXmlProtocolClientResolvedConfig;
 
-  constructor(configuration: RestXmlProtocolClientConfig) {
+  constructor(configuration: RestXmlProtocolClientConfig = {}) {
     const _config_0 = __getRuntimeConfig(configuration);
     const _config_1 = resolveRegionConfig(_config_0);
     const _config_2 = resolveEndpointsConfig(_config_1);


### PR DESCRIPTION
### Issue
Refs https://github.com/awslabs/smithy-typescript/pull/525

### Description
Sets default parameter for ClientConfig in constructor as empty object

### Testing
ToDo: Verify that TypeScript allows client creation with no parameters

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
