### PR TITLE
chore(shared-ini-file-loader): move code from util-credentials

### DIFF
--- a/packages/shared-ini-file-loader/src/getProfileName.spec.ts
+++ b/packages/shared-ini-file-loader/src/getProfileName.spec.ts
@@ -1,0 +1,31 @@
+import { DEFAULT_PROFILE, ENV_PROFILE, getProfileName } from "./getProfileName";
+
+describe(getProfileName.name, () => {
+  const OLD_ENV = process.env;
+  const mockProfileNameFromEnv = "mockProfileNameFromEnv";
+
+  beforeEach(() => {
+    process.env = {
+      ...OLD_ENV,
+      [ENV_PROFILE]: mockProfileNameFromEnv,
+    };
+  });
+
+  afterEach(() => {
+    process.env = OLD_ENV;
+  });
+
+  it("returns profile if present in param", () => {
+    const profile = "mockProfile";
+    expect(getProfileName({ profile })).toBe(profile);
+  });
+
+  it(`returns profile from env var '${ENV_PROFILE}' if present`, () => {
+    expect(getProfileName({})).toBe(mockProfileNameFromEnv);
+  });
+
+  it(`returns profile '${DEFAULT_PROFILE}' as default`, () => {
+    process.env[ENV_PROFILE] = undefined;
+    expect(getProfileName({})).toBe(DEFAULT_PROFILE);
+  });
+});

--- a/packages/shared-ini-file-loader/src/getProfileName.ts
+++ b/packages/shared-ini-file-loader/src/getProfileName.ts
@@ -1,0 +1,5 @@
+export const ENV_PROFILE = "AWS_PROFILE";
+export const DEFAULT_PROFILE = "default";
+
+export const getProfileName = (init: { profile?: string }): string =>
+  init.profile || process.env[ENV_PROFILE] || DEFAULT_PROFILE;

--- a/packages/shared-ini-file-loader/src/index.ts
+++ b/packages/shared-ini-file-loader/src/index.ts
@@ -1,3 +1,4 @@
 export * from "./getHomeDir";
 export * from "./loadSharedConfigFiles";
+export * from "./parseKnownFiles";
 export * from "./types";

--- a/packages/shared-ini-file-loader/src/index.ts
+++ b/packages/shared-ini-file-loader/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./getHomeDir";
+export * from "./getProfileName";
 export * from "./loadSharedConfigFiles";
 export * from "./parseKnownFiles";
 export * from "./types";

--- a/packages/shared-ini-file-loader/src/parseKnownFiles.spec.ts
+++ b/packages/shared-ini-file-loader/src/parseKnownFiles.spec.ts
@@ -1,0 +1,51 @@
+import { loadSharedConfigFiles } from "./loadSharedConfigFiles";
+import { parseKnownFiles } from "./parseKnownFiles";
+
+jest.mock("./loadSharedConfigFiles");
+
+describe(parseKnownFiles.name, () => {
+  const mockConfigFile = {
+    mockConfigProfileName1: { configKey1: "configValue1" },
+    mockConfigProfileName2: { configKey2: "configValue2" },
+  };
+  const mockCredentialsFile = {
+    mockCredentialsProfileName1: { credsKey1: "credsValue1" },
+    mockCredentialsProfileName2: { credsKey2: "credsValue2" },
+  };
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("gets parsedFiles from loadedConfig if provided in init", async () => {
+    const parsedFiles = await parseKnownFiles({
+      loadedConfig: Promise.resolve({
+        configFile: mockConfigFile,
+        credentialsFile: mockCredentialsFile,
+      }),
+    });
+
+    expect(loadSharedConfigFiles).not.toHaveBeenCalled();
+    expect(parsedFiles).toEqual({
+      ...mockConfigFile,
+      ...mockCredentialsFile,
+    });
+  });
+
+  it("gets parsedFiles from loadSharedConfigFiles if not provided in init", async () => {
+    (loadSharedConfigFiles as jest.Mock).mockReturnValue(
+      Promise.resolve({
+        configFile: mockConfigFile,
+        credentialsFile: mockCredentialsFile,
+      })
+    );
+    const mockInit = { profile: "mockProfile" };
+    const parsedFiles = await parseKnownFiles(mockInit);
+
+    expect(loadSharedConfigFiles).toHaveBeenCalledWith(mockInit);
+    expect(parsedFiles).toEqual({
+      ...mockConfigFile,
+      ...mockCredentialsFile,
+    });
+  });
+});

--- a/packages/shared-ini-file-loader/src/parseKnownFiles.ts
+++ b/packages/shared-ini-file-loader/src/parseKnownFiles.ts
@@ -1,0 +1,34 @@
+import { ParsedIniData, SharedConfigFiles } from "@aws-sdk/types";
+
+import { loadSharedConfigFiles, SharedConfigInit } from "./loadSharedConfigFiles";
+
+export interface SourceProfileInit extends SharedConfigInit {
+  /**
+   * The configuration profile to use.
+   */
+  profile?: string;
+
+  /**
+   * A promise that will be resolved with loaded and parsed credentials files.
+   * Used to avoid loading shared config files multiple times.
+   *
+   * @internal
+   */
+  loadedConfig?: Promise<SharedConfigFiles>;
+}
+
+/**
+ * Load profiles from credentials and config INI files and normalize them into a
+ * single profile list.
+ *
+ * @internal
+ */
+export const parseKnownFiles = async (init: SourceProfileInit): Promise<ParsedIniData> => {
+  const { loadedConfig = loadSharedConfigFiles(init) } = init;
+
+  const parsedFiles = await loadedConfig;
+  return {
+    ...parsedFiles.configFile,
+    ...parsedFiles.credentialsFile,
+  };
+};

--- a/packages/util-credentials/src/get-master-profile-name.ts
+++ b/packages/util-credentials/src/get-master-profile-name.ts
@@ -1,4 +1,18 @@
-import { getProfileName } from "@aws-sdk/shared-ini-file-loader";
+import {
+  DEFAULT_PROFILE as __DEFAULT_PROFILE,
+  ENV_PROFILE as __ENV_PROFILE,
+  getProfileName,
+} from "@aws-sdk/shared-ini-file-loader";
+
+/**
+ * @deprecated Use DEFAULT_PROFILE from "@aws-sdk/shared-ini-file-loader" instead.
+ */
+export const DEFAULT_PROFILE = __DEFAULT_PROFILE;
+
+/**
+ * @deprecated Use ENV_PROFILE from "@aws-sdk/shared-ini-file-loader" instead.
+ */
+export const ENV_PROFILE = __ENV_PROFILE;
 
 /**
  * @deprecated Use getProfileName from "@aws-sdk/shared-ini-file-loader" instead.

--- a/packages/util-credentials/src/get-master-profile-name.ts
+++ b/packages/util-credentials/src/get-master-profile-name.ts
@@ -1,5 +1,6 @@
-export const ENV_PROFILE = "AWS_PROFILE";
-export const DEFAULT_PROFILE = "default";
+import { getProfileName } from "@aws-sdk/shared-ini-file-loader";
 
-export const getMasterProfileName = (init: { profile?: string }): string =>
-  init.profile || process.env[ENV_PROFILE] || DEFAULT_PROFILE;
+/**
+ * @deprecated Use getProfileName from "@aws-sdk/shared-ini-file-loader" instead.
+ */
+export const getMasterProfileName = getProfileName;

--- a/packages/util-credentials/src/index.ts
+++ b/packages/util-credentials/src/index.ts
@@ -1,2 +1,4 @@
+// ToDo: Delete and deprecate util-credentials package after all dependents are moved
+// to use "@aws-sdk/shared-inin-file-loader" and a release is done.
 export * from "./get-master-profile-name";
 export * from "./parse-known-profiles";

--- a/packages/util-credentials/src/parse-known-profiles.ts
+++ b/packages/util-credentials/src/parse-known-profiles.ts
@@ -1,33 +1,14 @@
-import { loadSharedConfigFiles, SharedConfigInit } from "@aws-sdk/shared-ini-file-loader";
-import { ParsedIniData, SharedConfigFiles } from "@aws-sdk/types";
-
-export interface SourceProfileInit extends SharedConfigInit {
-  /**
-   * The configuration profile to use.
-   */
-  profile?: string;
-
-  /**
-   * A promise that will be resolved with loaded and parsed credentials files.
-   * Used to avoid loading shared config files multiple times.
-   *
-   * @internal
-   */
-  loadedConfig?: Promise<SharedConfigFiles>;
-}
+import {
+  parseKnownFiles as __parseKnownFiles,
+  SourceProfileInit as __SourceProfileInit,
+} from "@aws-sdk/shared-ini-file-loader";
 
 /**
- * Load profiles from credentials and config INI files and normalize them into a
- * single profile list.
- *
- * @internal
+ * @deprecated Use SourceProfileInit from "@aws-sdk/shared-ini-file-loader" instead.
  */
-export const parseKnownFiles = async (init: SourceProfileInit): Promise<ParsedIniData> => {
-  const { loadedConfig = loadSharedConfigFiles(init) } = init;
+export interface SourceProfileInit extends __SourceProfileInit {}
 
-  const parsedFiles = await loadedConfig;
-  return {
-    ...parsedFiles.configFile,
-    ...parsedFiles.credentialsFile,
-  };
-};
+/**
+ * @deprecated Use parseKnownFiles from "@aws-sdk/shared-ini-file-loader" instead.
+ */
+export const parseKnownFiles = __parseKnownFiles;


### PR DESCRIPTION
### Issue
Internal JS-3150

The code from util-credentials will be used outside credentials in future. Moving it to `shared-ini-file-loader` as it's most relevant there.

### Description
Move code from util-credentials to shared-ini-file-loader

### Testing
CI

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
