### PR TITLE
feat: Add keepAlive in FetchHttpOptions with default value true

### DIFF
--- a/packages/fetch-http-handler/src/fetch-http-handler.spec.ts
+++ b/packages/fetch-http-handler/src/fetch-http-handler.spec.ts
@@ -189,7 +189,7 @@ describe.skip(FetchHttpHandler.name, () => {
     expect(mockFetch.mock.calls.length).toBe(1);
   });
 
-  it("will pass keepalive as true by default to request", async () => {
+  it("will pass keepalive as true by default to request if supported", async () => {
     const mockResponse = {
       headers: {
         entries: jest.fn().mockReturnValue([
@@ -209,7 +209,7 @@ describe.skip(FetchHttpHandler.name, () => {
     expect(mockRequest.mock.calls[0][1].keepalive).toBe(true);
   });
 
-  it("will pass keepalive to request", async () => {
+  it("will pass keepalive to request if supported", async () => {
     const mockResponse = {
       headers: {
         entries: jest.fn().mockReturnValue([
@@ -227,6 +227,26 @@ describe.skip(FetchHttpHandler.name, () => {
     await fetchHttpHandler.handle({} as any, {});
 
     expect(mockRequest.mock.calls[0][1].keepalive).toBe(false);
+  });
+
+  it("will not have keepalive property in request if not supported", async () => {
+    const mockResponse = {
+      headers: {
+        entries: jest.fn().mockReturnValue([
+          ["foo", "bar"],
+          ["bizz", "bazz"],
+        ]),
+      },
+      blob: jest.fn().mockResolvedValue(new Blob()),
+    };
+    const mockFetch = jest.fn().mockResolvedValue(mockResponse);
+    (global as any).fetch = mockFetch;
+    mockRequest.mockImplementation(() => null);
+
+    const fetchHttpHandler = new FetchHttpHandler({ keepAlive: false });
+
+    await fetchHttpHandler.handle({} as any, {});
+    expect(mockRequest.mock.calls[0][1]).not.toHaveProperty("keepalive");
   });
 
   it("will pass timeout to request timeout", async () => {

--- a/packages/fetch-http-handler/src/fetch-http-handler.spec.ts
+++ b/packages/fetch-http-handler/src/fetch-http-handler.spec.ts
@@ -189,6 +189,46 @@ describe.skip(FetchHttpHandler.name, () => {
     expect(mockFetch.mock.calls.length).toBe(1);
   });
 
+  it("will pass keepalive as true by default to request", async () => {
+    const mockResponse = {
+      headers: {
+        entries: jest.fn().mockReturnValue([
+          ["foo", "bar"],
+          ["bizz", "bazz"],
+        ]),
+      },
+      blob: jest.fn().mockResolvedValue(new Blob()),
+    };
+    const mockFetch = jest.fn().mockResolvedValue(mockResponse);
+    (global as any).fetch = mockFetch;
+
+    const fetchHttpHandler = new FetchHttpHandler();
+
+    await fetchHttpHandler.handle({} as any, {});
+
+    expect(mockRequest.mock.calls[0][1].keepalive).toBe(true);
+  });
+
+  it("will pass keepalive to request", async () => {
+    const mockResponse = {
+      headers: {
+        entries: jest.fn().mockReturnValue([
+          ["foo", "bar"],
+          ["bizz", "bazz"],
+        ]),
+      },
+      blob: jest.fn().mockResolvedValue(new Blob()),
+    };
+    const mockFetch = jest.fn().mockResolvedValue(mockResponse);
+    (global as any).fetch = mockFetch;
+
+    const fetchHttpHandler = new FetchHttpHandler({ keepAlive: false });
+
+    await fetchHttpHandler.handle({} as any, {});
+
+    expect(mockRequest.mock.calls[0][1].keepalive).toBe(false);
+  });
+
   it("will pass timeout to request timeout", async () => {
     const mockResponse = {
       headers: {

--- a/packages/fetch-http-handler/src/fetch-http-handler.ts
+++ b/packages/fetch-http-handler/src/fetch-http-handler.ts
@@ -70,12 +70,15 @@ export class FetchHttpHandler implements HttpHandler {
       body,
       headers: new Headers(request.headers),
       method: method,
-      keepalive: keepAlive,
     };
 
     // some browsers support abort signal
     if (typeof AbortController !== "undefined") {
       (requestOptions as any)["signal"] = abortSignal;
+    }
+    // some browsers support abort signal
+    if (Boolean(typeof Request !== "undefined" && "keepalive" in new Request(""))) {
+      (requestOptions as any)["keepalive"] = keepAlive;
     }
 
     const fetchRequest = new Request(url, requestOptions);

--- a/packages/fetch-http-handler/src/fetch-http-handler.ts
+++ b/packages/fetch-http-handler/src/fetch-http-handler.ts
@@ -15,6 +15,11 @@ export interface FetchHttpHandlerOptions {
    * terminated.
    */
   requestTimeout?: number;
+
+  /**
+   * Whether to allow the request to outlive the page. Default value is true
+   */
+  keepAlive?: boolean;
 }
 
 type FetchHttpHandlerConfig = FetchHttpHandlerOptions;
@@ -40,7 +45,7 @@ export class FetchHttpHandler implements HttpHandler {
       this.config = await this.configProvider();
     }
     const requestTimeoutInMs = this.config!.requestTimeout;
-
+    const keepAlive = this.config!.keepAlive ?? true;
     // if the request was already aborted, prevent doing extra work
     if (abortSignal?.aborted) {
       const abortError = new Error("Request aborted");
@@ -65,6 +70,7 @@ export class FetchHttpHandler implements HttpHandler {
       body,
       headers: new Headers(request.headers),
       method: method,
+      keepalive: keepAlive,
     };
 
     // some browsers support abort signal

--- a/packages/fetch-http-handler/src/fetch-http-handler.ts
+++ b/packages/fetch-http-handler/src/fetch-http-handler.ts
@@ -76,7 +76,7 @@ export class FetchHttpHandler implements HttpHandler {
     if (typeof AbortController !== "undefined") {
       (requestOptions as any)["signal"] = abortSignal;
     }
-    // some browsers support abort signal
+    // some browsers support keepalive
     if (Boolean(typeof Request !== "undefined" && "keepalive" in new Request(""))) {
       (requestOptions as any)["keepalive"] = keepAlive;
     }


### PR DESCRIPTION
### Issue
#1003 

### Description
- added keepAlive in FetchHttpHandlerOptions
- modified fetch-http-handler to accept keepAlive
- set default keepAlive to true
- pass the keepAlive to `keepalive`  property of RequestInit. It allows the request to outlive the page. 

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
