### PR TITLE
chore(credential-providers): remove dependency on util-credentials

### DIFF
--- a/packages/credential-provider-ini/package.json
+++ b/packages/credential-provider-ini/package.json
@@ -30,7 +30,6 @@
     "@aws-sdk/property-provider": "*",
     "@aws-sdk/shared-ini-file-loader": "*",
     "@aws-sdk/types": "*",
-    "@aws-sdk/util-credentials": "*",
     "tslib": "^2.3.0"
   },
   "devDependencies": {

--- a/packages/credential-provider-ini/src/fromIni.spec.ts
+++ b/packages/credential-provider-ini/src/fromIni.spec.ts
@@ -1,12 +1,10 @@
-import { AssumeRoleWithWebIdentityParams } from "@aws-sdk/credential-provider-web-identity";
-import { CredentialProvider, Credentials } from "@aws-sdk/types";
-import { getMasterProfileName, parseKnownFiles } from "@aws-sdk/util-credentials";
+import { getProfileName, parseKnownFiles } from "@aws-sdk/shared-ini-file-loader";
+import { Credentials } from "@aws-sdk/types";
 
 import { fromIni } from "./fromIni";
-import { AssumeRoleParams } from "./resolveAssumeRoleCredentials";
 import { resolveProfileData } from "./resolveProfileData";
 
-jest.mock("@aws-sdk/util-credentials");
+jest.mock("@aws-sdk/shared-ini-file-loader");
 jest.mock("./resolveProfileData");
 
 describe(fromIni.name, () => {
@@ -17,7 +15,7 @@ describe(fromIni.name, () => {
 
   beforeEach(() => {
     (parseKnownFiles as jest.Mock).mockResolvedValue(mockProfiles);
-    (getMasterProfileName as jest.Mock).mockReturnValue(mockMasterProfileName);
+    (getProfileName as jest.Mock).mockReturnValue(mockMasterProfileName);
   });
 
   afterEach(() => {
@@ -34,7 +32,7 @@ describe(fromIni.name, () => {
       expect(error).toStrictEqual(expectedError);
     }
     expect(parseKnownFiles).toHaveBeenCalledWith(mockInit);
-    expect(getMasterProfileName).not.toHaveBeenCalled();
+    expect(getProfileName).not.toHaveBeenCalled();
     expect(resolveProfileData).not.toHaveBeenCalled();
   });
 
@@ -48,7 +46,7 @@ describe(fromIni.name, () => {
       expect(error).toStrictEqual(expectedError);
     }
     expect(parseKnownFiles).toHaveBeenCalledWith(mockInit);
-    expect(getMasterProfileName).toHaveBeenCalledWith(mockInit);
+    expect(getProfileName).toHaveBeenCalledWith(mockInit);
     expect(resolveProfileData).toHaveBeenCalledWith(mockMasterProfileName, mockProfiles, mockInit);
   });
 
@@ -61,7 +59,7 @@ describe(fromIni.name, () => {
     const receivedCreds = await fromIni(mockInit)();
     expect(receivedCreds).toStrictEqual(expectedCreds);
     expect(parseKnownFiles).toHaveBeenCalledWith(mockInit);
-    expect(getMasterProfileName).toHaveBeenCalledWith(mockInit);
+    expect(getProfileName).toHaveBeenCalledWith(mockInit);
     expect(resolveProfileData).toHaveBeenCalledWith(mockMasterProfileName, mockProfiles, mockInit);
   });
 });

--- a/packages/credential-provider-ini/src/fromIni.ts
+++ b/packages/credential-provider-ini/src/fromIni.ts
@@ -1,6 +1,6 @@
 import { AssumeRoleWithWebIdentityParams } from "@aws-sdk/credential-provider-web-identity";
+import { getProfileName, parseKnownFiles, SourceProfileInit } from "@aws-sdk/shared-ini-file-loader";
 import { CredentialProvider, Credentials } from "@aws-sdk/types";
-import { getMasterProfileName, parseKnownFiles, SourceProfileInit } from "@aws-sdk/util-credentials";
 
 import { AssumeRoleParams } from "./resolveAssumeRoleCredentials";
 import { resolveProfileData } from "./resolveProfileData";
@@ -43,5 +43,5 @@ export const fromIni =
   (init: FromIniInit = {}): CredentialProvider =>
   async () => {
     const profiles = await parseKnownFiles(init);
-    return resolveProfileData(getMasterProfileName(init), profiles, init);
+    return resolveProfileData(getProfileName(init), profiles, init);
   };

--- a/packages/credential-provider-ini/src/resolveAssumeRoleCredentials.spec.ts
+++ b/packages/credential-provider-ini/src/resolveAssumeRoleCredentials.spec.ts
@@ -1,11 +1,11 @@
 import { CredentialsProviderError } from "@aws-sdk/property-provider";
-import { getMasterProfileName } from "@aws-sdk/util-credentials";
+import { getProfileName } from "@aws-sdk/shared-ini-file-loader";
 
 import { isAssumeRoleProfile, resolveAssumeRoleCredentials } from "./resolveAssumeRoleCredentials";
 import { resolveCredentialSource } from "./resolveCredentialSource";
 import { resolveProfileData } from "./resolveProfileData";
 
-jest.mock("@aws-sdk/util-credentials");
+jest.mock("@aws-sdk/shared-ini-file-loader");
 jest.mock("./resolveCredentialSource");
 jest.mock("./resolveProfileData");
 
@@ -112,7 +112,7 @@ describe(resolveAssumeRoleCredentials.name, () => {
   });
 
   beforeEach(() => {
-    (getMasterProfileName as jest.Mock).mockReturnValue(mockProfileName);
+    (getProfileName as jest.Mock).mockReturnValue(mockProfileName);
     (resolveProfileData as jest.Mock).mockResolvedValue(mockSourceCredsFromProfile);
     (resolveCredentialSource as jest.Mock).mockReturnValue(() => Promise.resolve(mockSourceCredsFromCredential));
   });

--- a/packages/credential-provider-ini/src/resolveAssumeRoleCredentials.ts
+++ b/packages/credential-provider-ini/src/resolveAssumeRoleCredentials.ts
@@ -1,6 +1,6 @@
 import { CredentialsProviderError } from "@aws-sdk/property-provider";
+import { getProfileName } from "@aws-sdk/shared-ini-file-loader";
 import { ParsedIniData, Profile } from "@aws-sdk/types";
-import { getMasterProfileName } from "@aws-sdk/util-credentials";
 
 import { FromIniInit } from "./fromIni";
 import { resolveCredentialSource } from "./resolveCredentialSource";
@@ -83,7 +83,7 @@ export const resolveAssumeRoleCredentials = async (
   if (source_profile && source_profile in visitedProfiles) {
     throw new CredentialsProviderError(
       `Detected a cycle attempting to resolve credentials for profile` +
-        ` ${getMasterProfileName(options)}. Profiles visited: ` +
+        ` ${getProfileName(options)}. Profiles visited: ` +
         Object.keys(visitedProfiles).join(", "),
       false
     );

--- a/packages/credential-provider-node/package.json
+++ b/packages/credential-provider-node/package.json
@@ -35,7 +35,6 @@
     "@aws-sdk/property-provider": "*",
     "@aws-sdk/shared-ini-file-loader": "*",
     "@aws-sdk/types": "*",
-    "@aws-sdk/util-credentials": "*",
     "tslib": "^2.3.0"
   },
   "devDependencies": {

--- a/packages/credential-provider-node/src/defaultProvider.spec.ts
+++ b/packages/credential-provider-node/src/defaultProvider.spec.ts
@@ -1,13 +1,10 @@
 import { fromEnv } from "@aws-sdk/credential-provider-env";
-import { RemoteProviderInit } from "@aws-sdk/credential-provider-imds";
-import { fromIni, FromIniInit } from "@aws-sdk/credential-provider-ini";
-import { fromProcess, FromProcessInit } from "@aws-sdk/credential-provider-process";
-import { fromSSO, FromSSOInit } from "@aws-sdk/credential-provider-sso";
-import { fromTokenFile, FromTokenFileInit } from "@aws-sdk/credential-provider-web-identity";
+import { fromIni } from "@aws-sdk/credential-provider-ini";
+import { fromProcess } from "@aws-sdk/credential-provider-process";
+import { fromSSO } from "@aws-sdk/credential-provider-sso";
+import { fromTokenFile } from "@aws-sdk/credential-provider-web-identity";
 import { chain, CredentialsProviderError, memoize } from "@aws-sdk/property-provider";
-import { loadSharedConfigFiles } from "@aws-sdk/shared-ini-file-loader";
-import { CredentialProvider } from "@aws-sdk/types";
-import { ENV_PROFILE } from "@aws-sdk/util-credentials";
+import { ENV_PROFILE, loadSharedConfigFiles } from "@aws-sdk/shared-ini-file-loader";
 
 import { defaultProvider } from "./defaultProvider";
 import { remoteProvider } from "./remoteProvider";

--- a/packages/credential-provider-node/src/defaultProvider.ts
+++ b/packages/credential-provider-node/src/defaultProvider.ts
@@ -5,9 +5,8 @@ import { fromProcess, FromProcessInit } from "@aws-sdk/credential-provider-proce
 import { fromSSO, FromSSOInit } from "@aws-sdk/credential-provider-sso";
 import { fromTokenFile, FromTokenFileInit } from "@aws-sdk/credential-provider-web-identity";
 import { chain, CredentialsProviderError, memoize } from "@aws-sdk/property-provider";
-import { loadSharedConfigFiles } from "@aws-sdk/shared-ini-file-loader";
+import { ENV_PROFILE, loadSharedConfigFiles } from "@aws-sdk/shared-ini-file-loader";
 import { CredentialProvider } from "@aws-sdk/types";
-import { ENV_PROFILE } from "@aws-sdk/util-credentials";
 
 import { remoteProvider } from "./remoteProvider";
 

--- a/packages/credential-provider-process/package.json
+++ b/packages/credential-provider-process/package.json
@@ -26,7 +26,6 @@
     "@aws-sdk/property-provider": "*",
     "@aws-sdk/shared-ini-file-loader": "*",
     "@aws-sdk/types": "*",
-    "@aws-sdk/util-credentials": "*",
     "tslib": "^2.3.0"
   },
   "devDependencies": {

--- a/packages/credential-provider-process/src/fromProcess.spec.ts
+++ b/packages/credential-provider-process/src/fromProcess.spec.ts
@@ -1,10 +1,10 @@
+import { getProfileName, parseKnownFiles } from "@aws-sdk/shared-ini-file-loader";
 import { Credentials } from "@aws-sdk/types";
-import { getMasterProfileName, parseKnownFiles } from "@aws-sdk/util-credentials";
 
 import { fromProcess } from "./fromProcess";
 import { resolveProcessCredentials } from "./resolveProcessCredentials";
 
-jest.mock("@aws-sdk/util-credentials");
+jest.mock("@aws-sdk/shared-ini-file-loader");
 jest.mock("./resolveProcessCredentials");
 
 describe(fromProcess.name, () => {
@@ -15,7 +15,7 @@ describe(fromProcess.name, () => {
 
   beforeEach(() => {
     (parseKnownFiles as jest.Mock).mockResolvedValue(mockProfiles);
-    (getMasterProfileName as jest.Mock).mockReturnValue(mockMasterProfileName);
+    (getProfileName as jest.Mock).mockReturnValue(mockMasterProfileName);
   });
 
   afterEach(() => {
@@ -32,7 +32,7 @@ describe(fromProcess.name, () => {
       expect(error).toStrictEqual(expectedError);
     }
     expect(parseKnownFiles).toHaveBeenCalledWith(mockInit);
-    expect(getMasterProfileName).not.toHaveBeenCalled();
+    expect(getProfileName).not.toHaveBeenCalled();
     expect(resolveProcessCredentials).not.toHaveBeenCalled();
   });
 
@@ -46,7 +46,7 @@ describe(fromProcess.name, () => {
       expect(error).toStrictEqual(expectedError);
     }
     expect(parseKnownFiles).toHaveBeenCalledWith(mockInit);
-    expect(getMasterProfileName).toHaveBeenCalledWith(mockInit);
+    expect(getProfileName).toHaveBeenCalledWith(mockInit);
     expect(resolveProcessCredentials).toHaveBeenCalledWith(mockMasterProfileName, mockProfiles);
   });
 
@@ -59,7 +59,7 @@ describe(fromProcess.name, () => {
     const receivedCreds = await fromProcess(mockInit)();
     expect(receivedCreds).toStrictEqual(expectedCreds);
     expect(parseKnownFiles).toHaveBeenCalledWith(mockInit);
-    expect(getMasterProfileName).toHaveBeenCalledWith(mockInit);
+    expect(getProfileName).toHaveBeenCalledWith(mockInit);
     expect(resolveProcessCredentials).toHaveBeenCalledWith(mockMasterProfileName, mockProfiles);
   });
 });

--- a/packages/credential-provider-process/src/fromProcess.ts
+++ b/packages/credential-provider-process/src/fromProcess.ts
@@ -1,5 +1,5 @@
+import { getProfileName, parseKnownFiles, SourceProfileInit } from "@aws-sdk/shared-ini-file-loader";
 import { CredentialProvider } from "@aws-sdk/types";
-import { getMasterProfileName, parseKnownFiles, SourceProfileInit } from "@aws-sdk/util-credentials";
 
 import { resolveProcessCredentials } from "./resolveProcessCredentials";
 
@@ -13,5 +13,5 @@ export const fromProcess =
   (init: FromProcessInit = {}): CredentialProvider =>
   async () => {
     const profiles = await parseKnownFiles(init);
-    return resolveProcessCredentials(getMasterProfileName(init), profiles);
+    return resolveProcessCredentials(getProfileName(init), profiles);
   };

--- a/packages/credential-provider-sso/package.json
+++ b/packages/credential-provider-sso/package.json
@@ -27,7 +27,6 @@
     "@aws-sdk/property-provider": "*",
     "@aws-sdk/shared-ini-file-loader": "*",
     "@aws-sdk/types": "*",
-    "@aws-sdk/util-credentials": "*",
     "tslib": "^2.3.0"
   },
   "devDependencies": {

--- a/packages/credential-provider-sso/src/fromSSO.spec.ts
+++ b/packages/credential-provider-sso/src/fromSSO.spec.ts
@@ -1,13 +1,13 @@
 import { SSOClient } from "@aws-sdk/client-sso";
 import { CredentialsProviderError } from "@aws-sdk/property-provider";
-import { getMasterProfileName, parseKnownFiles } from "@aws-sdk/util-credentials";
+import { getProfileName, parseKnownFiles } from "@aws-sdk/shared-ini-file-loader";
 
 import { fromSSO } from "./fromSSO";
 import { isSsoProfile } from "./isSsoProfile";
 import { resolveSSOCredentials } from "./resolveSSOCredentials";
 import { validateSsoProfile } from "./validateSsoProfile";
 
-jest.mock("@aws-sdk/util-credentials");
+jest.mock("@aws-sdk/shared-ini-file-loader");
 jest.mock("./isSsoProfile");
 jest.mock("./resolveSSOCredentials");
 jest.mock("./validateSsoProfile");
@@ -42,13 +42,13 @@ describe(fromSSO.name, () => {
 
     beforeEach(() => {
       (parseKnownFiles as jest.Mock).mockResolvedValue(mockProfiles);
-      (getMasterProfileName as jest.Mock).mockReturnValue(mockProfileName);
+      (getProfileName as jest.Mock).mockReturnValue(mockProfileName);
       (isSsoProfile as unknown as jest.Mock).mockReturnValue(true);
     });
 
     afterEach(() => {
       expect(parseKnownFiles).toHaveBeenCalledWith(mockInit);
-      expect(getMasterProfileName).toHaveBeenCalledWith(mockInit);
+      expect(getProfileName).toHaveBeenCalledWith(mockInit);
       expect(isSsoProfile).toHaveBeenCalledWith(mockSsoProfile);
     });
 

--- a/packages/credential-provider-sso/src/fromSSO.ts
+++ b/packages/credential-provider-sso/src/fromSSO.ts
@@ -1,7 +1,7 @@
 import { SSOClient } from "@aws-sdk/client-sso";
 import { CredentialsProviderError } from "@aws-sdk/property-provider";
+import { getProfileName, parseKnownFiles, SourceProfileInit } from "@aws-sdk/shared-ini-file-loader";
 import { CredentialProvider } from "@aws-sdk/types";
-import { getMasterProfileName, parseKnownFiles, SourceProfileInit } from "@aws-sdk/util-credentials";
 
 import { isSsoProfile } from "./isSsoProfile";
 import { resolveSSOCredentials } from "./resolveSSOCredentials";
@@ -44,7 +44,7 @@ export const fromSSO =
     if (!ssoStartUrl && !ssoAccountId && !ssoRegion && !ssoRoleName) {
       // Load the SSO config from shared AWS config file.
       const profiles = await parseKnownFiles(init);
-      const profileName = getMasterProfileName(init);
+      const profileName = getProfileName(init);
       const profile = profiles[profileName];
 
       if (!isSsoProfile(profile)) {

--- a/packages/credential-providers/package.json
+++ b/packages/credential-providers/package.json
@@ -39,7 +39,6 @@
     "@aws-sdk/property-provider": "*",
     "@aws-sdk/shared-ini-file-loader": "*",
     "@aws-sdk/types": "*",
-    "@aws-sdk/util-credentials": "*",
     "tslib": "^2.3.0"
   },
   "devDependencies": {


### PR DESCRIPTION
### Issue
Follow-up to https://github.com/aws/aws-sdk-js-v3/pull/3420

### Description
Replace dependency on util-credentials files with new files in shared-ini-file-loader

### Testing
CI

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
