### PR TITLE
fix(smithy-client): exception option missing message property

### DIFF
--- a/packages/smithy-client/src/exceptions.spec.ts
+++ b/packages/smithy-client/src/exceptions.spec.ts
@@ -1,4 +1,4 @@
-import { decorateServiceException, ServiceException } from "./exceptions";
+import { decorateServiceException, ExceptionOptionType, ServiceException } from "./exceptions";
 
 it("ServiceException extends from Error", () => {
   expect(
@@ -9,6 +9,23 @@ it("ServiceException extends from Error", () => {
       $metadata: {},
     })
   ).toBeInstanceOf(Error);
+});
+
+it("ExceptionOptionType allows specifying message", () => {
+  class SomeException extends ServiceException {
+    constructor(opts: ExceptionOptionType<SomeException, ServiceException>) {
+      super({
+        name: "SomeException",
+        $fault: "client",
+        ...opts,
+      });
+    }
+  }
+  const exception = new SomeException({
+    message: "message",
+    $metadata: {},
+  });
+  expect(exception.message).toBe("message");
 });
 
 describe("decorateServiceException", () => {

--- a/packages/smithy-client/src/exceptions.spec.ts
+++ b/packages/smithy-client/src/exceptions.spec.ts
@@ -13,19 +13,23 @@ it("ServiceException extends from Error", () => {
 
 it("ExceptionOptionType allows specifying message", () => {
   class SomeException extends ServiceException {
+    readonly code: string;
     constructor(opts: ExceptionOptionType<SomeException, ServiceException>) {
       super({
         name: "SomeException",
         $fault: "client",
         ...opts,
       });
+      this.code = opts.code;
     }
   }
   const exception = new SomeException({
     message: "message",
+    code: "code",
     $metadata: {},
   });
   expect(exception.message).toBe("message");
+  expect(exception.code).toBe("code");
 });
 
 describe("decorateServiceException", () => {

--- a/packages/smithy-client/src/exceptions.ts
+++ b/packages/smithy-client/src/exceptions.ts
@@ -3,12 +3,12 @@ import { HttpResponse, MetadataBearer, ResponseMetadata, RetryableTrait, SmithyE
 /**
  * The type of the exception class constructor parameter. The returned type contains the properties
  * in the `ExceptionType` but not in the `BaseExceptionType`. If the `BaseExceptionType` contains
- * `$metadata` property, it's also included in the returned type.
+ * `$metadata` and `message` properties, it's also included in the returned type.
  * @internal
  */
 export type ExceptionOptionType<ExceptionType extends Error, BaseExceptionType extends Error> = Omit<
   ExceptionType,
-  Exclude<keyof BaseExceptionType, "$metadata">
+  Exclude<keyof BaseExceptionType, "$metadata" | "message">
 >;
 
 export interface ServiceExceptionOptions extends SmithyException, MetadataBearer {


### PR DESCRIPTION
### Issue
resolves: https://github.com/aws/aws-sdk-js-v3/issues/3492

The `message` property is being excluded in `ExceptionOptionType`.

### Description
From the type-system perspective, we were not allowed to pass the message whenever instantiating any Exception generated by the Smithy TypeScript generator.

### Testing
Unit test

### Additional context

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
