### PR TITLE
fix(middleware-serde): mark  error entry non-enumerable

### DIFF
--- a/packages/middleware-serde/src/deserializerMiddleware.spec.ts
+++ b/packages/middleware-serde/src/deserializerMiddleware.spec.ts
@@ -63,7 +63,7 @@ describe("deserializerMiddleware", () => {
     expect(mockDeserializer).toHaveBeenCalledWith(mockNextResponse.response, mockOptions);
   });
 
-  it("injects $response reference to deserializing exceptions", async () => {
+  it("injects non-enumerable $response reference to deserializing exceptions", async () => {
     const exception = Object.assign(new Error("MockException"), mockNextResponse.response);
     mockDeserializer.mockReset();
     mockDeserializer.mockRejectedValueOnce(exception);
@@ -73,6 +73,7 @@ describe("deserializerMiddleware", () => {
     } catch (e) {
       expect(e).toMatchObject(exception);
       expect(e.$response).toEqual(mockNextResponse.response);
+      expect(Object.keys(e)).not.toContain("$response");
     }
   });
 });

--- a/packages/middleware-serde/src/deserializerMiddleware.ts
+++ b/packages/middleware-serde/src/deserializerMiddleware.ts
@@ -22,6 +22,10 @@ export const deserializerMiddleware =
         output: parsed as Output,
       };
     } catch (error) {
-      throw Object.assign(error, { $response: response });
+      Object.defineProperty(error, "$response", {
+        // configurable and enumerable defaults to `false` in Object.defineProperty
+        value: response,
+      });
+      throw error;
     }
   };


### PR DESCRIPTION
### Issue
Ref: D38831498

### Description
The `$response` trait includes raw response for AWS service errors only. It's a low-risk that AWS service will include sensitive information in the error responses, but the possibility still exists.

This issue is scoped only with the logger, which means the logger should not print out the raw HTTP response for errors by default. This is because customer can access the raw HTTP response in variety of ways in the JavaScript SDK, we cannot prevent them from accessing potentially sensitive information.

This change makes the `$response` inenumerable makes sense here, so that the logger won't print the raw Http response by default. However, if customer need to access the raw Http response when handling the error, they can still access them specifically by `error.$response`.

### Testing
Unit test

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
