### PR TITLE
fix(middleware-content-length): swallow error if content-length computation fails

### DIFF
--- a/packages/middleware-content-length/src/index.ts
+++ b/packages/middleware-content-length/src/index.ts
@@ -11,7 +11,6 @@ import {
 } from "@aws-sdk/types";
 
 const CONTENT_LENGTH_HEADER = "content-length";
-const TRANSFER_ENCODING_HEADER = "transfer-encoding";
 
 export function contentLengthMiddleware(bodyLengthChecker: BodyLengthCalculator): BuildMiddleware<any, any> {
   return <Output extends MetadataBearer>(next: BuildHandler<any, Output>): BuildHandler<any, Output> =>
@@ -32,10 +31,8 @@ export function contentLengthMiddleware(bodyLengthChecker: BodyLengthCalculator)
               [CONTENT_LENGTH_HEADER]: String(length),
             };
           } catch (error) {
-            request.headers = {
-              ...request.headers,
-              [TRANSFER_ENCODING_HEADER]: "chunked",
-            };
+            // ToDo: Add 'transfer-encoding' as chunked only for HTTP/1.1 request
+            // Refs: https://github.com/aws/aws-sdk-js-v3/pull/3403
           }
         }
       }


### PR DESCRIPTION
### Issue
Fixes: https://github.com/aws/aws-sdk-js-v3/issues/3418

### Description
Switches back to previous experience where header 'content-length' was not set, and no other header was set.

The existing behavior was added after checking RFC 7230 in https://github.com/aws/aws-sdk-js-v3/issues/3400#issuecomment-1062257234, and AWS SDK for Python behavior in https://github.com/aws/aws-sdk-js-v3/issues/3400#issuecomment-1062366026. The issue happened in Transcribe Streaming as it uses HTTP/2, and the middleware doesn't check for version of HTTP protocol for setting 'transfer-encoding' header.

### Testing
Unit tests are absent, and to be added separately to the module.
No additional testing needed, as it's basic reverting to the previous flow.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
