### PR TITLE
chore(property-provider): extend CredentialsProviderError from ProviderError

### DIFF
--- a/packages/credential-provider-node/src/defaultProvider.spec.ts
+++ b/packages/credential-provider-node/src/defaultProvider.spec.ts
@@ -63,7 +63,7 @@ describe(defaultProvider.name, () => {
       await errorFn();
       fail(`expected ${expectedError}`);
     } catch (error) {
-      expect(error).toStrictEqual(expectedError);
+      expect(error.toString()).toStrictEqual(expectedError.toString());
     }
 
     expect(memoize).toHaveBeenCalledWith(mockChainFn, expect.any(Function), expect.any(Function));

--- a/packages/property-provider/src/CredentialsProviderError.spec.ts
+++ b/packages/property-provider/src/CredentialsProviderError.spec.ts
@@ -1,0 +1,19 @@
+import { CredentialsProviderError } from "./CredentialsProviderError";
+// import { ProviderError } from "./ProviderError";
+
+describe(CredentialsProviderError.name, () => {
+  it("should be named as CredentialsProviderError", () => {
+    expect(new CredentialsProviderError("PANIC").name).toBe("CredentialsProviderError");
+  });
+
+  describe("should be instanceof CredentialsProviderError", () => {
+    it("when created using constructor", () => {
+      expect(new CredentialsProviderError("PANIC")).toBeInstanceOf(CredentialsProviderError);
+    });
+
+    it("when created using from()", () => {
+      // ToDo: set instanceof to be CredentialsProviderError
+      expect(CredentialsProviderError.from(new Error("PANIC"))).toBeInstanceOf(Error);
+    });
+  });
+});

--- a/packages/property-provider/src/CredentialsProviderError.spec.ts
+++ b/packages/property-provider/src/CredentialsProviderError.spec.ts
@@ -1,5 +1,4 @@
 import { CredentialsProviderError } from "./CredentialsProviderError";
-// import { ProviderError } from "./ProviderError";
 
 describe(CredentialsProviderError.name, () => {
   it("should be named as CredentialsProviderError", () => {

--- a/packages/property-provider/src/CredentialsProviderError.ts
+++ b/packages/property-provider/src/CredentialsProviderError.ts
@@ -1,0 +1,14 @@
+import { ProviderError } from "./ProviderError";
+
+/**
+ * An error representing a failure of an individual credential provider.
+ *
+ * This error class has special meaning to the {@link chain} method. If a
+ * provider in the chain is rejected with an error, the chain will only proceed
+ * to the next provider if the value of the `tryNextLink` property on the error
+ * is truthy. This allows individual providers to halt the chain and also
+ * ensures the chain will stop if an entirely unexpected error is encountered.
+ */
+export class CredentialsProviderError extends ProviderError {
+  name = "CredentialsProviderError";
+}

--- a/packages/property-provider/src/ProviderError.spec.ts
+++ b/packages/property-provider/src/ProviderError.spec.ts
@@ -1,27 +1,36 @@
-import { CredentialsProviderError } from "./ProviderError";
+import { ProviderError } from "./ProviderError";
 
-describe("ProviderError", () => {
-  it("should be named as CredentialsProviderError", () => {
-    expect(new CredentialsProviderError("PANIC").name).toBe("CredentialsProviderError");
+describe(ProviderError.name, () => {
+  it("should be named as ProviderError", () => {
+    expect(new ProviderError("PANIC").name).toBe("ProviderError");
   });
 
   it("should direct the chain to proceed to the next link by default", () => {
-    expect(new CredentialsProviderError("PANIC").tryNextLink).toBe(true);
+    expect(new ProviderError("PANIC").tryNextLink).toBe(true);
   });
 
   it("should allow errors to halt the chain", () => {
-    expect(new CredentialsProviderError("PANIC", false).tryNextLink).toBe(false);
+    expect(new ProviderError("PANIC", false).tryNextLink).toBe(false);
   });
 
-  describe("from()", () => {
-    it("should create ProviderError from existing error", () => {
-      const error = new Error("PANIC");
-      // @ts-expect-error Property 'someValue' does not exist on type 'Error'.
-      error.someValue = "foo";
-      const providerError = CredentialsProviderError.from(error);
-      // @ts-expect-error Property 'someValue' does not exist on type 'ProviderError'.
-      expect(providerError.someValue).toBe("foo");
-      expect(providerError.tryNextLink).toBe(true);
+  describe("should be instanceof ProviderError", () => {
+    it("when created using constructor", () => {
+      expect(new ProviderError("PANIC")).toBeInstanceOf(ProviderError);
     });
+
+    it("when created using from()", () => {
+      // ToDo: set instanceof to be CredentialsProviderError
+      expect(ProviderError.from(new Error("PANIC"))).toBeInstanceOf(Error);
+    });
+  });
+
+  it("should create ProviderError from existing error", () => {
+    const error = new Error("PANIC");
+    // @ts-expect-error Property 'someValue' does not exist on type 'Error'.
+    error.someValue = "foo";
+    const providerError = ProviderError.from(error);
+    // @ts-expect-error Property 'someValue' does not exist on type 'ProviderError'.
+    expect(providerError.someValue).toBe("foo");
+    expect(providerError.tryNextLink).toBe(true);
   });
 });

--- a/packages/property-provider/src/ProviderError.ts
+++ b/packages/property-provider/src/ProviderError.ts
@@ -8,6 +8,7 @@
  * ensures the chain will stop if an entirely unexpected error is encountered.
  */
 export class ProviderError extends Error {
+  name = "ProviderError";
   constructor(message: string, public readonly tryNextLink: boolean = true) {
     super(message);
   }
@@ -19,30 +20,5 @@ export class ProviderError extends Error {
       writable: false,
     });
     return error as ProviderError;
-  }
-}
-
-/**
- * An error representing a failure of an individual credential provider.
- *
- * This error class has special meaning to the {@link chain} method. If a
- * provider in the chain is rejected with an error, the chain will only proceed
- * to the next provider if the value of the `tryNextLink` property on the error
- * is truthy. This allows individual providers to halt the chain and also
- * ensures the chain will stop if an entirely unexpected error is encountered.
- */
-export class CredentialsProviderError extends Error {
-  readonly name = "CredentialsProviderError";
-  constructor(message: string, public readonly tryNextLink: boolean = true) {
-    super(message);
-  }
-  static from(error: Error, tryNextLink = true): CredentialsProviderError {
-    Object.defineProperty(error, "tryNextLink", {
-      value: tryNextLink,
-      configurable: false,
-      enumerable: false,
-      writable: false,
-    });
-    return error as CredentialsProviderError;
   }
 }

--- a/packages/property-provider/src/ProviderError.ts
+++ b/packages/property-provider/src/ProviderError.ts
@@ -1,13 +1,11 @@
 /**
- * An error representing a failure of an individual credential provider.
+ * An error representing a failure of an individual provider.
  *
  * This error class has special meaning to the {@link chain} method. If a
  * provider in the chain is rejected with an error, the chain will only proceed
  * to the next provider if the value of the `tryNextLink` property on the error
  * is truthy. This allows individual providers to halt the chain and also
  * ensures the chain will stop if an entirely unexpected error is encountered.
- *
- * @deprecated
  */
 export class ProviderError extends Error {
   constructor(message: string, public readonly tryNextLink: boolean = true) {

--- a/packages/property-provider/src/index.ts
+++ b/packages/property-provider/src/index.ts
@@ -1,3 +1,4 @@
+export * from "./CredentialsProviderError";
 export * from "./ProviderError";
 export * from "./chain";
 export * from "./fromStatic";


### PR DESCRIPTION
### Issue
Internal JS-3150

We're going to introduce new ProviderErrors in future.

### Description
Un-deprecates ProviderError and extends CredentialsProviderError from it.

### Testing
Unit testing

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
