### PR TITLE
fix(property-provider): copy error properties to ProviderError in from()

### DIFF
--- a/packages/property-provider/src/CredentialsProviderError.spec.ts
+++ b/packages/property-provider/src/CredentialsProviderError.spec.ts
@@ -11,8 +11,7 @@ describe(CredentialsProviderError.name, () => {
     });
 
     it("when created using from()", () => {
-      // ToDo: set instanceof to be CredentialsProviderError
-      expect(CredentialsProviderError.from(new Error("PANIC"))).toBeInstanceOf(Error);
+      expect(CredentialsProviderError.from(new Error("PANIC"))).toBeInstanceOf(CredentialsProviderError);
     });
   });
 });

--- a/packages/property-provider/src/CredentialsProviderError.spec.ts
+++ b/packages/property-provider/src/CredentialsProviderError.spec.ts
@@ -1,17 +1,18 @@
 import { CredentialsProviderError } from "./CredentialsProviderError";
+import { ProviderError } from "./ProviderError";
 
 describe(CredentialsProviderError.name, () => {
   it("should be named as CredentialsProviderError", () => {
     expect(new CredentialsProviderError("PANIC").name).toBe("CredentialsProviderError");
   });
 
-  describe("should be instanceof CredentialsProviderError", () => {
+  describe.each([Error, ProviderError, CredentialsProviderError])("should be instanceof %p", (classConstructor) => {
     it("when created using constructor", () => {
-      expect(new CredentialsProviderError("PANIC")).toBeInstanceOf(CredentialsProviderError);
+      expect(new CredentialsProviderError("PANIC")).toBeInstanceOf(classConstructor);
     });
 
     it("when created using from()", () => {
-      expect(CredentialsProviderError.from(new Error("PANIC"))).toBeInstanceOf(CredentialsProviderError);
+      expect(CredentialsProviderError.from(new Error("PANIC"))).toBeInstanceOf(classConstructor);
     });
   });
 });

--- a/packages/property-provider/src/ProviderError.spec.ts
+++ b/packages/property-provider/src/ProviderError.spec.ts
@@ -13,13 +13,13 @@ describe(ProviderError.name, () => {
     expect(new ProviderError("PANIC", false).tryNextLink).toBe(false);
   });
 
-  describe("should be instanceof ProviderError", () => {
+  describe.each([Error, ProviderError])("should be instanceof %p", (classConstructor) => {
     it("when created using constructor", () => {
-      expect(new ProviderError("PANIC")).toBeInstanceOf(ProviderError);
+      expect(new ProviderError("PANIC")).toBeInstanceOf(classConstructor);
     });
 
     it("when created using from()", () => {
-      expect(ProviderError.from(new Error("PANIC"))).toBeInstanceOf(ProviderError);
+      expect(ProviderError.from(new Error("PANIC"))).toBeInstanceOf(classConstructor);
     });
   });
 

--- a/packages/property-provider/src/ProviderError.spec.ts
+++ b/packages/property-provider/src/ProviderError.spec.ts
@@ -19,8 +19,7 @@ describe(ProviderError.name, () => {
     });
 
     it("when created using from()", () => {
-      // ToDo: set instanceof to be CredentialsProviderError
-      expect(ProviderError.from(new Error("PANIC"))).toBeInstanceOf(Error);
+      expect(ProviderError.from(new Error("PANIC"))).toBeInstanceOf(ProviderError);
     });
   });
 

--- a/packages/property-provider/src/ProviderError.ts
+++ b/packages/property-provider/src/ProviderError.ts
@@ -13,12 +13,6 @@ export class ProviderError extends Error {
     super(message);
   }
   static from(error: Error, tryNextLink = true): ProviderError {
-    Object.defineProperty(error, "tryNextLink", {
-      value: tryNextLink,
-      configurable: false,
-      enumerable: false,
-      writable: false,
-    });
-    return error as ProviderError;
+    return Object.assign(new ProviderError(error.message, tryNextLink), error);
   }
 }

--- a/packages/property-provider/src/ProviderError.ts
+++ b/packages/property-provider/src/ProviderError.ts
@@ -13,6 +13,6 @@ export class ProviderError extends Error {
     super(message);
   }
   static from(error: Error, tryNextLink = true): ProviderError {
-    return Object.assign(new ProviderError(error.message, tryNextLink), error);
+    return Object.assign(new this(error.message, tryNextLink), error);
   }
 }


### PR DESCRIPTION
### Issue
The issue was observed in https://github.com/aws/aws-sdk-js-v3/pull/3438

### Description
Copy error properties to ProviderError in from()

### Testing
Unit testing

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
