### PR TITLE
fix(clients): allow non-streaming binary payload input to be string or buffer

### DIFF
--- a/clients/client-api-gateway/src/commands/ImportApiKeysCommand.ts
+++ b/clients/client-api-gateway/src/commands/ImportApiKeysCommand.ts
@@ -18,7 +18,16 @@ import {
   serializeAws_restJson1ImportApiKeysCommand,
 } from "../protocols/Aws_restJson1";
 
-export interface ImportApiKeysCommandInput extends ImportApiKeysRequest {}
+type ImportApiKeysCommandInputType = Omit<ImportApiKeysRequest, "body"> & {
+  /**
+   * For *`ImportApiKeysRequest["body"]`*, see {@link ImportApiKeysRequest.body}.
+   */
+  body: ImportApiKeysRequest["body"] | string | Uint8Array | Buffer;
+};
+/**
+ * This interface extends from `ImportApiKeysRequest` interface. There are more parameters than `body` defined in {@link ImportApiKeysRequest}
+ */
+export interface ImportApiKeysCommandInput extends ImportApiKeysCommandInputType {}
 export interface ImportApiKeysCommandOutput extends ApiKeyIds, __MetadataBearer {}
 
 /**

--- a/clients/client-api-gateway/src/commands/ImportDocumentationPartsCommand.ts
+++ b/clients/client-api-gateway/src/commands/ImportDocumentationPartsCommand.ts
@@ -18,7 +18,16 @@ import {
   serializeAws_restJson1ImportDocumentationPartsCommand,
 } from "../protocols/Aws_restJson1";
 
-export interface ImportDocumentationPartsCommandInput extends ImportDocumentationPartsRequest {}
+type ImportDocumentationPartsCommandInputType = Omit<ImportDocumentationPartsRequest, "body"> & {
+  /**
+   * For *`ImportDocumentationPartsRequest["body"]`*, see {@link ImportDocumentationPartsRequest.body}.
+   */
+  body: ImportDocumentationPartsRequest["body"] | string | Uint8Array | Buffer;
+};
+/**
+ * This interface extends from `ImportDocumentationPartsRequest` interface. There are more parameters than `body` defined in {@link ImportDocumentationPartsRequest}
+ */
+export interface ImportDocumentationPartsCommandInput extends ImportDocumentationPartsCommandInputType {}
 export interface ImportDocumentationPartsCommandOutput extends DocumentationPartIds, __MetadataBearer {}
 
 export class ImportDocumentationPartsCommand extends $Command<

--- a/clients/client-api-gateway/src/commands/ImportRestApiCommand.ts
+++ b/clients/client-api-gateway/src/commands/ImportRestApiCommand.ts
@@ -18,7 +18,16 @@ import {
   serializeAws_restJson1ImportRestApiCommand,
 } from "../protocols/Aws_restJson1";
 
-export interface ImportRestApiCommandInput extends ImportRestApiRequest {}
+type ImportRestApiCommandInputType = Omit<ImportRestApiRequest, "body"> & {
+  /**
+   * For *`ImportRestApiRequest["body"]`*, see {@link ImportRestApiRequest.body}.
+   */
+  body: ImportRestApiRequest["body"] | string | Uint8Array | Buffer;
+};
+/**
+ * This interface extends from `ImportRestApiRequest` interface. There are more parameters than `body` defined in {@link ImportRestApiRequest}
+ */
+export interface ImportRestApiCommandInput extends ImportRestApiCommandInputType {}
 export interface ImportRestApiCommandOutput extends RestApi, __MetadataBearer {}
 
 /**

--- a/clients/client-api-gateway/src/commands/PutRestApiCommand.ts
+++ b/clients/client-api-gateway/src/commands/PutRestApiCommand.ts
@@ -18,7 +18,16 @@ import {
   serializeAws_restJson1PutRestApiCommand,
 } from "../protocols/Aws_restJson1";
 
-export interface PutRestApiCommandInput extends PutRestApiRequest {}
+type PutRestApiCommandInputType = Omit<PutRestApiRequest, "body"> & {
+  /**
+   * For *`PutRestApiRequest["body"]`*, see {@link PutRestApiRequest.body}.
+   */
+  body: PutRestApiRequest["body"] | string | Uint8Array | Buffer;
+};
+/**
+ * This interface extends from `PutRestApiRequest` interface. There are more parameters than `body` defined in {@link PutRestApiRequest}
+ */
+export interface PutRestApiCommandInput extends PutRestApiCommandInputType {}
 export interface PutRestApiCommandOutput extends RestApi, __MetadataBearer {}
 
 /**

--- a/clients/client-apigatewaymanagementapi/src/commands/PostToConnectionCommand.ts
+++ b/clients/client-apigatewaymanagementapi/src/commands/PostToConnectionCommand.ts
@@ -22,7 +22,16 @@ import {
   serializeAws_restJson1PostToConnectionCommand,
 } from "../protocols/Aws_restJson1";
 
-export interface PostToConnectionCommandInput extends PostToConnectionRequest {}
+type PostToConnectionCommandInputType = Omit<PostToConnectionRequest, "Data"> & {
+  /**
+   * For *`PostToConnectionRequest["Data"]`*, see {@link PostToConnectionRequest.Data}.
+   */
+  Data: PostToConnectionRequest["Data"] | string | Uint8Array | Buffer;
+};
+/**
+ * This interface extends from `PostToConnectionRequest` interface. There are more parameters than `Data` defined in {@link PostToConnectionRequest}
+ */
+export interface PostToConnectionCommandInput extends PostToConnectionCommandInputType {}
 export interface PostToConnectionCommandOutput extends __MetadataBearer {}
 
 /**

--- a/clients/client-appconfig/src/commands/CreateHostedConfigurationVersionCommand.ts
+++ b/clients/client-appconfig/src/commands/CreateHostedConfigurationVersionCommand.ts
@@ -18,7 +18,17 @@ import {
   serializeAws_restJson1CreateHostedConfigurationVersionCommand,
 } from "../protocols/Aws_restJson1";
 
-export interface CreateHostedConfigurationVersionCommandInput extends CreateHostedConfigurationVersionRequest {}
+type CreateHostedConfigurationVersionCommandInputType = Omit<CreateHostedConfigurationVersionRequest, "Content"> & {
+  /**
+   * For *`CreateHostedConfigurationVersionRequest["Content"]`*, see {@link CreateHostedConfigurationVersionRequest.Content}.
+   */
+  Content: CreateHostedConfigurationVersionRequest["Content"] | string | Uint8Array | Buffer;
+};
+/**
+ * This interface extends from `CreateHostedConfigurationVersionRequest` interface. There are more parameters than `Content` defined in {@link CreateHostedConfigurationVersionRequest}
+ */
+export interface CreateHostedConfigurationVersionCommandInput
+  extends CreateHostedConfigurationVersionCommandInputType {}
 export interface CreateHostedConfigurationVersionCommandOutput extends HostedConfigurationVersion, __MetadataBearer {}
 
 /**

--- a/clients/client-codeguruprofiler/src/commands/PostAgentProfileCommand.ts
+++ b/clients/client-codeguruprofiler/src/commands/PostAgentProfileCommand.ts
@@ -18,7 +18,16 @@ import {
   serializeAws_restJson1PostAgentProfileCommand,
 } from "../protocols/Aws_restJson1";
 
-export interface PostAgentProfileCommandInput extends PostAgentProfileRequest {}
+type PostAgentProfileCommandInputType = Omit<PostAgentProfileRequest, "agentProfile"> & {
+  /**
+   * For *`PostAgentProfileRequest["agentProfile"]`*, see {@link PostAgentProfileRequest.agentProfile}.
+   */
+  agentProfile: PostAgentProfileRequest["agentProfile"] | string | Uint8Array | Buffer;
+};
+/**
+ * This interface extends from `PostAgentProfileRequest` interface. There are more parameters than `agentProfile` defined in {@link PostAgentProfileRequest}
+ */
+export interface PostAgentProfileCommandInput extends PostAgentProfileCommandInputType {}
 export interface PostAgentProfileCommandOutput extends PostAgentProfileResponse, __MetadataBearer {}
 
 /**

--- a/clients/client-iot-data-plane/src/commands/PublishCommand.ts
+++ b/clients/client-iot-data-plane/src/commands/PublishCommand.ts
@@ -18,7 +18,16 @@ import {
   serializeAws_restJson1PublishCommand,
 } from "../protocols/Aws_restJson1";
 
-export interface PublishCommandInput extends PublishRequest {}
+type PublishCommandInputType = Omit<PublishRequest, "payload"> & {
+  /**
+   * For *`PublishRequest["payload"]`*, see {@link PublishRequest.payload}.
+   */
+  payload?: PublishRequest["payload"] | string | Uint8Array | Buffer;
+};
+/**
+ * This interface extends from `PublishRequest` interface. There are more parameters than `payload` defined in {@link PublishRequest}
+ */
+export interface PublishCommandInput extends PublishCommandInputType {}
 export interface PublishCommandOutput extends __MetadataBearer {}
 
 /**

--- a/clients/client-iot-data-plane/src/commands/UpdateThingShadowCommand.ts
+++ b/clients/client-iot-data-plane/src/commands/UpdateThingShadowCommand.ts
@@ -18,7 +18,16 @@ import {
   serializeAws_restJson1UpdateThingShadowCommand,
 } from "../protocols/Aws_restJson1";
 
-export interface UpdateThingShadowCommandInput extends UpdateThingShadowRequest {}
+type UpdateThingShadowCommandInputType = Omit<UpdateThingShadowRequest, "payload"> & {
+  /**
+   * For *`UpdateThingShadowRequest["payload"]`*, see {@link UpdateThingShadowRequest.payload}.
+   */
+  payload: UpdateThingShadowRequest["payload"] | string | Uint8Array | Buffer;
+};
+/**
+ * This interface extends from `UpdateThingShadowRequest` interface. There are more parameters than `payload` defined in {@link UpdateThingShadowRequest}
+ */
+export interface UpdateThingShadowCommandInput extends UpdateThingShadowCommandInputType {}
 export interface UpdateThingShadowCommandOutput extends UpdateThingShadowResponse, __MetadataBearer {}
 
 /**

--- a/clients/client-lambda/src/commands/InvokeCommand.ts
+++ b/clients/client-lambda/src/commands/InvokeCommand.ts
@@ -15,7 +15,16 @@ import { LambdaClientResolvedConfig, ServiceInputTypes, ServiceOutputTypes } fro
 import { InvocationRequest, InvocationResponse } from "../models/models_0";
 import { deserializeAws_restJson1InvokeCommand, serializeAws_restJson1InvokeCommand } from "../protocols/Aws_restJson1";
 
-export interface InvokeCommandInput extends InvocationRequest {}
+type InvokeCommandInputType = Omit<InvocationRequest, "Payload"> & {
+  /**
+   * For *`InvocationRequest["Payload"]`*, see {@link InvocationRequest.Payload}.
+   */
+  Payload?: InvocationRequest["Payload"] | string | Uint8Array | Buffer;
+};
+/**
+ * This interface extends from `InvocationRequest` interface. There are more parameters than `Payload` defined in {@link InvocationRequest}
+ */
+export interface InvokeCommandInput extends InvokeCommandInputType {}
 export interface InvokeCommandOutput extends InvocationResponse, __MetadataBearer {}
 
 /**

--- a/clients/client-mobile/src/commands/CreateProjectCommand.ts
+++ b/clients/client-mobile/src/commands/CreateProjectCommand.ts
@@ -18,7 +18,16 @@ import {
   serializeAws_restJson1CreateProjectCommand,
 } from "../protocols/Aws_restJson1";
 
-export interface CreateProjectCommandInput extends CreateProjectRequest {}
+type CreateProjectCommandInputType = Omit<CreateProjectRequest, "contents"> & {
+  /**
+   * For *`CreateProjectRequest["contents"]`*, see {@link CreateProjectRequest.contents}.
+   */
+  contents?: CreateProjectRequest["contents"] | string | Uint8Array | Buffer;
+};
+/**
+ * This interface extends from `CreateProjectRequest` interface. There are more parameters than `contents` defined in {@link CreateProjectRequest}
+ */
+export interface CreateProjectCommandInput extends CreateProjectCommandInputType {}
 export interface CreateProjectCommandOutput extends CreateProjectResult, __MetadataBearer {}
 
 /**

--- a/clients/client-mobile/src/commands/UpdateProjectCommand.ts
+++ b/clients/client-mobile/src/commands/UpdateProjectCommand.ts
@@ -18,7 +18,16 @@ import {
   serializeAws_restJson1UpdateProjectCommand,
 } from "../protocols/Aws_restJson1";
 
-export interface UpdateProjectCommandInput extends UpdateProjectRequest {}
+type UpdateProjectCommandInputType = Omit<UpdateProjectRequest, "contents"> & {
+  /**
+   * For *`UpdateProjectRequest["contents"]`*, see {@link UpdateProjectRequest.contents}.
+   */
+  contents?: UpdateProjectRequest["contents"] | string | Uint8Array | Buffer;
+};
+/**
+ * This interface extends from `UpdateProjectRequest` interface. There are more parameters than `contents` defined in {@link UpdateProjectRequest}
+ */
+export interface UpdateProjectCommandInput extends UpdateProjectCommandInputType {}
 export interface UpdateProjectCommandOutput extends UpdateProjectResult, __MetadataBearer {}
 
 /**

--- a/clients/client-sagemaker-runtime/src/commands/InvokeEndpointCommand.ts
+++ b/clients/client-sagemaker-runtime/src/commands/InvokeEndpointCommand.ts
@@ -18,7 +18,16 @@ import {
 } from "../protocols/Aws_restJson1";
 import { SageMakerRuntimeClientResolvedConfig, ServiceInputTypes, ServiceOutputTypes } from "../SageMakerRuntimeClient";
 
-export interface InvokeEndpointCommandInput extends InvokeEndpointInput {}
+type InvokeEndpointCommandInputType = Omit<InvokeEndpointInput, "Body"> & {
+  /**
+   * For *`InvokeEndpointInput["Body"]`*, see {@link InvokeEndpointInput.Body}.
+   */
+  Body: InvokeEndpointInput["Body"] | string | Uint8Array | Buffer;
+};
+/**
+ * This interface extends from `InvokeEndpointInput` interface. There are more parameters than `Body` defined in {@link InvokeEndpointInput}
+ */
+export interface InvokeEndpointCommandInput extends InvokeEndpointCommandInputType {}
 export interface InvokeEndpointCommandOutput extends InvokeEndpointOutput, __MetadataBearer {}
 
 /**

--- a/private/aws-protocoltests-restjson/src/commands/HttpPayloadTraitsCommand.ts
+++ b/private/aws-protocoltests-restjson/src/commands/HttpPayloadTraitsCommand.ts
@@ -18,7 +18,16 @@ import {
 } from "../protocols/Aws_restJson1";
 import { RestJsonProtocolClientResolvedConfig, ServiceInputTypes, ServiceOutputTypes } from "../RestJsonProtocolClient";
 
-export interface HttpPayloadTraitsCommandInput extends HttpPayloadTraitsInputOutput {}
+type HttpPayloadTraitsCommandInputType = Omit<HttpPayloadTraitsInputOutput, "blob"> & {
+  /**
+   * For *`HttpPayloadTraitsInputOutput["blob"]`*, see {@link HttpPayloadTraitsInputOutput.blob}.
+   */
+  blob?: HttpPayloadTraitsInputOutput["blob"] | string | Uint8Array | Buffer;
+};
+/**
+ * This interface extends from `HttpPayloadTraitsInputOutput` interface. There are more parameters than `blob` defined in {@link HttpPayloadTraitsInputOutput}
+ */
+export interface HttpPayloadTraitsCommandInput extends HttpPayloadTraitsCommandInputType {}
 export interface HttpPayloadTraitsCommandOutput extends HttpPayloadTraitsInputOutput, __MetadataBearer {}
 
 /**

--- a/private/aws-protocoltests-restjson/src/commands/HttpPayloadTraitsWithMediaTypeCommand.ts
+++ b/private/aws-protocoltests-restjson/src/commands/HttpPayloadTraitsWithMediaTypeCommand.ts
@@ -18,7 +18,16 @@ import {
 } from "../protocols/Aws_restJson1";
 import { RestJsonProtocolClientResolvedConfig, ServiceInputTypes, ServiceOutputTypes } from "../RestJsonProtocolClient";
 
-export interface HttpPayloadTraitsWithMediaTypeCommandInput extends HttpPayloadTraitsWithMediaTypeInputOutput {}
+type HttpPayloadTraitsWithMediaTypeCommandInputType = Omit<HttpPayloadTraitsWithMediaTypeInputOutput, "blob"> & {
+  /**
+   * For *`HttpPayloadTraitsWithMediaTypeInputOutput["blob"]`*, see {@link HttpPayloadTraitsWithMediaTypeInputOutput.blob}.
+   */
+  blob?: HttpPayloadTraitsWithMediaTypeInputOutput["blob"] | string | Uint8Array | Buffer;
+};
+/**
+ * This interface extends from `HttpPayloadTraitsWithMediaTypeInputOutput` interface. There are more parameters than `blob` defined in {@link HttpPayloadTraitsWithMediaTypeInputOutput}
+ */
+export interface HttpPayloadTraitsWithMediaTypeCommandInput extends HttpPayloadTraitsWithMediaTypeCommandInputType {}
 export interface HttpPayloadTraitsWithMediaTypeCommandOutput
   extends HttpPayloadTraitsWithMediaTypeInputOutput,
     __MetadataBearer {}

--- a/private/aws-protocoltests-restjson/src/commands/MalformedAcceptWithGenericStringCommand.ts
+++ b/private/aws-protocoltests-restjson/src/commands/MalformedAcceptWithGenericStringCommand.ts
@@ -18,7 +18,17 @@ import {
 } from "../protocols/Aws_restJson1";
 import { RestJsonProtocolClientResolvedConfig, ServiceInputTypes, ServiceOutputTypes } from "../RestJsonProtocolClient";
 
-export interface MalformedAcceptWithGenericStringCommandInput extends MalformedAcceptWithGenericStringInput {}
+type MalformedAcceptWithGenericStringCommandInputType = Omit<MalformedAcceptWithGenericStringInput, "payload"> & {
+  /**
+   * For *`MalformedAcceptWithGenericStringInput["payload"]`*, see {@link MalformedAcceptWithGenericStringInput.payload}.
+   */
+  payload?: MalformedAcceptWithGenericStringInput["payload"] | string | Uint8Array | Buffer;
+};
+/**
+ * This interface extends from `MalformedAcceptWithGenericStringInput` interface. There are more parameters than `payload` defined in {@link MalformedAcceptWithGenericStringInput}
+ */
+export interface MalformedAcceptWithGenericStringCommandInput
+  extends MalformedAcceptWithGenericStringCommandInputType {}
 export interface MalformedAcceptWithGenericStringCommandOutput extends __MetadataBearer {}
 
 export class MalformedAcceptWithGenericStringCommand extends $Command<

--- a/private/aws-protocoltests-restjson/src/commands/MalformedContentTypeWithPayloadCommand.ts
+++ b/private/aws-protocoltests-restjson/src/commands/MalformedContentTypeWithPayloadCommand.ts
@@ -18,7 +18,16 @@ import {
 } from "../protocols/Aws_restJson1";
 import { RestJsonProtocolClientResolvedConfig, ServiceInputTypes, ServiceOutputTypes } from "../RestJsonProtocolClient";
 
-export interface MalformedContentTypeWithPayloadCommandInput extends MalformedContentTypeWithPayloadInput {}
+type MalformedContentTypeWithPayloadCommandInputType = Omit<MalformedContentTypeWithPayloadInput, "payload"> & {
+  /**
+   * For *`MalformedContentTypeWithPayloadInput["payload"]`*, see {@link MalformedContentTypeWithPayloadInput.payload}.
+   */
+  payload?: MalformedContentTypeWithPayloadInput["payload"] | string | Uint8Array | Buffer;
+};
+/**
+ * This interface extends from `MalformedContentTypeWithPayloadInput` interface. There are more parameters than `payload` defined in {@link MalformedContentTypeWithPayloadInput}
+ */
+export interface MalformedContentTypeWithPayloadCommandInput extends MalformedContentTypeWithPayloadCommandInputType {}
 export interface MalformedContentTypeWithPayloadCommandOutput extends __MetadataBearer {}
 
 export class MalformedContentTypeWithPayloadCommand extends $Command<

--- a/private/aws-protocoltests-restjson/src/commands/TestPayloadBlobCommand.ts
+++ b/private/aws-protocoltests-restjson/src/commands/TestPayloadBlobCommand.ts
@@ -18,7 +18,16 @@ import {
 } from "../protocols/Aws_restJson1";
 import { RestJsonProtocolClientResolvedConfig, ServiceInputTypes, ServiceOutputTypes } from "../RestJsonProtocolClient";
 
-export interface TestPayloadBlobCommandInput extends TestPayloadBlobInputOutput {}
+type TestPayloadBlobCommandInputType = Omit<TestPayloadBlobInputOutput, "data"> & {
+  /**
+   * For *`TestPayloadBlobInputOutput["data"]`*, see {@link TestPayloadBlobInputOutput.data}.
+   */
+  data?: TestPayloadBlobInputOutput["data"] | string | Uint8Array | Buffer;
+};
+/**
+ * This interface extends from `TestPayloadBlobInputOutput` interface. There are more parameters than `data` defined in {@link TestPayloadBlobInputOutput}
+ */
+export interface TestPayloadBlobCommandInput extends TestPayloadBlobCommandInputType {}
 export interface TestPayloadBlobCommandOutput extends TestPayloadBlobInputOutput, __MetadataBearer {}
 
 /**

--- a/private/aws-protocoltests-restxml/src/commands/HttpPayloadTraitsCommand.ts
+++ b/private/aws-protocoltests-restxml/src/commands/HttpPayloadTraitsCommand.ts
@@ -18,7 +18,16 @@ import {
 } from "../protocols/Aws_restXml";
 import { RestXmlProtocolClientResolvedConfig, ServiceInputTypes, ServiceOutputTypes } from "../RestXmlProtocolClient";
 
-export interface HttpPayloadTraitsCommandInput extends HttpPayloadTraitsInputOutput {}
+type HttpPayloadTraitsCommandInputType = Omit<HttpPayloadTraitsInputOutput, "blob"> & {
+  /**
+   * For *`HttpPayloadTraitsInputOutput["blob"]`*, see {@link HttpPayloadTraitsInputOutput.blob}.
+   */
+  blob?: HttpPayloadTraitsInputOutput["blob"] | string | Uint8Array | Buffer;
+};
+/**
+ * This interface extends from `HttpPayloadTraitsInputOutput` interface. There are more parameters than `blob` defined in {@link HttpPayloadTraitsInputOutput}
+ */
+export interface HttpPayloadTraitsCommandInput extends HttpPayloadTraitsCommandInputType {}
 export interface HttpPayloadTraitsCommandOutput extends HttpPayloadTraitsInputOutput, __MetadataBearer {}
 
 /**

--- a/private/aws-protocoltests-restxml/src/commands/HttpPayloadTraitsWithMediaTypeCommand.ts
+++ b/private/aws-protocoltests-restxml/src/commands/HttpPayloadTraitsWithMediaTypeCommand.ts
@@ -18,7 +18,16 @@ import {
 } from "../protocols/Aws_restXml";
 import { RestXmlProtocolClientResolvedConfig, ServiceInputTypes, ServiceOutputTypes } from "../RestXmlProtocolClient";
 
-export interface HttpPayloadTraitsWithMediaTypeCommandInput extends HttpPayloadTraitsWithMediaTypeInputOutput {}
+type HttpPayloadTraitsWithMediaTypeCommandInputType = Omit<HttpPayloadTraitsWithMediaTypeInputOutput, "blob"> & {
+  /**
+   * For *`HttpPayloadTraitsWithMediaTypeInputOutput["blob"]`*, see {@link HttpPayloadTraitsWithMediaTypeInputOutput.blob}.
+   */
+  blob?: HttpPayloadTraitsWithMediaTypeInputOutput["blob"] | string | Uint8Array | Buffer;
+};
+/**
+ * This interface extends from `HttpPayloadTraitsWithMediaTypeInputOutput` interface. There are more parameters than `blob` defined in {@link HttpPayloadTraitsWithMediaTypeInputOutput}
+ */
+export interface HttpPayloadTraitsWithMediaTypeCommandInput extends HttpPayloadTraitsWithMediaTypeCommandInputType {}
 export interface HttpPayloadTraitsWithMediaTypeCommandOutput
   extends HttpPayloadTraitsWithMediaTypeInputOutput,
     __MetadataBearer {}


### PR DESCRIPTION
### Issue
resolves: #3397 
related to: https://github.com/awslabs/smithy-typescript/pull/526

### Description
Previously only streaming blob payload are allow for extra types `Uint8Array | string | Buffer`. The non-streaming blob payload are still required to be casted to `Uint8Array`. However, casting is not required and may cause potential encoding issue, this change permits more types to be supplied to the binary payload shapes.

### Testing
Unit test

### Additional context
Add any other context about the PR here.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
