### PR TITLE
fix(property-provider): manually adjust the prototype of *ProviderError

### DIFF
--- a/packages/property-provider/src/CredentialsProviderError.ts
+++ b/packages/property-provider/src/CredentialsProviderError.ts
@@ -11,4 +11,9 @@ import { ProviderError } from "./ProviderError";
  */
 export class CredentialsProviderError extends ProviderError {
   name = "CredentialsProviderError";
+  constructor(message: string, public readonly tryNextLink: boolean = true) {
+    super(message, tryNextLink);
+    // Remove once we stop targetting ES5.
+    Object.setPrototypeOf(this, CredentialsProviderError.prototype);
+  }
 }

--- a/packages/property-provider/src/ProviderError.ts
+++ b/packages/property-provider/src/ProviderError.ts
@@ -11,6 +11,8 @@ export class ProviderError extends Error {
   name = "ProviderError";
   constructor(message: string, public readonly tryNextLink: boolean = true) {
     super(message);
+    // Remove once we stop targetting ES5.
+    Object.setPrototypeOf(this, ProviderError.prototype);
   }
   static from(error: Error, tryNextLink = true): ProviderError {
     return Object.assign(new this(error.message, tryNextLink), error);


### PR DESCRIPTION
### Issue
Fixes: https://github.com/aws/aws-sdk-js-v3/issues/3444

### Description
Manually adjust the prototype of *ProviderError

### Testing
Verified that instanceof checks succeed for ES5 versions of *ProviderError

```js
const { __extends } = require("tslib");

var ProviderError = (function (_super) {
  __extends(ProviderError, _super);
  function ProviderError(message, tryNextLink) {
    if (tryNextLink === void 0) {
      tryNextLink = true;
    }
    var _this = _super.call(this, message) || this;
    _this.tryNextLink = tryNextLink;
    _this.name = "ProviderError";
    Object.setPrototypeOf(_this, ProviderError.prototype);
    return _this;
  }
  ProviderError.from = function (error, tryNextLink) {
    if (tryNextLink === void 0) {
      tryNextLink = true;
    }
    return Object.assign(new this(error.message, tryNextLink), error);
  };
  return ProviderError;
})(Error);

var CredentialsProviderError = (function (_super) {
  __extends(CredentialsProviderError, _super);
  function CredentialsProviderError(message, tryNextLink) {
    if (tryNextLink === void 0) {
      tryNextLink = true;
    }
    var _this = _super.call(this, message, tryNextLink) || this;
    _this.tryNextLink = tryNextLink;
    _this.name = "CredentialsProviderError";
    Object.setPrototypeOf(_this, CredentialsProviderError.prototype);
    return _this;
  }
  return CredentialsProviderError;
})(ProviderError);

[Error, ProviderError].forEach((ErrorFn) => {
  console.log(new ProviderError("PANIC") instanceof ErrorFn);
  console.log(ProviderError.from(new Error("PANIC")) instanceof ErrorFn);
});

[Error, ProviderError, CredentialsProviderError].forEach((ErrorFn) => {
  console.log(new CredentialsProviderError("PANIC") instanceof ErrorFn);
  console.log(
    CredentialsProviderError.from(new Error("PANIC")) instanceof ErrorFn
  );
});
```

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
