### PR TITLE
fix(types): remove @internal jsdoc tag from profile types

### DIFF
--- a/packages/types/src/profile.ts
+++ b/packages/types/src/profile.ts
@@ -1,20 +1,11 @@
-/**
- * @internal
- */
 export interface Profile {
   [key: string]: string | undefined;
 }
 
-/**
- * @internal
- */
 export interface ParsedIniData {
   [key: string]: Profile;
 }
 
-/**
- * @internal
- */
 export interface SharedConfigFiles {
   credentialsFile: ParsedIniData;
   configFile: ParsedIniData;


### PR DESCRIPTION
### Issue
Fixes: https://github.com/aws/aws-sdk-js-v3/issues/3437

### Description
Removes @internal jsdoc tag from profile types

### Testing

```console
$ types> yarn clean && yarn build 
...

$ cat dist-types/profile.d.ts 
export interface Profile {
    [key: string]: string | undefined;
}
export interface ParsedIniData {
    [key: string]: Profile;
}
export interface SharedConfigFiles {
    credentialsFile: ParsedIniData;
    configFile: ParsedIniData;
}
```

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
