### PR TITLE
fix(scripts): update typescript version in generate-clients

### DIFF
--- a/scripts/generate-clients/copy-to-clients.js
+++ b/scripts/generate-clients/copy-to-clients.js
@@ -45,7 +45,7 @@ const mergeManifest = (fromContent = {}, toContent = {}) => {
           "downlevel-dts": "0.7.0",
           rimraf: "3.0.2",
           typedoc: "0.19.2",
-          typescript: "~4.3.5",
+          typescript: "~4.6.2",
         };
         fromContent[name] = Object.keys(fromContent[name])
           .filter((dep) => Object.keys(devDepToVersionHash).includes(dep))


### PR DESCRIPTION
### Issue
Fixes server-protocols test failures https://github.com/aws/aws-sdk-js-v3/runs/5631723369

### Description
The typescript version was updated in https://github.com/aws/aws-sdk-js-v3/pull/3448, but the override in generate-clients was not updated.

### Testing
CI is successful (including server-protocol tests)

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
