### PR TITLE
chore(middleware-retry): use normalizeProvider from util-middleware

### DIFF
--- a/packages/middleware-retry/package.json
+++ b/packages/middleware-retry/package.json
@@ -21,6 +21,7 @@
   "dependencies": {
     "@aws-sdk/protocol-http": "*",
     "@aws-sdk/service-error-classification": "*",
+    "@aws-sdk/util-middleware": "*",
     "@aws-sdk/types": "*",
     "tslib": "^2.3.1",
     "uuid": "^8.3.2"

--- a/packages/middleware-retry/src/configurations.spec.ts
+++ b/packages/middleware-retry/src/configurations.spec.ts
@@ -18,7 +18,9 @@ describe(resolveRetryConfig.name, () => {
   const retryMode = jest.fn() as any;
 
   beforeEach(() => {
-    (normalizeProvider as jest.Mock).mockImplementation((value) => () => Promise.resolve(value));
+    (normalizeProvider as jest.Mock).mockImplementation((input) =>
+      typeof input === "function" ? input : () => Promise.resolve(input)
+    );
   });
 
   afterEach(() => {

--- a/packages/middleware-retry/src/configurations.spec.ts
+++ b/packages/middleware-retry/src/configurations.spec.ts
@@ -1,3 +1,5 @@
+import { normalizeProvider } from "@aws-sdk/util-middleware";
+
 import { AdaptiveRetryStrategy } from "./AdaptiveRetryStrategy";
 import { DEFAULT_MAX_ATTEMPTS } from "./config";
 import {
@@ -10,19 +12,28 @@ import { StandardRetryStrategy } from "./StandardRetryStrategy";
 
 jest.mock("./AdaptiveRetryStrategy");
 jest.mock("./StandardRetryStrategy");
+jest.mock("@aws-sdk/util-middleware");
 
 describe(resolveRetryConfig.name, () => {
   const retryMode = jest.fn() as any;
+
+  beforeEach(() => {
+    (normalizeProvider as jest.Mock).mockImplementation((value) => () => Promise.resolve(value));
+  });
+
   afterEach(() => {
     jest.clearAllMocks();
   });
 
   describe("maxAttempts", () => {
-    it("assigns maxAttempts value if present", async () => {
-      for (const maxAttempts of [1, 2, 3]) {
-        const output = await resolveRetryConfig({ maxAttempts, retryMode }).maxAttempts();
-        expect(output).toStrictEqual(maxAttempts);
-      }
+    it.each([1, 2, 3])("assigns provided value %s", async (maxAttempts) => {
+      const output = await resolveRetryConfig({ maxAttempts, retryMode }).maxAttempts();
+      expect(output).toStrictEqual(maxAttempts);
+    });
+
+    it(`assigns default ${DEFAULT_MAX_ATTEMPTS} is value not provided`, async () => {
+      const output = await resolveRetryConfig({ retryMode }).maxAttempts();
+      expect(output).toStrictEqual(DEFAULT_MAX_ATTEMPTS);
     });
   });
 

--- a/packages/middleware-retry/src/configurations.ts
+++ b/packages/middleware-retry/src/configurations.ts
@@ -1,5 +1,6 @@
 import { LoadedConfigSelectors } from "@aws-sdk/node-config-provider";
 import { Provider, RetryStrategy } from "@aws-sdk/types";
+import { normalizeProvider } from "@aws-sdk/util-middleware";
 
 import { AdaptiveRetryStrategy } from "./AdaptiveRetryStrategy";
 import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE, RETRY_MODES } from "./config";
@@ -61,7 +62,7 @@ export interface RetryResolvedConfig {
 }
 
 export const resolveRetryConfig = <T>(input: T & PreviouslyResolved & RetryInputConfig): T & RetryResolvedConfig => {
-  const maxAttempts = normalizeMaxAttempts(input.maxAttempts);
+  const maxAttempts = normalizeProvider(input.maxAttempts ?? DEFAULT_MAX_ATTEMPTS);
   return {
     ...input,
     maxAttempts,
@@ -83,14 +84,6 @@ const getRetryMode = async (retryMode: string | Provider<string>): Promise<strin
     return retryMode;
   }
   return await retryMode();
-};
-
-const normalizeMaxAttempts = (maxAttempts: number | Provider<number> = DEFAULT_MAX_ATTEMPTS): Provider<number> => {
-  if (typeof maxAttempts === "number") {
-    const promisified = Promise.resolve(maxAttempts);
-    return () => promisified;
-  }
-  return maxAttempts;
 };
 
 export const ENV_RETRY_MODE = "AWS_RETRY_MODE";

--- a/packages/middleware-retry/src/configurations.ts
+++ b/packages/middleware-retry/src/configurations.ts
@@ -70,20 +70,13 @@ export const resolveRetryConfig = <T>(input: T & PreviouslyResolved & RetryInput
       if (input.retryStrategy) {
         return input.retryStrategy;
       }
-      const retryMode = await getRetryMode(input.retryMode);
+      const retryMode = await normalizeProvider(input.retryMode)();
       if (retryMode === RETRY_MODES.ADAPTIVE) {
         return new AdaptiveRetryStrategy(maxAttempts);
       }
       return new StandardRetryStrategy(maxAttempts);
     },
   };
-};
-
-const getRetryMode = async (retryMode: string | Provider<string>): Promise<string> => {
-  if (typeof retryMode === "string") {
-    return retryMode;
-  }
-  return await retryMode();
 };
 
 export const ENV_RETRY_MODE = "AWS_RETRY_MODE";


### PR DESCRIPTION
### Issue
Refs: https://github.com/aws/aws-sdk-js-v3/pull/3456

### Description
Use normalizeProvider from util-middleware

### Testing
CI

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
