### PR TITLE
chore(credential-providers): link to correct homepage and repository

### DIFF
--- a/packages/credential-providers/package.json
+++ b/packages/credential-providers/package.json
@@ -64,10 +64,10 @@
   "files": [
     "dist-*"
   ],
-  "homepage": "https://github.com/aws/aws-sdk-js-v3/tree/main/packages/credential-provider-ini",
+  "homepage": "https://github.com/aws/aws-sdk-js-v3/tree/main/packages/credential-providers",
   "repository": {
     "type": "git",
     "url": "https://github.com/aws/aws-sdk-js-v3.git",
-    "directory": "packages/credential-provider-ini"
+    "directory": "packages/credential-providers"
   }
 }


### PR DESCRIPTION
### Description
NPM always linked to the `credential-provider-ini` which is wrong in my opinion. I changed it to the `credential-providers`

### Testing
Checked manually if the `homepage` is the correct link