### PR TITLE
chore(middleware-sdk-s3): set peerDependenciesMeta to fix installation warning

### DIFF
--- a/packages/middleware-sdk-s3/package.json
+++ b/packages/middleware-sdk-s3/package.json
@@ -43,6 +43,11 @@
   "peerDependencies": {
     "@aws-sdk/signature-v4-crt": "^3.54.1"
   },
+  "peerDependenciesMeta": {
+    "@aws-sdk/signature-v4-crt": {
+      "optional": true
+    }
+  },
   "engines": {
     "node": ">= 12.0.0"
   },


### PR DESCRIPTION
### Issue
Use `peerDependenciesMeta` to suppress the peer dependency warning. https://github.com/aws/aws-sdk-js-v3/issues/2822#issuecomment-1022116272

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
