### PR TITLE
fix(types): make type in create input request required

### DIFF
--- a/clients/client-medialive/src/models/models_1.ts
+++ b/clients/client-medialive/src/models/models_1.ts
@@ -4077,7 +4077,7 @@ export interface CreateInputRequest {
   /**
    * The different types of inputs that AWS Elemental MediaLive supports.
    */
-  Type?: InputType | string;
+  Type: InputType | string;
 
   /**
    * Settings for a private VPC Input.


### PR DESCRIPTION
### Issue
There is no related issue yet.
The problem is that now AWS returns error "input type is required" if you don't put Type in your request.

### Description
- Make Type in CreateInputRequest required

### Testing
`yarn test:all`

### Additional context
nothing

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
