### PR TITLE
chore: remove profile specific data from providers

### DIFF
--- a/packages/credential-provider-ini/src/fromIni.ts
+++ b/packages/credential-provider-ini/src/fromIni.ts
@@ -1,11 +1,11 @@
 import { AssumeRoleWithWebIdentityParams } from "@aws-sdk/credential-provider-web-identity";
-import { getProfileName, parseKnownFiles, SourceProfileInit } from "@aws-sdk/shared-ini-file-loader";
+import { getProfileName, parseKnownFiles } from "@aws-sdk/shared-ini-file-loader";
 import { CredentialProvider, Credentials } from "@aws-sdk/types";
 
 import { AssumeRoleParams } from "./resolveAssumeRoleCredentials";
 import { resolveProfileData } from "./resolveProfileData";
 
-export interface FromIniInit extends SourceProfileInit {
+export interface FromIniInit {
   /**
    * A function that returns a promise fulfilled with an MFA token code for
    * the provided MFA Serial code. If a profile requires an MFA code and
@@ -42,6 +42,6 @@ export interface FromIniInit extends SourceProfileInit {
 export const fromIni =
   (init: FromIniInit = {}): CredentialProvider =>
   async () => {
-    const profiles = await parseKnownFiles(init);
-    return resolveProfileData(getProfileName(init), profiles, init);
+    const profiles = await parseKnownFiles();
+    return resolveProfileData(getProfileName(), profiles, init);
   };

--- a/packages/credential-provider-ini/src/resolveAssumeRoleCredentials.ts
+++ b/packages/credential-provider-ini/src/resolveAssumeRoleCredentials.ts
@@ -83,7 +83,7 @@ export const resolveAssumeRoleCredentials = async (
   if (source_profile && source_profile in visitedProfiles) {
     throw new CredentialsProviderError(
       `Detected a cycle attempting to resolve credentials for profile` +
-        ` ${getProfileName(options)}. Profiles visited: ` +
+        ` ${getProfileName()}. Profiles visited: ` +
         Object.keys(visitedProfiles).join(", "),
       false
     );

--- a/packages/credential-provider-node/src/defaultProvider.ts
+++ b/packages/credential-provider-node/src/defaultProvider.ts
@@ -57,7 +57,7 @@ export const defaultProvider = (
     ...(options.profile ? [] : [fromEnv()]),
     fromSSO(options),
     fromIni(options),
-    fromProcess(options),
+    fromProcess(),
     fromTokenFile(options),
     remoteProvider(options),
     async () => {

--- a/packages/credential-provider-node/src/defaultProvider.ts
+++ b/packages/credential-provider-node/src/defaultProvider.ts
@@ -50,7 +50,7 @@ export const defaultProvider = (
   const options = {
     profile: process.env[ENV_PROFILE],
     ...init,
-    ...(!init.loadedConfig && { loadedConfig: loadSharedConfigFiles(init) }),
+    ...(!init.loadedConfig && { loadedConfig: loadSharedConfigFiles() }),
   };
 
   const providerChain = chain(

--- a/packages/credential-provider-process/src/fromProcess.ts
+++ b/packages/credential-provider-process/src/fromProcess.ts
@@ -1,17 +1,13 @@
-import { getProfileName, parseKnownFiles, SourceProfileInit } from "@aws-sdk/shared-ini-file-loader";
+import { getProfileName, parseKnownFiles } from "@aws-sdk/shared-ini-file-loader";
 import { CredentialProvider } from "@aws-sdk/types";
 
 import { resolveProcessCredentials } from "./resolveProcessCredentials";
-
-export interface FromProcessInit extends SourceProfileInit {}
 
 /**
  * Creates a credential provider that will read from a credential_process specified
  * in ini files.
  */
-export const fromProcess =
-  (init: FromProcessInit = {}): CredentialProvider =>
-  async () => {
-    const profiles = await parseKnownFiles(init);
-    return resolveProcessCredentials(getProfileName(init), profiles);
-  };
+export const fromProcess = (): CredentialProvider => async () => {
+  const profiles = await parseKnownFiles();
+  return resolveProcessCredentials(getProfileName(), profiles);
+};

--- a/packages/credential-provider-sso/src/fromSSO.ts
+++ b/packages/credential-provider-sso/src/fromSSO.ts
@@ -1,6 +1,6 @@
 import { SSOClient } from "@aws-sdk/client-sso";
 import { CredentialsProviderError } from "@aws-sdk/property-provider";
-import { getProfileName, parseKnownFiles, SourceProfileInit } from "@aws-sdk/shared-ini-file-loader";
+import { getProfileName, parseKnownFiles } from "@aws-sdk/shared-ini-file-loader";
 import { CredentialProvider } from "@aws-sdk/types";
 
 import { isSsoProfile } from "./isSsoProfile";
@@ -29,7 +29,7 @@ export interface SsoCredentialsParameters {
   ssoRoleName: string;
 }
 
-export interface FromSSOInit extends SourceProfileInit {
+export interface FromSSOInit {
   ssoClient?: SSOClient;
 }
 
@@ -43,8 +43,8 @@ export const fromSSO =
     const { ssoStartUrl, ssoAccountId, ssoRegion, ssoRoleName, ssoClient } = init;
     if (!ssoStartUrl && !ssoAccountId && !ssoRegion && !ssoRoleName) {
       // Load the SSO config from shared AWS config file.
-      const profiles = await parseKnownFiles(init);
-      const profileName = getProfileName(init);
+      const profiles = await parseKnownFiles();
+      const profileName = getProfileName();
       const profile = profiles[profileName];
 
       if (!isSsoProfile(profile)) {

--- a/packages/node-config-provider/src/configLoader.spec.ts
+++ b/packages/node-config-provider/src/configLoader.spec.ts
@@ -10,10 +10,6 @@ jest.mock("./fromSharedConfigFiles");
 jest.mock("@aws-sdk/property-provider");
 
 describe("loadConfig", () => {
-  const configuration: SharedConfigInit = {
-    profile: "profile",
-  };
-
   afterEach(() => {
     jest.clearAllMocks();
   });
@@ -28,18 +24,15 @@ describe("loadConfig", () => {
     const envVarSelector = (env: NodeJS.ProcessEnv) => env["AWS_CONFIG_FOO"];
     const configKey = (profile: Profile) => profile["aws_config_foo"];
     const defaultValue = "foo-value";
-    loadConfig(
-      {
-        environmentVariableSelector: envVarSelector,
-        configFileSelector: configKey,
-        default: defaultValue,
-      },
-      configuration
-    );
+    loadConfig({
+      environmentVariableSelector: envVarSelector,
+      configFileSelector: configKey,
+      default: defaultValue,
+    });
     expect(fromEnv).toHaveBeenCalledTimes(1);
     expect(fromEnv).toHaveBeenCalledWith(envVarSelector);
     expect(fromSharedConfigFiles).toHaveBeenCalledTimes(1);
-    expect(fromSharedConfigFiles).toHaveBeenCalledWith(configKey, configuration);
+    expect(fromSharedConfigFiles).toHaveBeenCalledWith(configKey, {});
     expect(fromStatic).toHaveBeenCalledTimes(1);
     expect(fromStatic).toHaveBeenCalledWith(defaultValue);
     expect(chain).toHaveBeenCalledTimes(1);

--- a/packages/node-config-provider/src/fromSharedConfigFiles.ts
+++ b/packages/node-config-provider/src/fromSharedConfigFiles.ts
@@ -1,30 +1,17 @@
 import { CredentialsProviderError } from "@aws-sdk/property-provider";
-import { loadSharedConfigFiles, SharedConfigInit as BaseSharedConfigInit } from "@aws-sdk/shared-ini-file-loader";
-import { Profile, Provider, SharedConfigFiles } from "@aws-sdk/types";
+import { loadSharedConfigFiles } from "@aws-sdk/shared-ini-file-loader";
+import { Profile, Provider } from "@aws-sdk/types";
 
 const DEFAULT_PROFILE = "default";
 export const ENV_PROFILE = "AWS_PROFILE";
 
-export interface SharedConfigInit extends BaseSharedConfigInit {
-  /**
-   * The configuration profile to use.
-   */
-  profile?: string;
-
+export interface SharedConfigInit {
   /**
    * The preferred shared ini file to load the config. "config" option refers to
    * the shared config file(defaults to `~/.aws/config`). "credentials" option
    * refers to the shared credentials file(defaults to `~/.aws/credentials`)
    */
   preferredFile?: "config" | "credentials";
-
-  /**
-   * A promise that will be resolved with loaded and parsed credentials files.
-   * Used to avoid loading shared config files multiple times.
-   *
-   * @internal
-   */
-  loadedConfig?: Promise<SharedConfigFiles>;
 }
 
 export type GetterFromConfig<T> = (profile: Profile) => T | undefined;
@@ -33,12 +20,10 @@ export type GetterFromConfig<T> = (profile: Profile) => T | undefined;
  * Get config value from the shared config files with inferred profile name.
  */
 export const fromSharedConfigFiles =
-  <T = string>(
-    configSelector: GetterFromConfig<T>,
-    { preferredFile = "config", ...init }: SharedConfigInit = {}
-  ): Provider<T> =>
+  <T = string>(configSelector: GetterFromConfig<T>, { preferredFile = "config" }: SharedConfigInit = {}): Provider<T> =>
   async () => {
-    const { loadedConfig = loadSharedConfigFiles(init), profile = process.env[ENV_PROFILE] || DEFAULT_PROFILE } = init;
+    const loadedConfig = loadSharedConfigFiles();
+    const profile = process.env[ENV_PROFILE] || DEFAULT_PROFILE;
 
     const { configFile, credentialsFile } = await loadedConfig;
 

--- a/packages/shared-ini-file-loader/src/getProfileName.ts
+++ b/packages/shared-ini-file-loader/src/getProfileName.ts
@@ -1,5 +1,4 @@
 export const ENV_PROFILE = "AWS_PROFILE";
 export const DEFAULT_PROFILE = "default";
 
-export const getProfileName = (init: { profile?: string }): string =>
-  init.profile || process.env[ENV_PROFILE] || DEFAULT_PROFILE;
+export const getProfileName = (): string => process.env[ENV_PROFILE] || DEFAULT_PROFILE;

--- a/packages/shared-ini-file-loader/src/loadSharedConfigFiles.ts
+++ b/packages/shared-ini-file-loader/src/loadSharedConfigFiles.ts
@@ -9,29 +9,11 @@ import { slurpFile } from "./slurpFile";
 export const ENV_CREDENTIALS_PATH = "AWS_SHARED_CREDENTIALS_FILE";
 export const ENV_CONFIG_PATH = "AWS_CONFIG_FILE";
 
-export interface SharedConfigInit {
-  /**
-   * The path at which to locate the ini credentials file. Defaults to the
-   * value of the `AWS_SHARED_CREDENTIALS_FILE` environment variable (if
-   * defined) or `~/.aws/credentials` otherwise.
-   */
-  filepath?: string;
-
-  /**
-   * The path at which to locate the ini config file. Defaults to the value of
-   * the `AWS_CONFIG_FILE` environment variable (if defined) or
-   * `~/.aws/config` otherwise.
-   */
-  configFilepath?: string;
-}
-
 const swallowError = () => ({});
 
-export const loadSharedConfigFiles = async (init: SharedConfigInit = {}): Promise<SharedConfigFiles> => {
-  const {
-    filepath = process.env[ENV_CREDENTIALS_PATH] || join(getHomeDir(), ".aws", "credentials"),
-    configFilepath = process.env[ENV_CONFIG_PATH] || join(getHomeDir(), ".aws", "config"),
-  } = init;
+export const loadSharedConfigFiles = async (): Promise<SharedConfigFiles> => {
+  const filepath = process.env[ENV_CREDENTIALS_PATH] || join(getHomeDir(), ".aws", "credentials");
+  const configFilepath = process.env[ENV_CONFIG_PATH] || join(getHomeDir(), ".aws", "config");
 
   const parsedFiles = await Promise.all([
     slurpFile(configFilepath).then(parseIni).then(normalizeConfigFile).catch(swallowError),

--- a/packages/shared-ini-file-loader/src/parseKnownFiles.ts
+++ b/packages/shared-ini-file-loader/src/parseKnownFiles.ts
@@ -1,8 +1,8 @@
 import { ParsedIniData, SharedConfigFiles } from "@aws-sdk/types";
 
-import { loadSharedConfigFiles, SharedConfigInit } from "./loadSharedConfigFiles";
+import { loadSharedConfigFiles } from "./loadSharedConfigFiles";
 
-export interface SourceProfileInit extends SharedConfigInit {
+export interface SourceProfileInit {
   /**
    * The configuration profile to use.
    */
@@ -24,7 +24,7 @@ export interface SourceProfileInit extends SharedConfigInit {
  * @internal
  */
 export const parseKnownFiles = async (init: SourceProfileInit): Promise<ParsedIniData> => {
-  const { loadedConfig = loadSharedConfigFiles(init) } = init;
+  const { loadedConfig = loadSharedConfigFiles() } = init;
 
   const parsedFiles = await loadedConfig;
   return {

--- a/packages/shared-ini-file-loader/src/parseKnownFiles.ts
+++ b/packages/shared-ini-file-loader/src/parseKnownFiles.ts
@@ -1,21 +1,6 @@
-import { ParsedIniData, SharedConfigFiles } from "@aws-sdk/types";
+import { ParsedIniData } from "@aws-sdk/types";
 
 import { loadSharedConfigFiles } from "./loadSharedConfigFiles";
-
-export interface SourceProfileInit {
-  /**
-   * The configuration profile to use.
-   */
-  profile?: string;
-
-  /**
-   * A promise that will be resolved with loaded and parsed credentials files.
-   * Used to avoid loading shared config files multiple times.
-   *
-   * @internal
-   */
-  loadedConfig?: Promise<SharedConfigFiles>;
-}
 
 /**
  * Load profiles from credentials and config INI files and normalize them into a
@@ -23,8 +8,8 @@ export interface SourceProfileInit {
  *
  * @internal
  */
-export const parseKnownFiles = async (init: SourceProfileInit): Promise<ParsedIniData> => {
-  const { loadedConfig = loadSharedConfigFiles() } = init;
+export const parseKnownFiles = async (): Promise<ParsedIniData> => {
+  const loadedConfig = loadSharedConfigFiles();
 
   const parsedFiles = await loadedConfig;
   return {

--- a/packages/util-credentials/src/parse-known-profiles.ts
+++ b/packages/util-credentials/src/parse-known-profiles.ts
@@ -1,12 +1,4 @@
-import {
-  parseKnownFiles as __parseKnownFiles,
-  SourceProfileInit as __SourceProfileInit,
-} from "@aws-sdk/shared-ini-file-loader";
-
-/**
- * @deprecated Use SourceProfileInit from "@aws-sdk/shared-ini-file-loader" instead.
- */
-export interface SourceProfileInit extends __SourceProfileInit {}
+import { parseKnownFiles as __parseKnownFiles } from "@aws-sdk/shared-ini-file-loader";
 
 /**
  * @deprecated Use parseKnownFiles from "@aws-sdk/shared-ini-file-loader" instead.


### PR DESCRIPTION
### Issue
Refs: https://github.com/aws/aws-sdk-js-v3/issues/3469

### Description
Removes profile specific data from providers.
* Since we support setting profile only in AWS_PROFILE, this information is only read from getProfileName().
* Caching of configuration happens at slurpFile level in https://github.com/aws/aws-sdk-js-v3/pull/3285, so the function can be called multiple times and doesn't have to be called at the top.

### Testing
* ToDo: Unit testing
* ToDo: Integration testing
* ToDo: Manual testing to ensure there are only two readFile calls.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
