### PR TITLE
fix(node-config-provider): remove profile specific data from fromSharedConfigFiles

### DIFF
--- a/packages/node-config-provider/src/configLoader.spec.ts
+++ b/packages/node-config-provider/src/configLoader.spec.ts
@@ -10,10 +10,6 @@ jest.mock("./fromSharedConfigFiles");
 jest.mock("@aws-sdk/property-provider");
 
 describe("loadConfig", () => {
-  const configuration: SharedConfigInit = {
-    profile: "profile",
-  };
-
   afterEach(() => {
     jest.clearAllMocks();
   });
@@ -28,18 +24,15 @@ describe("loadConfig", () => {
     const envVarSelector = (env: NodeJS.ProcessEnv) => env["AWS_CONFIG_FOO"];
     const configKey = (profile: Profile) => profile["aws_config_foo"];
     const defaultValue = "foo-value";
-    loadConfig(
-      {
-        environmentVariableSelector: envVarSelector,
-        configFileSelector: configKey,
-        default: defaultValue,
-      },
-      configuration
-    );
+    loadConfig({
+      environmentVariableSelector: envVarSelector,
+      configFileSelector: configKey,
+      default: defaultValue,
+    });
     expect(fromEnv).toHaveBeenCalledTimes(1);
     expect(fromEnv).toHaveBeenCalledWith(envVarSelector);
     expect(fromSharedConfigFiles).toHaveBeenCalledTimes(1);
-    expect(fromSharedConfigFiles).toHaveBeenCalledWith(configKey, configuration);
+    expect(fromSharedConfigFiles).toHaveBeenCalledWith(configKey, {});
     expect(fromStatic).toHaveBeenCalledTimes(1);
     expect(fromStatic).toHaveBeenCalledWith(defaultValue);
     expect(chain).toHaveBeenCalledTimes(1);

--- a/packages/node-config-provider/src/fromSharedConfigFiles.ts
+++ b/packages/node-config-provider/src/fromSharedConfigFiles.ts
@@ -1,30 +1,17 @@
 import { CredentialsProviderError } from "@aws-sdk/property-provider";
-import { loadSharedConfigFiles, SharedConfigInit as BaseSharedConfigInit } from "@aws-sdk/shared-ini-file-loader";
-import { Profile, Provider, SharedConfigFiles } from "@aws-sdk/types";
+import { loadSharedConfigFiles } from "@aws-sdk/shared-ini-file-loader";
+import { Profile, Provider } from "@aws-sdk/types";
 
 const DEFAULT_PROFILE = "default";
 export const ENV_PROFILE = "AWS_PROFILE";
 
-export interface SharedConfigInit extends BaseSharedConfigInit {
-  /**
-   * The configuration profile to use.
-   */
-  profile?: string;
-
+export interface SharedConfigInit {
   /**
    * The preferred shared ini file to load the config. "config" option refers to
    * the shared config file(defaults to `~/.aws/config`). "credentials" option
    * refers to the shared credentials file(defaults to `~/.aws/credentials`)
    */
   preferredFile?: "config" | "credentials";
-
-  /**
-   * A promise that will be resolved with loaded and parsed credentials files.
-   * Used to avoid loading shared config files multiple times.
-   *
-   * @internal
-   */
-  loadedConfig?: Promise<SharedConfigFiles>;
 }
 
 export type GetterFromConfig<T> = (profile: Profile) => T | undefined;
@@ -33,12 +20,10 @@ export type GetterFromConfig<T> = (profile: Profile) => T | undefined;
  * Get config value from the shared config files with inferred profile name.
  */
 export const fromSharedConfigFiles =
-  <T = string>(
-    configSelector: GetterFromConfig<T>,
-    { preferredFile = "config", ...init }: SharedConfigInit = {}
-  ): Provider<T> =>
+  <T = string>(configSelector: GetterFromConfig<T>, { preferredFile = "config" }: SharedConfigInit = {}): Provider<T> =>
   async () => {
-    const { loadedConfig = loadSharedConfigFiles(init), profile = process.env[ENV_PROFILE] || DEFAULT_PROFILE } = init;
+    const loadedConfig = loadSharedConfigFiles();
+    const profile = process.env[ENV_PROFILE] || DEFAULT_PROFILE;
 
     const { configFile, credentialsFile } = await loadedConfig;
 


### PR DESCRIPTION
### Issue
Refs: https://github.com/aws/aws-sdk-js-v3/issues/3469

### Description
Removes profile specific data from fromSharedConfigFiles.
* Since we support setting profile only in AWS_PROFILE, this information is not required from callee.
* Caching of loadedConfig happens at slurpFile level as done in https://github.com/aws/aws-sdk-js-v3/pull/3285, so it's not required to be done by callee.

### Testing
Unit testing

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.