### PR TITLE
chore(packages): remove loadedConfig option

### DIFF
--- a/packages/credential-provider-node/src/defaultProvider.spec.ts
+++ b/packages/credential-provider-node/src/defaultProvider.spec.ts
@@ -27,7 +27,6 @@ describe(defaultProvider.name, () => {
 
   const mockInit = {
     profile: "mockProfile",
-    loadedConfig: Promise.resolve({ configFile: {}, credentialsFile: {} }),
   };
 
   const mockEnvFn = jest.fn();
@@ -112,25 +111,6 @@ describe(defaultProvider.name, () => {
       }
 
       process.env = ORIGINAL_ENV;
-    });
-
-    it(`gets loadedConfig from loadSharedConfigFiles, if not provided in init`, async () => {
-      const mockSharedConfigFiles = Promise.resolve({
-        configFile: { key: "value" },
-        credentialsFile: { key: "value" },
-      });
-      (loadSharedConfigFiles as jest.Mock).mockReturnValue(mockSharedConfigFiles);
-
-      const { loadedConfig, ...mockInitWithoutLoadedConfig } = mockInit;
-      const receivedCreds = await defaultProvider(mockInitWithoutLoadedConfig)();
-      expect(receivedCreds).toStrictEqual(mockCreds);
-
-      expect(loadSharedConfigFiles).toHaveBeenCalledWith(mockInitWithoutLoadedConfig);
-
-      expect(fromEnv).not.toHaveBeenCalled();
-      for (const fromFn of [fromSSO, fromIni, fromProcess, fromTokenFile, remoteProvider]) {
-        expect(fromFn).toHaveBeenCalledWith({ ...mockInit, loadedConfig: mockSharedConfigFiles });
-      }
     });
   });
 

--- a/packages/credential-provider-node/src/defaultProvider.ts
+++ b/packages/credential-provider-node/src/defaultProvider.ts
@@ -5,7 +5,7 @@ import { fromProcess, FromProcessInit } from "@aws-sdk/credential-provider-proce
 import { fromSSO, FromSSOInit } from "@aws-sdk/credential-provider-sso";
 import { fromTokenFile, FromTokenFileInit } from "@aws-sdk/credential-provider-web-identity";
 import { chain, CredentialsProviderError, memoize } from "@aws-sdk/property-provider";
-import { ENV_PROFILE, loadSharedConfigFiles } from "@aws-sdk/shared-ini-file-loader";
+import { ENV_PROFILE } from "@aws-sdk/shared-ini-file-loader";
 import { Credentials, MemoizedProvider } from "@aws-sdk/types";
 
 import { remoteProvider } from "./remoteProvider";
@@ -50,7 +50,6 @@ export const defaultProvider = (
   const options = {
     profile: process.env[ENV_PROFILE],
     ...init,
-    ...(!init.loadedConfig && { loadedConfig: loadSharedConfigFiles(init) }),
   };
 
   const providerChain = chain(

--- a/packages/node-config-provider/src/fromSharedConfigFiles.spec.ts
+++ b/packages/node-config-provider/src/fromSharedConfigFiles.spec.ts
@@ -115,59 +115,29 @@ describe("fromSharedConfigFiles", () => {
       },
     ];
 
-    describe("uses the shared ini file loader if pre-loaded config is not supplied", () => {
-      loadedConfigResolves.forEach(
-        ({ message, iniDataInConfig, iniDataInCredentials, configValueToVerify, profile, preferredFile }) => {
-          it(message, () => {
-            (loadSharedConfigFiles as jest.Mock).mockResolvedValueOnce({
-              configFile: iniDataInConfig,
-              credentialsFile: iniDataInCredentials,
-            });
-            return expect(fromSharedConfigFiles(configGetter, { profile, preferredFile })()).resolves.toBe(
-              configValueToVerify
-            );
-          });
-        }
-      );
-
-      loadedConfigRejects.forEach(({ message, iniDataInConfig, iniDataInCredentials, profile, preferredFile }) => {
+    loadedConfigResolves.forEach(
+      ({ message, iniDataInConfig, iniDataInCredentials, configValueToVerify, profile, preferredFile }) => {
         it(message, () => {
           (loadSharedConfigFiles as jest.Mock).mockResolvedValueOnce({
             configFile: iniDataInConfig,
             credentialsFile: iniDataInCredentials,
           });
-          return expect(fromSharedConfigFiles(configGetter, { profile, preferredFile })()).rejects.toMatchObject(
-            getCredentialsProviderError(profile ?? "default", configGetter)
+          return expect(fromSharedConfigFiles(configGetter, { profile, preferredFile })()).resolves.toBe(
+            configValueToVerify
           );
         });
-      });
-    });
+      }
+    );
 
-    describe("uses pre-loaded config if supplied", () => {
-      loadedConfigResolves.forEach(
-        ({ message, iniDataInConfig, iniDataInCredentials, configValueToVerify, profile, preferredFile }) => {
-          it(`${message} from config file`, () => {
-            const loadedConfig = Promise.resolve({
-              configFile: iniDataInConfig,
-              credentialsFile: iniDataInCredentials,
-            });
-            return expect(
-              fromSharedConfigFiles(configGetter, { loadedConfig, profile, preferredFile })()
-            ).resolves.toBe(configValueToVerify);
-          });
-        }
-      );
-
-      loadedConfigRejects.forEach(({ message, iniDataInConfig, iniDataInCredentials, profile, preferredFile }) => {
-        it(message, () => {
-          const loadedConfig = Promise.resolve({
-            configFile: iniDataInConfig,
-            credentialsFile: iniDataInCredentials,
-          });
-          return expect(
-            fromSharedConfigFiles(configGetter, { loadedConfig, profile, preferredFile })()
-          ).rejects.toMatchObject(getCredentialsProviderError(profile ?? "default", configGetter));
+    loadedConfigRejects.forEach(({ message, iniDataInConfig, iniDataInCredentials, profile, preferredFile }) => {
+      it(message, () => {
+        (loadSharedConfigFiles as jest.Mock).mockResolvedValueOnce({
+          configFile: iniDataInConfig,
+          credentialsFile: iniDataInCredentials,
         });
+        return expect(fromSharedConfigFiles(configGetter, { profile, preferredFile })()).rejects.toMatchObject(
+          getCredentialsProviderError(profile ?? "default", configGetter)
+        );
       });
     });
 
@@ -194,19 +164,22 @@ describe("fromSharedConfigFiles", () => {
         default: { [configKey]: "credentialsFileDefault" },
       },
     };
-    const loadedConfig = Promise.resolve(loadedConfigData);
 
     describe("when profile is not defined", () => {
+      beforeEach(() => {
+        (loadSharedConfigFiles as jest.Mock).mockResolvedValueOnce(loadedConfigData);
+      });
+
       it(`returns configValue from value in '${ENV_PROFILE}' env var if it is set`, () => {
         const profile = "foo";
         process.env[ENV_PROFILE] = profile;
-        return expect(fromSharedConfigFiles(configGetter, { loadedConfig })()).resolves.toBe(
+        return expect(fromSharedConfigFiles(configGetter, {})()).resolves.toBe(
           loadedConfigData.configFile[profile][configKey]
         );
       });
 
       it(`returns configValue from default profile if '${ENV_PROFILE}' env var is not set`, () => {
-        return expect(fromSharedConfigFiles(configGetter, { loadedConfig })()).resolves.toBe(
+        return expect(fromSharedConfigFiles(configGetter, {})()).resolves.toBe(
           loadedConfigData.configFile.default[configKey]
         );
       });

--- a/packages/node-config-provider/src/fromSharedConfigFiles.spec.ts
+++ b/packages/node-config-provider/src/fromSharedConfigFiles.spec.ts
@@ -173,13 +173,13 @@ describe("fromSharedConfigFiles", () => {
       it(`returns configValue from value in '${ENV_PROFILE}' env var if it is set`, () => {
         const profile = "foo";
         process.env[ENV_PROFILE] = profile;
-        return expect(fromSharedConfigFiles(configGetter, {})()).resolves.toBe(
+        return expect(fromSharedConfigFiles(configGetter)()).resolves.toBe(
           loadedConfigData.configFile[profile][configKey]
         );
       });
 
       it(`returns configValue from default profile if '${ENV_PROFILE}' env var is not set`, () => {
-        return expect(fromSharedConfigFiles(configGetter, {})()).resolves.toBe(
+        return expect(fromSharedConfigFiles(configGetter)()).resolves.toBe(
           loadedConfigData.configFile.default[configKey]
         );
       });

--- a/packages/node-config-provider/src/fromSharedConfigFiles.ts
+++ b/packages/node-config-provider/src/fromSharedConfigFiles.ts
@@ -1,6 +1,6 @@
 import { CredentialsProviderError } from "@aws-sdk/property-provider";
 import { loadSharedConfigFiles, SharedConfigInit as BaseSharedConfigInit } from "@aws-sdk/shared-ini-file-loader";
-import { Profile, Provider, SharedConfigFiles } from "@aws-sdk/types";
+import { Profile, Provider } from "@aws-sdk/types";
 
 const DEFAULT_PROFILE = "default";
 export const ENV_PROFILE = "AWS_PROFILE";
@@ -17,14 +17,6 @@ export interface SharedConfigInit extends BaseSharedConfigInit {
    * refers to the shared credentials file(defaults to `~/.aws/credentials`)
    */
   preferredFile?: "config" | "credentials";
-
-  /**
-   * A promise that will be resolved with loaded and parsed credentials files.
-   * Used to avoid loading shared config files multiple times.
-   *
-   * @internal
-   */
-  loadedConfig?: Promise<SharedConfigFiles>;
 }
 
 export type GetterFromConfig<T> = (profile: Profile) => T | undefined;
@@ -38,9 +30,9 @@ export const fromSharedConfigFiles =
     { preferredFile = "config", ...init }: SharedConfigInit = {}
   ): Provider<T> =>
   async () => {
-    const { loadedConfig = loadSharedConfigFiles(init), profile = process.env[ENV_PROFILE] || DEFAULT_PROFILE } = init;
+    const { profile = process.env[ENV_PROFILE] || DEFAULT_PROFILE } = init;
 
-    const { configFile, credentialsFile } = await loadedConfig;
+    const { configFile, credentialsFile } = await loadSharedConfigFiles(init);
 
     const profileFromCredentials = credentialsFile[profile] || {};
     const profileFromConfig = configFile[profile] || {};

--- a/packages/shared-ini-file-loader/src/parseKnownFiles.spec.ts
+++ b/packages/shared-ini-file-loader/src/parseKnownFiles.spec.ts
@@ -17,22 +17,7 @@ describe(parseKnownFiles.name, () => {
     jest.clearAllMocks();
   });
 
-  it("gets parsedFiles from loadedConfig if provided in init", async () => {
-    const parsedFiles = await parseKnownFiles({
-      loadedConfig: Promise.resolve({
-        configFile: mockConfigFile,
-        credentialsFile: mockCredentialsFile,
-      }),
-    });
-
-    expect(loadSharedConfigFiles).not.toHaveBeenCalled();
-    expect(parsedFiles).toEqual({
-      ...mockConfigFile,
-      ...mockCredentialsFile,
-    });
-  });
-
-  it("gets parsedFiles from loadSharedConfigFiles if not provided in init", async () => {
+  it("gets parsedFiles from loadSharedConfigFiles", async () => {
     (loadSharedConfigFiles as jest.Mock).mockReturnValue(
       Promise.resolve({
         configFile: mockConfigFile,

--- a/packages/shared-ini-file-loader/src/parseKnownFiles.ts
+++ b/packages/shared-ini-file-loader/src/parseKnownFiles.ts
@@ -1,4 +1,4 @@
-import { ParsedIniData, SharedConfigFiles } from "@aws-sdk/types";
+import { ParsedIniData } from "@aws-sdk/types";
 
 import { loadSharedConfigFiles, SharedConfigInit } from "./loadSharedConfigFiles";
 
@@ -7,14 +7,6 @@ export interface SourceProfileInit extends SharedConfigInit {
    * The configuration profile to use.
    */
   profile?: string;
-
-  /**
-   * A promise that will be resolved with loaded and parsed credentials files.
-   * Used to avoid loading shared config files multiple times.
-   *
-   * @internal
-   */
-  loadedConfig?: Promise<SharedConfigFiles>;
 }
 
 /**
@@ -24,9 +16,7 @@ export interface SourceProfileInit extends SharedConfigInit {
  * @internal
  */
 export const parseKnownFiles = async (init: SourceProfileInit): Promise<ParsedIniData> => {
-  const { loadedConfig = loadSharedConfigFiles(init) } = init;
-
-  const parsedFiles = await loadedConfig;
+  const parsedFiles = await loadSharedConfigFiles(init);
   return {
     ...parsedFiles.configFile,
     ...parsedFiles.credentialsFile,


### PR DESCRIPTION
### Issue
Refs: https://github.com/aws/aws-sdk-js-v3/pull/3285

### Description
Caching of configuration happens at slurpFile level in https://github.com/aws/aws-sdk-js-v3/pull/3285
The function loadSharedConfigFiles can be called multiple times, and doesn't have to be called at top level.

### Testing

#### Unit testing

#### Manual testing to ensure two readFile calls

```js
// packages/shared-ini-file-loader/src/slurpFile.ts

let readFileCallTotal = 0;

export const slurpFile = (path: string) =>
  new Promise<string>((resolve, reject) => {
    if (!fileStatusHash[path]) {
      // File not read yet, set file isReading to true and read file.
      fileStatusHash[path] = { isReading: true, contents: "", requestQueue: [] };
      fileStatusHash[path].requestQueue.push({ resolve, reject });
      const readFileCallMsg = `readFile call #${++readFileCallTotal} for: ${path}`;
      console.log(`start: ${readFileCallMsg}`);
      readFile(path, "utf8")
        .then((data) => {
          console.log(`end: ${readFileCallMsg}`);
```

<details>
<summary>Single client</summary>

```js
import { S3 } from "../aws-sdk-js-v3/clients/client-s3/dist-cjs/index.js";

console.log("Before client instantiation");
const client = new S3({});
console.log("After client instantiation");
```

```console
Before client instantiation
After client instantiation
start: readFile call #1 for: /home/trivikr/.aws/config
start: readFile call #2 for: /home/trivikr/.aws/credentials
end: readFile call #1 for: /home/trivikr/.aws/config
end: readFile call #2 for: /home/trivikr/.aws/credentials
```

</details>

<details>
<summary>Two clients</summary>

```js
import { S3 } from "../aws-sdk-js-v3/clients/client-s3/dist-cjs/index.js";

console.log("Before client1 instantiation");
const client1 = new S3({});
console.log("After client1 instantiation");

console.log("Before client2 instantiation");
const client2 = new S3({});
console.log("After client2 instantiation");

```

```console
Before client1 instantiation
After client1 instantiation
Before client2 instantiation
After client2 instantiation
start: readFile call #1 for: /home/trivikr/.aws/config
start: readFile call #2 for: /home/trivikr/.aws/credentials
end: readFile call #1 for: /home/trivikr/.aws/config
end: readFile call #2 for: /home/trivikr/.aws/credentials
```

</details>

<details>
<summary>Client with an operation</summary>

```js
import { S3 } from "../aws-sdk-js-v3/clients/client-s3/dist-cjs/index.js";

console.log("Before client instantiation");
const client = new S3({});
console.log("After client instantiation");

console.log("Before calling operation");
await client.listBuckets({});
console.log("After calling operation");
```

```console
Before client instantiation
After client instantiation
Before calling operation
start: readFile call #1 for: /home/trivikr/.aws/config
start: readFile call #2 for: /home/trivikr/.aws/credentials
end: readFile call #1 for: /home/trivikr/.aws/config
end: readFile call #2 for: /home/trivikr/.aws/credentials
After calling operation
```

</details>

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
