### PR TITLE
chore(credential-provider-node): do not set profile from env

### DIFF
--- a/packages/credential-provider-node/src/defaultProvider.spec.ts
+++ b/packages/credential-provider-node/src/defaultProvider.spec.ts
@@ -94,7 +94,7 @@ describe(defaultProvider.name, () => {
       expect(loadSharedConfigFiles).not.toHaveBeenCalled();
     });
 
-    it(`reads profile from env['${ENV_PROFILE}'], if not provided in init`, async () => {
+    it(`if env['${ENV_PROFILE}'] is set`, async () => {
       const ORIGINAL_ENV = process.env;
       process.env = {
         ...ORIGINAL_ENV,
@@ -107,7 +107,7 @@ describe(defaultProvider.name, () => {
 
       expect(fromEnv).not.toHaveBeenCalled();
       for (const fromFn of [fromSSO, fromIni, fromProcess, fromTokenFile, remoteProvider]) {
-        expect(fromFn).toHaveBeenCalledWith({ ...mockInit, profile: process.env[ENV_PROFILE] });
+        expect(fromFn).toHaveBeenCalledWith(mockInitWithoutProfile);
       }
 
       process.env = ORIGINAL_ENV;


### PR DESCRIPTION
### Issue
Noticed while working on https://github.com/aws/aws-sdk-js-v3/pull/3479

### Description
All upstream packages get profile name from `getProfileName` call which checks for env[AWS_PROFILE]
The value is not required to be set in defaultProvider.

### Testing
Unit testing

### Additional context
~~To be rebased after https://github.com/aws/aws-sdk-js-v3/pull/3478 is merged.~~ Ready!

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.