### PR TITLE
chore(node-config-provider): extend SharedConfigInit from SourceProfileInit

### DIFF
--- a/packages/node-config-provider/src/fromSharedConfigFiles.ts
+++ b/packages/node-config-provider/src/fromSharedConfigFiles.ts
@@ -1,17 +1,8 @@
 import { CredentialsProviderError } from "@aws-sdk/property-provider";
-import {
-  getProfileName,
-  loadSharedConfigFiles,
-  SharedConfigInit as BaseSharedConfigInit,
-} from "@aws-sdk/shared-ini-file-loader";
+import { getProfileName, loadSharedConfigFiles, SourceProfileInit } from "@aws-sdk/shared-ini-file-loader";
 import { Profile, Provider } from "@aws-sdk/types";
 
-export interface SharedConfigInit extends BaseSharedConfigInit {
-  /**
-   * The configuration profile to use.
-   */
-  profile?: string;
-
+export interface SharedConfigInit extends SourceProfileInit {
   /**
    * The preferred shared ini file to load the config. "config" option refers to
    * the shared config file(defaults to `~/.aws/config`). "credentials" option


### PR DESCRIPTION
### Issue
N/A

### Description
The `profile?: string;` is added in existing interface `SourceProfileInit`, and `SharedConfigInit` in fromSharedConfigFiles can extend from it.

### Testing
CI

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
