### PR TITLE
chore: replace deprecated String.prototype.substr()

### DIFF
--- a/clients/client-s3-control/test/S3Control.spec.ts
+++ b/clients/client-s3-control/test/S3Control.spec.ts
@@ -16,7 +16,7 @@ describe("S3Control Client", () => {
   s3Control.middlewareStack.add(interceptionMiddleware, { step: "finalizeRequest", name: "interceptionMiddleware" });
   const HEADER_OUTPOST_ID = "x-amz-outpost-id";
   const HEADER_ACCOUNT_ID = "x-amz-account-id";
-  const dateStr = new Date().toISOString().substr(0, 10).replace(/[\-:]/g, "");
+  const dateStr = new Date().toISOString().slice(0, 10).replace(/[\-:]/g, "");
 
   describe("CreateBucket", () => {
     it("should populate correct endpoint and signing region", async () => {

--- a/clients/client-s3/test/S3.spec.ts
+++ b/clients/client-s3/test/S3.spec.ts
@@ -93,7 +93,7 @@ describe("Accesspoint ARN", async () => {
       Body: "body",
     });
     expect(result.request.hostname).to.eql(`abc-111-${AccountId}.${OutpostId}.s3-outposts.us-west-2.amazonaws.com`);
-    const date = new Date().toISOString().substr(0, 10).replace(/-/g, ""); //20201029
+    const date = new Date().toISOString().slice(0, 10).replace(/-/g, ""); //20201029
     expect(result.request.headers["authorization"]).contains(
       `Credential=${credentials.accessKeyId}/${date}/${region}/s3-outposts/aws4_request`
     );

--- a/packages/eventstream-marshaller/scripts/buildTestVectorsFixture.js
+++ b/packages/eventstream-marshaller/scripts/buildTestVectorsFixture.js
@@ -80,7 +80,7 @@ function headerValue(type, vectorRepresentation) {
       return `new Date(${vectorRepresentation})`;
     case 9:
       const hex = Buffer.from(vectorRepresentation, "base64").toString("hex");
-      return `'${hex.substr(0, 8)}-${hex.substr(8, 4)}-${hex.substr(12, 4)}-${hex.substr(16, 4)}-${hex.substr(20)}'`;
+      return `'${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}'`;
     default:
       return vectorRepresentation;
   }

--- a/packages/middleware-endpoint-discovery/src/updateDiscoveredEndpointInCache.spec.ts
+++ b/packages/middleware-endpoint-discovery/src/updateDiscoveredEndpointInCache.spec.ts
@@ -49,7 +49,7 @@ describe(updateDiscoveredEndpointInCache.name, () => {
       expect(mockGet).toHaveBeenCalledTimes(1);
 
       expect(options.endpointDiscoveryCommandCtor).toHaveBeenCalledWith({
-        Operation: options.commandName.substr(0, options.commandName.length - 7),
+        Operation: options.commandName.slice(0, -7),
         Identifiers: options.identifiers,
       });
       expect(mockHandler).toHaveBeenCalledTimes(1);
@@ -88,7 +88,7 @@ describe(updateDiscoveredEndpointInCache.name, () => {
       expect(mockGet).toHaveBeenCalledTimes(3);
 
       expect(options.endpointDiscoveryCommandCtor).toHaveBeenCalledWith({
-        Operation: options.commandName.substr(0, options.commandName.length - 7),
+        Operation: options.commandName.slice(0, -7),
         Identifiers: options.identifiers,
       });
       expect(mockHandler).toHaveBeenCalledTimes(1);

--- a/packages/middleware-endpoint-discovery/src/updateDiscoveredEndpointInCache.ts
+++ b/packages/middleware-endpoint-discovery/src/updateDiscoveredEndpointInCache.ts
@@ -38,7 +38,7 @@ export const updateDiscoveredEndpointInCache = async (
       endpointCache.set(cacheKey, placeholderEndpoints);
 
       const command = new options.endpointDiscoveryCommandCtor({
-        Operation: commandName.substr(0, commandName.length - 7), // strip "Command"
+        Operation: commandName.slice(0, -7), // strip "Command"
         Identifiers: identifiers,
       });
       const handler = command.resolveMiddleware(options.clientStack, config, options.options);

--- a/packages/protocol-http/src/httpRequest.ts
+++ b/packages/protocol-http/src/httpRequest.ts
@@ -22,7 +22,7 @@ export class HttpRequest implements HttpMessage, Endpoint {
     this.headers = options.headers || {};
     this.body = options.body;
     this.protocol = options.protocol
-      ? options.protocol.substr(-1) !== ":"
+      ? options.protocol.slice(-1) !== ":"
         ? `${options.protocol}:`
         : options.protocol
       : "https:";

--- a/packages/s3-presigned-post/src/createPresignedPost.ts
+++ b/packages/s3-presigned-post/src/createPresignedPost.ts
@@ -41,7 +41,7 @@ export const createPresignedPost = async (
 
   // signingDate in format like '20201028T070711Z'.
   const signingDate = iso8601(now).replace(/[\-:]/g, "");
-  const shortDate = signingDate.substr(0, 8);
+  const shortDate = signingDate.slice(0, 8);
   const clientRegion = await client.config.region();
 
   // Prepare credentials.

--- a/packages/service-client-documentation-generator/src/sdk-client-comment-update.ts
+++ b/packages/service-client-documentation-generator/src/sdk-client-comment-update.ts
@@ -31,7 +31,7 @@ export class SdkClientCommentUpdatePlugin extends ConverterComponent {
     return comment.startsWith("/*") && comment.endsWith("*/")
       ? comment
           .split("\n")
-          .filter((line) => line.substr(line.indexOf("*") + 1).trim().length !== 0)
+          .filter((line) => line.slice(line.indexOf("*") + 1).trim().length !== 0)
           .join("\n")
       : comment;
   }

--- a/packages/signature-v4/src/SignatureV4.ts
+++ b/packages/signature-v4/src/SignatureV4.ts
@@ -333,7 +333,7 @@ const formatDate = (now: DateInput): { longDate: string; shortDate: string } => 
   const longDate = iso8601(now).replace(/[\-:]/g, "");
   return {
     longDate,
-    shortDate: longDate.substr(0, 8),
+    shortDate: longDate.slice(0, 8),
   };
 };
 

--- a/packages/signature-v4/src/moveHeadersToQuery.ts
+++ b/packages/signature-v4/src/moveHeadersToQuery.ts
@@ -13,7 +13,7 @@ export const moveHeadersToQuery = (
     typeof (request as any).clone === "function" ? (request as any).clone() : cloneRequest(request);
   for (const name of Object.keys(headers)) {
     const lname = name.toLowerCase();
-    if (lname.substr(0, 6) === "x-amz-" && !options.unhoistableHeaders?.has(lname)) {
+    if (lname.slice(0, 6) === "x-amz-" && !options.unhoistableHeaders?.has(lname)) {
       query[name] = headers[name];
       delete headers[name];
     }

--- a/packages/util-base64-browser/src/index.ts
+++ b/packages/util-base64-browser/src/index.ts
@@ -40,9 +40,9 @@ const maxLetterValue = 0b111111;
  */
 export function fromBase64(input: string): Uint8Array {
   let totalByteLength = (input.length / 4) * 3;
-  if (input.substr(-2) === "==") {
+  if (input.slice(-2) === "==") {
     totalByteLength -= 2;
-  } else if (input.substr(-1) === "=") {
+  } else if (input.slice(-1) === "=") {
     totalByteLength--;
   }
   const out = new ArrayBuffer(totalByteLength);

--- a/packages/util-format-url/src/index.ts
+++ b/packages/util-format-url/src/index.ts
@@ -4,7 +4,7 @@ import { HttpRequest } from "@aws-sdk/types";
 export function formatUrl(request: Omit<HttpRequest, "headers" | "method">): string {
   const { port, query } = request;
   let { protocol, path, hostname } = request;
-  if (protocol && protocol.substr(-1) !== ":") {
+  if (protocol && protocol.slice(-1) !== ":") {
     protocol += ":";
   }
   if (port) {

--- a/packages/util-hex-encoding/src/index.ts
+++ b/packages/util-hex-encoding/src/index.ts
@@ -23,7 +23,7 @@ export function fromHex(encoded: string): Uint8Array {
 
   const out = new Uint8Array(encoded.length / 2);
   for (let i = 0; i < encoded.length; i += 2) {
-    const encodedByte = encoded.substr(i, 2).toLowerCase();
+    const encodedByte = encoded.slice(i, i + 2).toLowerCase();
     if (encodedByte in HEX_TO_SHORT) {
       out[i / 2] = HEX_TO_SHORT[encodedByte];
     } else {


### PR DESCRIPTION
### Description

[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.

### Testing
I have checked the return of each statement to make sure it's still the same as before

