### PR TITLE
docs(readme): fix type of proccess in READMEs

### DIFF
--- a/clients/client-accessanalyzer/README.md
+++ b/clients/client-accessanalyzer/README.md
@@ -123,7 +123,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -157,7 +157,7 @@ client
 
 // callbacks.
 client.applyArchiveRule(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-account/README.md
+++ b/clients/client-account/README.md
@@ -115,7 +115,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -149,7 +149,7 @@ client
 
 // callbacks.
 client.deleteAlternateContact(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-acm-pca/README.md
+++ b/clients/client-acm-pca/README.md
@@ -131,7 +131,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -165,7 +165,7 @@ client
 
 // callbacks.
 client.createCertificateAuthority(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-acm/README.md
+++ b/clients/client-acm/README.md
@@ -118,7 +118,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -152,7 +152,7 @@ client
 
 // callbacks.
 client.addTagsToCertificate(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-alexa-for-business/README.md
+++ b/clients/client-alexa-for-business/README.md
@@ -122,7 +122,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -156,7 +156,7 @@ client
 
 // callbacks.
 client.approveSkill(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-amp/README.md
+++ b/clients/client-amp/README.md
@@ -115,7 +115,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -149,7 +149,7 @@ client
 
 // callbacks.
 client.createAlertManagerDefinition(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-amplify/README.md
+++ b/clients/client-amplify/README.md
@@ -120,7 +120,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -154,7 +154,7 @@ client
 
 // callbacks.
 client.createApp(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-amplifybackend/README.md
+++ b/clients/client-amplifybackend/README.md
@@ -115,7 +115,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -149,7 +149,7 @@ client
 
 // callbacks.
 client.cloneBackend(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-amplifyuibuilder/README.md
+++ b/clients/client-amplifyuibuilder/README.md
@@ -123,7 +123,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -157,7 +157,7 @@ client
 
 // callbacks.
 client.createComponent(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-api-gateway/README.md
+++ b/clients/client-api-gateway/README.md
@@ -117,7 +117,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -151,7 +151,7 @@ client
 
 // callbacks.
 client.createApiKey(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-apigatewaymanagementapi/README.md
+++ b/clients/client-apigatewaymanagementapi/README.md
@@ -115,7 +115,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -149,7 +149,7 @@ client
 
 // callbacks.
 client.deleteConnection(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-apigatewayv2/README.md
+++ b/clients/client-apigatewayv2/README.md
@@ -115,7 +115,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -149,7 +149,7 @@ client
 
 // callbacks.
 client.createApi(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-app-mesh/README.md
+++ b/clients/client-app-mesh/README.md
@@ -127,7 +127,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -161,7 +161,7 @@ client
 
 // callbacks.
 client.createGatewayRoute(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-appconfig/README.md
+++ b/clients/client-appconfig/README.md
@@ -159,7 +159,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -193,7 +193,7 @@ client
 
 // callbacks.
 client.createApplication(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-appconfigdata/README.md
+++ b/clients/client-appconfigdata/README.md
@@ -159,7 +159,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -193,7 +193,7 @@ client
 
 // callbacks.
 client.getLatestConfiguration(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-appflow/README.md
+++ b/clients/client-appflow/README.md
@@ -153,7 +153,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -187,7 +187,7 @@ client
 
 // callbacks.
 client.createConnectorProfile(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-appintegrations/README.md
+++ b/clients/client-appintegrations/README.md
@@ -119,7 +119,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -153,7 +153,7 @@ client
 
 // callbacks.
 client.createDataIntegration(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-application-auto-scaling/README.md
+++ b/clients/client-application-auto-scaling/README.md
@@ -190,7 +190,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -224,7 +224,7 @@ client
 
 // callbacks.
 client.deleteScalingPolicy(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-application-discovery-service/README.md
+++ b/clients/client-application-discovery-service/README.md
@@ -246,7 +246,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -280,7 +280,7 @@ client
 
 // callbacks.
 client.associateConfigurationItemsToApplication(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-application-insights/README.md
+++ b/clients/client-application-insights/README.md
@@ -128,7 +128,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -162,7 +162,7 @@ client
 
 // callbacks.
 client.createApplication(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-applicationcostprofiler/README.md
+++ b/clients/client-applicationcostprofiler/README.md
@@ -123,7 +123,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -157,7 +157,7 @@ client
 
 // callbacks.
 client.deleteReportDefinition(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-apprunner/README.md
+++ b/clients/client-apprunner/README.md
@@ -132,7 +132,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -166,7 +166,7 @@ client
 
 // callbacks.
 client.associateCustomDomain(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-appstream/README.md
+++ b/clients/client-appstream/README.md
@@ -136,7 +136,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -170,7 +170,7 @@ client
 
 // callbacks.
 client.associateApplicationFleet(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-appsync/README.md
+++ b/clients/client-appsync/README.md
@@ -116,7 +116,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -150,7 +150,7 @@ client
 
 // callbacks.
 client.associateApi(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-athena/README.md
+++ b/clients/client-athena/README.md
@@ -128,7 +128,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -162,7 +162,7 @@ client
 
 // callbacks.
 client.batchGetNamedQuery(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-auditmanager/README.md
+++ b/clients/client-auditmanager/README.md
@@ -150,7 +150,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -184,7 +184,7 @@ client
 
 // callbacks.
 client.associateAssessmentReportEvidenceFolder(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-auto-scaling-plans/README.md
+++ b/clients/client-auto-scaling-plans/README.md
@@ -148,7 +148,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -182,7 +182,7 @@ client
 
 // callbacks.
 client.createScalingPlan(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-auto-scaling/README.md
+++ b/clients/client-auto-scaling/README.md
@@ -122,7 +122,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -156,7 +156,7 @@ client
 
 // callbacks.
 client.attachInstances(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-backup-gateway/README.md
+++ b/clients/client-backup-gateway/README.md
@@ -124,7 +124,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -158,7 +158,7 @@ client
 
 // callbacks.
 client.associateGatewayToServer(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-backup/README.md
+++ b/clients/client-backup/README.md
@@ -120,7 +120,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -154,7 +154,7 @@ client
 
 // callbacks.
 client.createBackupPlan(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-batch/README.md
+++ b/clients/client-batch/README.md
@@ -126,7 +126,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -160,7 +160,7 @@ client
 
 // callbacks.
 client.cancelJob(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-billingconductor/README.md
+++ b/clients/client-billingconductor/README.md
@@ -127,7 +127,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -161,7 +161,7 @@ client
 
 // callbacks.
 client.associateAccounts(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-braket/README.md
+++ b/clients/client-braket/README.md
@@ -115,7 +115,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -149,7 +149,7 @@ client
 
 // callbacks.
 client.cancelJob(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-budgets/README.md
+++ b/clients/client-budgets/README.md
@@ -157,7 +157,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -191,7 +191,7 @@ client
 
 // callbacks.
 client.createBudget(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-chime-sdk-identity/README.md
+++ b/clients/client-chime-sdk-identity/README.md
@@ -118,7 +118,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -152,7 +152,7 @@ client
 
 // callbacks.
 client.createAppInstance(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-chime-sdk-meetings/README.md
+++ b/clients/client-chime-sdk-meetings/README.md
@@ -116,7 +116,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -150,7 +150,7 @@ client
 
 // callbacks.
 client.batchCreateAttendee(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-chime-sdk-messaging/README.md
+++ b/clients/client-chime-sdk-messaging/README.md
@@ -119,7 +119,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -153,7 +153,7 @@ client
 
 // callbacks.
 client.associateChannelFlow(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-chime/README.md
+++ b/clients/client-chime/README.md
@@ -153,7 +153,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -187,7 +187,7 @@ client
 
 // callbacks.
 client.associatePhoneNumbersWithVoiceConnector(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-cloud9/README.md
+++ b/clients/client-cloud9/README.md
@@ -182,7 +182,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -216,7 +216,7 @@ client
 
 // callbacks.
 client.createEnvironmentEC2(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-cloudcontrol/README.md
+++ b/clients/client-cloudcontrol/README.md
@@ -121,7 +121,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -155,7 +155,7 @@ client
 
 // callbacks.
 client.cancelResourceRequest(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-clouddirectory/README.md
+++ b/clients/client-clouddirectory/README.md
@@ -121,7 +121,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -155,7 +155,7 @@ client
 
 // callbacks.
 client.addFacetToObject(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-cloudformation/README.md
+++ b/clients/client-cloudformation/README.md
@@ -132,7 +132,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -166,7 +166,7 @@ client
 
 // callbacks.
 client.activateType(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-cloudfront/README.md
+++ b/clients/client-cloudfront/README.md
@@ -119,7 +119,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -153,7 +153,7 @@ client
 
 // callbacks.
 client.associateAlias(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-cloudhsm-v2/README.md
+++ b/clients/client-cloudhsm-v2/README.md
@@ -116,7 +116,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -150,7 +150,7 @@ client
 
 // callbacks.
 client.copyBackupToRegion(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-cloudhsm/README.md
+++ b/clients/client-cloudhsm/README.md
@@ -126,7 +126,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -160,7 +160,7 @@ client
 
 // callbacks.
 client.addTagsToResource(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-cloudsearch-domain/README.md
+++ b/clients/client-cloudsearch-domain/README.md
@@ -118,7 +118,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -152,7 +152,7 @@ client
 
 // callbacks.
 client.search(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-cloudsearch/README.md
+++ b/clients/client-cloudsearch/README.md
@@ -122,7 +122,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -156,7 +156,7 @@ client
 
 // callbacks.
 client.buildSuggesters(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-cloudtrail/README.md
+++ b/clients/client-cloudtrail/README.md
@@ -131,7 +131,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -165,7 +165,7 @@ client
 
 // callbacks.
 client.addTags(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-cloudwatch-events/README.md
+++ b/clients/client-cloudwatch-events/README.md
@@ -135,7 +135,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -169,7 +169,7 @@ client
 
 // callbacks.
 client.activateEventSource(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-cloudwatch-logs/README.md
+++ b/clients/client-cloudwatch-logs/README.md
@@ -148,7 +148,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -182,7 +182,7 @@ client
 
 // callbacks.
 client.associateKmsKey(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-cloudwatch/README.md
+++ b/clients/client-cloudwatch/README.md
@@ -129,7 +129,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -163,7 +163,7 @@ client
 
 // callbacks.
 client.deleteAlarms(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-codeartifact/README.md
+++ b/clients/client-codeartifact/README.md
@@ -368,7 +368,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -402,7 +402,7 @@ client
 
 // callbacks.
 client.associateExternalConnection(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-codebuild/README.md
+++ b/clients/client-codebuild/README.md
@@ -126,7 +126,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -160,7 +160,7 @@ client
 
 // callbacks.
 client.batchDeleteBuilds(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-codecommit/README.md
+++ b/clients/client-codecommit/README.md
@@ -506,7 +506,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -540,7 +540,7 @@ client
 
 // callbacks.
 client.associateApprovalRuleTemplateWithRepository(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-codedeploy/README.md
+++ b/clients/client-codedeploy/README.md
@@ -215,7 +215,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -249,7 +249,7 @@ client
 
 // callbacks.
 client.addTagsToOnPremisesInstances(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-codeguru-reviewer/README.md
+++ b/clients/client-codeguru-reviewer/README.md
@@ -130,7 +130,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -164,7 +164,7 @@ client
 
 // callbacks.
 client.associateRepository(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-codeguruprofiler/README.md
+++ b/clients/client-codeguruprofiler/README.md
@@ -137,7 +137,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -171,7 +171,7 @@ client
 
 // callbacks.
 client.addNotificationChannels(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-codepipeline/README.md
+++ b/clients/client-codepipeline/README.md
@@ -310,7 +310,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -344,7 +344,7 @@ client
 
 // callbacks.
 client.acknowledgeJob(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-codestar-connections/README.md
+++ b/clients/client-codestar-connections/README.md
@@ -195,7 +195,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -229,7 +229,7 @@ client
 
 // callbacks.
 client.createConnection(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-codestar-notifications/README.md
+++ b/clients/client-codestar-notifications/README.md
@@ -199,7 +199,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -233,7 +233,7 @@ client
 
 // callbacks.
 client.createNotificationRule(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-codestar/README.md
+++ b/clients/client-codestar/README.md
@@ -205,7 +205,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -239,7 +239,7 @@ client
 
 // callbacks.
 client.associateTeamMember(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-cognito-identity-provider/README.md
+++ b/clients/client-cognito-identity-provider/README.md
@@ -120,7 +120,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -154,7 +154,7 @@ client
 
 // callbacks.
 client.addCustomAttributes(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-cognito-identity/README.md
+++ b/clients/client-cognito-identity/README.md
@@ -129,7 +129,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -163,7 +163,7 @@ client
 
 // callbacks.
 client.createIdentityPool(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-cognito-sync/README.md
+++ b/clients/client-cognito-sync/README.md
@@ -128,7 +128,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -162,7 +162,7 @@ client
 
 // callbacks.
 client.bulkPublish(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-comprehend/README.md
+++ b/clients/client-comprehend/README.md
@@ -118,7 +118,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -152,7 +152,7 @@ client
 
 // callbacks.
 client.batchDetectDominantLanguage(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-comprehendmedical/README.md
+++ b/clients/client-comprehendmedical/README.md
@@ -116,7 +116,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -150,7 +150,7 @@ client
 
 // callbacks.
 client.describeEntitiesDetectionV2Job(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-compute-optimizer/README.md
+++ b/clients/client-compute-optimizer/README.md
@@ -125,7 +125,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -159,7 +159,7 @@ client
 
 // callbacks.
 client.deleteRecommendationPreferences(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-config-service/README.md
+++ b/clients/client-config-service/README.md
@@ -137,7 +137,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -171,7 +171,7 @@ client
 
 // callbacks.
 client.batchGetAggregateResourceConfig(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-connect-contact-lens/README.md
+++ b/clients/client-connect-contact-lens/README.md
@@ -127,7 +127,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -161,7 +161,7 @@ client
 
 // callbacks.
 client.listRealtimeContactAnalysisSegments(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-connect/README.md
+++ b/clients/client-connect/README.md
@@ -127,7 +127,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -161,7 +161,7 @@ client
 
 // callbacks.
 client.associateApprovedOrigin(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-connectparticipant/README.md
+++ b/clients/client-connectparticipant/README.md
@@ -120,7 +120,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -154,7 +154,7 @@ client
 
 // callbacks.
 client.completeAttachmentUpload(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-cost-and-usage-report-service/README.md
+++ b/clients/client-cost-and-usage-report-service/README.md
@@ -138,7 +138,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -172,7 +172,7 @@ client
 
 // callbacks.
 client.deleteReportDefinition(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-cost-explorer/README.md
+++ b/clients/client-cost-explorer/README.md
@@ -130,7 +130,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -164,7 +164,7 @@ client
 
 // callbacks.
 client.createAnomalyMonitor(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-customer-profiles/README.md
+++ b/clients/client-customer-profiles/README.md
@@ -125,7 +125,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -159,7 +159,7 @@ client
 
 // callbacks.
 client.addProfileKey(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-data-pipeline/README.md
+++ b/clients/client-data-pipeline/README.md
@@ -131,7 +131,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -165,7 +165,7 @@ client
 
 // callbacks.
 client.activatePipeline(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-database-migration-service/README.md
+++ b/clients/client-database-migration-service/README.md
@@ -128,7 +128,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -162,7 +162,7 @@ client
 
 // callbacks.
 client.addTagsToResource(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-databrew/README.md
+++ b/clients/client-databrew/README.md
@@ -118,7 +118,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -152,7 +152,7 @@ client
 
 // callbacks.
 client.batchDeleteRecipeVersion(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-dataexchange/README.md
+++ b/clients/client-dataexchange/README.md
@@ -115,7 +115,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -149,7 +149,7 @@ client
 
 // callbacks.
 client.cancelJob(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-datasync/README.md
+++ b/clients/client-datasync/README.md
@@ -121,7 +121,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -155,7 +155,7 @@ client
 
 // callbacks.
 client.cancelTaskExecution(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-dax/README.md
+++ b/clients/client-dax/README.md
@@ -120,7 +120,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -154,7 +154,7 @@ client
 
 // callbacks.
 client.createCluster(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-detective/README.md
+++ b/clients/client-detective/README.md
@@ -188,7 +188,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -222,7 +222,7 @@ client
 
 // callbacks.
 client.acceptInvitation(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-device-farm/README.md
+++ b/clients/client-device-farm/README.md
@@ -129,7 +129,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -163,7 +163,7 @@ client
 
 // callbacks.
 client.createDevicePool(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-devops-guru/README.md
+++ b/clients/client-devops-guru/README.md
@@ -128,7 +128,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -162,7 +162,7 @@ client
 
 // callbacks.
 client.addNotificationChannel(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-direct-connect/README.md
+++ b/clients/client-direct-connect/README.md
@@ -126,7 +126,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -160,7 +160,7 @@ client
 
 // callbacks.
 client.acceptDirectConnectGatewayAssociationProposal(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-directory-service/README.md
+++ b/clients/client-directory-service/README.md
@@ -129,7 +129,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -163,7 +163,7 @@ client
 
 // callbacks.
 client.acceptSharedDirectory(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-dlm/README.md
+++ b/clients/client-dlm/README.md
@@ -122,7 +122,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -156,7 +156,7 @@ client
 
 // callbacks.
 client.createLifecyclePolicy(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-docdb/README.md
+++ b/clients/client-docdb/README.md
@@ -115,7 +115,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -149,7 +149,7 @@ client
 
 // callbacks.
 client.addSourceIdentifierToSubscription(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-drs/README.md
+++ b/clients/client-drs/README.md
@@ -115,7 +115,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -149,7 +149,7 @@ client
 
 // callbacks.
 client.createReplicationConfigurationTemplate(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-dynamodb-streams/README.md
+++ b/clients/client-dynamodb-streams/README.md
@@ -120,7 +120,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -154,7 +154,7 @@ client
 
 // callbacks.
 client.describeStream(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-dynamodb/README.md
+++ b/clients/client-dynamodb/README.md
@@ -134,7 +134,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -168,7 +168,7 @@ client
 
 // callbacks.
 client.batchExecuteStatement(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-ebs/README.md
+++ b/clients/client-ebs/README.md
@@ -133,7 +133,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -167,7 +167,7 @@ client
 
 // callbacks.
 client.completeSnapshot(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-ec2-instance-connect/README.md
+++ b/clients/client-ec2-instance-connect/README.md
@@ -120,7 +120,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -154,7 +154,7 @@ client
 
 // callbacks.
 client.sendSerialConsoleSSHPublicKey(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-ec2/README.md
+++ b/clients/client-ec2/README.md
@@ -141,7 +141,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -175,7 +175,7 @@ client
 
 // callbacks.
 client.acceptReservedInstancesExchangeQuote(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-ecr-public/README.md
+++ b/clients/client-ecr-public/README.md
@@ -122,7 +122,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -156,7 +156,7 @@ client
 
 // callbacks.
 client.batchCheckLayerAvailability(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-ecr/README.md
+++ b/clients/client-ecr/README.md
@@ -124,7 +124,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -158,7 +158,7 @@ client
 
 // callbacks.
 client.batchCheckLayerAvailability(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-ecs/README.md
+++ b/clients/client-ecs/README.md
@@ -128,7 +128,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -162,7 +162,7 @@ client
 
 // callbacks.
 client.createCapacityProvider(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-efs/README.md
+++ b/clients/client-efs/README.md
@@ -120,7 +120,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -154,7 +154,7 @@ client
 
 // callbacks.
 client.createAccessPoint(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-eks/README.md
+++ b/clients/client-eks/README.md
@@ -124,7 +124,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -158,7 +158,7 @@ client
 
 // callbacks.
 client.associateEncryptionConfig(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-elastic-beanstalk/README.md
+++ b/clients/client-elastic-beanstalk/README.md
@@ -128,7 +128,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -162,7 +162,7 @@ client
 
 // callbacks.
 client.abortEnvironmentUpdate(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-elastic-inference/README.md
+++ b/clients/client-elastic-inference/README.md
@@ -117,7 +117,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -151,7 +151,7 @@ client
 
 // callbacks.
 client.describeAcceleratorOfferings(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-elastic-load-balancing-v2/README.md
+++ b/clients/client-elastic-load-balancing-v2/README.md
@@ -153,7 +153,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -187,7 +187,7 @@ client
 
 // callbacks.
 client.addListenerCertificates(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-elastic-load-balancing/README.md
+++ b/clients/client-elastic-load-balancing/README.md
@@ -135,7 +135,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -169,7 +169,7 @@ client
 
 // callbacks.
 client.addTags(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-elastic-transcoder/README.md
+++ b/clients/client-elastic-transcoder/README.md
@@ -117,7 +117,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -151,7 +151,7 @@ client
 
 // callbacks.
 client.cancelJob(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-elasticache/README.md
+++ b/clients/client-elasticache/README.md
@@ -125,7 +125,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -159,7 +159,7 @@ client
 
 // callbacks.
 client.addTagsToResource(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-elasticsearch-service/README.md
+++ b/clients/client-elasticsearch-service/README.md
@@ -128,7 +128,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -162,7 +162,7 @@ client
 
 // callbacks.
 client.acceptInboundCrossClusterSearchConnection(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-emr-containers/README.md
+++ b/clients/client-emr-containers/README.md
@@ -136,7 +136,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -170,7 +170,7 @@ client
 
 // callbacks.
 client.cancelJobRun(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-emr/README.md
+++ b/clients/client-emr/README.md
@@ -118,7 +118,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -152,7 +152,7 @@ client
 
 // callbacks.
 client.addInstanceFleet(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-eventbridge/README.md
+++ b/clients/client-eventbridge/README.md
@@ -135,7 +135,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -169,7 +169,7 @@ client
 
 // callbacks.
 client.activateEventSource(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-evidently/README.md
+++ b/clients/client-evidently/README.md
@@ -123,7 +123,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -157,7 +157,7 @@ client
 
 // callbacks.
 client.batchEvaluateFeature(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-finspace-data/README.md
+++ b/clients/client-finspace-data/README.md
@@ -115,7 +115,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -149,7 +149,7 @@ client
 
 // callbacks.
 client.createChangeset(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-finspace/README.md
+++ b/clients/client-finspace/README.md
@@ -115,7 +115,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -149,7 +149,7 @@ client
 
 // callbacks.
 client.createEnvironment(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-firehose/README.md
+++ b/clients/client-firehose/README.md
@@ -119,7 +119,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -153,7 +153,7 @@ client
 
 // callbacks.
 client.createDeliveryStream(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-fis/README.md
+++ b/clients/client-fis/README.md
@@ -116,7 +116,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -150,7 +150,7 @@ client
 
 // callbacks.
 client.createExperimentTemplate(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-fms/README.md
+++ b/clients/client-fms/README.md
@@ -121,7 +121,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -155,7 +155,7 @@ client
 
 // callbacks.
 client.associateAdminAccount(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-forecast/README.md
+++ b/clients/client-forecast/README.md
@@ -115,7 +115,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -149,7 +149,7 @@ client
 
 // callbacks.
 client.createAutoPredictor(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-forecastquery/README.md
+++ b/clients/client-forecastquery/README.md
@@ -115,7 +115,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -149,7 +149,7 @@ client
 
 // callbacks.
 client.queryForecast(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-frauddetector/README.md
+++ b/clients/client-frauddetector/README.md
@@ -117,7 +117,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -151,7 +151,7 @@ client
 
 // callbacks.
 client.batchCreateVariable(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-fsx/README.md
+++ b/clients/client-fsx/README.md
@@ -116,7 +116,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -150,7 +150,7 @@ client
 
 // callbacks.
 client.associateFileSystemAliases(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-gamelift/README.md
+++ b/clients/client-gamelift/README.md
@@ -173,7 +173,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -207,7 +207,7 @@ client
 
 // callbacks.
 client.acceptMatch(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-glacier/README.md
+++ b/clients/client-glacier/README.md
@@ -152,7 +152,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -186,7 +186,7 @@ client
 
 // callbacks.
 client.abortMultipartUpload(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-global-accelerator/README.md
+++ b/clients/client-global-accelerator/README.md
@@ -263,7 +263,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -297,7 +297,7 @@ client
 
 // callbacks.
 client.addCustomRoutingEndpoints(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-glue/README.md
+++ b/clients/client-glue/README.md
@@ -117,7 +117,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -151,7 +151,7 @@ client
 
 // callbacks.
 client.batchCreatePartition(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-grafana/README.md
+++ b/clients/client-grafana/README.md
@@ -121,7 +121,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -155,7 +155,7 @@ client
 
 // callbacks.
 client.associateLicense(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-greengrass/README.md
+++ b/clients/client-greengrass/README.md
@@ -115,7 +115,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -149,7 +149,7 @@ client
 
 // callbacks.
 client.associateRoleToGroup(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-greengrassv2/README.md
+++ b/clients/client-greengrassv2/README.md
@@ -125,7 +125,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -159,7 +159,7 @@ client
 
 // callbacks.
 client.associateServiceRoleToAccount(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-groundstation/README.md
+++ b/clients/client-groundstation/README.md
@@ -118,7 +118,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -152,7 +152,7 @@ client
 
 // callbacks.
 client.cancelContact(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-guardduty/README.md
+++ b/clients/client-guardduty/README.md
@@ -131,7 +131,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -165,7 +165,7 @@ client
 
 // callbacks.
 client.acceptInvitation(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-health/README.md
+++ b/clients/client-health/README.md
@@ -163,7 +163,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -197,7 +197,7 @@ client
 
 // callbacks.
 client.describeAffectedAccountsForOrganization(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-healthlake/README.md
+++ b/clients/client-healthlake/README.md
@@ -116,7 +116,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -150,7 +150,7 @@ client
 
 // callbacks.
 client.createFHIRDatastore(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-honeycode/README.md
+++ b/clients/client-honeycode/README.md
@@ -119,7 +119,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -153,7 +153,7 @@ client
 
 // callbacks.
 client.batchCreateTableRows(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-iam/README.md
+++ b/clients/client-iam/README.md
@@ -120,7 +120,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -154,7 +154,7 @@ client
 
 // callbacks.
 client.addClientIDToOpenIDConnectProvider(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-identitystore/README.md
+++ b/clients/client-identitystore/README.md
@@ -117,7 +117,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -151,7 +151,7 @@ client
 
 // callbacks.
 client.describeGroup(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-imagebuilder/README.md
+++ b/clients/client-imagebuilder/README.md
@@ -118,7 +118,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -152,7 +152,7 @@ client
 
 // callbacks.
 client.cancelImageCreation(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-inspector/README.md
+++ b/clients/client-inspector/README.md
@@ -119,7 +119,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -153,7 +153,7 @@ client
 
 // callbacks.
 client.addAttributesToFindings(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-inspector2/README.md
+++ b/clients/client-inspector2/README.md
@@ -116,7 +116,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -150,7 +150,7 @@ client
 
 // callbacks.
 client.associateMember(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-iot-1click-devices-service/README.md
+++ b/clients/client-iot-1click-devices-service/README.md
@@ -123,7 +123,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -157,7 +157,7 @@ client
 
 // callbacks.
 client.claimDevicesByClaimCode(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-iot-1click-projects/README.md
+++ b/clients/client-iot-1click-projects/README.md
@@ -115,7 +115,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -149,7 +149,7 @@ client
 
 // callbacks.
 client.associateDeviceWithPlacement(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-iot-data-plane/README.md
+++ b/clients/client-iot-data-plane/README.md
@@ -126,7 +126,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -160,7 +160,7 @@ client
 
 // callbacks.
 client.deleteThingShadow(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-iot-events-data/README.md
+++ b/clients/client-iot-events-data/README.md
@@ -119,7 +119,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -153,7 +153,7 @@ client
 
 // callbacks.
 client.batchAcknowledgeAlarm(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-iot-events/README.md
+++ b/clients/client-iot-events/README.md
@@ -117,7 +117,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -151,7 +151,7 @@ client
 
 // callbacks.
 client.createAlarmModel(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-iot-jobs-data-plane/README.md
+++ b/clients/client-iot-jobs-data-plane/README.md
@@ -125,7 +125,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -159,7 +159,7 @@ client
 
 // callbacks.
 client.describeJobExecution(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-iot-wireless/README.md
+++ b/clients/client-iot-wireless/README.md
@@ -125,7 +125,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -159,7 +159,7 @@ client
 
 // callbacks.
 client.associateAwsAccountWithPartnerAccount(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-iot/README.md
+++ b/clients/client-iot/README.md
@@ -131,7 +131,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -165,7 +165,7 @@ client
 
 // callbacks.
 client.acceptCertificateTransfer(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-iotanalytics/README.md
+++ b/clients/client-iotanalytics/README.md
@@ -133,7 +133,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -167,7 +167,7 @@ client
 
 // callbacks.
 client.batchPutMessage(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-iotdeviceadvisor/README.md
+++ b/clients/client-iotdeviceadvisor/README.md
@@ -123,7 +123,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -157,7 +157,7 @@ client
 
 // callbacks.
 client.createSuiteDefinition(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-iotfleethub/README.md
+++ b/clients/client-iotfleethub/README.md
@@ -118,7 +118,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -152,7 +152,7 @@ client
 
 // callbacks.
 client.createApplication(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-iotsecuretunneling/README.md
+++ b/clients/client-iotsecuretunneling/README.md
@@ -120,7 +120,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -154,7 +154,7 @@ client
 
 // callbacks.
 client.closeTunnel(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-iotsitewise/README.md
+++ b/clients/client-iotsitewise/README.md
@@ -116,7 +116,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -150,7 +150,7 @@ client
 
 // callbacks.
 client.associateAssets(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-iotthingsgraph/README.md
+++ b/clients/client-iotthingsgraph/README.md
@@ -120,7 +120,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -154,7 +154,7 @@ client
 
 // callbacks.
 client.associateEntityToThing(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-iottwinmaker/README.md
+++ b/clients/client-iottwinmaker/README.md
@@ -124,7 +124,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -158,7 +158,7 @@ client
 
 // callbacks.
 client.batchPutPropertyValues(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-ivs/README.md
+++ b/clients/client-ivs/README.md
@@ -426,7 +426,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -460,7 +460,7 @@ client
 
 // callbacks.
 client.batchGetChannel(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-kafka/README.md
+++ b/clients/client-kafka/README.md
@@ -115,7 +115,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -149,7 +149,7 @@ client
 
 // callbacks.
 client.batchAssociateScramSecret(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-kafkaconnect/README.md
+++ b/clients/client-kafkaconnect/README.md
@@ -115,7 +115,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -149,7 +149,7 @@ client
 
 // callbacks.
 client.createConnector(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-kendra/README.md
+++ b/clients/client-kendra/README.md
@@ -115,7 +115,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -149,7 +149,7 @@ client
 
 // callbacks.
 client.associateEntitiesToExperience(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-keyspaces/README.md
+++ b/clients/client-keyspaces/README.md
@@ -127,7 +127,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -161,7 +161,7 @@ client
 
 // callbacks.
 client.createKeyspace(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-kinesis-analytics-v2/README.md
+++ b/clients/client-kinesis-analytics-v2/README.md
@@ -123,7 +123,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -157,7 +157,7 @@ client
 
 // callbacks.
 client.addApplicationCloudWatchLoggingOption(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-kinesis-analytics/README.md
+++ b/clients/client-kinesis-analytics/README.md
@@ -131,7 +131,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -165,7 +165,7 @@ client
 
 // callbacks.
 client.addApplicationCloudWatchLoggingOption(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-kinesis-video-archived-media/README.md
+++ b/clients/client-kinesis-video-archived-media/README.md
@@ -115,7 +115,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -149,7 +149,7 @@ client
 
 // callbacks.
 client.getClip(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-kinesis-video-media/README.md
+++ b/clients/client-kinesis-video-media/README.md
@@ -115,7 +115,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -149,7 +149,7 @@ client
 
 // callbacks.
 client.getMedia(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-kinesis-video-signaling/README.md
+++ b/clients/client-kinesis-video-signaling/README.md
@@ -117,7 +117,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -151,7 +151,7 @@ client
 
 // callbacks.
 client.getIceServerConfig(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-kinesis-video/README.md
+++ b/clients/client-kinesis-video/README.md
@@ -115,7 +115,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -149,7 +149,7 @@ client
 
 // callbacks.
 client.createSignalingChannel(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-kinesis/README.md
+++ b/clients/client-kinesis/README.md
@@ -118,7 +118,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -152,7 +152,7 @@ client
 
 // callbacks.
 client.addTagsToStream(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-kms/README.md
+++ b/clients/client-kms/README.md
@@ -205,7 +205,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -239,7 +239,7 @@ client
 
 // callbacks.
 client.cancelKeyDeletion(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-lakeformation/README.md
+++ b/clients/client-lakeformation/README.md
@@ -117,7 +117,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -151,7 +151,7 @@ client
 
 // callbacks.
 client.addLFTagsToResource(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-lambda/README.md
+++ b/clients/client-lambda/README.md
@@ -181,7 +181,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -215,7 +215,7 @@ client
 
 // callbacks.
 client.addLayerVersionPermission(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-lex-model-building-service/README.md
+++ b/clients/client-lex-model-building-service/README.md
@@ -122,7 +122,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -156,7 +156,7 @@ client
 
 // callbacks.
 client.createBotVersion(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-lex-models-v2/README.md
+++ b/clients/client-lex-models-v2/README.md
@@ -115,7 +115,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -149,7 +149,7 @@ client
 
 // callbacks.
 client.buildBotLocale(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-lex-runtime-service/README.md
+++ b/clients/client-lex-runtime-service/README.md
@@ -126,7 +126,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -160,7 +160,7 @@ client
 
 // callbacks.
 client.deleteSession(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-lex-runtime-v2/README.md
+++ b/clients/client-lex-runtime-v2/README.md
@@ -115,7 +115,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -149,7 +149,7 @@ client
 
 // callbacks.
 client.deleteSession(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-license-manager/README.md
+++ b/clients/client-license-manager/README.md
@@ -116,7 +116,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -150,7 +150,7 @@ client
 
 // callbacks.
 client.acceptGrant(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-lightsail/README.md
+++ b/clients/client-lightsail/README.md
@@ -129,7 +129,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -163,7 +163,7 @@ client
 
 // callbacks.
 client.allocateStaticIp(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-location/README.md
+++ b/clients/client-location/README.md
@@ -115,7 +115,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -149,7 +149,7 @@ client
 
 // callbacks.
 client.associateTrackerConsumer(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-lookoutequipment/README.md
+++ b/clients/client-lookoutequipment/README.md
@@ -116,7 +116,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -150,7 +150,7 @@ client
 
 // callbacks.
 client.createDataset(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-lookoutmetrics/README.md
+++ b/clients/client-lookoutmetrics/README.md
@@ -117,7 +117,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -151,7 +151,7 @@ client
 
 // callbacks.
 client.activateAnomalyDetector(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-lookoutvision/README.md
+++ b/clients/client-lookoutvision/README.md
@@ -121,7 +121,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -155,7 +155,7 @@ client
 
 // callbacks.
 client.createDataset(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-machine-learning/README.md
+++ b/clients/client-machine-learning/README.md
@@ -116,7 +116,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -150,7 +150,7 @@ client
 
 // callbacks.
 client.addTags(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-macie/README.md
+++ b/clients/client-macie/README.md
@@ -122,7 +122,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -156,7 +156,7 @@ client
 
 // callbacks.
 client.associateMemberAccount(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-macie2/README.md
+++ b/clients/client-macie2/README.md
@@ -115,7 +115,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -149,7 +149,7 @@ client
 
 // callbacks.
 client.acceptInvitation(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-managedblockchain/README.md
+++ b/clients/client-managedblockchain/README.md
@@ -118,7 +118,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -152,7 +152,7 @@ client
 
 // callbacks.
 client.createMember(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-marketplace-catalog/README.md
+++ b/clients/client-marketplace-catalog/README.md
@@ -121,7 +121,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -155,7 +155,7 @@ client
 
 // callbacks.
 client.cancelChangeSet(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-marketplace-commerce-analytics/README.md
+++ b/clients/client-marketplace-commerce-analytics/README.md
@@ -121,7 +121,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -155,7 +155,7 @@ client
 
 // callbacks.
 client.generateDataSet(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-marketplace-entitlement-service/README.md
+++ b/clients/client-marketplace-entitlement-service/README.md
@@ -138,7 +138,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -172,7 +172,7 @@ client
 
 // callbacks.
 client.getEntitlements(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-marketplace-metering/README.md
+++ b/clients/client-marketplace-metering/README.md
@@ -179,7 +179,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -213,7 +213,7 @@ client
 
 // callbacks.
 client.batchMeterUsage(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-mediaconnect/README.md
+++ b/clients/client-mediaconnect/README.md
@@ -115,7 +115,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -149,7 +149,7 @@ client
 
 // callbacks.
 client.addFlowMediaStreams(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-mediaconvert/README.md
+++ b/clients/client-mediaconvert/README.md
@@ -115,7 +115,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -149,7 +149,7 @@ client
 
 // callbacks.
 client.associateCertificate(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-medialive/README.md
+++ b/clients/client-medialive/README.md
@@ -115,7 +115,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -149,7 +149,7 @@ client
 
 // callbacks.
 client.acceptInputDeviceTransfer(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-mediapackage-vod/README.md
+++ b/clients/client-mediapackage-vod/README.md
@@ -115,7 +115,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -149,7 +149,7 @@ client
 
 // callbacks.
 client.configureLogs(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-mediapackage/README.md
+++ b/clients/client-mediapackage/README.md
@@ -115,7 +115,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -149,7 +149,7 @@ client
 
 // callbacks.
 client.configureLogs(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-mediastore-data/README.md
+++ b/clients/client-mediastore-data/README.md
@@ -117,7 +117,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -151,7 +151,7 @@ client
 
 // callbacks.
 client.deleteObject(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-mediastore/README.md
+++ b/clients/client-mediastore/README.md
@@ -116,7 +116,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -150,7 +150,7 @@ client
 
 // callbacks.
 client.createContainer(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-mediatailor/README.md
+++ b/clients/client-mediatailor/README.md
@@ -115,7 +115,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -149,7 +149,7 @@ client
 
 // callbacks.
 client.configureLogsForPlaybackConfiguration(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-memorydb/README.md
+++ b/clients/client-memorydb/README.md
@@ -117,7 +117,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -151,7 +151,7 @@ client
 
 // callbacks.
 client.batchUpdateCluster(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-mgn/README.md
+++ b/clients/client-mgn/README.md
@@ -115,7 +115,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -149,7 +149,7 @@ client
 
 // callbacks.
 client.changeServerLifeCycleState(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-migration-hub-refactor-spaces/README.md
+++ b/clients/client-migration-hub-refactor-spaces/README.md
@@ -130,7 +130,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -164,7 +164,7 @@ client
 
 // callbacks.
 client.createApplication(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-migration-hub/README.md
+++ b/clients/client-migration-hub/README.md
@@ -120,7 +120,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -154,7 +154,7 @@ client
 
 // callbacks.
 client.associateCreatedArtifact(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-migrationhub-config/README.md
+++ b/clients/client-migrationhub-config/README.md
@@ -140,7 +140,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -174,7 +174,7 @@ client
 
 // callbacks.
 client.createHomeRegionControl(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-migrationhubstrategy/README.md
+++ b/clients/client-migrationhubstrategy/README.md
@@ -127,7 +127,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -161,7 +161,7 @@ client
 
 // callbacks.
 client.getApplicationComponentDetails(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-mobile/README.md
+++ b/clients/client-mobile/README.md
@@ -119,7 +119,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -153,7 +153,7 @@ client
 
 // callbacks.
 client.createProject(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-mq/README.md
+++ b/clients/client-mq/README.md
@@ -115,7 +115,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -149,7 +149,7 @@ client
 
 // callbacks.
 client.createBroker(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-mturk/README.md
+++ b/clients/client-mturk/README.md
@@ -115,7 +115,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -149,7 +149,7 @@ client
 
 // callbacks.
 client.acceptQualificationRequest(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-mwaa/README.md
+++ b/clients/client-mwaa/README.md
@@ -201,7 +201,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -235,7 +235,7 @@ client
 
 // callbacks.
 client.createCliToken(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-neptune/README.md
+++ b/clients/client-neptune/README.md
@@ -133,7 +133,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -167,7 +167,7 @@ client
 
 // callbacks.
 client.addRoleToDBCluster(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-network-firewall/README.md
+++ b/clients/client-network-firewall/README.md
@@ -192,7 +192,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -226,7 +226,7 @@ client
 
 // callbacks.
 client.associateFirewallPolicy(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-networkmanager/README.md
+++ b/clients/client-networkmanager/README.md
@@ -116,7 +116,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -150,7 +150,7 @@ client
 
 // callbacks.
 client.acceptAttachment(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-nimble/README.md
+++ b/clients/client-nimble/README.md
@@ -120,7 +120,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -154,7 +154,7 @@ client
 
 // callbacks.
 client.acceptEulas(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-opensearch/README.md
+++ b/clients/client-opensearch/README.md
@@ -127,7 +127,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -161,7 +161,7 @@ client
 
 // callbacks.
 client.acceptInboundConnection(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-opsworks/README.md
+++ b/clients/client-opsworks/README.md
@@ -230,7 +230,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -264,7 +264,7 @@ client
 
 // callbacks.
 client.assignInstance(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-opsworkscm/README.md
+++ b/clients/client-opsworkscm/README.md
@@ -203,7 +203,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -237,7 +237,7 @@ client
 
 // callbacks.
 client.associateNode(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-organizations/README.md
+++ b/clients/client-organizations/README.md
@@ -185,7 +185,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -219,7 +219,7 @@ client
 
 // callbacks.
 client.acceptHandshake(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-outposts/README.md
+++ b/clients/client-outposts/README.md
@@ -119,7 +119,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -153,7 +153,7 @@ client
 
 // callbacks.
 client.cancelOrder(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-panorama/README.md
+++ b/clients/client-panorama/README.md
@@ -122,7 +122,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -156,7 +156,7 @@ client
 
 // callbacks.
 client.createApplicationInstance(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-personalize-events/README.md
+++ b/clients/client-personalize-events/README.md
@@ -117,7 +117,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -151,7 +151,7 @@ client
 
 // callbacks.
 client.putEvents(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-personalize-runtime/README.md
+++ b/clients/client-personalize-runtime/README.md
@@ -115,7 +115,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -149,7 +149,7 @@ client
 
 // callbacks.
 client.getPersonalizedRanking(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-personalize/README.md
+++ b/clients/client-personalize/README.md
@@ -116,7 +116,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -150,7 +150,7 @@ client
 
 // callbacks.
 client.createBatchInferenceJob(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-pi/README.md
+++ b/clients/client-pi/README.md
@@ -141,7 +141,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -175,7 +175,7 @@ client
 
 // callbacks.
 client.describeDimensionKeys(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-pinpoint-email/README.md
+++ b/clients/client-pinpoint-email/README.md
@@ -144,7 +144,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -178,7 +178,7 @@ client
 
 // callbacks.
 client.createConfigurationSet(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-pinpoint-sms-voice/README.md
+++ b/clients/client-pinpoint-sms-voice/README.md
@@ -115,7 +115,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -149,7 +149,7 @@ client
 
 // callbacks.
 client.createConfigurationSet(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-pinpoint/README.md
+++ b/clients/client-pinpoint/README.md
@@ -115,7 +115,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -149,7 +149,7 @@ client
 
 // callbacks.
 client.createApp(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-polly/README.md
+++ b/clients/client-polly/README.md
@@ -120,7 +120,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -154,7 +154,7 @@ client
 
 // callbacks.
 client.deleteLexicon(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-pricing/README.md
+++ b/clients/client-pricing/README.md
@@ -138,7 +138,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -172,7 +172,7 @@ client
 
 // callbacks.
 client.describeServices(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-proton/README.md
+++ b/clients/client-proton/README.md
@@ -244,7 +244,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -278,7 +278,7 @@ client
 
 // callbacks.
 client.acceptEnvironmentAccountConnection(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-qldb-session/README.md
+++ b/clients/client-qldb-session/README.md
@@ -135,7 +135,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -169,7 +169,7 @@ client
 
 // callbacks.
 client.sendCommand(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-qldb/README.md
+++ b/clients/client-qldb/README.md
@@ -115,7 +115,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -149,7 +149,7 @@ client
 
 // callbacks.
 client.cancelJournalKinesisStream(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-quicksight/README.md
+++ b/clients/client-quicksight/README.md
@@ -120,7 +120,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -154,7 +154,7 @@ client
 
 // callbacks.
 client.cancelIngestion(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-ram/README.md
+++ b/clients/client-ram/README.md
@@ -136,7 +136,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -170,7 +170,7 @@ client
 
 // callbacks.
 client.acceptResourceShareInvitation(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-rbin/README.md
+++ b/clients/client-rbin/README.md
@@ -128,7 +128,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -162,7 +162,7 @@ client
 
 // callbacks.
 client.createRule(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-rds-data/README.md
+++ b/clients/client-rds-data/README.md
@@ -121,7 +121,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -155,7 +155,7 @@ client
 
 // callbacks.
 client.batchExecuteStatement(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-rds/README.md
+++ b/clients/client-rds/README.md
@@ -169,7 +169,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -203,7 +203,7 @@ client
 
 // callbacks.
 client.addRoleToDBCluster(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-redshift-data/README.md
+++ b/clients/client-redshift-data/README.md
@@ -119,7 +119,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -153,7 +153,7 @@ client
 
 // callbacks.
 client.batchExecuteStatement(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-redshift/README.md
+++ b/clients/client-redshift/README.md
@@ -137,7 +137,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -171,7 +171,7 @@ client
 
 // callbacks.
 client.acceptReservedNodeExchange(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-rekognition/README.md
+++ b/clients/client-rekognition/README.md
@@ -115,7 +115,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -149,7 +149,7 @@ client
 
 // callbacks.
 client.compareFaces(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-resiliencehub/README.md
+++ b/clients/client-resiliencehub/README.md
@@ -119,7 +119,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -153,7 +153,7 @@ client
 
 // callbacks.
 client.addDraftAppVersionResourceMappings(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-resource-groups-tagging-api/README.md
+++ b/clients/client-resource-groups-tagging-api/README.md
@@ -121,7 +121,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -155,7 +155,7 @@ client
 
 // callbacks.
 client.describeReportCreation(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-resource-groups/README.md
+++ b/clients/client-resource-groups/README.md
@@ -150,7 +150,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -184,7 +184,7 @@ client
 
 // callbacks.
 client.createGroup(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-robomaker/README.md
+++ b/clients/client-robomaker/README.md
@@ -115,7 +115,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -149,7 +149,7 @@ client
 
 // callbacks.
 client.batchDeleteWorlds(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-route-53-domains/README.md
+++ b/clients/client-route-53-domains/README.md
@@ -121,7 +121,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -155,7 +155,7 @@ client
 
 // callbacks.
 client.acceptDomainTransferFromAnotherAwsAccount(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-route-53/README.md
+++ b/clients/client-route-53/README.md
@@ -115,7 +115,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -149,7 +149,7 @@ client
 
 // callbacks.
 client.activateKeySigningKey(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-route53-recovery-cluster/README.md
+++ b/clients/client-route53-recovery-cluster/README.md
@@ -156,7 +156,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -190,7 +190,7 @@ client
 
 // callbacks.
 client.getRoutingControlState(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-route53-recovery-control-config/README.md
+++ b/clients/client-route53-recovery-control-config/README.md
@@ -121,7 +121,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -155,7 +155,7 @@ client
 
 // callbacks.
 client.createCluster(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-route53-recovery-readiness/README.md
+++ b/clients/client-route53-recovery-readiness/README.md
@@ -115,7 +115,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -149,7 +149,7 @@ client
 
 // callbacks.
 client.createCell(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-route53resolver/README.md
+++ b/clients/client-route53resolver/README.md
@@ -147,7 +147,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -181,7 +181,7 @@ client
 
 // callbacks.
 client.associateFirewallRuleGroup(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-rum/README.md
+++ b/clients/client-rum/README.md
@@ -123,7 +123,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -157,7 +157,7 @@ client
 
 // callbacks.
 client.createAppMonitor(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-s3-control/README.md
+++ b/clients/client-s3-control/README.md
@@ -115,7 +115,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -149,7 +149,7 @@ client
 
 // callbacks.
 client.createAccessPoint(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-s3/README.md
+++ b/clients/client-s3/README.md
@@ -115,7 +115,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -149,7 +149,7 @@ client
 
 // callbacks.
 client.abortMultipartUpload(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-s3outposts/README.md
+++ b/clients/client-s3outposts/README.md
@@ -115,7 +115,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -149,7 +149,7 @@ client
 
 // callbacks.
 client.createEndpoint(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-sagemaker-a2i-runtime/README.md
+++ b/clients/client-sagemaker-a2i-runtime/README.md
@@ -140,7 +140,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -174,7 +174,7 @@ client
 
 // callbacks.
 client.deleteHumanLoop(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-sagemaker-edge/README.md
+++ b/clients/client-sagemaker-edge/README.md
@@ -115,7 +115,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -149,7 +149,7 @@ client
 
 // callbacks.
 client.getDeviceRegistration(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-sagemaker-featurestore-runtime/README.md
+++ b/clients/client-sagemaker-featurestore-runtime/README.md
@@ -147,7 +147,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -181,7 +181,7 @@ client
 
 // callbacks.
 client.batchGetRecord(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-sagemaker-runtime/README.md
+++ b/clients/client-sagemaker-runtime/README.md
@@ -115,7 +115,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -149,7 +149,7 @@ client
 
 // callbacks.
 client.invokeEndpoint(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-sagemaker/README.md
+++ b/clients/client-sagemaker/README.md
@@ -130,7 +130,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -164,7 +164,7 @@ client
 
 // callbacks.
 client.addAssociation(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-savingsplans/README.md
+++ b/clients/client-savingsplans/README.md
@@ -118,7 +118,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -152,7 +152,7 @@ client
 
 // callbacks.
 client.createSavingsPlan(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-schemas/README.md
+++ b/clients/client-schemas/README.md
@@ -115,7 +115,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -149,7 +149,7 @@ client
 
 // callbacks.
 client.createDiscoverer(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-secrets-manager/README.md
+++ b/clients/client-secrets-manager/README.md
@@ -144,7 +144,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -178,7 +178,7 @@ client
 
 // callbacks.
 client.cancelRotateSecret(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-securityhub/README.md
+++ b/clients/client-securityhub/README.md
@@ -157,7 +157,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -191,7 +191,7 @@ client
 
 // callbacks.
 client.acceptAdministratorInvitation(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-serverlessapplicationrepository/README.md
+++ b/clients/client-serverlessapplicationrepository/README.md
@@ -140,7 +140,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -174,7 +174,7 @@ client
 
 // callbacks.
 client.createApplication(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-service-catalog-appregistry/README.md
+++ b/clients/client-service-catalog-appregistry/README.md
@@ -121,7 +121,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -155,7 +155,7 @@ client
 
 // callbacks.
 client.associateAttributeGroup(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-service-catalog/README.md
+++ b/clients/client-service-catalog/README.md
@@ -122,7 +122,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -156,7 +156,7 @@ client
 
 // callbacks.
 client.acceptPortfolioShare(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-service-quotas/README.md
+++ b/clients/client-service-quotas/README.md
@@ -117,7 +117,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -151,7 +151,7 @@ client
 
 // callbacks.
 client.associateServiceQuotaTemplate(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-servicediscovery/README.md
+++ b/clients/client-servicediscovery/README.md
@@ -121,7 +121,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -155,7 +155,7 @@ client
 
 // callbacks.
 client.createHttpNamespace(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-ses/README.md
+++ b/clients/client-ses/README.md
@@ -124,7 +124,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -158,7 +158,7 @@ client
 
 // callbacks.
 client.cloneReceiptRuleSet(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-sesv2/README.md
+++ b/clients/client-sesv2/README.md
@@ -122,7 +122,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -156,7 +156,7 @@ client
 
 // callbacks.
 client.createConfigurationSet(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-sfn/README.md
+++ b/clients/client-sfn/README.md
@@ -131,7 +131,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -165,7 +165,7 @@ client
 
 // callbacks.
 client.createActivity(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-shield/README.md
+++ b/clients/client-shield/README.md
@@ -119,7 +119,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -153,7 +153,7 @@ client
 
 // callbacks.
 client.associateDRTLogBucket(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-signer/README.md
+++ b/clients/client-signer/README.md
@@ -131,7 +131,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -165,7 +165,7 @@ client
 
 // callbacks.
 client.addProfilePermission(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-sms/README.md
+++ b/clients/client-sms/README.md
@@ -143,7 +143,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -177,7 +177,7 @@ client
 
 // callbacks.
 client.createApp(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-snow-device-management/README.md
+++ b/clients/client-snow-device-management/README.md
@@ -115,7 +115,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -149,7 +149,7 @@ client
 
 // callbacks.
 client.cancelTask(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-snowball/README.md
+++ b/clients/client-snowball/README.md
@@ -120,7 +120,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -154,7 +154,7 @@ client
 
 // callbacks.
 client.cancelCluster(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-sns/README.md
+++ b/clients/client-sns/README.md
@@ -128,7 +128,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -162,7 +162,7 @@ client
 
 // callbacks.
 client.addPermission(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-sqs/README.md
+++ b/clients/client-sqs/README.md
@@ -183,7 +183,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -217,7 +217,7 @@ client
 
 // callbacks.
 client.addPermission(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-ssm-contacts/README.md
+++ b/clients/client-ssm-contacts/README.md
@@ -122,7 +122,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -156,7 +156,7 @@ client
 
 // callbacks.
 client.acceptPage(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-ssm-incidents/README.md
+++ b/clients/client-ssm-incidents/README.md
@@ -122,7 +122,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -156,7 +156,7 @@ client
 
 // callbacks.
 client.createReplicationSet(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-ssm/README.md
+++ b/clients/client-ssm/README.md
@@ -151,7 +151,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -185,7 +185,7 @@ client
 
 // callbacks.
 client.addTagsToResource(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-sso-admin/README.md
+++ b/clients/client-sso-admin/README.md
@@ -122,7 +122,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -156,7 +156,7 @@ client
 
 // callbacks.
 client.attachManagedPolicyToPermissionSet(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-sso-oidc/README.md
+++ b/clients/client-sso-oidc/README.md
@@ -132,7 +132,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -166,7 +166,7 @@ client
 
 // callbacks.
 client.createToken(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-sso/README.md
+++ b/clients/client-sso/README.md
@@ -130,7 +130,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -164,7 +164,7 @@ client
 
 // callbacks.
 client.getRoleCredentials(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-storage-gateway/README.md
+++ b/clients/client-storage-gateway/README.md
@@ -182,7 +182,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -216,7 +216,7 @@ client
 
 // callbacks.
 client.activateGateway(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-sts/README.md
+++ b/clients/client-sts/README.md
@@ -120,7 +120,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -154,7 +154,7 @@ client
 
 // callbacks.
 client.assumeRole(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-support/README.md
+++ b/clients/client-support/README.md
@@ -189,7 +189,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -223,7 +223,7 @@ client
 
 // callbacks.
 client.addAttachmentsToSet(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-swf/README.md
+++ b/clients/client-swf/README.md
@@ -130,7 +130,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -164,7 +164,7 @@ client
 
 // callbacks.
 client.countClosedWorkflowExecutions(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-synthetics/README.md
+++ b/clients/client-synthetics/README.md
@@ -131,7 +131,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -165,7 +165,7 @@ client
 
 // callbacks.
 client.createCanary(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-textract/README.md
+++ b/clients/client-textract/README.md
@@ -117,7 +117,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -151,7 +151,7 @@ client
 
 // callbacks.
 client.analyzeDocument(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-timestream-query/README.md
+++ b/clients/client-timestream-query/README.md
@@ -118,7 +118,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -152,7 +152,7 @@ client
 
 // callbacks.
 client.cancelQuery(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-timestream-write/README.md
+++ b/clients/client-timestream-write/README.md
@@ -122,7 +122,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -156,7 +156,7 @@ client
 
 // callbacks.
 client.createDatabase(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-transcribe-streaming/README.md
+++ b/clients/client-transcribe-streaming/README.md
@@ -121,7 +121,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -155,7 +155,7 @@ client
 
 // callbacks.
 client.startMedicalStreamTranscription(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-transcribe/README.md
+++ b/clients/client-transcribe/README.md
@@ -115,7 +115,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -149,7 +149,7 @@ client
 
 // callbacks.
 client.createCallAnalyticsCategory(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-transfer/README.md
+++ b/clients/client-transfer/README.md
@@ -123,7 +123,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -157,7 +157,7 @@ client
 
 // callbacks.
 client.createAccess(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-translate/README.md
+++ b/clients/client-translate/README.md
@@ -116,7 +116,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -150,7 +150,7 @@ client
 
 // callbacks.
 client.createParallelData(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-voice-id/README.md
+++ b/clients/client-voice-id/README.md
@@ -117,7 +117,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -151,7 +151,7 @@ client
 
 // callbacks.
 client.createDomain(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-waf-regional/README.md
+++ b/clients/client-waf-regional/README.md
@@ -125,7 +125,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -159,7 +159,7 @@ client
 
 // callbacks.
 client.associateWebACL(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-waf/README.md
+++ b/clients/client-waf/README.md
@@ -125,7 +125,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -159,7 +159,7 @@ client
 
 // callbacks.
 client.createByteMatchSet(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-wafv2/README.md
+++ b/clients/client-wafv2/README.md
@@ -174,7 +174,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -208,7 +208,7 @@ client
 
 // callbacks.
 client.associateWebACL(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-wellarchitected/README.md
+++ b/clients/client-wellarchitected/README.md
@@ -121,7 +121,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -155,7 +155,7 @@ client
 
 // callbacks.
 client.associateLenses(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-wisdom/README.md
+++ b/clients/client-wisdom/README.md
@@ -119,7 +119,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -153,7 +153,7 @@ client
 
 // callbacks.
 client.createAssistant(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-workdocs/README.md
+++ b/clients/client-workdocs/README.md
@@ -147,7 +147,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -181,7 +181,7 @@ client
 
 // callbacks.
 client.abortDocumentVersionUpload(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-worklink/README.md
+++ b/clients/client-worklink/README.md
@@ -121,7 +121,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -155,7 +155,7 @@ client
 
 // callbacks.
 client.associateDomain(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-workmail/README.md
+++ b/clients/client-workmail/README.md
@@ -150,7 +150,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -184,7 +184,7 @@ client
 
 // callbacks.
 client.associateDelegateToResource(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-workmailmessageflow/README.md
+++ b/clients/client-workmailmessageflow/README.md
@@ -119,7 +119,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -153,7 +153,7 @@ client
 
 // callbacks.
 client.getRawMessageContent(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-workspaces-web/README.md
+++ b/clients/client-workspaces-web/README.md
@@ -120,7 +120,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -154,7 +154,7 @@ client
 
 // callbacks.
 client.associateBrowserSettings(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-workspaces/README.md
+++ b/clients/client-workspaces/README.md
@@ -118,7 +118,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -152,7 +152,7 @@ client
 
 // callbacks.
 client.associateConnectionAlias(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/clients/client-xray/README.md
+++ b/clients/client-xray/README.md
@@ -116,7 +116,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -150,7 +150,7 @@ client
 
 // callbacks.
 client.batchGetTraces(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/codegen/smithy-aws-typescript-codegen/src/main/resources/software/amazon/smithy/aws/typescript/codegen/README.md.template
+++ b/codegen/smithy-aws-typescript-codegen/src/main/resources/software/amazon/smithy/aws/typescript/codegen/README.md.template
@@ -111,7 +111,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -145,7 +145,7 @@ client
 
 // callbacks.
 client.${operationName}(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/private/aws-protocoltests-ec2/README.md
+++ b/private/aws-protocoltests-ec2/README.md
@@ -115,7 +115,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -149,7 +149,7 @@ client
 
 // callbacks.
 client.emptyInputAndEmptyOutput(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/private/aws-protocoltests-json-10/README.md
+++ b/private/aws-protocoltests-json-10/README.md
@@ -113,7 +113,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -147,7 +147,7 @@ client
 
 // callbacks.
 client.emptyInputAndEmptyOutput(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/private/aws-protocoltests-json/README.md
+++ b/private/aws-protocoltests-json/README.md
@@ -113,7 +113,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -147,7 +147,7 @@ client
 
 // callbacks.
 client.emptyOperation(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/private/aws-protocoltests-query/README.md
+++ b/private/aws-protocoltests-query/README.md
@@ -115,7 +115,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -149,7 +149,7 @@ client
 
 // callbacks.
 client.emptyInputAndEmptyOutput(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/private/aws-protocoltests-restjson/README.md
+++ b/private/aws-protocoltests-restjson/README.md
@@ -115,7 +115,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -149,7 +149,7 @@ client
 
 // callbacks.
 client.allQueryStringTypes(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 

--- a/private/aws-protocoltests-restxml/README.md
+++ b/private/aws-protocoltests-restxml/README.md
@@ -115,7 +115,7 @@ but they are supported by the send operation.
 ```js
 // callbacks.
 client.send(command, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 
@@ -149,7 +149,7 @@ client
 
 // callbacks.
 client.allQueryStringTypes(params, (err, data) => {
-  // proccess err and data.
+  // process err and data.
 });
 ```
 


### PR DESCRIPTION
### Issue
#3460 

### Description
Fixes typo proccess -> process. Don't know if it will be automatically updated by bots when the template is updated, but if that's the case feel free to let me know so I can update my PR.

### Testing
No testing required, only docs typo change

### Additional context
N/A

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
