### PR TITLE
test(size): remove the test preventing 10% size increase

### DIFF
--- a/scripts/benchmark-size/limit.json
+++ b/scripts/benchmark-size/limit.json
@@ -1,6 +1,6 @@
 {
   "default": {
-    "publishSize": { "limit": "5 mb", "hike": "10 %" }
+    "publishSize": { "limit": "5 mb" }
   },
   "@aws-sdk/client-ec2": {
     "publishSize": { "limit": "20 mb" }


### PR DESCRIPTION
### Description
Remove the test preventing 10% size increase. This is to unblock the service launching a bigger release. We still have test to prevent the package size grow beyond 5 mb. 

In the future, we will change the size increase test to only monitoring a service client's dependency, instead of it's own size, because it depends on the model change.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
