### PR TITLE
chore(codegen): update to Smithy 1.19.x

### DIFF
--- a/codegen/build.gradle.kts
+++ b/codegen/build.gradle.kts
@@ -31,7 +31,7 @@ allprojects {
     version = "0.10.0"
 }
 
-extra["smithyVersion"] = "[1.17.0,1.18.0["
+extra["smithyVersion"] = "[1.19.0,1.20.0["
 
 // The root project doesn't produce a JAR.
 tasks["jar"].enabled = false

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsProtocolUtils.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsProtocolUtils.java
@@ -314,12 +314,6 @@ final class AwsProtocolUtils {
             return true;
         }
 
-        // TODO remove after 1.17.1 or later
-        // https://github.com/awslabs/smithy/pull/1084
-        if (testCase.getId().equals("RestJsonOutputUnionWithUnitMember")) {
-            return true;
-        }
-
         return false;
     }
 

--- a/private/aws-protocoltests-restjson/src/commands/StreamingTraitsRequireLengthCommand.ts
+++ b/private/aws-protocoltests-restjson/src/commands/StreamingTraitsRequireLengthCommand.ts
@@ -11,26 +11,24 @@ import {
   SerdeContext as __SerdeContext,
 } from "@aws-sdk/types";
 
-import { StreamingTraitsRequireLengthInputOutput } from "../models/models_0";
+import { StreamingTraitsRequireLengthInput } from "../models/models_0";
 import {
   deserializeAws_restJson1StreamingTraitsRequireLengthCommand,
   serializeAws_restJson1StreamingTraitsRequireLengthCommand,
 } from "../protocols/Aws_restJson1";
 import { RestJsonProtocolClientResolvedConfig, ServiceInputTypes, ServiceOutputTypes } from "../RestJsonProtocolClient";
 
-type StreamingTraitsRequireLengthCommandInputType = Omit<StreamingTraitsRequireLengthInputOutput, "blob"> & {
+type StreamingTraitsRequireLengthCommandInputType = Omit<StreamingTraitsRequireLengthInput, "blob"> & {
   /**
-   * For *`StreamingTraitsRequireLengthInputOutput["blob"]`*, see {@link StreamingTraitsRequireLengthInputOutput.blob}.
+   * For *`StreamingTraitsRequireLengthInput["blob"]`*, see {@link StreamingTraitsRequireLengthInput.blob}.
    */
-  blob?: StreamingTraitsRequireLengthInputOutput["blob"] | string | Uint8Array | Buffer;
+  blob?: StreamingTraitsRequireLengthInput["blob"] | string | Uint8Array | Buffer;
 };
 /**
- * This interface extends from `StreamingTraitsRequireLengthInputOutput` interface. There are more parameters than `blob` defined in {@link StreamingTraitsRequireLengthInputOutput}
+ * This interface extends from `StreamingTraitsRequireLengthInput` interface. There are more parameters than `blob` defined in {@link StreamingTraitsRequireLengthInput}
  */
 export interface StreamingTraitsRequireLengthCommandInput extends StreamingTraitsRequireLengthCommandInputType {}
-export interface StreamingTraitsRequireLengthCommandOutput
-  extends StreamingTraitsRequireLengthInputOutput,
-    __MetadataBearer {}
+export interface StreamingTraitsRequireLengthCommandOutput extends __MetadataBearer {}
 
 /**
  * This examples serializes a streaming blob shape with a required content
@@ -86,8 +84,8 @@ export class StreamingTraitsRequireLengthCommand extends $Command<
       logger,
       clientName,
       commandName,
-      inputFilterSensitiveLog: StreamingTraitsRequireLengthInputOutput.filterSensitiveLog,
-      outputFilterSensitiveLog: StreamingTraitsRequireLengthInputOutput.filterSensitiveLog,
+      inputFilterSensitiveLog: StreamingTraitsRequireLengthInput.filterSensitiveLog,
+      outputFilterSensitiveLog: (output: any) => output,
     };
     const { requestHandler } = configuration;
     return stack.resolve(

--- a/private/aws-protocoltests-restjson/src/models/models_0.ts
+++ b/private/aws-protocoltests-restjson/src/models/models_0.ts
@@ -1094,6 +1094,7 @@ export namespace MalformedRequestBodyInput {
 
 export interface MalformedSetInput {
   set?: string[];
+  blobSet?: Uint8Array[];
 }
 
 export namespace MalformedSetInput {
@@ -1473,7 +1474,7 @@ export namespace PlayerAction {
 }
 
 export interface PostPlayerActionInput {
-  action: PlayerAction | undefined;
+  action?: PlayerAction;
 }
 
 export namespace PostPlayerActionInput {
@@ -1577,16 +1578,16 @@ export namespace StreamingTraitsInputOutput {
   });
 }
 
-export interface StreamingTraitsRequireLengthInputOutput {
+export interface StreamingTraitsRequireLengthInput {
   foo?: string;
   blob?: Readable | ReadableStream | Blob;
 }
 
-export namespace StreamingTraitsRequireLengthInputOutput {
+export namespace StreamingTraitsRequireLengthInput {
   /**
    * @internal
    */
-  export const filterSensitiveLog = (obj: StreamingTraitsRequireLengthInputOutput): any => ({
+  export const filterSensitiveLog = (obj: StreamingTraitsRequireLengthInput): any => ({
     ...obj,
   });
 }

--- a/private/aws-protocoltests-restjson/src/protocols/Aws_restJson1.ts
+++ b/private/aws-protocoltests-restjson/src/protocols/Aws_restJson1.ts
@@ -1939,6 +1939,8 @@ export const serializeAws_restJson1MalformedSetCommand = async (
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/MalformedSet";
   let body: any;
   body = JSON.stringify({
+    ...(input.blobSet !== undefined &&
+      input.blobSet !== null && { blobSet: serializeAws_restJson1BlobSet(input.blobSet, context) }),
     ...(input.set !== undefined && input.set !== null && { set: serializeAws_restJson1SimpleSet(input.set, context) }),
   });
   return new __HttpRequest({
@@ -6145,14 +6147,8 @@ export const deserializeAws_restJson1StreamingTraitsRequireLengthCommand = async
   }
   const contents: StreamingTraitsRequireLengthCommandOutput = {
     $metadata: deserializeMetadata(output),
-    blob: undefined,
-    foo: undefined,
   };
-  if (output.headers["x-foo"] !== undefined) {
-    contents.foo = output.headers["x-foo"];
-  }
-  const data: any = output.body;
-  contents.blob = data;
+  await collectBody(output.body, context);
   return Promise.resolve(contents);
 };
 
@@ -6545,6 +6541,17 @@ const deserializeAws_restJson1InvalidGreetingResponse = async (
     ...contents,
   });
   return __decorateServiceException(exception, parsedOutput.body);
+};
+
+const serializeAws_restJson1BlobSet = (input: Uint8Array[], context: __SerdeContext): any => {
+  return input
+    .filter((e: any) => e != null)
+    .map((entry) => {
+      if (entry === null) {
+        return null as any;
+      }
+      return context.base64Encoder(entry);
+    });
 };
 
 const serializeAws_restJson1DenseBooleanMap = (input: { [key: string]: boolean }, context: __SerdeContext): any => {

--- a/private/aws-protocoltests-restjson/test/functional/restjson1.spec.ts
+++ b/private/aws-protocoltests-restjson/test/functional/restjson1.spec.ts
@@ -384,6 +384,12 @@ it("RestJsonSupportsNaNFloatQueryValues:Request", async () => {
     queryFloat: NaN,
 
     queryDouble: NaN,
+
+    queryParamsMapOfStringList: {
+      Float: ["NaN"],
+
+      Double: ["NaN"],
+    } as any,
   } as any);
   try {
     await client.send(command);
@@ -419,6 +425,12 @@ it("RestJsonSupportsInfinityFloatQueryValues:Request", async () => {
     queryFloat: Infinity,
 
     queryDouble: Infinity,
+
+    queryParamsMapOfStringList: {
+      Float: ["Infinity"],
+
+      Double: ["Infinity"],
+    } as any,
   } as any);
   try {
     await client.send(command);
@@ -454,6 +466,12 @@ it("RestJsonSupportsNegativeInfinityFloatQueryValues:Request", async () => {
     queryFloat: -Infinity,
 
     queryDouble: -Infinity,
+
+    queryParamsMapOfStringList: {
+      Float: ["-Infinity"],
+
+      Double: ["-Infinity"],
+    } as any,
   } as any);
   try {
     await client.send(command);
@@ -6478,7 +6496,7 @@ it("RestJsonInputUnionWithUnitMember:Request", async () => {
 /**
  * Unit types in unions are serialized like normal structures in responses.
  */
-it.skip("RestJsonOutputUnionWithUnitMember:Response", async () => {
+it("RestJsonOutputUnionWithUnitMember:Response", async () => {
   const client = new RestJsonProtocolClient({
     ...clientParams,
     requestHandler: new ResponseDeserializationTestHandler(
@@ -7472,95 +7490,6 @@ it("RestJsonStreamingTraitsRequireLengthWithNoBlobBody:Request", async () => {
 
     expect(r.body).toBeFalsy();
   }
-});
-
-/**
- * Serializes a blob in the HTTP payload with a required length
- */
-it("RestJsonStreamingTraitsRequireLengthWithBlob:Response", async () => {
-  const client = new RestJsonProtocolClient({
-    ...clientParams,
-    requestHandler: new ResponseDeserializationTestHandler(
-      true,
-      200,
-      {
-        "x-foo": "Foo",
-        "content-type": "application/octet-stream",
-      },
-      `blobby blob blob`
-    ),
-  });
-
-  const params: any = {};
-  const command = new StreamingTraitsRequireLengthCommand(params);
-
-  let r: any;
-  try {
-    r = await client.send(command);
-  } catch (err) {
-    fail("Expected a valid response to be returned, got err.");
-    return;
-  }
-  expect(r["$metadata"].httpStatusCode).toBe(200);
-  const paramsToValidate: any = [
-    {
-      foo: "Foo",
-
-      blob: Uint8Array.from("blobby blob blob", (c) => c.charCodeAt(0)),
-    },
-  ][0];
-  const comparableBlob = await client.config.streamCollector(r["blob"]);
-  Object.keys(paramsToValidate).forEach((param) => {
-    expect(r[param]).toBeDefined();
-    if (param === "blob") {
-      expect(equivalentContents(comparableBlob, paramsToValidate[param])).toBe(true);
-    } else {
-      expect(equivalentContents(r[param], paramsToValidate[param])).toBe(true);
-    }
-  });
-});
-
-/**
- * Serializes an empty blob in the HTTP payload
- */
-it("RestJsonStreamingTraitsRequireLengthWithNoBlobBody:Response", async () => {
-  const client = new RestJsonProtocolClient({
-    ...clientParams,
-    requestHandler: new ResponseDeserializationTestHandler(
-      true,
-      200,
-      {
-        "x-foo": "Foo",
-      },
-      ``
-    ),
-  });
-
-  const params: any = {};
-  const command = new StreamingTraitsRequireLengthCommand(params);
-
-  let r: any;
-  try {
-    r = await client.send(command);
-  } catch (err) {
-    fail("Expected a valid response to be returned, got err.");
-    return;
-  }
-  expect(r["$metadata"].httpStatusCode).toBe(200);
-  const paramsToValidate: any = [
-    {
-      foo: "Foo",
-    },
-  ][0];
-  const comparableBlob = await client.config.streamCollector(r["blob"]);
-  Object.keys(paramsToValidate).forEach((param) => {
-    expect(r[param]).toBeDefined();
-    if (param === "blob") {
-      expect(equivalentContents(comparableBlob, paramsToValidate[param])).toBe(true);
-    } else {
-      expect(equivalentContents(r[param], paramsToValidate[param])).toBe(true);
-    }
-  });
 });
 
 /**


### PR DESCRIPTION
Also bumping smithy version for smithy-typescript-codegen in https://github.com/awslabs/smithy-typescript/pull/531

### Testing
Using locally published smithy-typescript-codegen and smithy-aws-typescript-codegen, ran
`yarn generate-clients && yarn test:protocols && yarn generate-clients -s && yarn test:server-protocols`

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
