### PR TITLE
chore(codegen): bump code generators to 0.11.0

### DIFF
--- a/codegen/CHANGELOG.md
+++ b/codegen/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Smithy AWS Typescript Codegen Changelog
 
+## 0.11.0 (2022-04-04)
+
+### Features
+
+* Updated Smithy version to `1.19.x`. ([#3507](https://github.com/aws/aws-sdk-js-v3/pull/3507))
+
 ## 0.10.0 (2022-03-02)
 
 ### Features

--- a/codegen/build.gradle.kts
+++ b/codegen/build.gradle.kts
@@ -28,7 +28,7 @@ allprojects {
         mavenCentral()
     }
     group = "software.amazon.smithy.typescript"
-    version = "0.10.0"
+    version = "0.11.0"
 }
 
 extra["smithyVersion"] = "[1.17.0,1.18.0["

--- a/codegen/smithy-aws-typescript-codegen/build.gradle.kts
+++ b/codegen/smithy-aws-typescript-codegen/build.gradle.kts
@@ -36,7 +36,7 @@ dependencies {
     api("software.amazon.smithy:smithy-aws-iam-traits:${rootProject.extra["smithyVersion"]}")
     api("software.amazon.smithy:smithy-protocol-test-traits:${rootProject.extra["smithyVersion"]}")
     api("software.amazon.smithy:smithy-model:${rootProject.extra["smithyVersion"]}")
-    api("software.amazon.smithy.typescript:smithy-typescript-codegen:0.10.0")
+    api("software.amazon.smithy.typescript:smithy-typescript-codegen:0.11.0")
 }
 
 tasks.register("set-aws-sdk-versions") {


### PR DESCRIPTION
This will not pass CI until https://github.com/awslabs/smithy-typescript/pull/532 is merged.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
