### PR TITLE
Fix kinesis client `SubscribeToShardOutput` `EventStream` type

### DIFF
--- a/clients/client-kinesis/src/models/models_0.ts
+++ b/clients/client-kinesis/src/models/models_0.ts
@@ -2993,7 +2993,7 @@ export interface SubscribeToShardOutput {
   /**
    * <p>The event stream that your consumer can use to read records from the shard.</p>
    */
-  EventStream: AsyncIterable<SubscribeToShardEventStream> | undefined;
+  EventStream: AsyncIterable<SubscribeToShardEvent> | undefined;
 }
 
 export namespace SubscribeToShardOutput {


### PR DESCRIPTION
### Description
Fixes type of kinesis client `SubscribeToShardOutput` interface `EventStream` type

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
