### PR TITLE
test(endpoints): accomodate iot data plane changing prefix to data-ats.iot

### DIFF
--- a/tests/functional/endpoints/test_cases_supported.json
+++ b/tests/functional/endpoints/test_cases_supported.json
@@ -1856,31 +1856,31 @@
     "hostname": "cur-fips.us-east-1.api.aws"
   },
   {
-    "endpointPrefix": "data.iot",
+    "endpointPrefix": "data-ats.iot",
     "sdkId": "IoT Data Plane",
     "region": "ap-east-1",
     "useFipsEndpoint": false,
     "useDualstackEndpoint": false,
-    "hostname": "data.iot.ap-east-1.amazonaws.com"
+    "hostname": "data-ats.iot.ap-east-1.amazonaws.com"
   },
   {
-    "endpointPrefix": "data.iot",
+    "endpointPrefix": "data-ats.iot",
     "sdkId": "IoT Data Plane",
     "region": "ap-east-1",
     "useFipsEndpoint": false,
     "useDualstackEndpoint": true,
-    "hostname": "data.iot.ap-east-1.api.aws"
+    "hostname": "data-ats.iot.ap-east-1.api.aws"
   },
   {
-    "endpointPrefix": "data.iot",
+    "endpointPrefix": "data-ats.iot",
     "sdkId": "IoT Data Plane",
     "region": "ap-east-1",
     "useFipsEndpoint": true,
     "useDualstackEndpoint": false,
-    "hostname": "data.iot-fips.ap-east-1.amazonaws.com"
+    "hostname": "data-ats.iot-fips.ap-east-1.amazonaws.com"
   },
   {
-    "endpointPrefix": "data.iot",
+    "endpointPrefix": "data-ats.iot",
     "sdkId": "IoT Data Plane",
     "region": "ca-central-1",
     "useFipsEndpoint": true,
@@ -1888,12 +1888,12 @@
     "hostname": "data.iot-fips.ca-central-1.amazonaws.com"
   },
   {
-    "endpointPrefix": "data.iot",
+    "endpointPrefix": "data-ats.iot",
     "sdkId": "IoT Data Plane",
     "region": "ap-east-1",
     "useFipsEndpoint": true,
     "useDualstackEndpoint": true,
-    "hostname": "data.iot-fips.ap-east-1.api.aws"
+    "hostname": "data-ats.iot-fips.ap-east-1.api.aws"
   },
   {
     "endpointPrefix": "data.jobs.iot",
@@ -7640,36 +7640,36 @@
     "hostname": "cur-fips.cn-northwest-1.api.amazonwebservices.com.cn"
   },
   {
-    "endpointPrefix": "data.iot",
+    "endpointPrefix": "data-ats.iot",
     "sdkId": "IoT Data Plane",
     "region": "cn-north-1",
     "useFipsEndpoint": false,
     "useDualstackEndpoint": false,
-    "hostname": "data.iot.cn-north-1.amazonaws.com.cn"
+    "hostname": "data-ats.iot.cn-north-1.amazonaws.com.cn"
   },
   {
-    "endpointPrefix": "data.iot",
+    "endpointPrefix": "data-ats.iot",
     "sdkId": "IoT Data Plane",
     "region": "cn-north-1",
     "useFipsEndpoint": false,
     "useDualstackEndpoint": true,
-    "hostname": "data.iot.cn-north-1.api.amazonwebservices.com.cn"
+    "hostname": "data-ats.iot.cn-north-1.api.amazonwebservices.com.cn"
   },
   {
-    "endpointPrefix": "data.iot",
+    "endpointPrefix": "data-ats.iot",
     "sdkId": "IoT Data Plane",
     "region": "cn-north-1",
     "useFipsEndpoint": true,
     "useDualstackEndpoint": false,
-    "hostname": "data.iot-fips.cn-north-1.amazonaws.com.cn"
+    "hostname": "data-ats.iot-fips.cn-north-1.amazonaws.com.cn"
   },
   {
-    "endpointPrefix": "data.iot",
+    "endpointPrefix": "data-ats.iot",
     "sdkId": "IoT Data Plane",
     "region": "cn-north-1",
     "useFipsEndpoint": true,
     "useDualstackEndpoint": true,
-    "hostname": "data.iot-fips.cn-north-1.api.amazonwebservices.com.cn"
+    "hostname": "data-ats.iot-fips.cn-north-1.api.amazonwebservices.com.cn"
   },
   {
     "endpointPrefix": "data.jobs.iot",
@@ -10360,7 +10360,7 @@
     "hostname": "connect-fips.us-gov-west-1.api.aws"
   },
   {
-    "endpointPrefix": "data.iot",
+    "endpointPrefix": "data-ats.iot",
     "sdkId": "IoT Data Plane",
     "region": "us-gov-east-1",
     "useFipsEndpoint": true,


### PR DESCRIPTION
### Issue
The main branch CI has been blocked since [3.60.0 release](https://github.com/aws/aws-sdk-js-v3/commit/4eb7eee22a581e4b5042e47a498986b2d404c5e9). This is caused by `iot data plain` service replacing their endpoint prefix from `data.iot` to `data-ats.iot` and our static endpoint functional test is not updated. 

### Description
This change update the iot data test to accomodate the endpoints.json change.

### Testing
`yarn test:functional`

### Additional context
Updated the testcases using the script in #2980 with minor updates. Then copy all the testcase with `"endpointPrefix": "data-ats.iot"` to **replace** all the testcases with `"endpointPrefix": "data.iot"`. 

This script also generates cases with `"endpointPrefix": "data.iot"`, but they should be ignored because endpoints.json keeps `data.iot` prefix for backwards compatibility in other SDKs, but not applicable in JS v3 SDK.

Here's an updated version of script to generate test cases:

<details>
<summary>Code used for populating functional tests</summary>

```js
// The models directory smithy models
// from https://github.com/aws/aws-sdk-js-v3/tree/main/codegen/sdk-codegen/aws-models
// The endpoints.json contains RIP endpoints.

// In JS SDK v3, the test case for SimpleDB and mobileanalytics is removed as they're deprecated.

import { readdir, readFile, writeFile } from "fs/promises";

const modelsDir = "codegen/sdk-codegen/aws-models";
const endpointsPath =
  "codegen/smithy-aws-typescript-codegen/src/main/resources/software/amazon/smithy/aws/typescript/codegen/endpoints.json";

const findVal = (object, key) => {
  let value;
  Object.keys(object).some((k) => {
    if (k === key) {
      value = object[k];
      return true;
    }
    if (object[k] && typeof object[k] === "object") {
      value = findVal(object[k], key);
      return value !== undefined;
    }
  });
  return value;
};

const getServiceInfo = (api) => {
  return findVal(api, "aws.api#service");
};

const endpointPrefixSdkIdHash = {};
const models = await readdir(modelsDir);
for (const modelFileName of models) {
  const model = JSON.parse((await readFile(`${modelsDir}/${modelFileName}`)).toString());
  const { endpointPrefix, sdkId } = getServiceInfo(model);
  endpointPrefixSdkIdHash[endpointPrefix] = sdkId;
}

// Add exceptions
endpointPrefixSdkIdHash["rds"] = "RDS";
endpointPrefixSdkIdHash["docdb"] = "DocDB";
endpointPrefixSdkIdHash["neptune"] = "Neptune";
endpointPrefixSdkIdHash["importexport"] = "S3";
endpointPrefixSdkIdHash["ioteventsdata"] = "IoT Events Data";
endpointPrefixSdkIdHash["iotsecuredtunneling"] = "IoTSecureTunneling";
endpointPrefixSdkIdHash["iotwireless"] = "IoT Wireless";
endpointPrefixSdkIdHash["mobileanalytics"] = "Pinpoint";
endpointPrefixSdkIdHash["sdb"] = "SimpleDB";

const getHostnameWithDnsSuffix = (template, dnsSuffix) => template.replace("{dnsSuffix}", dnsSuffix || "{dnsSuffix}");

const getVariantsWithDnsSuffix = (variants = [], parentDnsSuffix) =>
  variants.map(({ hostname, dnsSuffix, tags }) => ({
    hostname: getHostnameWithDnsSuffix(hostname, dnsSuffix || parentDnsSuffix),
    tags,
  }));

const getHostname = (variants, { useFipsEndpoint, useDualstackEndpoint }) =>
  variants.find(
    ({ tags }) => useFipsEndpoint === tags.includes("fips") && useDualstackEndpoint === tags.includes("dualstack")
  )?.hostname;

const testCases = [];
const endpoints = JSON.parse((await readFile(endpointsPath)).toString());
for (const partition of endpoints.partitions) {
  const partitionDnsSuffix = partition.dnsSuffix;
  const partitionVariants = getVariantsWithDnsSuffix(partition.defaults.variants, partitionDnsSuffix);
  if (partition.defaults.hostname) {
    partitionVariants.push({
      hostname: getHostnameWithDnsSuffix(partition.defaults.hostname, partitionDnsSuffix),
      tags: [],
    });
  }

  for (const [endpointPrefix, serviceConfig] of Object.entries(partition.services)) {
    const serviceDnsSuffix = serviceConfig.dnsSuffix;
    const serviceVariants = getVariantsWithDnsSuffix(
      serviceConfig.defaults?.variants,
      serviceDnsSuffix || partitionDnsSuffix
    );
    if (serviceConfig.hostname) {
      serviceVariants.push({
        hostname: getHostnameWithDnsSuffix(serviceConfig.hostname, serviceDnsSuffix),
        tags: [],
      });
    }

    for (const useFipsEndpoint of [false, true]) {
      for (const useDualstackEndpoint of [false, true]) {
        const options = { useFipsEndpoint, useDualstackEndpoint };
        const partitionHostname = getHostname(partitionVariants, options);
        const serviceHostname = getHostname(serviceVariants, options);

        const notSupportedByService = serviceVariants.length > 0 && serviceHostname === undefined;
        if (notSupportedByService) {
          continue;
        }

        let hostnameFromParentCase = partitionHostname === undefined;
        let hostnameFromEndpointCase = false;

        for (const [region, regionConfig] of Object.entries(serviceConfig.endpoints)) {
          if (hostnameFromParentCase && hostnameFromEndpointCase) {
            break;
          }

          const { hostname, variants, deprecated } = regionConfig;
          if (deprecated) {
            continue;
          }

          if (!hostnameFromEndpointCase && variants) {
            if (hostname) {
              variants.push({
                hostname: getHostnameWithDnsSuffix(hostname),
                tags: [],
              });
            }

            const endpointHostname = getHostname(variants, options);
            if (endpointHostname) {
              testCases.push({
                endpointPrefix,
                sdkId: endpointPrefixSdkIdHash[endpointPrefix],
                region,
                useFipsEndpoint,
                useDualstackEndpoint,
                hostname: endpointHostname,
              });
              hostnameFromEndpointCase = true;
            }
          } else if (!hostnameFromParentCase && !variants && !hostname) {
            testCases.push({
              endpointPrefix,
              sdkId: endpointPrefixSdkIdHash[endpointPrefix],
              region,
              useFipsEndpoint,
              useDualstackEndpoint,
              hostname: (serviceHostname || partitionHostname)
                .replace("{region}", region)
                .replace("{service}", endpointPrefix),
            });
            hostnameFromParentCase = true;
          }
        }
      }
    }
  }
}
await writeFile("testCases.json", JSON.stringify(testCases, null, 2));

```

</details>

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
