### PR TITLE
chore(signature-v4-crt): bump aws-crt version to 1.12.1

### DIFF
--- a/packages/middleware-sdk-s3/package.json
+++ b/packages/middleware-sdk-s3/package.json
@@ -41,7 +41,7 @@
     "typescript": "~4.6.2"
   },
   "peerDependencies": {
-    "@aws-sdk/signature-v4-crt": "^3.54.1"
+    "@aws-sdk/signature-v4-crt": "^3.65.0"
   },
   "peerDependenciesMeta": {
     "@aws-sdk/signature-v4-crt": {

--- a/packages/signature-v4-crt/package.json
+++ b/packages/signature-v4-crt/package.json
@@ -26,7 +26,7 @@
     "@aws-sdk/util-hex-encoding": "*",
     "@aws-sdk/util-middleware": "*",
     "@aws-sdk/util-uri-escape": "*",
-    "aws-crt": "^1.11.3",
+    "aws-crt": "^1.12.1",
     "tslib": "^2.3.1"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3020,10 +3020,10 @@ available-typed-arrays@^1.0.2:
   dependencies:
     array-filter "^1.0.0"
 
-aws-crt@^1.11.3:
-  version "1.11.3"
-  resolved "https://registry.yarnpkg.com/aws-crt/-/aws-crt-1.11.3.tgz#2a40b64fa765a34231b05a2659798e242505983f"
-  integrity sha512-tqBFFzoM7bA2KsHuDa7j4Q+SOK208BRmz8C05vrFzH1XjlYconhJtmzNfT1h8MJzxV2AQBABpVblTlRcxue2MA==
+aws-crt@^1.12.1:
+  version "1.12.1"
+  resolved "https://registry.yarnpkg.com/aws-crt/-/aws-crt-1.12.1.tgz#049b329b3d3787908b5553874c18cf2292405e43"
+  integrity sha512-ZBj6cdLeesKAVLsTCnuie5kk6R+lfvJH+Nnb/tHN4AtQwFin0u0WWqC7cjlFoCPxSZQ9dSueGH9FZste0pKbhA==
   dependencies:
     "@httptoolkit/websocket-stream" "^6.0.0"
     axios "^0.24.0"


### PR DESCRIPTION
Replace https://github.com/aws/aws-sdk-js-v3/pull/3514 because it was mistakenly merged during the release.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
