### PR TITLE
feat(util-waiter): include reason on waiter result

### DIFF
--- a/packages/util-waiter/src/poller.spec.ts
+++ b/packages/util-waiter/src/poller.spec.ts
@@ -19,12 +19,19 @@ describe(runPolling.name, () => {
   };
   const failureState = {
     state: WaiterState.FAILURE,
+    reason: {
+      mockedReason: "some-failure-value",
+    },
   };
   const successState = {
     state: WaiterState.SUCCESS,
+    reason: {
+      mockedReason: "some-success-value",
+    },
   };
   const retryState = {
     state: WaiterState.RETRY,
+    reason: undefined,
   };
   const timeoutState = {
     state: WaiterState.TIMEOUT,
@@ -42,7 +49,7 @@ describe(runPolling.name, () => {
     jest.spyOn(global.Math, "random").mockRestore();
   });
 
-  it("should returns state in case of failure", async () => {
+  it("should returns state and reason in case of failure", async () => {
     mockAcceptorChecks = jest.fn().mockResolvedValueOnce(failureState);
     await expect(runPolling(config, input, mockAcceptorChecks)).resolves.toStrictEqual(failureState);
 
@@ -52,7 +59,7 @@ describe(runPolling.name, () => {
     expect(sleep).toHaveBeenCalledTimes(0);
   });
 
-  it("returns state in case of success", async () => {
+  it("returns state and reason in case of success", async () => {
     mockAcceptorChecks = jest.fn().mockResolvedValueOnce(successState);
     await expect(runPolling(config, input, mockAcceptorChecks)).resolves.toStrictEqual(successState);
     expect(mockAcceptorChecks).toHaveBeenCalled();

--- a/packages/util-waiter/src/poller.ts
+++ b/packages/util-waiter/src/poller.ts
@@ -25,9 +25,9 @@ export const runPolling = async <Client, Input>(
   input: Input,
   acceptorChecks: (client: Client, input: Input) => Promise<WaiterResult>
 ): Promise<WaiterResult> => {
-  const { state } = await acceptorChecks(client, input);
+  const { state, reason } = await acceptorChecks(client, input);
   if (state !== WaiterState.RETRY) {
-    return { state };
+    return { state, reason };
   }
 
   let currentAttempt = 1;
@@ -46,9 +46,9 @@ export const runPolling = async <Client, Input>(
       return { state: WaiterState.TIMEOUT };
     }
     await sleep(delay);
-    const { state } = await acceptorChecks(client, input);
+    const { state, reason } = await acceptorChecks(client, input);
     if (state !== WaiterState.RETRY) {
-      return { state };
+      return { state, reason };
     }
 
     currentAttempt += 1;


### PR DESCRIPTION
### Issue
https://github.com/aws/aws-sdk-js-v3/issues/2809

### Description
When generating the waiter result, we are not taking into account the reason. We should expose the result from the underlying API call and add that to the `reason` property as expected.

### Testing
Unit tests

### Additional context


---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
