### PR TITLE
fix(util-dynamodb): allow marshall function to handle more input types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ jspm_packages
 .DS_Store
 .vscode/launch.json
 
+Makefile
 lerna-debug.log
 package-lock.json
 

--- a/lib/lib-dynamodb/src/commands/marshallInput.spec.ts
+++ b/lib/lib-dynamodb/src/commands/marshallInput.spec.ts
@@ -1,0 +1,92 @@
+import { marshallInput } from "./utils";
+
+describe("marshallInput and processObj", () => {
+  it("marshallInput should not ignore falsy values", () => {
+    expect(marshallInput({ Items: [0, false, null, ""] }, [{ key: "Items" }])).toEqual({
+      Items: [{ N: "0" }, { BOOL: false }, { NULL: true }, { S: "" }],
+    });
+  });
+});
+
+describe("marshallInput for commands", () => {
+  it("marshals QueryCommand input", () => {
+    const input = {
+      TableName: "TestTable",
+      KeyConditions: {
+        id: {
+          AttributeValueList: ["test"],
+          ComparisonOperator: "EQ",
+        },
+      },
+    };
+    const inputKeyNodes = [
+      {
+        key: "KeyConditions",
+        children: {
+          children: [{ key: "AttributeValueList" }],
+        },
+      },
+      {
+        key: "QueryFilter",
+        children: {
+          children: [{ key: "AttributeValueList" }],
+        },
+      },
+      { key: "ExclusiveStartKey" },
+      { key: "ExpressionAttributeValues" },
+    ];
+    const output = {
+      TableName: "TestTable",
+      KeyConditions: { id: { AttributeValueList: [{ S: "test" }], ComparisonOperator: "EQ" } },
+      QueryFilter: undefined,
+      ExclusiveStartKey: undefined,
+      ExpressionAttributeValues: undefined,
+    };
+    expect(marshallInput(input, inputKeyNodes)).toEqual(output);
+  });
+  it("marshals ExecuteStatementCommand input", () => {
+    const input = {
+      Statement: `SELECT col_1
+                        FROM some_table
+                        WHERE contains("col_1", ?)`,
+      Parameters: ["some_param"],
+    };
+    const inputKeyNodes = [{ key: "Parameters" }];
+    const output = {
+      Statement: input.Statement,
+      Parameters: [{ S: "some_param" }],
+    };
+    expect(marshallInput(input, inputKeyNodes)).toEqual(output);
+  });
+  it("marshals BatchExecuteStatementCommand input", () => {
+    const input = {
+      Statements: [
+        {
+          Statement: `
+                        UPDATE "table"
+                        SET field1=?
+                        WHERE field2 = ?
+                          AND field3 = ?
+                    `,
+          Parameters: [false, "field 2 value", 1234],
+        },
+      ],
+    };
+    const inputKeyNodes = [{ key: "Statements", children: [{ key: "Parameters" }] }];
+    const output = {
+      Statements: [
+        {
+          Statement: input.Statements[0].Statement,
+          Parameters: [
+            {
+              BOOL: false,
+            },
+            { S: "field 2 value" },
+            { N: "1234" },
+          ],
+        },
+      ],
+    };
+    expect(marshallInput(input, inputKeyNodes)).toEqual(output);
+  });
+});

--- a/lib/lib-dynamodb/src/commands/utils.ts
+++ b/lib/lib-dynamodb/src/commands/utils.ts
@@ -10,7 +10,7 @@ export type AllNodes = {
 };
 
 const processObj = (obj: any, processFunc: Function, children?: KeyNode[] | AllNodes): any => {
-  if (obj) {
+  if (obj !== undefined) {
     if (!children || (Array.isArray(children) && children.length === 0)) {
       // Leaf of KeyNode, process the object.
       return processFunc(obj);

--- a/packages/util-dynamodb/src/marshall.spec.ts
+++ b/packages/util-dynamodb/src/marshall.spec.ts
@@ -4,64 +4,62 @@ import { marshall } from "./marshall";
 jest.mock("./convertToAttr");
 
 describe("marshall", () => {
-  describe("mocked convertToAttr", () => {
-    const mockOutput = { S: "mockOutput" };
-    (convertToAttr as jest.Mock).mockReturnValue({ M: mockOutput });
+  const mockOutput = { S: "mockOutput" };
+  (convertToAttr as jest.Mock).mockReturnValue({ M: mockOutput });
 
-    afterEach(() => {
-      jest.clearAllMocks();
-    });
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
 
-    it("with object as an input", () => {
-      const input = { a: "A", b: "B" };
-      expect(marshall(input)).toEqual(mockOutput);
-      expect(convertToAttr).toHaveBeenCalledTimes(1);
-      expect(convertToAttr).toHaveBeenCalledWith(input, undefined);
-    });
+  it("with object as an input", () => {
+    const input = { a: "A", b: "B" };
+    expect(marshall(input)).toEqual(mockOutput);
+    expect(convertToAttr).toHaveBeenCalledTimes(1);
+    expect(convertToAttr).toHaveBeenCalledWith(input, undefined);
+  });
 
-    ["convertEmptyValues", "removeUndefinedValues"].forEach((option) => {
-      describe(`options.${option}`, () => {
-        [false, true].forEach((value) => {
-          it(`passes ${value} to convertToAttr`, () => {
-            const input = { a: "A", b: "B" };
-            expect(marshall(input, { [option]: value })).toEqual(mockOutput);
-            expect(convertToAttr).toHaveBeenCalledTimes(1);
-            expect(convertToAttr).toHaveBeenCalledWith(input, { [option]: value });
-          });
+  ["convertEmptyValues", "removeUndefinedValues"].forEach((option) => {
+    describe(`options.${option}`, () => {
+      [false, true].forEach((value) => {
+        it(`passes ${value} to convertToAttr`, () => {
+          const input = { a: "A", b: "B" };
+          expect(marshall(input, { [option]: value })).toEqual(mockOutput);
+          expect(convertToAttr).toHaveBeenCalledTimes(1);
+          expect(convertToAttr).toHaveBeenCalledWith(input, { [option]: value });
         });
       });
     });
+  });
 
-    it("with type as an input", () => {
-      type TestInputType = { a: string; b: string };
-      const input: TestInputType = { a: "A", b: "B" };
+  it("with type as an input", () => {
+    type TestInputType = { a: string; b: string };
+    const input: TestInputType = { a: "A", b: "B" };
 
-      expect(marshall(input)).toEqual(mockOutput);
-      expect(convertToAttr).toHaveBeenCalledTimes(1);
-      expect(convertToAttr).toHaveBeenCalledWith(input, undefined);
-    });
+    expect(marshall(input)).toEqual(mockOutput);
+    expect(convertToAttr).toHaveBeenCalledTimes(1);
+    expect(convertToAttr).toHaveBeenCalledWith(input, undefined);
+  });
 
-    it("with Interface as an input", () => {
-      interface TestInputInterface {
-        a: string;
-        b: string;
-      }
-      const input: TestInputInterface = { a: "A", b: "B" };
+  it("with Interface as an input", () => {
+    interface TestInputInterface {
+      a: string;
+      b: string;
+    }
+    const input: TestInputInterface = { a: "A", b: "B" };
 
-      expect(marshall(input)).toEqual(mockOutput);
-      expect(convertToAttr).toHaveBeenCalledTimes(1);
-      expect(convertToAttr).toHaveBeenCalledWith(input, undefined);
-    });
+    expect(marshall(input)).toEqual(mockOutput);
+    expect(convertToAttr).toHaveBeenCalledTimes(1);
+    expect(convertToAttr).toHaveBeenCalledWith(input, undefined);
+  });
 
-    it("with class instance as an input", () => {
-      class TestInputClass {
-        constructor(private readonly a: string, private readonly b: string) {}
-      }
-      const input = new TestInputClass("A", "B");
+  it("with class instance as an input", () => {
+    class TestInputClass {
+      constructor(private readonly a: string, private readonly b: string) {}
+    }
+    const input = new TestInputClass("A", "B");
 
-      expect(marshall(input)).toEqual(mockOutput);
-      expect(convertToAttr).toHaveBeenCalledTimes(1);
-      expect(convertToAttr).toHaveBeenCalledWith(input, undefined);
-    });
+    expect(marshall(input)).toEqual(mockOutput);
+    expect(convertToAttr).toHaveBeenCalledTimes(1);
+    expect(convertToAttr).toHaveBeenCalledWith(input, undefined);
   });
 });

--- a/packages/util-dynamodb/src/marshall.spec.ts
+++ b/packages/util-dynamodb/src/marshall.spec.ts
@@ -4,62 +4,64 @@ import { marshall } from "./marshall";
 jest.mock("./convertToAttr");
 
 describe("marshall", () => {
-  const mockOutput = { S: "mockOutput" };
-  (convertToAttr as jest.Mock).mockReturnValue({ M: mockOutput });
+  describe("mocked convertToAttr", () => {
+    const mockOutput = { S: "mockOutput" };
+    (convertToAttr as jest.Mock).mockReturnValue({ M: mockOutput });
 
-  afterEach(() => {
-    jest.clearAllMocks();
-  });
+    afterEach(() => {
+      jest.clearAllMocks();
+    });
 
-  it("with object as an input", () => {
-    const input = { a: "A", b: "B" };
-    expect(marshall(input)).toEqual(mockOutput);
-    expect(convertToAttr).toHaveBeenCalledTimes(1);
-    expect(convertToAttr).toHaveBeenCalledWith(input, undefined);
-  });
+    it("with object as an input", () => {
+      const input = { a: "A", b: "B" };
+      expect(marshall(input)).toEqual(mockOutput);
+      expect(convertToAttr).toHaveBeenCalledTimes(1);
+      expect(convertToAttr).toHaveBeenCalledWith(input, undefined);
+    });
 
-  ["convertEmptyValues", "removeUndefinedValues"].forEach((option) => {
-    describe(`options.${option}`, () => {
-      [false, true].forEach((value) => {
-        it(`passes ${value} to convertToAttr`, () => {
-          const input = { a: "A", b: "B" };
-          expect(marshall(input, { [option]: value })).toEqual(mockOutput);
-          expect(convertToAttr).toHaveBeenCalledTimes(1);
-          expect(convertToAttr).toHaveBeenCalledWith(input, { [option]: value });
+    ["convertEmptyValues", "removeUndefinedValues"].forEach((option) => {
+      describe(`options.${option}`, () => {
+        [false, true].forEach((value) => {
+          it(`passes ${value} to convertToAttr`, () => {
+            const input = { a: "A", b: "B" };
+            expect(marshall(input, { [option]: value })).toEqual(mockOutput);
+            expect(convertToAttr).toHaveBeenCalledTimes(1);
+            expect(convertToAttr).toHaveBeenCalledWith(input, { [option]: value });
+          });
         });
       });
     });
-  });
 
-  it("with type as an input", () => {
-    type TestInputType = { a: string; b: string };
-    const input: TestInputType = { a: "A", b: "B" };
+    it("with type as an input", () => {
+      type TestInputType = { a: string; b: string };
+      const input: TestInputType = { a: "A", b: "B" };
 
-    expect(marshall(input)).toEqual(mockOutput);
-    expect(convertToAttr).toHaveBeenCalledTimes(1);
-    expect(convertToAttr).toHaveBeenCalledWith(input, undefined);
-  });
+      expect(marshall(input)).toEqual(mockOutput);
+      expect(convertToAttr).toHaveBeenCalledTimes(1);
+      expect(convertToAttr).toHaveBeenCalledWith(input, undefined);
+    });
 
-  it("with Interface as an input", () => {
-    interface TestInputInterface {
-      a: string;
-      b: string;
-    }
-    const input: TestInputInterface = { a: "A", b: "B" };
+    it("with Interface as an input", () => {
+      interface TestInputInterface {
+        a: string;
+        b: string;
+      }
+      const input: TestInputInterface = { a: "A", b: "B" };
 
-    expect(marshall(input)).toEqual(mockOutput);
-    expect(convertToAttr).toHaveBeenCalledTimes(1);
-    expect(convertToAttr).toHaveBeenCalledWith(input, undefined);
-  });
+      expect(marshall(input)).toEqual(mockOutput);
+      expect(convertToAttr).toHaveBeenCalledTimes(1);
+      expect(convertToAttr).toHaveBeenCalledWith(input, undefined);
+    });
 
-  it("with class instance as an input", () => {
-    class TestInputClass {
-      constructor(private readonly a: string, private readonly b: string) {}
-    }
-    const input = new TestInputClass("A", "B");
+    it("with class instance as an input", () => {
+      class TestInputClass {
+        constructor(private readonly a: string, private readonly b: string) {}
+      }
+      const input = new TestInputClass("A", "B");
 
-    expect(marshall(input)).toEqual(mockOutput);
-    expect(convertToAttr).toHaveBeenCalledTimes(1);
-    expect(convertToAttr).toHaveBeenCalledWith(input, undefined);
+      expect(marshall(input)).toEqual(mockOutput);
+      expect(convertToAttr).toHaveBeenCalledTimes(1);
+      expect(convertToAttr).toHaveBeenCalledWith(input, undefined);
+    });
   });
 });

--- a/packages/util-dynamodb/src/marshallTypes.spec.ts
+++ b/packages/util-dynamodb/src/marshallTypes.spec.ts
@@ -1,0 +1,59 @@
+import { convertToAttr } from "./convertToAttr";
+import { marshall } from "./marshall";
+
+describe("marshall type discernment", () => {
+  describe("behaves as convertToAttr for non-collection values or Sets", () => {
+    it("marshals string", () => {
+      const value = "hello";
+      expect(marshall(value)).toEqual(convertToAttr(value));
+    });
+    it("marshals number", () => {
+      const value = 1578;
+      expect(marshall(value)).toEqual(convertToAttr(value));
+    });
+    it("marshals binary", () => {
+      const value = new Uint8Array([0, 1, 0, 1]);
+      expect(marshall(value)).toEqual(convertToAttr(value));
+    });
+    it("marshals boolean", () => {
+      let value = false;
+      expect(marshall(value)).toEqual(convertToAttr(value));
+      value = true;
+      expect(marshall(value)).toEqual(convertToAttr(value));
+    });
+    it("marshals null", () => {
+      const value = null;
+      expect(marshall(value)).toEqual(convertToAttr(value));
+    });
+    it("marshals string set", () => {
+      const value = new Set(["a", "b"]);
+      expect(marshall(value)).toEqual(convertToAttr(value));
+    });
+    it("marshals number set", () => {
+      const value = new Set([1, 2]);
+      expect(marshall(value)).toEqual(convertToAttr(value));
+    });
+    it("marshals binary set", () => {
+      const value = new Set([new Uint8Array([1, 0]), new Uint8Array([0, 1])]);
+      expect(marshall(value)).toEqual(convertToAttr(value));
+    });
+  });
+  describe("unwraps one level for input data which are lists or maps", () => {
+    it("marshals and unwraps map", () => {
+      expect(marshall({ a: 1, b: { a: 2, b: [1, 2, 3] } })).toEqual({
+        a: { N: "1" },
+        b: {
+          M: {
+            a: { N: "2" },
+            b: {
+              L: [{ N: "1" }, { N: "2" }, { N: "3" }],
+            },
+          },
+        },
+      });
+    });
+    it("marshals and unwraps list", () => {
+      expect(marshall(["test", 2, null])).toEqual([{ S: "test" }, { N: "2" }, { NULL: true }]);
+    });
+  });
+});

--- a/packages/util-dynamodb/src/marshallTypes.spec.ts
+++ b/packages/util-dynamodb/src/marshallTypes.spec.ts
@@ -44,6 +44,7 @@ describe("marshall type discernment", () => {
       expect(marshall(value)).toEqual(convertToAttr(value));
     });
   });
+
   describe("unwraps one level for input data which are lists or maps", () => {
     it("marshals and unwraps map", () => {
       expect(marshall({ a: 1, b: { a: 2, b: [1, 2, 3] } })).toEqual({

--- a/packages/util-dynamodb/src/marshallTypes.spec.ts
+++ b/packages/util-dynamodb/src/marshallTypes.spec.ts
@@ -7,20 +7,24 @@ describe("marshall type discernment", () => {
       const value = "hello";
       expect(marshall(value)).toEqual(convertToAttr(value));
     });
+
     it("marshals number", () => {
       const value = 1578;
       expect(marshall(value)).toEqual(convertToAttr(value));
     });
+
     it("marshals binary", () => {
       const value = new Uint8Array([0, 1, 0, 1]);
       expect(marshall(value)).toEqual(convertToAttr(value));
     });
+
     it("marshals boolean", () => {
       let value = false;
       expect(marshall(value)).toEqual(convertToAttr(value));
       value = true;
       expect(marshall(value)).toEqual(convertToAttr(value));
     });
+
     it("marshals null", () => {
       const value = null;
       expect(marshall(value)).toEqual(convertToAttr(value));
@@ -29,10 +33,12 @@ describe("marshall type discernment", () => {
       const value = new Set(["a", "b"]);
       expect(marshall(value)).toEqual(convertToAttr(value));
     });
+
     it("marshals number set", () => {
       const value = new Set([1, 2]);
       expect(marshall(value)).toEqual(convertToAttr(value));
     });
+
     it("marshals binary set", () => {
       const value = new Set([new Uint8Array([1, 0]), new Uint8Array([0, 1])]);
       expect(marshall(value)).toEqual(convertToAttr(value));
@@ -52,6 +58,7 @@ describe("marshall type discernment", () => {
         },
       });
     });
+
     it("marshals and unwraps list", () => {
       expect(marshall(["test", 2, null])).toEqual([{ S: "test" }, { N: "2" }, { NULL: true }]);
     });


### PR DESCRIPTION
### Issue
Fixes https://github.com/aws/aws-sdk-js-v3/issues/2807 
> @aws-sdk/lib-dynamodb incorrectly marshalls non-object types

### Description
- modify the `marshall` method in util-dynamodb and used by lib-dynamodb
  - currently this only returns the `M` property assuming a map is the input
  - I modified this function to return the M or L properties for maps and lists, but otherwise return the converted attributeValue. 
- separately, I believe the function `processObj` in lib-dynamodb needs to accept falsy values other than undef.

### Testing
added unit/integration specs to cover the cases described in the issue and my other change to lib-dynamodb

### Additional context
`util-dynamodb` is an internal package providing the marshaling functionality.
`lib-dynamodb` is a wrapper for `client-dynamodb` that aims to simplify the object structure to one that is more JavaScript-like. 
