### PR TITLE
chore(packages): add missing @types/node dep

### DIFF
--- a/packages/eventstream-handler-node/package.json
+++ b/packages/eventstream-handler-node/package.json
@@ -26,6 +26,7 @@
   "devDependencies": {
     "@aws-sdk/util-utf8-node": "*",
     "@tsconfig/recommended": "1.0.1",
+    "@types/node": "^10.0.0",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",

--- a/packages/eventstream-serde-node/package.json
+++ b/packages/eventstream-serde-node/package.json
@@ -27,6 +27,7 @@
   "devDependencies": {
     "@aws-sdk/util-utf8-node": "*",
     "@tsconfig/recommended": "1.0.1",
+    "@types/node": "^12.0.0",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",

--- a/packages/eventstream-serde-universal/package.json
+++ b/packages/eventstream-serde-universal/package.json
@@ -26,6 +26,7 @@
   "devDependencies": {
     "@aws-sdk/util-utf8-node": "*",
     "@tsconfig/recommended": "1.0.1",
+    "@types/node": "^10.0.0",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",

--- a/packages/smithy-client/package.json
+++ b/packages/smithy-client/package.json
@@ -44,6 +44,7 @@
   },
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",
+    "@types/node": "^10.0.0",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",


### PR DESCRIPTION
### Issue
Issue uncovered in #3536 

I will bulk update the nodejs types in a separate PR.

### Description
Add missing dependency of `@types/node` in some of the dependency packages

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
