### PR TITLE
chore(shared-ini-file-loader): use Promises in slurpFile hash

### DIFF
--- a/packages/shared-ini-file-loader/src/slurpFile.spec.ts
+++ b/packages/shared-ini-file-loader/src/slurpFile.spec.ts
@@ -8,16 +8,17 @@ describe("slurpFile", () => {
   const getMockFileContents = (path: string, options = UTF8) => JSON.stringify({ path, options });
 
   beforeEach(() => {
-    (promises.readFile as jest.Mock).mockImplementation((path, options) =>
-      Promise.resolve(getMockFileContents(path, options))
-    );
+    (promises.readFile as jest.Mock).mockImplementation(async (path, options) => {
+      await new Promise((resolve) => setTimeout(resolve, 100));
+      return getMockFileContents(path, options);
+    });
   });
 
   afterEach(() => {
     jest.clearAllMocks();
   });
 
-  it("makes one readFile call for a filepath irrepsective of slurpFile calls", (done) => {
+  it("makes one readFile call for a filepath irrespective of slurpFile calls", (done) => {
     jest.isolateModules(async () => {
       const { slurpFile } = require("./slurpFile");
       const mockPath = "/mock/path";

--- a/packages/shared-ini-file-loader/src/slurpFile.spec.ts
+++ b/packages/shared-ini-file-loader/src/slurpFile.spec.ts
@@ -18,26 +18,46 @@ describe("slurpFile", () => {
     jest.clearAllMocks();
   });
 
-  it("makes one readFile call for a filepath irrespective of slurpFile calls", (done) => {
-    jest.isolateModules(async () => {
-      const { slurpFile } = require("./slurpFile");
-      const mockPath = "/mock/path";
-      const mockPathContent = getMockFileContents(mockPath);
+  describe("makes one readFile call for a filepath irrespective of slurpFile calls", () => {
+    // @ts-ignore: https://github.com/DefinitelyTyped/DefinitelyTyped/issues/34617
+    it.each([10, 100, 1000, 10000])("parallel calls: %d ", (num: number, done: Function) => {
+      jest.isolateModules(async () => {
+        const { slurpFile } = require("./slurpFile");
+        const mockPath = "/mock/path";
+        const mockPathContent = getMockFileContents(mockPath);
 
-      expect(promises.readFile).not.toHaveBeenCalled();
-      const fileContentArr = await Promise.all([slurpFile(mockPath), slurpFile(mockPath)]);
-      expect(fileContentArr).toStrictEqual([mockPathContent, mockPathContent]);
+        expect(promises.readFile).not.toHaveBeenCalled();
+        const fileContentArr = await Promise.all(Array(num).fill(slurpFile(mockPath)));
+        expect(fileContentArr).toStrictEqual(Array(num).fill(mockPathContent));
 
-      // There is one readFile call even through slurpFile is called in parallel twice.
-      expect(promises.readFile).toHaveBeenCalledTimes(1);
-      expect(promises.readFile).toHaveBeenCalledWith(mockPath, UTF8);
+        // There is one readFile call even through slurpFile is called in parallel num times.
+        expect(promises.readFile).toHaveBeenCalledTimes(1);
+        expect(promises.readFile).toHaveBeenCalledWith(mockPath, UTF8);
+        done();
+      });
+    });
 
-      const fileContent = await slurpFile(mockPath);
-      expect(fileContent).toStrictEqual(mockPathContent);
+    it("two parallel calls and one sequential call", (done) => {
+      jest.isolateModules(async () => {
+        const { slurpFile } = require("./slurpFile");
+        const mockPath = "/mock/path";
+        const mockPathContent = getMockFileContents(mockPath);
 
-      // There is one readFile call even through slurpFile is called for the third time.
-      expect(promises.readFile).toHaveBeenCalledTimes(1);
-      done();
+        expect(promises.readFile).not.toHaveBeenCalled();
+        const fileContentArr = await Promise.all([slurpFile(mockPath), slurpFile(mockPath)]);
+        expect(fileContentArr).toStrictEqual([mockPathContent, mockPathContent]);
+
+        // There is one readFile call even through slurpFile is called in parallel twice.
+        expect(promises.readFile).toHaveBeenCalledTimes(1);
+        expect(promises.readFile).toHaveBeenCalledWith(mockPath, UTF8);
+
+        const fileContent = await slurpFile(mockPath);
+        expect(fileContent).toStrictEqual(mockPathContent);
+
+        // There is one readFile call even through slurpFile is called for the third time.
+        expect(promises.readFile).toHaveBeenCalledTimes(1);
+        done();
+      });
     });
   });
 

--- a/packages/shared-ini-file-loader/src/slurpFile.ts
+++ b/packages/shared-ini-file-loader/src/slurpFile.ts
@@ -3,45 +3,19 @@ import { promises as fsPromises } from "fs";
 
 const { readFile } = fsPromises;
 
-type callbacks = { resolve: Function; reject: Function };
-type FileStatus = {
-  contents: string;
-  isReading: boolean;
-  requestQueue: callbacks[];
-};
+const filePromisesHash: { [key: string]: Promise<string> } = {};
 
-const fileStatusHash: { [key: string]: FileStatus } = {};
-
-export const slurpFile = (path: string) =>
-  new Promise<string>((resolve, reject) => {
-    if (!fileStatusHash[path]) {
-      // File not read yet, set file isReading to true and read file.
-      fileStatusHash[path] = { isReading: true, contents: "", requestQueue: [] };
-      fileStatusHash[path].requestQueue.push({ resolve, reject });
+export const slurpFile = (path: string) => {
+  if (!filePromisesHash[path]) {
+    filePromisesHash[path] = new Promise((resolve, reject) => {
       readFile(path, "utf8")
         .then((data) => {
-          // File read successful
-          fileStatusHash[path].isReading = false;
-          fileStatusHash[path].contents = data;
-          const { requestQueue } = fileStatusHash[path];
-          while (requestQueue.length) {
-            const { resolve } = requestQueue.pop()!;
-            resolve(data);
-          }
+          resolve(data);
         })
         .catch((err) => {
-          // File read failed;
-          fileStatusHash[path].isReading = false;
-          const { requestQueue } = fileStatusHash[path];
-          while (requestQueue.length) {
-            const { reject } = requestQueue.pop()!;
-            reject(err);
-          }
+          reject(err);
         });
-    } else if (fileStatusHash[path].isReading) {
-      // File currently being read. Add callbacks to the request queue.
-      fileStatusHash[path].requestQueue.push({ resolve, reject });
-    } else {
-      resolve(fileStatusHash[path].contents);
-    }
-  });
+    });
+  }
+  return filePromisesHash[path];
+};

--- a/packages/shared-ini-file-loader/src/slurpFile.ts
+++ b/packages/shared-ini-file-loader/src/slurpFile.ts
@@ -7,15 +7,7 @@ const filePromisesHash: { [key: string]: Promise<string> } = {};
 
 export const slurpFile = (path: string) => {
   if (!filePromisesHash[path]) {
-    filePromisesHash[path] = new Promise((resolve, reject) => {
-      readFile(path, "utf8")
-        .then((data) => {
-          resolve(data);
-        })
-        .catch((err) => {
-          reject(err);
-        });
-    });
+    filePromisesHash[path] = readFile(path, "utf8");
   }
   return filePromisesHash[path];
 };


### PR DESCRIPTION
### Issue
Noticed that Promises can be resolved/rejected only once while reviewing https://github.com/aws/aws-sdk-js-v3/pull/3545

### Description
Uses Promises in slurpFile hash

### Testing
Unit testing

### Additional context
StackOverflow discussion https://codereview.stackexchange.com/a/51658

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
