### PR TITLE
chore(shared-ini-file-loader): rename normalizeConfigFile to getProfileData

### DIFF
--- a/packages/shared-ini-file-loader/src/getProfileData.spec.ts
+++ b/packages/shared-ini-file-loader/src/getProfileData.spec.ts
@@ -1,18 +1,18 @@
-import { normalizeConfigFile } from "./normalizeConfigFile";
+import { getProfileData } from "./getProfileData";
 
-describe(normalizeConfigFile.name, () => {
+describe(getProfileData.name, () => {
   it("returns empty for no data", () => {
-    expect(normalizeConfigFile({})).toStrictEqual({});
+    expect(getProfileData({})).toStrictEqual({});
   });
 
   it("returns default profile if present", () => {
     const mockInput = { default: { key: "value" } };
-    expect(normalizeConfigFile(mockInput)).toStrictEqual(mockInput);
+    expect(getProfileData(mockInput)).toStrictEqual(mockInput);
   });
 
   it("skips profiles without prefix profile", () => {
     const mockInput = { test: { key: "value" } };
-    expect(normalizeConfigFile(mockInput)).toStrictEqual({});
+    expect(getProfileData(mockInput)).toStrictEqual({});
   });
 
   describe("normalizes profile names", () => {
@@ -30,33 +30,33 @@ describe(normalizeConfigFile.name, () => {
     it("single profile", () => {
       const mockOutput = getMockOutput(["one"]);
       const mockInput = getMockInput(mockOutput);
-      expect(normalizeConfigFile(mockInput)).toStrictEqual(mockOutput);
+      expect(getProfileData(mockInput)).toStrictEqual(mockOutput);
     });
 
     it("two profiles", () => {
       const mockOutput = getMockOutput(["one", "two"]);
       const mockInput = getMockInput(mockOutput);
-      expect(normalizeConfigFile(mockInput)).toStrictEqual(mockOutput);
+      expect(getProfileData(mockInput)).toStrictEqual(mockOutput);
     });
 
     it("three profiles", () => {
       const mockOutput = getMockOutput(["one", "two", "three"]);
       const mockInput = getMockInput(mockOutput);
-      expect(normalizeConfigFile(mockInput)).toStrictEqual(mockOutput);
+      expect(getProfileData(mockInput)).toStrictEqual(mockOutput);
     });
 
     it("with default", () => {
       const defaultInput = { default: { key: "value" } };
       const mockOutput = getMockOutput(["one"]);
       const mockInput = getMockInput(mockOutput);
-      expect(normalizeConfigFile({ ...defaultInput, ...mockInput })).toStrictEqual({ ...defaultInput, ...mockOutput });
+      expect(getProfileData({ ...defaultInput, ...mockInput })).toStrictEqual({ ...defaultInput, ...mockOutput });
     });
 
     it("with profileName without prefix", () => {
       const profileWithPrefix = { test: { key: "value" } };
       const mockOutput = getMockOutput(["one"]);
       const mockInput = getMockInput(mockOutput);
-      expect(normalizeConfigFile({ ...profileWithPrefix, ...mockInput })).toStrictEqual(mockOutput);
+      expect(getProfileData({ ...profileWithPrefix, ...mockInput })).toStrictEqual(mockOutput);
     });
   });
 });

--- a/packages/shared-ini-file-loader/src/getProfileData.spec.ts
+++ b/packages/shared-ini-file-loader/src/getProfileData.spec.ts
@@ -15,6 +15,11 @@ describe(getProfileData.name, () => {
     expect(getProfileData(mockInput)).toStrictEqual({});
   });
 
+  it("skips profiles with different prefix", () => {
+    const mockInput = { "not-profile test": { key: "value" } };
+    expect(getProfileData(mockInput)).toStrictEqual({});
+  });
+
   describe("normalizes profile names", () => {
     const getMockProfileData = (profileName: string) =>
       [1, 2, 3]

--- a/packages/shared-ini-file-loader/src/getProfileData.spec.ts
+++ b/packages/shared-ini-file-loader/src/getProfileData.spec.ts
@@ -16,13 +16,13 @@ describe(getProfileData.name, () => {
   });
 
   describe("normalizes profile names", () => {
-    const getProfileData = (profileName: string) =>
+    const getMockProfileData = (profileName: string) =>
       [1, 2, 3]
         .map((num) => [`key_${profileName}_${num}`, `value_${profileName}_${num}`])
         .reduce((acc, [key, value]) => ({ ...acc, [key]: value }), {});
 
     const getMockOutput = (profileNames: string[]) =>
-      profileNames.reduce((acc, profileName) => ({ ...acc, [profileName]: getProfileData(profileName) }), {});
+      profileNames.reduce((acc, profileName) => ({ ...acc, [profileName]: getMockProfileData(profileName) }), {});
 
     const getMockInput = (mockOutput: { [key: string]: { [key: string]: string } }) =>
       Object.entries(mockOutput).reduce((acc, [key, value]) => ({ ...acc, [`profile ${key}`]: value }), {});

--- a/packages/shared-ini-file-loader/src/getProfileData.ts
+++ b/packages/shared-ini-file-loader/src/getProfileData.ts
@@ -2,6 +2,11 @@ import { ParsedIniData } from "@aws-sdk/types";
 
 const profileKeyRegex = /^profile\s(["'])?([^\1]+)\1$/;
 
+/**
+ * Returns the profile data from parsed ini data.
+ * * Returns data for `default`
+ * * Reads profileName after profile prefix including/excluding quotes
+ */
 export const getProfileData = (data: ParsedIniData): ParsedIniData => {
   const map: ParsedIniData = {};
   for (const key of Object.keys(data)) {

--- a/packages/shared-ini-file-loader/src/getProfileData.ts
+++ b/packages/shared-ini-file-loader/src/getProfileData.ts
@@ -2,7 +2,7 @@ import { ParsedIniData } from "@aws-sdk/types";
 
 const profileKeyRegex = /^profile\s(["'])?([^\1]+)\1$/;
 
-export const normalizeConfigFile = (data: ParsedIniData): ParsedIniData => {
+export const getProfileData = (data: ParsedIniData): ParsedIniData => {
   const map: ParsedIniData = {};
   for (const key of Object.keys(data)) {
     let matches: Array<string> | null;

--- a/packages/shared-ini-file-loader/src/getProfileData.ts
+++ b/packages/shared-ini-file-loader/src/getProfileData.ts
@@ -7,20 +7,11 @@ const profileKeyRegex = /^profile\s(["'])?([^\1]+)\1$/;
  * * Returns data for `default`
  * * Reads profileName after profile prefix including/excluding quotes
  */
-export const getProfileData = (data: ParsedIniData): ParsedIniData => {
-  const map: ParsedIniData = {};
-  for (const key of Object.keys(data)) {
-    let matches: Array<string> | null;
-    if (key === "default") {
-      map.default = data.default;
-    } else if ((matches = profileKeyRegex.exec(key))) {
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      const [_1, _2, normalizedKey] = matches;
-      if (normalizedKey) {
-        map[normalizedKey] = data[key];
-      }
-    }
-  }
-
-  return map;
-};
+export const getProfileData = (data: ParsedIniData): ParsedIniData =>
+  Object.entries(data)
+    // filter out non-profile keys
+    .filter(([key]) => profileKeyRegex.test(key))
+    .reduce((acc, [key, value]) => ({ ...acc, [profileKeyRegex.exec(key)[2]]: value }), {
+      // Populate default profile, if present.
+      ...(data.default && { default: data.default }),
+    });

--- a/packages/shared-ini-file-loader/src/getProfileData.ts
+++ b/packages/shared-ini-file-loader/src/getProfileData.ts
@@ -11,7 +11,8 @@ export const getProfileData = (data: ParsedIniData): ParsedIniData =>
   Object.entries(data)
     // filter out non-profile keys
     .filter(([key]) => profileKeyRegex.test(key))
-    .reduce((acc, [key, value]) => ({ ...acc, [profileKeyRegex.exec(key)[2]]: value }), {
+    // replace profile key with profile name
+    .reduce((acc, [key, value]) => ({ ...acc, [profileKeyRegex.exec(key)![2]]: value }), {
       // Populate default profile, if present.
       ...(data.default && { default: data.default }),
     });

--- a/packages/shared-ini-file-loader/src/loadSharedConfigFiles.spec.ts
+++ b/packages/shared-ini-file-loader/src/loadSharedConfigFiles.spec.ts
@@ -1,14 +1,14 @@
 import { join } from "path";
 
 import { getHomeDir } from "./getHomeDir";
+import { getProfileData } from "./getProfileData";
 import { ENV_CONFIG_PATH, ENV_CREDENTIALS_PATH, loadSharedConfigFiles } from "./loadSharedConfigFiles";
-import { normalizeConfigFile } from "./normalizeConfigFile";
 import { parseIni } from "./parseIni";
 import { slurpFile } from "./slurpFile";
 
 jest.mock("path");
 jest.mock("./getHomeDir");
-jest.mock("./normalizeConfigFile");
+jest.mock("./getProfileData");
 jest.mock("./parseIni");
 jest.mock("./slurpFile");
 
@@ -34,7 +34,7 @@ describe("loadSharedConfigFiles", () => {
     (join as jest.Mock).mockImplementation((...args) => args.join(mockSeparator));
     (getHomeDir as jest.Mock).mockReturnValue(mockHomeDir);
     (parseIni as jest.Mock).mockImplementation((args) => args);
-    (normalizeConfigFile as jest.Mock).mockImplementation((args) => args);
+    (getProfileData as jest.Mock).mockImplementation((args) => args);
     (slurpFile as jest.Mock).mockImplementation((path) => Promise.resolve(path));
   });
 
@@ -82,7 +82,7 @@ describe("loadSharedConfigFiles", () => {
     });
 
     it("when normalizeConfigFile throws error", async () => {
-      (normalizeConfigFile as jest.Mock).mockRejectedValue("error");
+      (getProfileData as jest.Mock).mockRejectedValue("error");
       const sharedConfigFiles = await loadSharedConfigFiles();
       expect(sharedConfigFiles).toStrictEqual({
         configFile: {},

--- a/packages/shared-ini-file-loader/src/loadSharedConfigFiles.ts
+++ b/packages/shared-ini-file-loader/src/loadSharedConfigFiles.ts
@@ -2,7 +2,7 @@ import { SharedConfigFiles } from "@aws-sdk/types";
 import { join } from "path";
 
 import { getHomeDir } from "./getHomeDir";
-import { normalizeConfigFile } from "./normalizeConfigFile";
+import { getProfileData } from "./getProfileData";
 import { parseIni } from "./parseIni";
 import { slurpFile } from "./slurpFile";
 
@@ -34,7 +34,7 @@ export const loadSharedConfigFiles = async (init: SharedConfigInit = {}): Promis
   } = init;
 
   const parsedFiles = await Promise.all([
-    slurpFile(configFilepath).then(parseIni).then(normalizeConfigFile).catch(swallowError),
+    slurpFile(configFilepath).then(parseIni).then(getProfileData).catch(swallowError),
     slurpFile(filepath).then(parseIni).catch(swallowError),
   ]);
 


### PR DESCRIPTION
### Issue
Internal JS-3252

### Description
Renames normalizeConfigFile to getProfileData

### Testing
CI

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
