### PR TITLE
chore(types): deprecate Profile in favor of ParsedIniSection

### DIFF
--- a/packages/types/src/profile.ts
+++ b/packages/types/src/profile.ts
@@ -1,14 +1,14 @@
-export interface ParsedIniSection {
+export interface IniSection {
   [key: string]: string | undefined;
 }
 
 /**
- * @deprecated: Please use ParsedIniSection
+ * @deprecated: Please use IniSection
  */
-export interface Profile extends ParsedIniSection {}
+export interface Profile extends IniSection {}
 
 export interface ParsedIniData {
-  [key: string]: ParsedIniSection;
+  [key: string]: IniSection;
 }
 
 export interface SharedConfigFiles {

--- a/packages/types/src/profile.ts
+++ b/packages/types/src/profile.ts
@@ -1,9 +1,14 @@
-export interface Profile {
+export interface ParsedIniSection {
   [key: string]: string | undefined;
 }
 
+/**
+ * @deprecated: Please use ParsedIniSection
+ */
+export interface Profile extends ParsedIniSection {}
+
 export interface ParsedIniData {
-  [key: string]: Profile;
+  [key: string]: ParsedIniSection;
 }
 
 export interface SharedConfigFiles {


### PR DESCRIPTION
### Issue
Internal JS-3252

### Description
Deprecates type Profile in favor of ParsedIniSection, as new sections would be introduced in parsed ini in future.

### Testing
Unit testing

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
