### PR TITLE
feat(credential-provider-imds): adjust static stability expiration to 5-10 mins

### DIFF
--- a/packages/credential-provider-imds/src/utils/getExtendedInstanceMetadataCredentials.spec.ts
+++ b/packages/credential-provider-imds/src/utils/getExtendedInstanceMetadataCredentials.spec.ts
@@ -21,13 +21,13 @@ describe("getExtendedInstanceMetadataCredentials()", () => {
     nowMock.mockRestore();
   });
 
-  it("should extend the expiration random time(~15 mins) from now", () => {
+  it("should extend the expiration random time(5~10 mins) from now", () => {
     const anyDate: Date = "any date" as unknown as Date;
     (Math.random as jest.Mock).mockReturnValue(0.5);
     expect(getExtendedInstanceMetadataCredentials({ ...staticSecret, expiration: anyDate }, logger)).toEqual({
       ...staticSecret,
       originalExpiration: anyDate,
-      expiration: new Date("2022-02-22T00:17:30Z"),
+      expiration: new Date("2022-02-22T00:07:30Z"),
     });
     expect(Math.random).toBeCalledTimes(1);
   });

--- a/packages/credential-provider-imds/src/utils/getExtendedInstanceMetadataCredentials.ts
+++ b/packages/credential-provider-imds/src/utils/getExtendedInstanceMetadataCredentials.ts
@@ -2,7 +2,7 @@ import { Logger } from "@aws-sdk/types";
 
 import { InstanceMetadataCredentials } from "../types";
 
-const STATIC_STABILITY_REFRESH_INTERVAL_SECONDS = 15 * 60;
+const STATIC_STABILITY_REFRESH_INTERVAL_SECONDS = 5 * 60;
 const STATIC_STABILITY_REFRESH_INTERVAL_JITTER_WINDOW_SECONDS = 5 * 60;
 const STATIC_STABILITY_DOC_URL = "https://docs.aws.amazon.com/sdkref/latest/guide/feature-static-credentials.html";
 


### PR DESCRIPTION
### Issue
Ref: JS-3624

### Description
The 10 minute limit is established to ensure disable Static Stability
in a reasonable amount of time (i.e. 30 minutes, 3x refresh window) and
minimizes time the expired credentials remain active.

### Testing
Unit test

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
