### PR TITLE
chore(client-kinesis): switch to H2 handler

### DIFF
--- a/clients/client-kinesis/jest.integ.config.js
+++ b/clients/client-kinesis/jest.integ.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "ts-jest",
+  testMatch: ["**/*.integ.spec.ts"],
+};

--- a/clients/client-kinesis/src/runtimeConfig.ts
+++ b/clients/client-kinesis/src/runtimeConfig.ts
@@ -17,7 +17,7 @@ import {
   NODE_RETRY_MODE_CONFIG_OPTIONS,
 } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
-import { NodeHttpHandler as RequestHandler, streamCollector } from "@aws-sdk/node-http-handler";
+import { NodeHttp2Handler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-node";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-node";
@@ -50,7 +50,7 @@ export const getRuntimeConfig = (config: KinesisClientConfig) => {
     eventStreamSerdeProvider: config?.eventStreamSerdeProvider ?? eventStreamSerdeProvider,
     maxAttempts: config?.maxAttempts ?? loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
     region: config?.region ?? loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
-    requestHandler: config?.requestHandler ?? new RequestHandler(defaultConfigProvider),
+    requestHandler: config?.requestHandler ?? new NodeHttp2Handler(),
     retryMode:
       config?.retryMode ??
       loadNodeConfig({

--- a/clients/client-kinesis/test/Kinesis.integ.spec.ts
+++ b/clients/client-kinesis/test/Kinesis.integ.spec.ts
@@ -1,0 +1,15 @@
+import { KinesisClient, ListStreamsCommand } from "../src/index";
+
+describe("@aws-sdk/client-kinesis", () => {
+  const client = new KinesisClient({});
+  const ONE_SECOND = 1 * 1000;
+
+  it(
+    `${ListStreamsCommand.name} should succeed`,
+    async () => {
+      const { StreamNames } = await client.send(new ListStreamsCommand({}));
+      expect(StreamNames).toBeInstanceOf(Array);
+    },
+    ONE_SECOND
+  );
+});

--- a/clients/client-kinesis/test/Kinesis.integ.spec.ts
+++ b/clients/client-kinesis/test/Kinesis.integ.spec.ts
@@ -10,6 +10,6 @@ describe("@aws-sdk/client-kinesis", () => {
       const { StreamNames } = await client.send(new ListStreamsCommand({}));
       expect(StreamNames).toBeInstanceOf(Array);
     },
-    ONE_SECOND
+    ONE_SECOND // prevent issue https://github.com/aws/aws-sdk-js-v3/issues/1206
   );
 });

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddHttp2Dependency.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddHttp2Dependency.java
@@ -16,9 +16,10 @@
 package software.amazon.smithy.aws.typescript.codegen;
 
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
-import software.amazon.smithy.aws.traits.ServiceTrait;
+import software.amazon.smithy.aws.traits.protocols.AwsProtocolTrait;
 import software.amazon.smithy.codegen.core.SymbolProvider;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.shapes.ServiceShape;
@@ -38,8 +39,7 @@ public class AddHttp2Dependency implements TypeScriptIntegration {
             TypeScriptSettings settings,
             Model model,
             SymbolProvider symbolProvider,
-            LanguageTarget target
-    ) {
+            LanguageTarget target) {
         if (!isHttp2Applicable(settings.getService(model))) {
             return Collections.emptyMap();
         }
@@ -57,9 +57,8 @@ public class AddHttp2Dependency implements TypeScriptIntegration {
     }
 
     private static boolean isHttp2Applicable(ServiceShape service) {
-        String serviceId = service.getTrait(ServiceTrait.class).map(ServiceTrait::getSdkId).orElse("");
-        // TODO: Add "Kinesis" service to http2 applicable, but blocked by potential breaking change.
-        // Reference: https://github.com/aws/aws-sdk-js-v3/issues/1206
-        return ListUtils.of("Lex Runtime V2", "Transcribe Streaming").contains(serviceId);
+        List<String> eventStreamFlag = service.getTrait(AwsProtocolTrait.class)
+                .map(AwsProtocolTrait::getEventStreamHttp).orElse(ListUtils.of());
+        return eventStreamFlag.contains("h2");
     }
 }


### PR DESCRIPTION
### Issue
Resolves: https://github.com/aws/aws-sdk-js-v3/issues/1206

### Description
Thanks to #3541, using HTTP/2 handler in service client is no longer blocked by weird socket timeout. This change removes hard-coding HTTP/2 clients but rely on the Smithy model. 

This change enable us to use HTTP/2 in Kinesis client without breaking customer. Added integration test for it.

This change doesn't include `defaultConfigProvider` to the handler constructor because none of the default config is applicable to HTTP/2 handler for now.

### Testing
Integration test

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
