### PR TITLE
chore(node-http-handler): h2 handler accept options in provider

### DIFF
--- a/packages/smithy-client/src/defaults-mode.ts
+++ b/packages/smithy-client/src/defaults-mode.ts
@@ -50,7 +50,20 @@ export type ResolvedDefaultsMode = Exclude<DefaultsMode, "auto">;
  * @internal
  */
 export interface DefaultsModeConfigs {
+  /**
+   * The retry mode describing how the retry strategy control the traffic flow.
+   */
   retryMode?: string;
+  /**
+   * The maximum time in milliseconds that the connection phase of a request
+   * may take before the connection attempt is abandoned.
+   */
   connectionTimeout?: number;
+  /**
+   * This timeout measures the time between when the first byte is sent over an
+   * established, open connection and when the last byte is received from the
+   * service. If the response is not received by the timeout, then the request
+   * is considered timed out.
+   */
   requestTimeout?: number;
 }


### PR DESCRIPTION
### Issue
Similar to #3545 

### Description
Support provider functions in the contructor of H2 handler.

### Testing
Unit test

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
