### PR TITLE
feat(clients): http2 handler accept parameters from default config provider

### DIFF
--- a/clients/client-kinesis/src/runtimeConfig.ts
+++ b/clients/client-kinesis/src/runtimeConfig.ts
@@ -17,7 +17,7 @@ import {
   NODE_RETRY_MODE_CONFIG_OPTIONS,
 } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
-import { NodeHttp2Handler, streamCollector } from "@aws-sdk/node-http-handler";
+import { NodeHttp2Handler as RequestHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-node";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-node";
@@ -50,7 +50,7 @@ export const getRuntimeConfig = (config: KinesisClientConfig) => {
     eventStreamSerdeProvider: config?.eventStreamSerdeProvider ?? eventStreamSerdeProvider,
     maxAttempts: config?.maxAttempts ?? loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
     region: config?.region ?? loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
-    requestHandler: config?.requestHandler ?? new NodeHttp2Handler(),
+    requestHandler: config?.requestHandler ?? new RequestHandler(defaultConfigProvider),
     retryMode:
       config?.retryMode ??
       loadNodeConfig({

--- a/clients/client-lex-runtime-v2/src/runtimeConfig.ts
+++ b/clients/client-lex-runtime-v2/src/runtimeConfig.ts
@@ -18,7 +18,7 @@ import {
   NODE_RETRY_MODE_CONFIG_OPTIONS,
 } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
-import { NodeHttp2Handler, streamCollector } from "@aws-sdk/node-http-handler";
+import { NodeHttp2Handler as RequestHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-node";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-node";
@@ -52,7 +52,7 @@ export const getRuntimeConfig = (config: LexRuntimeV2ClientConfig) => {
     eventStreamSerdeProvider: config?.eventStreamSerdeProvider ?? eventStreamSerdeProvider,
     maxAttempts: config?.maxAttempts ?? loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
     region: config?.region ?? loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
-    requestHandler: config?.requestHandler ?? new NodeHttp2Handler(),
+    requestHandler: config?.requestHandler ?? new RequestHandler(defaultConfigProvider),
     retryMode:
       config?.retryMode ??
       loadNodeConfig({

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddHttp2Dependency.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddHttp2Dependency.java
@@ -47,9 +47,9 @@ public class AddHttp2Dependency implements TypeScriptIntegration {
             case NODE:
                 return MapUtils.of("requestHandler", writer -> {
                     writer.addDependency(TypeScriptDependency.AWS_SDK_NODE_HTTP_HANDLER);
-                    writer.addImport("NodeHttp2Handler", "NodeHttp2Handler",
+                    writer.addImport("NodeHttp2Handler", "RequestHandler",
                             TypeScriptDependency.AWS_SDK_NODE_HTTP_HANDLER.packageName);
-                    writer.write("new NodeHttp2Handler()");
+                    writer.write("new RequestHandler(defaultConfigProvider)");
                 });
             default:
                 return Collections.emptyMap();


### PR DESCRIPTION
### Description
The default config provider may specify the request timeout, which is applicable to the H2 handler.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
