### PR TITLE
Fix NPE where data.Error is undefined from a 400 response

### DIFF
--- a/clients/client-auto-scaling/src/protocols/Aws_query.ts
+++ b/clients/client-auto-scaling/src/protocols/Aws_query.ts
@@ -10173,7 +10173,7 @@ const buildFormUrlencodedString = (formEntries: { [key: string]: string }): stri
     .join("&");
 
 const loadQueryErrorCode = (output: __HttpResponse, data: any): string => {
-  if (data.Error.Code !== undefined) {
+  if (data.Error?.Code !== undefined) {
     return data.Error.Code;
   }
   if (output.statusCode == 404) {

--- a/clients/client-cloudformation/src/protocols/Aws_query.ts
+++ b/clients/client-cloudformation/src/protocols/Aws_query.ts
@@ -10637,7 +10637,7 @@ const buildFormUrlencodedString = (formEntries: { [key: string]: string }): stri
     .join("&");
 
 const loadQueryErrorCode = (output: __HttpResponse, data: any): string => {
-  if (data.Error.Code !== undefined) {
+  if (data.Error?.Code !== undefined) {
     return data.Error.Code;
   }
   if (output.statusCode == 404) {

--- a/clients/client-cloudfront/src/protocols/Aws_restXml.ts
+++ b/clients/client-cloudfront/src/protocols/Aws_restXml.ts
@@ -17675,7 +17675,7 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
   });
 
 const loadRestXmlErrorCode = (output: __HttpResponse, data: any): string => {
-  if (data.Error.Code !== undefined) {
+  if (data.Error?.Code !== undefined) {
     return data.Error.Code;
   }
   if (output.statusCode == 404) {

--- a/clients/client-cloudsearch/src/protocols/Aws_query.ts
+++ b/clients/client-cloudsearch/src/protocols/Aws_query.ts
@@ -4286,7 +4286,7 @@ const buildFormUrlencodedString = (formEntries: { [key: string]: string }): stri
     .join("&");
 
 const loadQueryErrorCode = (output: __HttpResponse, data: any): string => {
-  if (data.Error.Code !== undefined) {
+  if (data.Error?.Code !== undefined) {
     return data.Error.Code;
   }
   if (output.statusCode == 404) {

--- a/clients/client-cloudwatch/src/protocols/Aws_query.ts
+++ b/clients/client-cloudwatch/src/protocols/Aws_query.ts
@@ -6092,7 +6092,7 @@ const buildFormUrlencodedString = (formEntries: { [key: string]: string }): stri
     .join("&");
 
 const loadQueryErrorCode = (output: __HttpResponse, data: any): string => {
-  if (data.Error.Code !== undefined) {
+  if (data.Error?.Code !== undefined) {
     return data.Error.Code;
   }
   if (output.statusCode == 404) {

--- a/clients/client-docdb/src/protocols/Aws_query.ts
+++ b/clients/client-docdb/src/protocols/Aws_query.ts
@@ -9336,7 +9336,7 @@ const buildFormUrlencodedString = (formEntries: { [key: string]: string }): stri
     .join("&");
 
 const loadQueryErrorCode = (output: __HttpResponse, data: any): string => {
-  if (data.Error.Code !== undefined) {
+  if (data.Error?.Code !== undefined) {
     return data.Error.Code;
   }
   if (output.statusCode == 404) {

--- a/clients/client-elastic-beanstalk/src/protocols/Aws_query.ts
+++ b/clients/client-elastic-beanstalk/src/protocols/Aws_query.ts
@@ -7586,7 +7586,7 @@ const buildFormUrlencodedString = (formEntries: { [key: string]: string }): stri
     .join("&");
 
 const loadQueryErrorCode = (output: __HttpResponse, data: any): string => {
-  if (data.Error.Code !== undefined) {
+  if (data.Error?.Code !== undefined) {
     return data.Error.Code;
   }
   if (output.statusCode == 404) {

--- a/clients/client-elastic-load-balancing-v2/src/protocols/Aws_query.ts
+++ b/clients/client-elastic-load-balancing-v2/src/protocols/Aws_query.ts
@@ -6912,7 +6912,7 @@ const buildFormUrlencodedString = (formEntries: { [key: string]: string }): stri
     .join("&");
 
 const loadQueryErrorCode = (output: __HttpResponse, data: any): string => {
-  if (data.Error.Code !== undefined) {
+  if (data.Error?.Code !== undefined) {
     return data.Error.Code;
   }
   if (output.statusCode == 404) {

--- a/clients/client-elastic-load-balancing/src/protocols/Aws_query.ts
+++ b/clients/client-elastic-load-balancing/src/protocols/Aws_query.ts
@@ -4822,7 +4822,7 @@ const buildFormUrlencodedString = (formEntries: { [key: string]: string }): stri
     .join("&");
 
 const loadQueryErrorCode = (output: __HttpResponse, data: any): string => {
-  if (data.Error.Code !== undefined) {
+  if (data.Error?.Code !== undefined) {
     return data.Error.Code;
   }
   if (output.statusCode == 404) {

--- a/clients/client-elasticache/src/protocols/Aws_query.ts
+++ b/clients/client-elasticache/src/protocols/Aws_query.ts
@@ -12824,7 +12824,7 @@ const buildFormUrlencodedString = (formEntries: { [key: string]: string }): stri
     .join("&");
 
 const loadQueryErrorCode = (output: __HttpResponse, data: any): string => {
-  if (data.Error.Code !== undefined) {
+  if (data.Error?.Code !== undefined) {
     return data.Error.Code;
   }
   if (output.statusCode == 404) {

--- a/clients/client-iam/src/protocols/Aws_query.ts
+++ b/clients/client-iam/src/protocols/Aws_query.ts
@@ -17913,7 +17913,7 @@ const buildFormUrlencodedString = (formEntries: { [key: string]: string }): stri
     .join("&");
 
 const loadQueryErrorCode = (output: __HttpResponse, data: any): string => {
-  if (data.Error.Code !== undefined) {
+  if (data.Error?.Code !== undefined) {
     return data.Error.Code;
   }
   if (output.statusCode == 404) {

--- a/clients/client-neptune/src/protocols/Aws_query.ts
+++ b/clients/client-neptune/src/protocols/Aws_query.ts
@@ -11567,7 +11567,7 @@ const buildFormUrlencodedString = (formEntries: { [key: string]: string }): stri
     .join("&");
 
 const loadQueryErrorCode = (output: __HttpResponse, data: any): string => {
-  if (data.Error.Code !== undefined) {
+  if (data.Error?.Code !== undefined) {
     return data.Error.Code;
   }
   if (output.statusCode == 404) {

--- a/clients/client-rds/src/protocols/Aws_query.ts
+++ b/clients/client-rds/src/protocols/Aws_query.ts
@@ -24526,7 +24526,7 @@ const buildFormUrlencodedString = (formEntries: { [key: string]: string }): stri
     .join("&");
 
 const loadQueryErrorCode = (output: __HttpResponse, data: any): string => {
-  if (data.Error.Code !== undefined) {
+  if (data.Error?.Code !== undefined) {
     return data.Error.Code;
   }
   if (output.statusCode == 404) {

--- a/clients/client-redshift/src/protocols/Aws_query.ts
+++ b/clients/client-redshift/src/protocols/Aws_query.ts
@@ -19787,7 +19787,7 @@ const buildFormUrlencodedString = (formEntries: { [key: string]: string }): stri
     .join("&");
 
 const loadQueryErrorCode = (output: __HttpResponse, data: any): string => {
-  if (data.Error.Code !== undefined) {
+  if (data.Error?.Code !== undefined) {
     return data.Error.Code;
   }
   if (output.statusCode == 404) {

--- a/clients/client-route-53/src/protocols/Aws_restXml.ts
+++ b/clients/client-route-53/src/protocols/Aws_restXml.ts
@@ -8868,7 +8868,7 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
   });
 
 const loadRestXmlErrorCode = (output: __HttpResponse, data: any): string => {
-  if (data.Error.Code !== undefined) {
+  if (data.Error?.Code !== undefined) {
     return data.Error.Code;
   }
   if (output.statusCode == 404) {

--- a/clients/client-s3-control/src/protocols/Aws_restXml.ts
+++ b/clients/client-s3-control/src/protocols/Aws_restXml.ts
@@ -9358,7 +9358,7 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
   });
 
 const loadRestXmlErrorCode = (output: __HttpResponse, data: any): string => {
-  if (data.Error.Code !== undefined) {
+  if (data.Error?.Code !== undefined) {
     return data.Error.Code;
   }
   if (output.statusCode == 404) {

--- a/clients/client-ses/src/protocols/Aws_query.ts
+++ b/clients/client-ses/src/protocols/Aws_query.ts
@@ -9321,7 +9321,7 @@ const buildFormUrlencodedString = (formEntries: { [key: string]: string }): stri
     .join("&");
 
 const loadQueryErrorCode = (output: __HttpResponse, data: any): string => {
-  if (data.Error.Code !== undefined) {
+  if (data.Error?.Code !== undefined) {
     return data.Error.Code;
   }
   if (output.statusCode == 404) {

--- a/clients/client-sns/src/protocols/Aws_query.ts
+++ b/clients/client-sns/src/protocols/Aws_query.ts
@@ -5539,7 +5539,7 @@ const buildFormUrlencodedString = (formEntries: { [key: string]: string }): stri
     .join("&");
 
 const loadQueryErrorCode = (output: __HttpResponse, data: any): string => {
-  if (data.Error.Code !== undefined) {
+  if (data.Error?.Code !== undefined) {
     return data.Error.Code;
   }
   if (output.statusCode == 404) {

--- a/clients/client-sqs/src/protocols/Aws_query.ts
+++ b/clients/client-sqs/src/protocols/Aws_query.ts
@@ -2860,7 +2860,7 @@ const buildFormUrlencodedString = (formEntries: { [key: string]: string }): stri
     .join("&");
 
 const loadQueryErrorCode = (output: __HttpResponse, data: any): string => {
-  if (data.Error.Code !== undefined) {
+  if (data.Error?.Code !== undefined) {
     return data.Error.Code;
   }
   if (output.statusCode == 404) {

--- a/clients/client-sts/src/protocols/Aws_query.ts
+++ b/clients/client-sts/src/protocols/Aws_query.ts
@@ -1330,7 +1330,7 @@ const buildFormUrlencodedString = (formEntries: { [key: string]: string }): stri
     .join("&");
 
 const loadQueryErrorCode = (output: __HttpResponse, data: any): string => {
-  if (data.Error.Code !== undefined) {
+  if (data.Error?.Code !== undefined) {
     return data.Error.Code;
   }
   if (output.statusCode == 404) {

--- a/private/aws-protocoltests-query/src/protocols/Aws_query.ts
+++ b/private/aws-protocoltests-query/src/protocols/Aws_query.ts
@@ -2907,7 +2907,7 @@ const buildFormUrlencodedString = (formEntries: { [key: string]: string }): stri
     .join("&");
 
 const loadQueryErrorCode = (output: __HttpResponse, data: any): string => {
-  if (data.Error.Code !== undefined) {
+  if (data.Error?.Code !== undefined) {
     return data.Error.Code;
   }
   if (output.statusCode == 404) {

--- a/private/aws-protocoltests-restxml/src/protocols/Aws_restXml.ts
+++ b/private/aws-protocoltests-restxml/src/protocols/Aws_restXml.ts
@@ -5879,7 +5879,7 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
   });
 
 const loadRestXmlErrorCode = (output: __HttpResponse, data: any): string => {
-  if (data.Error.Code !== undefined) {
+  if (data.Error?.Code !== undefined) {
     return data.Error.Code;
   }
   if (output.statusCode == 404) {


### PR DESCRIPTION
### Description
Sometimes (seemingly on a 400 response) the `Error` is undefined, and `data.Error.Code` throws a NPE.

### Testing
Existing tests should suffice.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
