### PR TITLE
chore(codegen): update to Smithy 1.21.x

### DIFF
--- a/codegen/build.gradle.kts
+++ b/codegen/build.gradle.kts
@@ -31,7 +31,7 @@ allprojects {
     version = "0.11.0"
 }
 
-extra["smithyVersion"] = "[1.19.0,1.20.0["
+extra["smithyVersion"] = "[1.21.0,1.22.0["
 
 // The root project doesn't produce a JAR.
 tasks["jar"].enabled = false


### PR DESCRIPTION
Also bumping smithy version for smithy-typescript-codegen in https://github.com/awslabs/smithy-typescript/pull/540

### Testing 

Using locally published smithy-typescript-codegen and smithy-aws-typescript-codegen, ran
`yarn generate-clients && yarn test:protocols && yarn generate-clients -s && yarn test:server-protocols`

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
