### PR TITLE
chore(lib-storage): narrow types in Upload

### DIFF
--- a/lib/lib-storage/README.md
+++ b/lib/lib-storage/README.md
@@ -8,26 +8,28 @@
 Upload allows for easy and efficient uploading of buffers, blobs, or streams, using a configurable amount of concurrency to perform multipart uploads where possible. This abstraction enables uploading large files or streams of unknown size due to the use of multipart uploads under the hood.
 
 ```js
-  import { Upload } from "@aws-sdk/lib-storage";
-  import { S3Client, S3 } from "@aws-sdk/client-s3";
+import { Upload } from "@aws-sdk/lib-storage";
+import { S3Client, S3 } from "@aws-sdk/client-s3";
 
-  const target = { Bucket, Key, Body };
-  try {
-    const parallelUploads3 = new Upload({
-      client: new S3({}) || new S3Client({}),
-      tags: [...], // optional tags
-      queueSize: 4, // optional concurrency configuration
-      partSize: 5MB, // optional size of each part
-      leavePartsOnError: false, // optional manually handle dropped parts
-      params: target,
-    });
+try {
+  const parallelUploads3 = new Upload({
+    client: new S3({}) || new S3Client({}),
+    params: { Bucket, Key, Body },
 
-    parallelUploads3.on("httpUploadProgress", (progress) => {
-      console.log(progress);
-    });
+    tags: [
+      /*...*/
+    ], // optional tags
+    queueSize: 4, // optional concurrency configuration
+    partSize: 1024 * 1024 * 5, // optional size of each part, in bytes, at least 5MB
+    leavePartsOnError: false, // optional manually handle dropped parts
+  });
 
-    await parallelUploads3.done();
-  } catch (e) {
-    console.log(e);
-  }
+  parallelUploads3.on("httpUploadProgress", (progress) => {
+    console.log(progress);
+  });
+
+  await parallelUploads3.done();
+} catch (e) {
+  console.log(e);
+}
 ```

--- a/lib/lib-storage/src/Upload.ts
+++ b/lib/lib-storage/src/Upload.ts
@@ -59,7 +59,7 @@ export class Upload extends EventEmitter {
   private isMultiPart = true;
   private singleUploadResult?: CompleteMultipartUploadCommandOutput;
 
-  constructor(options: Options & { client: S3Client }) {
+  constructor(options: Options) {
     super();
 
     // set defaults from options.

--- a/lib/lib-storage/src/types.ts
+++ b/lib/lib-storage/src/types.ts
@@ -11,6 +11,9 @@ export interface Progress {
 // string | Uint8Array | Buffer | Readable | ReadableStream | Blob.
 export type BodyDataTypes = PutObjectCommandInput["Body"];
 
+/**
+ * @deprecated redundant, use {@link S3Client} directly.
+ */
 export type ServiceClients = S3Client;
 
 export interface Configuration {
@@ -49,5 +52,5 @@ export interface Options extends Partial<Configuration> {
    * A service client.
    * This the target where we upload data.
    */
-  client: ServiceClients;
+  client: S3Client;
 }


### PR DESCRIPTION
### Issue
Followup to https://github.com/aws/aws-sdk-js-v3/issues/2694
and its PR: https://github.com/aws/aws-sdk-js-v3/pull/2700

### Description
Clean up some type declarations in Upload.ts
- narrower input and output types
- add access modifiers to methods
- add explicit return types

### Testing
Ran existing unit tests.