### PR TITLE
chore(signature-v4-crt): bump aws-crt to 1.22.2

### DIFF
--- a/packages/signature-v4-crt/package.json
+++ b/packages/signature-v4-crt/package.json
@@ -26,7 +26,7 @@
     "@aws-sdk/util-hex-encoding": "*",
     "@aws-sdk/util-middleware": "*",
     "@aws-sdk/util-uri-escape": "*",
-    "aws-crt": "^1.12.1",
+    "aws-crt": "^1.12.2",
     "tslib": "^2.3.1"
   },
   "devDependencies": {

--- a/packages/signature-v4-multi-region/package.json
+++ b/packages/signature-v4-multi-region/package.json
@@ -41,7 +41,7 @@
     "typescript": "~4.6.2"
   },
   "peerDependencies": {
-    "@aws-sdk/signature-v4-crt": "^3.66.0"
+    "@aws-sdk/signature-v4-crt": "^3.79.0"
   },
   "peerDependenciesMeta": {
     "@aws-sdk/signature-v4-crt": {


### PR DESCRIPTION
### Description
The aws-crt dependency starts to support [Apple M1](https://github.com/awslabs/aws-crt-nodejs/commit/05389e312a95b5d4377b4b9a745353f390dde45a) since latest 1.22.2. 

This change bumps the peer dependency requirement of aws-crt to the latest version

/cc @graebm

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
