### PR TITLE
Change `preprocessModel` to take `Model` instead of `PluginContext`

### DIFF
--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddNimbleCustomizations.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddNimbleCustomizations.java
@@ -17,7 +17,6 @@ package software.amazon.smithy.aws.typescript.codegen;
 
 import java.util.Map;
 import software.amazon.smithy.aws.traits.ServiceTrait;
-import software.amazon.smithy.build.PluginContext;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.shapes.ServiceShape;
 import software.amazon.smithy.model.shapes.ShapeId;
@@ -35,12 +34,11 @@ import software.amazon.smithy.utils.SmithyInternalApi;
 public class AddNimbleCustomizations implements TypeScriptIntegration {
 
     @Override
-    public Model preprocessModel(PluginContext context, TypeScriptSettings settings) {
-        Model model = context.getModel();
+    public Model preprocessModel(Model model, TypeScriptSettings settings) {
         ServiceShape service = settings.getService(model);
         String serviceId = service.getTrait(ServiceTrait.class).map(ServiceTrait::getSdkId).orElse("");
         if (!serviceId.equals("nimble")) {
-            return context.getModel();
+            return model;
         }
         Map<ShapeId, ShapeType> overWriteTypeMap = MapUtils.of(
                 ShapeId.from("com.amazonaws.nimble#StudioComponentConfiguration"), ShapeType.STRUCTURE);

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddS3Config.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddS3Config.java
@@ -26,7 +26,6 @@ import java.util.Set;
 import java.util.function.Consumer;
 import java.util.logging.Logger;
 import software.amazon.smithy.aws.traits.ServiceTrait;
-import software.amazon.smithy.build.PluginContext;
 import software.amazon.smithy.codegen.core.SymbolProvider;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.knowledge.OperationIndex;
@@ -76,8 +75,7 @@ public final class AddS3Config implements TypeScriptIntegration {
             + "For more information, please go to https://github.com/aws/aws-sdk-js-v3#known-issues</p>";
 
     @Override
-    public Model preprocessModel(PluginContext context, TypeScriptSettings settings) {
-        Model model = context.getModel();
+    public Model preprocessModel(Model model, TypeScriptSettings settings) {
         ServiceShape serviceShape = settings.getService(model);
         if (!testServiceId(serviceShape)) {
             return model;

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddS3ControlDependency.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddS3ControlDependency.java
@@ -21,7 +21,6 @@ import static software.amazon.smithy.typescript.codegen.integration.RuntimeClien
 import java.util.List;
 import java.util.Optional;
 import software.amazon.smithy.aws.traits.ServiceTrait;
-import software.amazon.smithy.build.PluginContext;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.shapes.MemberShape;
 import software.amazon.smithy.model.shapes.OperationShape;
@@ -67,8 +66,7 @@ public class AddS3ControlDependency implements TypeScriptIntegration {
     }
 
     @Override
-    public Model preprocessModel(PluginContext context, TypeScriptSettings settings) {
-        Model model = context.getModel();
+    public Model preprocessModel(Model model, TypeScriptSettings settings) {
         if (!isS3Control(settings.getService(model))) {
             return model;
         }

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddS3ObjectSizeMemberShapeType.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddS3ObjectSizeMemberShapeType.java
@@ -18,7 +18,6 @@ package software.amazon.smithy.aws.typescript.codegen;
 import java.util.Map;
 import java.util.Set;
 import java.util.logging.Logger;
-import software.amazon.smithy.build.PluginContext;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.shapes.LongShape;
 import software.amazon.smithy.model.shapes.ShapeId;
@@ -49,8 +48,7 @@ public final class AddS3ObjectSizeMemberShapeType implements TypeScriptIntegrati
     }
 
     @Override
-    public Model preprocessModel(PluginContext context, TypeScriptSettings settings) {
-        Model model = context.getModel();
+    public Model preprocessModel(Model model, TypeScriptSettings settings) {
         ShapeId serviceId = settings.getService();
         if (!SERVICE_TO_SHAPE_MAP.containsKey(serviceId)) {
             return model;

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/StripNewEnumNames.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/StripNewEnumNames.java
@@ -19,7 +19,6 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
-import software.amazon.smithy.build.PluginContext;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.node.Node;
 import software.amazon.smithy.model.shapes.Shape;
@@ -59,8 +58,7 @@ public final class StripNewEnumNames implements TypeScriptIntegration {
     }
 
     @Override
-    public Model preprocessModel(PluginContext context, TypeScriptSettings settings) {
-        Model model = context.getModel();
+    public Model preprocessModel(Model model, TypeScriptSettings settings) {
         Set<Shape> shapesToUpdate = model.shapes(StringShape.class)
                 .filter(shape -> enumsToStrip.contains(shape.getId()))
                 .flatMap(shape -> Trait.flatMapStream(shape, EnumTrait.class))


### PR DESCRIPTION
Based on https://github.com/awslabs/smithy-typescript/pull/542. CI will fail till that's merged. Ran `yarn generate-clients && yarn test:protocols && yarn generate-clients -s && yarn test:server-protocols` locally with both PRs and no change to generated clients.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
