### PR TITLE
chore(codegen): refactor decorateSymbolProvider to match SmithyIntegration

### DIFF
--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsServiceIdIntegration.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsServiceIdIntegration.java
@@ -40,7 +40,7 @@ public final class AwsServiceIdIntegration implements TypeScriptIntegration {
 
     @Override
     public SymbolProvider decorateSymbolProvider(
-            TypeScriptSettings settings, Model model, SymbolProvider symbolProvider) {
+            Model model, TypeScriptSettings settings, SymbolProvider symbolProvider) {
         return shape -> {
             Symbol symbol = symbolProvider.toSymbol(shape);
 

--- a/codegen/smithy-aws-typescript-codegen/src/test/java/software/amazon/smithy/aws/typescript/codegen/AwsServiceIdIntegrationTest.java
+++ b/codegen/smithy-aws-typescript-codegen/src/test/java/software/amazon/smithy/aws/typescript/codegen/AwsServiceIdIntegrationTest.java
@@ -29,7 +29,7 @@ public class AwsServiceIdIntegrationTest {
         TypeScriptSettings settings = new TypeScriptSettings();
         settings.setService(ShapeId.from("smithy.example#OriginalName"));
         SymbolProvider provider = TypeScriptCodegenPlugin.createSymbolProvider(model, settings);
-        SymbolProvider decorated = integration.decorateSymbolProvider(settings, model, provider);
+        SymbolProvider decorated = integration.decorateSymbolProvider(model, settings, provider);
         Symbol symbol = decorated.toSymbol(service);
 
         assertThat(symbol.getName(), equalTo("NotSameClient"));
@@ -48,7 +48,7 @@ public class AwsServiceIdIntegrationTest {
         AwsServiceIdIntegration integration = new AwsServiceIdIntegration();
         TypeScriptSettings settings = new TypeScriptSettings();
         SymbolProvider provider = TypeScriptCodegenPlugin.createSymbolProvider(model, settings);
-        SymbolProvider decorated = integration.decorateSymbolProvider(settings, model, provider);
+        SymbolProvider decorated = integration.decorateSymbolProvider(model, settings, provider);
         Symbol symbol = decorated.toSymbol(service);
 
         assertThat(symbol.getName(), equalTo("FirstNotCapitalizedClient"));
@@ -68,7 +68,7 @@ public class AwsServiceIdIntegrationTest {
         AwsServiceIdIntegration integration = new AwsServiceIdIntegration();
         TypeScriptSettings settings = new TypeScriptSettings();
         SymbolProvider provider = TypeScriptCodegenPlugin.createSymbolProvider(model, settings);
-        SymbolProvider decorated = integration.decorateSymbolProvider(settings, model, provider);
+        SymbolProvider decorated = integration.decorateSymbolProvider(model, settings, provider);
         Symbol symbol = decorated.toSymbol(service);
 
         assertThat(symbol.getName(), equalTo("RestNotCapitalizedClient"));


### PR DESCRIPTION
Based on https://github.com/awslabs/smithy-typescript/pull/544. CI will fail till that's merged. Ran `yarn generate-clients && yarn test:protocols && yarn generate-clients -s && yarn test:server-protocols` locally with both PRs and no change to generated clients.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
