### PR TITLE
fix(node-http-handler): handle close event in H2 from server side

### DIFF
--- a/packages/node-http-handler/package.json
+++ b/packages/node-http-handler/package.json
@@ -36,12 +36,6 @@
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"
   },
-  "jest": {
-    "coveragePathIgnorePatterns": [
-      "/node_modules/",
-      "<rootDir>/*.mock.ts"
-    ]
-  },
   "engines": {
     "node": ">= 12.0.0"
   },

--- a/packages/node-http-handler/src/node-http2-handler.ts
+++ b/packages/node-http-handler/src/node-http2-handler.ts
@@ -190,6 +190,8 @@ export class NodeHttp2Handler implements HttpHandler {
     newSession.on("error", destroySessionCb);
     newSession.on("frameError", destroySessionCb);
 
+    newSession.on("close", () => this.deleteSessionFromCache(authority, newSession));
+
     if (this.config?.sessionTimeout) {
       newSession.setTimeout(this.config.sessionTimeout, destroySessionCb);
     }


### PR DESCRIPTION
### Issue
May fixes https://github.com/aws/aws-sdk-js-v3/pull/3577#issuecomment-1118870752. 

### Description
I found the H2 handler's session cache **cannot** evict the session if the session is closed from the server side. Hence when making the new request, the users will see error that the request made on destroyed session.

This change handles this event. I also re-evaluated the [current session events](https://nodejs.org/api/http2.html#class-http2session), and made sure the necessary events are handled.

### Testing
Unit test

### Additional Infomation
Whether this will fix the mentioned issue cannot be fully confirmed without server-side logs. But I could reproduce the same mentioned issue by server-side closing the session.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
