### PR TITLE
chore(clients): remove unnecessary MetadataBearer imports

### DIFF
--- a/clients/client-accessanalyzer/src/models/models_0.ts
+++ b/clients/client-accessanalyzer/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { AccessAnalyzerServiceException as __BaseException } from "./AccessAnalyzerServiceException";
 

--- a/clients/client-account/src/models/models_0.ts
+++ b/clients/client-account/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType, SENSITIVE_STRING } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { AccountServiceException as __BaseException } from "./AccountServiceException";
 

--- a/clients/client-acm-pca/src/models/models_0.ts
+++ b/clients/client-acm-pca/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { ACMPCAServiceException as __BaseException } from "./ACMPCAServiceException";
 

--- a/clients/client-acm/src/models/models_0.ts
+++ b/clients/client-acm/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType, SENSITIVE_STRING } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { ACMServiceException as __BaseException } from "./ACMServiceException";
 

--- a/clients/client-alexa-for-business/src/models/models_0.ts
+++ b/clients/client-alexa-for-business/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType, SENSITIVE_STRING } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { AlexaForBusinessServiceException as __BaseException } from "./AlexaForBusinessServiceException";
 

--- a/clients/client-amp/src/models/models_0.ts
+++ b/clients/client-amp/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { AmpServiceException as __BaseException } from "./AmpServiceException";
 

--- a/clients/client-amplify/src/models/models_0.ts
+++ b/clients/client-amplify/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType, SENSITIVE_STRING } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { AmplifyServiceException as __BaseException } from "./AmplifyServiceException";
 

--- a/clients/client-amplifybackend/src/models/models_0.ts
+++ b/clients/client-amplifybackend/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { AmplifyBackendServiceException as __BaseException } from "./AmplifyBackendServiceException";
 

--- a/clients/client-amplifyuibuilder/src/models/models_0.ts
+++ b/clients/client-amplifyuibuilder/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType, SENSITIVE_STRING } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { AmplifyUIBuilderServiceException as __BaseException } from "./AmplifyUIBuilderServiceException";
 

--- a/clients/client-api-gateway/src/models/models_0.ts
+++ b/clients/client-api-gateway/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { APIGatewayServiceException as __BaseException } from "./APIGatewayServiceException";
 

--- a/clients/client-apigatewaymanagementapi/src/models/models_0.ts
+++ b/clients/client-apigatewaymanagementapi/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { ApiGatewayManagementApiServiceException as __BaseException } from "./ApiGatewayManagementApiServiceException";
 

--- a/clients/client-apigatewayv2/src/models/models_0.ts
+++ b/clients/client-apigatewayv2/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { ApiGatewayV2ServiceException as __BaseException } from "./ApiGatewayV2ServiceException";
 

--- a/clients/client-app-mesh/src/models/models_0.ts
+++ b/clients/client-app-mesh/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { AppMeshServiceException as __BaseException } from "./AppMeshServiceException";
 

--- a/clients/client-appconfig/src/models/models_0.ts
+++ b/clients/client-appconfig/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType, SENSITIVE_STRING } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { AppConfigServiceException as __BaseException } from "./AppConfigServiceException";
 

--- a/clients/client-appconfigdata/src/models/models_0.ts
+++ b/clients/client-appconfigdata/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType, SENSITIVE_STRING } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { AppConfigDataServiceException as __BaseException } from "./AppConfigDataServiceException";
 

--- a/clients/client-appflow/src/models/models_0.ts
+++ b/clients/client-appflow/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType, SENSITIVE_STRING } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { AppflowServiceException as __BaseException } from "./AppflowServiceException";
 

--- a/clients/client-appintegrations/src/models/models_0.ts
+++ b/clients/client-appintegrations/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { AppIntegrationsServiceException as __BaseException } from "./AppIntegrationsServiceException";
 

--- a/clients/client-application-auto-scaling/src/models/models_0.ts
+++ b/clients/client-application-auto-scaling/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { ApplicationAutoScalingServiceException as __BaseException } from "./ApplicationAutoScalingServiceException";
 

--- a/clients/client-application-discovery-service/src/models/models_0.ts
+++ b/clients/client-application-discovery-service/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { ApplicationDiscoveryServiceServiceException as __BaseException } from "./ApplicationDiscoveryServiceServiceException";
 

--- a/clients/client-application-insights/src/models/models_0.ts
+++ b/clients/client-application-insights/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { ApplicationInsightsServiceException as __BaseException } from "./ApplicationInsightsServiceException";
 

--- a/clients/client-applicationcostprofiler/src/models/models_0.ts
+++ b/clients/client-applicationcostprofiler/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { ApplicationCostProfilerServiceException as __BaseException } from "./ApplicationCostProfilerServiceException";
 

--- a/clients/client-apprunner/src/models/models_0.ts
+++ b/clients/client-apprunner/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType, SENSITIVE_STRING } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { AppRunnerServiceException as __BaseException } from "./AppRunnerServiceException";
 

--- a/clients/client-appstream/src/models/models_0.ts
+++ b/clients/client-appstream/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType, SENSITIVE_STRING } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { AppStreamServiceException as __BaseException } from "./AppStreamServiceException";
 

--- a/clients/client-appsync/src/models/models_0.ts
+++ b/clients/client-appsync/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { AppSyncServiceException as __BaseException } from "./AppSyncServiceException";
 

--- a/clients/client-athena/src/models/models_0.ts
+++ b/clients/client-athena/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { AthenaServiceException as __BaseException } from "./AthenaServiceException";
 

--- a/clients/client-auditmanager/src/models/models_0.ts
+++ b/clients/client-auditmanager/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { AuditManagerServiceException as __BaseException } from "./AuditManagerServiceException";
 

--- a/clients/client-auto-scaling-plans/src/models/models_0.ts
+++ b/clients/client-auto-scaling-plans/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { AutoScalingPlansServiceException as __BaseException } from "./AutoScalingPlansServiceException";
 

--- a/clients/client-auto-scaling/src/models/models_0.ts
+++ b/clients/client-auto-scaling/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { AutoScalingServiceException as __BaseException } from "./AutoScalingServiceException";
 

--- a/clients/client-backup-gateway/src/models/models_0.ts
+++ b/clients/client-backup-gateway/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType, SENSITIVE_STRING } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { BackupGatewayServiceException as __BaseException } from "./BackupGatewayServiceException";
 

--- a/clients/client-backup/src/models/models_0.ts
+++ b/clients/client-backup/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType, SENSITIVE_STRING } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { BackupServiceException as __BaseException } from "./BackupServiceException";
 

--- a/clients/client-batch/src/models/models_0.ts
+++ b/clients/client-batch/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { BatchServiceException as __BaseException } from "./BatchServiceException";
 

--- a/clients/client-billingconductor/src/models/models_0.ts
+++ b/clients/client-billingconductor/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType, SENSITIVE_STRING } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { BillingconductorServiceException as __BaseException } from "./BillingconductorServiceException";
 

--- a/clients/client-braket/src/models/models_0.ts
+++ b/clients/client-braket/src/models/models_0.ts
@@ -3,7 +3,6 @@ import {
   ExceptionOptionType as __ExceptionOptionType,
   LazyJsonString as __LazyJsonString,
 } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { BraketServiceException as __BaseException } from "./BraketServiceException";
 

--- a/clients/client-budgets/src/models/models_0.ts
+++ b/clients/client-budgets/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType, SENSITIVE_STRING } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { BudgetsServiceException as __BaseException } from "./BudgetsServiceException";
 

--- a/clients/client-chime-sdk-identity/src/models/models_0.ts
+++ b/clients/client-chime-sdk-identity/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType, SENSITIVE_STRING } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { ChimeSDKIdentityServiceException as __BaseException } from "./ChimeSDKIdentityServiceException";
 

--- a/clients/client-chime-sdk-media-pipelines/src/models/models_0.ts
+++ b/clients/client-chime-sdk-media-pipelines/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType, SENSITIVE_STRING } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { ChimeSDKMediaPipelinesServiceException as __BaseException } from "./ChimeSDKMediaPipelinesServiceException";
 

--- a/clients/client-chime-sdk-meetings/src/models/models_0.ts
+++ b/clients/client-chime-sdk-meetings/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType, SENSITIVE_STRING } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { ChimeSDKMeetingsServiceException as __BaseException } from "./ChimeSDKMeetingsServiceException";
 

--- a/clients/client-chime-sdk-messaging/src/models/models_0.ts
+++ b/clients/client-chime-sdk-messaging/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType, SENSITIVE_STRING } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { ChimeSDKMessagingServiceException as __BaseException } from "./ChimeSDKMessagingServiceException";
 

--- a/clients/client-chime/src/models/models_0.ts
+++ b/clients/client-chime/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType, SENSITIVE_STRING } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { ChimeServiceException as __BaseException } from "./ChimeServiceException";
 

--- a/clients/client-cloud9/src/models/models_0.ts
+++ b/clients/client-cloud9/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType, SENSITIVE_STRING } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { Cloud9ServiceException as __BaseException } from "./Cloud9ServiceException";
 

--- a/clients/client-cloudcontrol/src/models/models_0.ts
+++ b/clients/client-cloudcontrol/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType, SENSITIVE_STRING } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { CloudControlServiceException as __BaseException } from "./CloudControlServiceException";
 

--- a/clients/client-clouddirectory/src/models/models_0.ts
+++ b/clients/client-clouddirectory/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { CloudDirectoryServiceException as __BaseException } from "./CloudDirectoryServiceException";
 

--- a/clients/client-cloudformation/src/models/models_0.ts
+++ b/clients/client-cloudformation/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { CloudFormationServiceException as __BaseException } from "./CloudFormationServiceException";
 

--- a/clients/client-cloudfront/src/models/models_0.ts
+++ b/clients/client-cloudfront/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType, SENSITIVE_STRING } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { CloudFrontServiceException as __BaseException } from "./CloudFrontServiceException";
 

--- a/clients/client-cloudfront/src/models/models_1.ts
+++ b/clients/client-cloudfront/src/models/models_1.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType, SENSITIVE_STRING } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { CloudFrontServiceException as __BaseException } from "./CloudFrontServiceException";
 import {

--- a/clients/client-cloudhsm-v2/src/models/models_0.ts
+++ b/clients/client-cloudhsm-v2/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { CloudHSMV2ServiceException as __BaseException } from "./CloudHSMV2ServiceException";
 

--- a/clients/client-cloudhsm/src/models/models_0.ts
+++ b/clients/client-cloudhsm/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { CloudHSMServiceException as __BaseException } from "./CloudHSMServiceException";
 

--- a/clients/client-cloudsearch-domain/src/models/models_0.ts
+++ b/clients/client-cloudsearch-domain/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 import { Readable } from "stream";
 
 import { CloudSearchDomainServiceException as __BaseException } from "./CloudSearchDomainServiceException";

--- a/clients/client-cloudsearch/src/models/models_0.ts
+++ b/clients/client-cloudsearch/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { CloudSearchServiceException as __BaseException } from "./CloudSearchServiceException";
 

--- a/clients/client-cloudtrail/src/models/models_0.ts
+++ b/clients/client-cloudtrail/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { CloudTrailServiceException as __BaseException } from "./CloudTrailServiceException";
 

--- a/clients/client-cloudwatch-events/src/models/models_0.ts
+++ b/clients/client-cloudwatch-events/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { CloudWatchEventsServiceException as __BaseException } from "./CloudWatchEventsServiceException";
 

--- a/clients/client-cloudwatch-logs/src/models/models_0.ts
+++ b/clients/client-cloudwatch-logs/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { CloudWatchLogsServiceException as __BaseException } from "./CloudWatchLogsServiceException";
 

--- a/clients/client-cloudwatch/src/models/models_0.ts
+++ b/clients/client-cloudwatch/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { CloudWatchServiceException as __BaseException } from "./CloudWatchServiceException";
 

--- a/clients/client-codeartifact/src/models/models_0.ts
+++ b/clients/client-codeartifact/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 import { Readable } from "stream";
 
 import { CodeartifactServiceException as __BaseException } from "./CodeartifactServiceException";

--- a/clients/client-codebuild/src/models/models_0.ts
+++ b/clients/client-codebuild/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType, SENSITIVE_STRING } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { CodeBuildServiceException as __BaseException } from "./CodeBuildServiceException";
 

--- a/clients/client-codecommit/src/models/models_0.ts
+++ b/clients/client-codecommit/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { CodeCommitServiceException as __BaseException } from "./CodeCommitServiceException";
 

--- a/clients/client-codecommit/src/models/models_1.ts
+++ b/clients/client-codecommit/src/models/models_1.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { CodeCommitServiceException as __BaseException } from "./CodeCommitServiceException";
 import {

--- a/clients/client-codedeploy/src/models/models_0.ts
+++ b/clients/client-codedeploy/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { CodeDeployServiceException as __BaseException } from "./CodeDeployServiceException";
 

--- a/clients/client-codeguru-reviewer/src/models/models_0.ts
+++ b/clients/client-codeguru-reviewer/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { CodeGuruReviewerServiceException as __BaseException } from "./CodeGuruReviewerServiceException";
 

--- a/clients/client-codeguruprofiler/src/models/models_0.ts
+++ b/clients/client-codeguruprofiler/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { CodeGuruProfilerServiceException as __BaseException } from "./CodeGuruProfilerServiceException";
 

--- a/clients/client-codepipeline/src/models/models_0.ts
+++ b/clients/client-codepipeline/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType, SENSITIVE_STRING } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { CodePipelineServiceException as __BaseException } from "./CodePipelineServiceException";
 

--- a/clients/client-codestar-connections/src/models/models_0.ts
+++ b/clients/client-codestar-connections/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { CodeStarConnectionsServiceException as __BaseException } from "./CodeStarConnectionsServiceException";
 

--- a/clients/client-codestar-notifications/src/models/models_0.ts
+++ b/clients/client-codestar-notifications/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType, SENSITIVE_STRING } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { CodestarNotificationsServiceException as __BaseException } from "./CodestarNotificationsServiceException";
 

--- a/clients/client-codestar/src/models/models_0.ts
+++ b/clients/client-codestar/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType, SENSITIVE_STRING } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { CodeStarServiceException as __BaseException } from "./CodeStarServiceException";
 

--- a/clients/client-cognito-identity-provider/src/models/models_0.ts
+++ b/clients/client-cognito-identity-provider/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType, SENSITIVE_STRING } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { CognitoIdentityProviderServiceException as __BaseException } from "./CognitoIdentityProviderServiceException";
 

--- a/clients/client-cognito-identity-provider/src/models/models_1.ts
+++ b/clients/client-cognito-identity-provider/src/models/models_1.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType, SENSITIVE_STRING } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { CognitoIdentityProviderServiceException as __BaseException } from "./CognitoIdentityProviderServiceException";
 import {

--- a/clients/client-cognito-identity/src/models/models_0.ts
+++ b/clients/client-cognito-identity/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { CognitoIdentityServiceException as __BaseException } from "./CognitoIdentityServiceException";
 

--- a/clients/client-cognito-sync/src/models/models_0.ts
+++ b/clients/client-cognito-sync/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { CognitoSyncServiceException as __BaseException } from "./CognitoSyncServiceException";
 

--- a/clients/client-comprehend/src/models/models_0.ts
+++ b/clients/client-comprehend/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType, SENSITIVE_STRING } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { ComprehendServiceException as __BaseException } from "./ComprehendServiceException";
 

--- a/clients/client-comprehendmedical/src/models/models_0.ts
+++ b/clients/client-comprehendmedical/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { ComprehendMedicalServiceException as __BaseException } from "./ComprehendMedicalServiceException";
 

--- a/clients/client-compute-optimizer/src/models/models_0.ts
+++ b/clients/client-compute-optimizer/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { ComputeOptimizerServiceException as __BaseException } from "./ComputeOptimizerServiceException";
 

--- a/clients/client-config-service/src/models/models_0.ts
+++ b/clients/client-config-service/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { ConfigServiceServiceException as __BaseException } from "./ConfigServiceServiceException";
 

--- a/clients/client-config-service/src/models/models_1.ts
+++ b/clients/client-config-service/src/models/models_1.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { ConfigServiceServiceException as __BaseException } from "./ConfigServiceServiceException";
 import {

--- a/clients/client-connect-contact-lens/src/models/models_0.ts
+++ b/clients/client-connect-contact-lens/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { ConnectContactLensServiceException as __BaseException } from "./ConnectContactLensServiceException";
 

--- a/clients/client-connect/src/models/models_0.ts
+++ b/clients/client-connect/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType, SENSITIVE_STRING } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { ConnectServiceException as __BaseException } from "./ConnectServiceException";
 

--- a/clients/client-connect/src/models/models_1.ts
+++ b/clients/client-connect/src/models/models_1.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { ConnectServiceException as __BaseException } from "./ConnectServiceException";
 import {

--- a/clients/client-connectparticipant/src/models/models_0.ts
+++ b/clients/client-connectparticipant/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { ConnectParticipantServiceException as __BaseException } from "./ConnectParticipantServiceException";
 

--- a/clients/client-cost-and-usage-report-service/src/models/models_0.ts
+++ b/clients/client-cost-and-usage-report-service/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { CostAndUsageReportServiceServiceException as __BaseException } from "./CostAndUsageReportServiceServiceException";
 

--- a/clients/client-cost-explorer/src/models/models_0.ts
+++ b/clients/client-cost-explorer/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { CostExplorerServiceException as __BaseException } from "./CostExplorerServiceException";
 

--- a/clients/client-customer-profiles/src/models/models_0.ts
+++ b/clients/client-customer-profiles/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { CustomerProfilesServiceException as __BaseException } from "./CustomerProfilesServiceException";
 

--- a/clients/client-data-pipeline/src/models/models_0.ts
+++ b/clients/client-data-pipeline/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { DataPipelineServiceException as __BaseException } from "./DataPipelineServiceException";
 

--- a/clients/client-database-migration-service/src/models/models_0.ts
+++ b/clients/client-database-migration-service/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType, SENSITIVE_STRING } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { DatabaseMigrationServiceServiceException as __BaseException } from "./DatabaseMigrationServiceServiceException";
 

--- a/clients/client-databrew/src/models/models_0.ts
+++ b/clients/client-databrew/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType, SENSITIVE_STRING } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { DataBrewServiceException as __BaseException } from "./DataBrewServiceException";
 

--- a/clients/client-dataexchange/src/models/models_0.ts
+++ b/clients/client-dataexchange/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { DataExchangeServiceException as __BaseException } from "./DataExchangeServiceException";
 

--- a/clients/client-datasync/src/models/models_0.ts
+++ b/clients/client-datasync/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType, SENSITIVE_STRING } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { DataSyncServiceException as __BaseException } from "./DataSyncServiceException";
 

--- a/clients/client-dax/src/models/models_0.ts
+++ b/clients/client-dax/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { DAXServiceException as __BaseException } from "./DAXServiceException";
 

--- a/clients/client-detective/src/models/models_0.ts
+++ b/clients/client-detective/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { DetectiveServiceException as __BaseException } from "./DetectiveServiceException";
 

--- a/clients/client-device-farm/src/models/models_0.ts
+++ b/clients/client-device-farm/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType, SENSITIVE_STRING } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { DeviceFarmServiceException as __BaseException } from "./DeviceFarmServiceException";
 

--- a/clients/client-devops-guru/src/models/models_0.ts
+++ b/clients/client-devops-guru/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { DevOpsGuruServiceException as __BaseException } from "./DevOpsGuruServiceException";
 

--- a/clients/client-direct-connect/src/models/models_0.ts
+++ b/clients/client-direct-connect/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { DirectConnectServiceException as __BaseException } from "./DirectConnectServiceException";
 

--- a/clients/client-directory-service/src/models/models_0.ts
+++ b/clients/client-directory-service/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType, SENSITIVE_STRING } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { DirectoryServiceServiceException as __BaseException } from "./DirectoryServiceServiceException";
 

--- a/clients/client-dlm/src/models/models_0.ts
+++ b/clients/client-dlm/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { DLMServiceException as __BaseException } from "./DLMServiceException";
 

--- a/clients/client-docdb/src/models/models_0.ts
+++ b/clients/client-docdb/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { DocDBServiceException as __BaseException } from "./DocDBServiceException";
 

--- a/clients/client-drs/src/models/models_0.ts
+++ b/clients/client-drs/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType, SENSITIVE_STRING } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { DrsServiceException as __BaseException } from "./DrsServiceException";
 

--- a/clients/client-dynamodb-streams/src/models/models_0.ts
+++ b/clients/client-dynamodb-streams/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { DynamoDBStreamsServiceException as __BaseException } from "./DynamoDBStreamsServiceException";
 

--- a/clients/client-dynamodb/src/models/models_0.ts
+++ b/clients/client-dynamodb/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { DynamoDBServiceException as __BaseException } from "./DynamoDBServiceException";
 

--- a/clients/client-ebs/src/models/models_0.ts
+++ b/clients/client-ebs/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType, SENSITIVE_STRING } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 import { Readable } from "stream";
 
 import { EBSServiceException as __BaseException } from "./EBSServiceException";

--- a/clients/client-ec2-instance-connect/src/models/models_0.ts
+++ b/clients/client-ec2-instance-connect/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { EC2InstanceConnectServiceException as __BaseException } from "./EC2InstanceConnectServiceException";
 

--- a/clients/client-ecr-public/src/models/models_0.ts
+++ b/clients/client-ecr-public/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { ECRPUBLICServiceException as __BaseException } from "./ECRPUBLICServiceException";
 

--- a/clients/client-ecr/src/models/models_0.ts
+++ b/clients/client-ecr/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { ECRServiceException as __BaseException } from "./ECRServiceException";
 

--- a/clients/client-ecs/src/models/models_0.ts
+++ b/clients/client-ecs/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType, SENSITIVE_STRING } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { ECSServiceException as __BaseException } from "./ECSServiceException";
 

--- a/clients/client-efs/src/models/models_0.ts
+++ b/clients/client-efs/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { EFSServiceException as __BaseException } from "./EFSServiceException";
 

--- a/clients/client-eks/src/models/models_0.ts
+++ b/clients/client-eks/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { EKSServiceException as __BaseException } from "./EKSServiceException";
 

--- a/clients/client-elastic-beanstalk/src/models/models_0.ts
+++ b/clients/client-elastic-beanstalk/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { ElasticBeanstalkServiceException as __BaseException } from "./ElasticBeanstalkServiceException";
 

--- a/clients/client-elastic-inference/src/models/models_0.ts
+++ b/clients/client-elastic-inference/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { ElasticInferenceServiceException as __BaseException } from "./ElasticInferenceServiceException";
 

--- a/clients/client-elastic-load-balancing-v2/src/models/models_0.ts
+++ b/clients/client-elastic-load-balancing-v2/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { ElasticLoadBalancingV2ServiceException as __BaseException } from "./ElasticLoadBalancingV2ServiceException";
 

--- a/clients/client-elastic-load-balancing/src/models/models_0.ts
+++ b/clients/client-elastic-load-balancing/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { ElasticLoadBalancingServiceException as __BaseException } from "./ElasticLoadBalancingServiceException";
 

--- a/clients/client-elastic-transcoder/src/models/models_0.ts
+++ b/clients/client-elastic-transcoder/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { ElasticTranscoderServiceException as __BaseException } from "./ElasticTranscoderServiceException";
 

--- a/clients/client-elasticache/src/models/models_0.ts
+++ b/clients/client-elasticache/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { ElastiCacheServiceException as __BaseException } from "./ElastiCacheServiceException";
 

--- a/clients/client-elasticsearch-service/src/models/models_0.ts
+++ b/clients/client-elasticsearch-service/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType, SENSITIVE_STRING } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { ElasticsearchServiceServiceException as __BaseException } from "./ElasticsearchServiceServiceException";
 

--- a/clients/client-emr-containers/src/models/models_0.ts
+++ b/clients/client-emr-containers/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType, SENSITIVE_STRING } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { EMRContainersServiceException as __BaseException } from "./EMRContainersServiceException";
 

--- a/clients/client-emr/src/models/models_0.ts
+++ b/clients/client-emr/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { EMRServiceException as __BaseException } from "./EMRServiceException";
 

--- a/clients/client-eventbridge/src/models/models_0.ts
+++ b/clients/client-eventbridge/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { EventBridgeServiceException as __BaseException } from "./EventBridgeServiceException";
 

--- a/clients/client-evidently/src/models/models_0.ts
+++ b/clients/client-evidently/src/models/models_0.ts
@@ -3,7 +3,6 @@ import {
   ExceptionOptionType as __ExceptionOptionType,
   LazyJsonString as __LazyJsonString,
 } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { EvidentlyServiceException as __BaseException } from "./EvidentlyServiceException";
 

--- a/clients/client-finspace-data/src/models/models_0.ts
+++ b/clients/client-finspace-data/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType, SENSITIVE_STRING } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { FinspaceDataServiceException as __BaseException } from "./FinspaceDataServiceException";
 

--- a/clients/client-finspace/src/models/models_0.ts
+++ b/clients/client-finspace/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType, SENSITIVE_STRING } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { FinspaceServiceException as __BaseException } from "./FinspaceServiceException";
 

--- a/clients/client-firehose/src/models/models_0.ts
+++ b/clients/client-firehose/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType, SENSITIVE_STRING } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { FirehoseServiceException as __BaseException } from "./FirehoseServiceException";
 

--- a/clients/client-fis/src/models/models_0.ts
+++ b/clients/client-fis/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { FisServiceException as __BaseException } from "./FisServiceException";
 

--- a/clients/client-fms/src/models/models_0.ts
+++ b/clients/client-fms/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { FMSServiceException as __BaseException } from "./FMSServiceException";
 

--- a/clients/client-forecast/src/models/models_0.ts
+++ b/clients/client-forecast/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType, SENSITIVE_STRING } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { ForecastServiceException as __BaseException } from "./ForecastServiceException";
 

--- a/clients/client-forecastquery/src/models/models_0.ts
+++ b/clients/client-forecastquery/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { ForecastqueryServiceException as __BaseException } from "./ForecastqueryServiceException";
 

--- a/clients/client-frauddetector/src/models/models_0.ts
+++ b/clients/client-frauddetector/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType, SENSITIVE_STRING } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { FraudDetectorServiceException as __BaseException } from "./FraudDetectorServiceException";
 

--- a/clients/client-fsx/src/models/models_0.ts
+++ b/clients/client-fsx/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType, SENSITIVE_STRING } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { FSxServiceException as __BaseException } from "./FSxServiceException";
 

--- a/clients/client-gamelift/src/models/models_0.ts
+++ b/clients/client-gamelift/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType, SENSITIVE_STRING } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { GameLiftServiceException as __BaseException } from "./GameLiftServiceException";
 

--- a/clients/client-gamesparks/src/models/models_0.ts
+++ b/clients/client-gamesparks/src/models/models_0.ts
@@ -1,6 +1,6 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { DocumentType as __DocumentType, MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
+import { DocumentType as __DocumentType } from "@aws-sdk/types";
 
 import { GameSparksServiceException as __BaseException } from "./GameSparksServiceException";
 

--- a/clients/client-glacier/src/models/models_0.ts
+++ b/clients/client-glacier/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 import { Readable } from "stream";
 
 import { GlacierServiceException as __BaseException } from "./GlacierServiceException";

--- a/clients/client-global-accelerator/src/models/models_0.ts
+++ b/clients/client-global-accelerator/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { GlobalAcceleratorServiceException as __BaseException } from "./GlobalAcceleratorServiceException";
 

--- a/clients/client-glue/src/models/models_0.ts
+++ b/clients/client-glue/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { GlueServiceException as __BaseException } from "./GlueServiceException";
 

--- a/clients/client-glue/src/models/models_1.ts
+++ b/clients/client-glue/src/models/models_1.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { GlueServiceException as __BaseException } from "./GlueServiceException";
 import {

--- a/clients/client-glue/src/models/models_2.ts
+++ b/clients/client-glue/src/models/models_2.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType, SENSITIVE_STRING } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { GlueServiceException as __BaseException } from "./GlueServiceException";
 import {

--- a/clients/client-grafana/src/models/models_0.ts
+++ b/clients/client-grafana/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType, SENSITIVE_STRING } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { GrafanaServiceException as __BaseException } from "./GrafanaServiceException";
 

--- a/clients/client-greengrass/src/models/models_0.ts
+++ b/clients/client-greengrass/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { GreengrassServiceException as __BaseException } from "./GreengrassServiceException";
 

--- a/clients/client-greengrassv2/src/models/models_0.ts
+++ b/clients/client-greengrassv2/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { GreengrassV2ServiceException as __BaseException } from "./GreengrassV2ServiceException";
 

--- a/clients/client-groundstation/src/models/models_0.ts
+++ b/clients/client-groundstation/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { GroundStationServiceException as __BaseException } from "./GroundStationServiceException";
 

--- a/clients/client-guardduty/src/models/models_0.ts
+++ b/clients/client-guardduty/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { GuardDutyServiceException as __BaseException } from "./GuardDutyServiceException";
 

--- a/clients/client-health/src/models/models_0.ts
+++ b/clients/client-health/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { HealthServiceException as __BaseException } from "./HealthServiceException";
 

--- a/clients/client-healthlake/src/models/models_0.ts
+++ b/clients/client-healthlake/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { HealthLakeServiceException as __BaseException } from "./HealthLakeServiceException";
 

--- a/clients/client-honeycode/src/models/models_0.ts
+++ b/clients/client-honeycode/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType, SENSITIVE_STRING } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { HoneycodeServiceException as __BaseException } from "./HoneycodeServiceException";
 

--- a/clients/client-iam/src/models/models_0.ts
+++ b/clients/client-iam/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType, SENSITIVE_STRING } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { IAMServiceException as __BaseException } from "./IAMServiceException";
 

--- a/clients/client-iam/src/models/models_1.ts
+++ b/clients/client-iam/src/models/models_1.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType, SENSITIVE_STRING } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { IAMServiceException as __BaseException } from "./IAMServiceException";
 import { Role, ServerCertificateMetadata, SigningCertificate, SSHPublicKey, StatusType, Tag } from "./models_0";

--- a/clients/client-identitystore/src/models/models_0.ts
+++ b/clients/client-identitystore/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType, SENSITIVE_STRING } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { IdentitystoreServiceException as __BaseException } from "./IdentitystoreServiceException";
 

--- a/clients/client-imagebuilder/src/models/models_0.ts
+++ b/clients/client-imagebuilder/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { ImagebuilderServiceException as __BaseException } from "./ImagebuilderServiceException";
 

--- a/clients/client-inspector/src/models/models_0.ts
+++ b/clients/client-inspector/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { InspectorServiceException as __BaseException } from "./InspectorServiceException";
 

--- a/clients/client-inspector2/src/models/models_0.ts
+++ b/clients/client-inspector2/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { Inspector2ServiceException as __BaseException } from "./Inspector2ServiceException";
 

--- a/clients/client-iot-1click-devices-service/src/models/models_0.ts
+++ b/clients/client-iot-1click-devices-service/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { IoT1ClickDevicesServiceServiceException as __BaseException } from "./IoT1ClickDevicesServiceServiceException";
 

--- a/clients/client-iot-1click-projects/src/models/models_0.ts
+++ b/clients/client-iot-1click-projects/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { IoT1ClickProjectsServiceException as __BaseException } from "./IoT1ClickProjectsServiceException";
 

--- a/clients/client-iot-data-plane/src/models/models_0.ts
+++ b/clients/client-iot-data-plane/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { IoTDataPlaneServiceException as __BaseException } from "./IoTDataPlaneServiceException";
 

--- a/clients/client-iot-events-data/src/models/models_0.ts
+++ b/clients/client-iot-events-data/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { IoTEventsDataServiceException as __BaseException } from "./IoTEventsDataServiceException";
 

--- a/clients/client-iot-events/src/models/models_0.ts
+++ b/clients/client-iot-events/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { IoTEventsServiceException as __BaseException } from "./IoTEventsServiceException";
 

--- a/clients/client-iot-jobs-data-plane/src/models/models_0.ts
+++ b/clients/client-iot-jobs-data-plane/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { IoTJobsDataPlaneServiceException as __BaseException } from "./IoTJobsDataPlaneServiceException";
 

--- a/clients/client-iot-wireless/src/models/models_0.ts
+++ b/clients/client-iot-wireless/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType, SENSITIVE_STRING } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { IoTWirelessServiceException as __BaseException } from "./IoTWirelessServiceException";
 

--- a/clients/client-iot/src/models/models_0.ts
+++ b/clients/client-iot/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType, SENSITIVE_STRING } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { IoTServiceException as __BaseException } from "./IoTServiceException";
 

--- a/clients/client-iot/src/models/models_1.ts
+++ b/clients/client-iot/src/models/models_1.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { IoTServiceException as __BaseException } from "./IoTServiceException";
 import {

--- a/clients/client-iot/src/models/models_2.ts
+++ b/clients/client-iot/src/models/models_2.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { IoTServiceException as __BaseException } from "./IoTServiceException";
 import {

--- a/clients/client-iotanalytics/src/models/models_0.ts
+++ b/clients/client-iotanalytics/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { IoTAnalyticsServiceException as __BaseException } from "./IoTAnalyticsServiceException";
 

--- a/clients/client-iotdeviceadvisor/src/models/models_0.ts
+++ b/clients/client-iotdeviceadvisor/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { IotDeviceAdvisorServiceException as __BaseException } from "./IotDeviceAdvisorServiceException";
 

--- a/clients/client-iotfleethub/src/models/models_0.ts
+++ b/clients/client-iotfleethub/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { IoTFleetHubServiceException as __BaseException } from "./IoTFleetHubServiceException";
 

--- a/clients/client-iotsecuretunneling/src/models/models_0.ts
+++ b/clients/client-iotsecuretunneling/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType, SENSITIVE_STRING } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { IoTSecureTunnelingServiceException as __BaseException } from "./IoTSecureTunnelingServiceException";
 

--- a/clients/client-iotsitewise/src/models/models_0.ts
+++ b/clients/client-iotsitewise/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { IoTSiteWiseServiceException as __BaseException } from "./IoTSiteWiseServiceException";
 

--- a/clients/client-iotthingsgraph/src/models/models_0.ts
+++ b/clients/client-iotthingsgraph/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { IoTThingsGraphServiceException as __BaseException } from "./IoTThingsGraphServiceException";
 

--- a/clients/client-iottwinmaker/src/models/models_0.ts
+++ b/clients/client-iottwinmaker/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { IoTTwinMakerServiceException as __BaseException } from "./IoTTwinMakerServiceException";
 

--- a/clients/client-ivs/src/models/models_0.ts
+++ b/clients/client-ivs/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType, SENSITIVE_STRING } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { IvsServiceException as __BaseException } from "./IvsServiceException";
 

--- a/clients/client-ivschat/src/models/models_0.ts
+++ b/clients/client-ivschat/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { IvschatServiceException as __BaseException } from "./IvschatServiceException";
 

--- a/clients/client-kafka/src/models/models_0.ts
+++ b/clients/client-kafka/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { KafkaServiceException as __BaseException } from "./KafkaServiceException";
 

--- a/clients/client-kafkaconnect/src/models/models_0.ts
+++ b/clients/client-kafkaconnect/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType, SENSITIVE_STRING } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { KafkaConnectServiceException as __BaseException } from "./KafkaConnectServiceException";
 

--- a/clients/client-kendra/src/models/models_0.ts
+++ b/clients/client-kendra/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType, SENSITIVE_STRING } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { KendraServiceException as __BaseException } from "./KendraServiceException";
 

--- a/clients/client-keyspaces/src/models/models_0.ts
+++ b/clients/client-keyspaces/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { KeyspacesServiceException as __BaseException } from "./KeyspacesServiceException";
 

--- a/clients/client-kinesis-analytics-v2/src/models/models_0.ts
+++ b/clients/client-kinesis-analytics-v2/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { KinesisAnalyticsV2ServiceException as __BaseException } from "./KinesisAnalyticsV2ServiceException";
 

--- a/clients/client-kinesis-analytics/src/models/models_0.ts
+++ b/clients/client-kinesis-analytics/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { KinesisAnalyticsServiceException as __BaseException } from "./KinesisAnalyticsServiceException";
 

--- a/clients/client-kinesis-video-archived-media/src/models/models_0.ts
+++ b/clients/client-kinesis-video-archived-media/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 import { Readable } from "stream";
 
 import { KinesisVideoArchivedMediaServiceException as __BaseException } from "./KinesisVideoArchivedMediaServiceException";

--- a/clients/client-kinesis-video-media/src/models/models_0.ts
+++ b/clients/client-kinesis-video-media/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 import { Readable } from "stream";
 
 import { KinesisVideoMediaServiceException as __BaseException } from "./KinesisVideoMediaServiceException";

--- a/clients/client-kinesis-video-signaling/src/models/models_0.ts
+++ b/clients/client-kinesis-video-signaling/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { KinesisVideoSignalingServiceException as __BaseException } from "./KinesisVideoSignalingServiceException";
 

--- a/clients/client-kinesis-video/src/models/models_0.ts
+++ b/clients/client-kinesis-video/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { KinesisVideoServiceException as __BaseException } from "./KinesisVideoServiceException";
 

--- a/clients/client-kinesis/src/models/models_0.ts
+++ b/clients/client-kinesis/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { KinesisServiceException as __BaseException } from "./KinesisServiceException";
 

--- a/clients/client-kms/src/models/models_0.ts
+++ b/clients/client-kms/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType, SENSITIVE_STRING } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { KMSServiceException as __BaseException } from "./KMSServiceException";
 

--- a/clients/client-lakeformation/src/models/models_0.ts
+++ b/clients/client-lakeformation/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType, SENSITIVE_STRING } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 import { Readable } from "stream";
 
 import { LakeFormationServiceException as __BaseException } from "./LakeFormationServiceException";

--- a/clients/client-lambda/src/models/models_0.ts
+++ b/clients/client-lambda/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType, SENSITIVE_STRING } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 import { Readable } from "stream";
 
 import { LambdaServiceException as __BaseException } from "./LambdaServiceException";

--- a/clients/client-lex-model-building-service/src/models/models_0.ts
+++ b/clients/client-lex-model-building-service/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType, SENSITIVE_STRING } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { LexModelBuildingServiceServiceException as __BaseException } from "./LexModelBuildingServiceServiceException";
 

--- a/clients/client-lex-models-v2/src/models/models_0.ts
+++ b/clients/client-lex-models-v2/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType, SENSITIVE_STRING } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { LexModelsV2ServiceException as __BaseException } from "./LexModelsV2ServiceException";
 

--- a/clients/client-lex-runtime-service/src/models/models_0.ts
+++ b/clients/client-lex-runtime-service/src/models/models_0.ts
@@ -4,7 +4,6 @@ import {
   LazyJsonString as __LazyJsonString,
   SENSITIVE_STRING,
 } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 import { Readable } from "stream";
 
 import { LexRuntimeServiceServiceException as __BaseException } from "./LexRuntimeServiceServiceException";

--- a/clients/client-lex-runtime-v2/src/models/models_0.ts
+++ b/clients/client-lex-runtime-v2/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType, SENSITIVE_STRING } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 import { Readable } from "stream";
 
 import { LexRuntimeV2ServiceException as __BaseException } from "./LexRuntimeV2ServiceException";

--- a/clients/client-license-manager/src/models/models_0.ts
+++ b/clients/client-license-manager/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { LicenseManagerServiceException as __BaseException } from "./LicenseManagerServiceException";
 

--- a/clients/client-lightsail/src/models/models_0.ts
+++ b/clients/client-lightsail/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType, SENSITIVE_STRING } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { LightsailServiceException as __BaseException } from "./LightsailServiceException";
 

--- a/clients/client-location/src/models/models_0.ts
+++ b/clients/client-location/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType, SENSITIVE_STRING } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { LocationServiceException as __BaseException } from "./LocationServiceException";
 

--- a/clients/client-lookoutequipment/src/models/models_0.ts
+++ b/clients/client-lookoutequipment/src/models/models_0.ts
@@ -3,7 +3,6 @@ import {
   ExceptionOptionType as __ExceptionOptionType,
   LazyJsonString as __LazyJsonString,
 } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { LookoutEquipmentServiceException as __BaseException } from "./LookoutEquipmentServiceException";
 

--- a/clients/client-lookoutmetrics/src/models/models_0.ts
+++ b/clients/client-lookoutmetrics/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { LookoutMetricsServiceException as __BaseException } from "./LookoutMetricsServiceException";
 

--- a/clients/client-lookoutvision/src/models/models_0.ts
+++ b/clients/client-lookoutvision/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 import { Readable } from "stream";
 
 import { LookoutVisionServiceException as __BaseException } from "./LookoutVisionServiceException";

--- a/clients/client-machine-learning/src/models/models_0.ts
+++ b/clients/client-machine-learning/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { MachineLearningServiceException as __BaseException } from "./MachineLearningServiceException";
 

--- a/clients/client-macie/src/models/models_0.ts
+++ b/clients/client-macie/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { MacieServiceException as __BaseException } from "./MacieServiceException";
 

--- a/clients/client-macie2/src/models/models_0.ts
+++ b/clients/client-macie2/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { Macie2ServiceException as __BaseException } from "./Macie2ServiceException";
 

--- a/clients/client-managedblockchain/src/models/models_0.ts
+++ b/clients/client-managedblockchain/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType, SENSITIVE_STRING } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { ManagedBlockchainServiceException as __BaseException } from "./ManagedBlockchainServiceException";
 

--- a/clients/client-marketplace-catalog/src/models/models_0.ts
+++ b/clients/client-marketplace-catalog/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { MarketplaceCatalogServiceException as __BaseException } from "./MarketplaceCatalogServiceException";
 

--- a/clients/client-marketplace-commerce-analytics/src/models/models_0.ts
+++ b/clients/client-marketplace-commerce-analytics/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { MarketplaceCommerceAnalyticsServiceException as __BaseException } from "./MarketplaceCommerceAnalyticsServiceException";
 

--- a/clients/client-marketplace-entitlement-service/src/models/models_0.ts
+++ b/clients/client-marketplace-entitlement-service/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { MarketplaceEntitlementServiceServiceException as __BaseException } from "./MarketplaceEntitlementServiceServiceException";
 

--- a/clients/client-marketplace-metering/src/models/models_0.ts
+++ b/clients/client-marketplace-metering/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { MarketplaceMeteringServiceException as __BaseException } from "./MarketplaceMeteringServiceException";
 

--- a/clients/client-mediaconnect/src/models/models_0.ts
+++ b/clients/client-mediaconnect/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { MediaConnectServiceException as __BaseException } from "./MediaConnectServiceException";
 

--- a/clients/client-mediaconvert/src/models/models_1.ts
+++ b/clients/client-mediaconvert/src/models/models_1.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { MediaConvertServiceException as __BaseException } from "./MediaConvertServiceException";
 import {

--- a/clients/client-medialive/src/models/models_1.ts
+++ b/clients/client-medialive/src/models/models_1.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 import { Readable } from "stream";
 
 import { MediaLiveServiceException as __BaseException } from "./MediaLiveServiceException";

--- a/clients/client-mediapackage-vod/src/models/models_0.ts
+++ b/clients/client-mediapackage-vod/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { MediaPackageVodServiceException as __BaseException } from "./MediaPackageVodServiceException";
 

--- a/clients/client-mediapackage/src/models/models_0.ts
+++ b/clients/client-mediapackage/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { MediaPackageServiceException as __BaseException } from "./MediaPackageServiceException";
 

--- a/clients/client-mediastore-data/src/models/models_0.ts
+++ b/clients/client-mediastore-data/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 import { Readable } from "stream";
 
 import { MediaStoreDataServiceException as __BaseException } from "./MediaStoreDataServiceException";

--- a/clients/client-mediastore/src/models/models_0.ts
+++ b/clients/client-mediastore/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { MediaStoreServiceException as __BaseException } from "./MediaStoreServiceException";
 

--- a/clients/client-mediatailor/src/models/models_0.ts
+++ b/clients/client-mediatailor/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { MediaTailorServiceException as __BaseException } from "./MediaTailorServiceException";
 

--- a/clients/client-memorydb/src/models/models_0.ts
+++ b/clients/client-memorydb/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { MemoryDBServiceException as __BaseException } from "./MemoryDBServiceException";
 

--- a/clients/client-mgn/src/models/models_0.ts
+++ b/clients/client-mgn/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType, SENSITIVE_STRING } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { MgnServiceException as __BaseException } from "./MgnServiceException";
 

--- a/clients/client-migration-hub-refactor-spaces/src/models/models_0.ts
+++ b/clients/client-migration-hub-refactor-spaces/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType, SENSITIVE_STRING } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { MigrationHubRefactorSpacesServiceException as __BaseException } from "./MigrationHubRefactorSpacesServiceException";
 

--- a/clients/client-migration-hub/src/models/models_0.ts
+++ b/clients/client-migration-hub/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { MigrationHubServiceException as __BaseException } from "./MigrationHubServiceException";
 

--- a/clients/client-migrationhub-config/src/models/models_0.ts
+++ b/clients/client-migrationhub-config/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { MigrationHubConfigServiceException as __BaseException } from "./MigrationHubConfigServiceException";
 

--- a/clients/client-migrationhubstrategy/src/models/models_0.ts
+++ b/clients/client-migrationhubstrategy/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType, SENSITIVE_STRING } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { MigrationHubStrategyServiceException as __BaseException } from "./MigrationHubStrategyServiceException";
 

--- a/clients/client-mobile/src/models/models_0.ts
+++ b/clients/client-mobile/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { MobileServiceException as __BaseException } from "./MobileServiceException";
 

--- a/clients/client-mq/src/models/models_0.ts
+++ b/clients/client-mq/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { MqServiceException as __BaseException } from "./MqServiceException";
 

--- a/clients/client-mturk/src/models/models_0.ts
+++ b/clients/client-mturk/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { MTurkServiceException as __BaseException } from "./MTurkServiceException";
 

--- a/clients/client-mwaa/src/models/models_0.ts
+++ b/clients/client-mwaa/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType, SENSITIVE_STRING } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { MWAAServiceException as __BaseException } from "./MWAAServiceException";
 

--- a/clients/client-neptune/src/models/models_0.ts
+++ b/clients/client-neptune/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { NeptuneServiceException as __BaseException } from "./NeptuneServiceException";
 

--- a/clients/client-network-firewall/src/models/models_0.ts
+++ b/clients/client-network-firewall/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { NetworkFirewallServiceException as __BaseException } from "./NetworkFirewallServiceException";
 

--- a/clients/client-networkmanager/src/models/models_0.ts
+++ b/clients/client-networkmanager/src/models/models_0.ts
@@ -4,7 +4,6 @@ import {
   LazyJsonString as __LazyJsonString,
   SENSITIVE_STRING,
 } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { NetworkManagerServiceException as __BaseException } from "./NetworkManagerServiceException";
 

--- a/clients/client-nimble/src/models/models_0.ts
+++ b/clients/client-nimble/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType, SENSITIVE_STRING } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { NimbleServiceException as __BaseException } from "./NimbleServiceException";
 

--- a/clients/client-opensearch/src/models/models_0.ts
+++ b/clients/client-opensearch/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType, SENSITIVE_STRING } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { OpenSearchServiceException as __BaseException } from "./OpenSearchServiceException";
 

--- a/clients/client-opsworks/src/models/models_0.ts
+++ b/clients/client-opsworks/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { OpsWorksServiceException as __BaseException } from "./OpsWorksServiceException";
 

--- a/clients/client-opsworkscm/src/models/models_0.ts
+++ b/clients/client-opsworkscm/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType, SENSITIVE_STRING } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { OpsWorksCMServiceException as __BaseException } from "./OpsWorksCMServiceException";
 

--- a/clients/client-organizations/src/models/models_0.ts
+++ b/clients/client-organizations/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType, SENSITIVE_STRING } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { OrganizationsServiceException as __BaseException } from "./OrganizationsServiceException";
 

--- a/clients/client-outposts/src/models/models_0.ts
+++ b/clients/client-outposts/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { OutpostsServiceException as __BaseException } from "./OutpostsServiceException";
 

--- a/clients/client-panorama/src/models/models_0.ts
+++ b/clients/client-panorama/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType, SENSITIVE_STRING } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { PanoramaServiceException as __BaseException } from "./PanoramaServiceException";
 

--- a/clients/client-personalize-events/src/models/models_0.ts
+++ b/clients/client-personalize-events/src/models/models_0.ts
@@ -3,7 +3,6 @@ import {
   ExceptionOptionType as __ExceptionOptionType,
   LazyJsonString as __LazyJsonString,
 } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { PersonalizeEventsServiceException as __BaseException } from "./PersonalizeEventsServiceException";
 

--- a/clients/client-personalize-runtime/src/models/models_0.ts
+++ b/clients/client-personalize-runtime/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType, SENSITIVE_STRING } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { PersonalizeRuntimeServiceException as __BaseException } from "./PersonalizeRuntimeServiceException";
 

--- a/clients/client-personalize/src/models/models_0.ts
+++ b/clients/client-personalize/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType, SENSITIVE_STRING } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { PersonalizeServiceException as __BaseException } from "./PersonalizeServiceException";
 

--- a/clients/client-pi/src/models/models_0.ts
+++ b/clients/client-pi/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { PIServiceException as __BaseException } from "./PIServiceException";
 

--- a/clients/client-pinpoint-email/src/models/models_0.ts
+++ b/clients/client-pinpoint-email/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { PinpointEmailServiceException as __BaseException } from "./PinpointEmailServiceException";
 

--- a/clients/client-pinpoint-sms-voice-v2/src/models/models_0.ts
+++ b/clients/client-pinpoint-sms-voice-v2/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { PinpointSMSVoiceV2ServiceException as __BaseException } from "./PinpointSMSVoiceV2ServiceException";
 

--- a/clients/client-pinpoint-sms-voice/src/models/models_0.ts
+++ b/clients/client-pinpoint-sms-voice/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { PinpointSMSVoiceServiceException as __BaseException } from "./PinpointSMSVoiceServiceException";
 

--- a/clients/client-pinpoint/src/models/models_0.ts
+++ b/clients/client-pinpoint/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { PinpointServiceException as __BaseException } from "./PinpointServiceException";
 

--- a/clients/client-polly/src/models/models_0.ts
+++ b/clients/client-polly/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType, SENSITIVE_STRING } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 import { Readable } from "stream";
 
 import { PollyServiceException as __BaseException } from "./PollyServiceException";

--- a/clients/client-pricing/src/models/models_0.ts
+++ b/clients/client-pricing/src/models/models_0.ts
@@ -3,7 +3,6 @@ import {
   ExceptionOptionType as __ExceptionOptionType,
   LazyJsonString as __LazyJsonString,
 } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { PricingServiceException as __BaseException } from "./PricingServiceException";
 

--- a/clients/client-proton/src/models/models_0.ts
+++ b/clients/client-proton/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType, SENSITIVE_STRING } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { ProtonServiceException as __BaseException } from "./ProtonServiceException";
 

--- a/clients/client-qldb-session/src/models/models_0.ts
+++ b/clients/client-qldb-session/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { QLDBSessionServiceException as __BaseException } from "./QLDBSessionServiceException";
 

--- a/clients/client-qldb/src/models/models_0.ts
+++ b/clients/client-qldb/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType, SENSITIVE_STRING } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { QLDBServiceException as __BaseException } from "./QLDBServiceException";
 

--- a/clients/client-quicksight/src/models/models_0.ts
+++ b/clients/client-quicksight/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType, SENSITIVE_STRING } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { QuickSightServiceException as __BaseException } from "./QuickSightServiceException";
 

--- a/clients/client-quicksight/src/models/models_1.ts
+++ b/clients/client-quicksight/src/models/models_1.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType, SENSITIVE_STRING } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import {
   _Parameters,

--- a/clients/client-ram/src/models/models_0.ts
+++ b/clients/client-ram/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { RAMServiceException as __BaseException } from "./RAMServiceException";
 

--- a/clients/client-rbin/src/models/models_0.ts
+++ b/clients/client-rbin/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { RbinServiceException as __BaseException } from "./RbinServiceException";
 

--- a/clients/client-rds-data/src/models/models_0.ts
+++ b/clients/client-rds-data/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { RDSDataServiceException as __BaseException } from "./RDSDataServiceException";
 

--- a/clients/client-rds/src/models/models_0.ts
+++ b/clients/client-rds/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { RDSServiceException as __BaseException } from "./RDSServiceException";
 

--- a/clients/client-rds/src/models/models_1.ts
+++ b/clients/client-rds/src/models/models_1.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import {
   ActivityStreamMode,

--- a/clients/client-redshift-data/src/models/models_0.ts
+++ b/clients/client-redshift-data/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { RedshiftDataServiceException as __BaseException } from "./RedshiftDataServiceException";
 

--- a/clients/client-redshift/src/models/models_0.ts
+++ b/clients/client-redshift/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType, SENSITIVE_STRING } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { RedshiftServiceException as __BaseException } from "./RedshiftServiceException";
 

--- a/clients/client-redshift/src/models/models_1.ts
+++ b/clients/client-redshift/src/models/models_1.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import {
   ActionType,

--- a/clients/client-rekognition/src/models/models_0.ts
+++ b/clients/client-rekognition/src/models/models_0.ts
@@ -3,7 +3,6 @@ import {
   ExceptionOptionType as __ExceptionOptionType,
   LazyJsonString as __LazyJsonString,
 } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { RekognitionServiceException as __BaseException } from "./RekognitionServiceException";
 

--- a/clients/client-resiliencehub/src/models/models_0.ts
+++ b/clients/client-resiliencehub/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType, SENSITIVE_STRING } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { ResiliencehubServiceException as __BaseException } from "./ResiliencehubServiceException";
 

--- a/clients/client-resource-groups-tagging-api/src/models/models_0.ts
+++ b/clients/client-resource-groups-tagging-api/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { ResourceGroupsTaggingAPIServiceException as __BaseException } from "./ResourceGroupsTaggingAPIServiceException";
 

--- a/clients/client-resource-groups/src/models/models_0.ts
+++ b/clients/client-resource-groups/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { ResourceGroupsServiceException as __BaseException } from "./ResourceGroupsServiceException";
 

--- a/clients/client-robomaker/src/models/models_0.ts
+++ b/clients/client-robomaker/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { RoboMakerServiceException as __BaseException } from "./RoboMakerServiceException";
 

--- a/clients/client-route-53-domains/src/models/models_0.ts
+++ b/clients/client-route-53-domains/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType, SENSITIVE_STRING } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { Route53DomainsServiceException as __BaseException } from "./Route53DomainsServiceException";
 

--- a/clients/client-route-53/src/models/models_0.ts
+++ b/clients/client-route-53/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { Route53ServiceException as __BaseException } from "./Route53ServiceException";
 

--- a/clients/client-route53-recovery-cluster/src/models/models_0.ts
+++ b/clients/client-route53-recovery-cluster/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { Route53RecoveryClusterServiceException as __BaseException } from "./Route53RecoveryClusterServiceException";
 

--- a/clients/client-route53-recovery-control-config/src/models/models_0.ts
+++ b/clients/client-route53-recovery-control-config/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { Route53RecoveryControlConfigServiceException as __BaseException } from "./Route53RecoveryControlConfigServiceException";
 

--- a/clients/client-route53-recovery-readiness/src/models/models_0.ts
+++ b/clients/client-route53-recovery-readiness/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { Route53RecoveryReadinessServiceException as __BaseException } from "./Route53RecoveryReadinessServiceException";
 

--- a/clients/client-route53resolver/src/models/models_0.ts
+++ b/clients/client-route53resolver/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { Route53ResolverServiceException as __BaseException } from "./Route53ResolverServiceException";
 

--- a/clients/client-rum/src/models/models_0.ts
+++ b/clients/client-rum/src/models/models_0.ts
@@ -3,7 +3,6 @@ import {
   ExceptionOptionType as __ExceptionOptionType,
   LazyJsonString as __LazyJsonString,
 } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { RUMServiceException as __BaseException } from "./RUMServiceException";
 

--- a/clients/client-s3-control/src/models/models_0.ts
+++ b/clients/client-s3-control/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { S3ControlServiceException as __BaseException } from "./S3ControlServiceException";
 

--- a/clients/client-s3/src/models/models_0.ts
+++ b/clients/client-s3/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType, SENSITIVE_STRING } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 import { Readable } from "stream";
 
 import { S3ServiceException as __BaseException } from "./S3ServiceException";

--- a/clients/client-s3/src/models/models_1.ts
+++ b/clients/client-s3/src/models/models_1.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType, SENSITIVE_STRING } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 import { Readable } from "stream";
 
 import {

--- a/clients/client-s3outposts/src/models/models_0.ts
+++ b/clients/client-s3outposts/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { S3OutpostsServiceException as __BaseException } from "./S3OutpostsServiceException";
 

--- a/clients/client-sagemaker-a2i-runtime/src/models/models_0.ts
+++ b/clients/client-sagemaker-a2i-runtime/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { SageMakerA2IRuntimeServiceException as __BaseException } from "./SageMakerA2IRuntimeServiceException";
 

--- a/clients/client-sagemaker-edge/src/models/models_0.ts
+++ b/clients/client-sagemaker-edge/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { SagemakerEdgeServiceException as __BaseException } from "./SagemakerEdgeServiceException";
 

--- a/clients/client-sagemaker-featurestore-runtime/src/models/models_0.ts
+++ b/clients/client-sagemaker-featurestore-runtime/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { SageMakerFeatureStoreRuntimeServiceException as __BaseException } from "./SageMakerFeatureStoreRuntimeServiceException";
 

--- a/clients/client-sagemaker-runtime/src/models/models_0.ts
+++ b/clients/client-sagemaker-runtime/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType, SENSITIVE_STRING } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { SageMakerRuntimeServiceException as __BaseException } from "./SageMakerRuntimeServiceException";
 

--- a/clients/client-sagemaker/src/models/models_0.ts
+++ b/clients/client-sagemaker/src/models/models_0.ts
@@ -3,7 +3,6 @@ import {
   ExceptionOptionType as __ExceptionOptionType,
   LazyJsonString as __LazyJsonString,
 } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { SageMakerServiceException as __BaseException } from "./SageMakerServiceException";
 

--- a/clients/client-savingsplans/src/models/models_0.ts
+++ b/clients/client-savingsplans/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { SavingsplansServiceException as __BaseException } from "./SavingsplansServiceException";
 

--- a/clients/client-schemas/src/models/models_0.ts
+++ b/clients/client-schemas/src/models/models_0.ts
@@ -3,7 +3,6 @@ import {
   ExceptionOptionType as __ExceptionOptionType,
   LazyJsonString as __LazyJsonString,
 } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { SchemasServiceException as __BaseException } from "./SchemasServiceException";
 

--- a/clients/client-secrets-manager/src/models/models_0.ts
+++ b/clients/client-secrets-manager/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType, SENSITIVE_STRING } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { SecretsManagerServiceException as __BaseException } from "./SecretsManagerServiceException";
 

--- a/clients/client-securityhub/src/models/models_0.ts
+++ b/clients/client-securityhub/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { SecurityHubServiceException as __BaseException } from "./SecurityHubServiceException";
 

--- a/clients/client-securityhub/src/models/models_1.ts
+++ b/clients/client-securityhub/src/models/models_1.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import {
   AccountDetails,

--- a/clients/client-serverlessapplicationrepository/src/models/models_0.ts
+++ b/clients/client-serverlessapplicationrepository/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { ServerlessApplicationRepositoryServiceException as __BaseException } from "./ServerlessApplicationRepositoryServiceException";
 

--- a/clients/client-service-catalog-appregistry/src/models/models_0.ts
+++ b/clients/client-service-catalog-appregistry/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { ServiceCatalogAppRegistryServiceException as __BaseException } from "./ServiceCatalogAppRegistryServiceException";
 

--- a/clients/client-service-catalog/src/models/models_0.ts
+++ b/clients/client-service-catalog/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { ServiceCatalogServiceException as __BaseException } from "./ServiceCatalogServiceException";
 

--- a/clients/client-service-quotas/src/models/models_0.ts
+++ b/clients/client-service-quotas/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { ServiceQuotasServiceException as __BaseException } from "./ServiceQuotasServiceException";
 

--- a/clients/client-servicediscovery/src/models/models_0.ts
+++ b/clients/client-servicediscovery/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { ServiceDiscoveryServiceException as __BaseException } from "./ServiceDiscoveryServiceException";
 

--- a/clients/client-ses/src/models/models_0.ts
+++ b/clients/client-ses/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { SESServiceException as __BaseException } from "./SESServiceException";
 

--- a/clients/client-sesv2/src/models/models_0.ts
+++ b/clients/client-sesv2/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType, SENSITIVE_STRING } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { SESv2ServiceException as __BaseException } from "./SESv2ServiceException";
 

--- a/clients/client-sfn/src/models/models_0.ts
+++ b/clients/client-sfn/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType, SENSITIVE_STRING } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { SFNServiceException as __BaseException } from "./SFNServiceException";
 

--- a/clients/client-shield/src/models/models_0.ts
+++ b/clients/client-shield/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { ShieldServiceException as __BaseException } from "./ShieldServiceException";
 

--- a/clients/client-signer/src/models/models_0.ts
+++ b/clients/client-signer/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { SignerServiceException as __BaseException } from "./SignerServiceException";
 

--- a/clients/client-sms/src/models/models_0.ts
+++ b/clients/client-sms/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { SMSServiceException as __BaseException } from "./SMSServiceException";
 

--- a/clients/client-snow-device-management/src/models/models_0.ts
+++ b/clients/client-snow-device-management/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { SnowDeviceManagementServiceException as __BaseException } from "./SnowDeviceManagementServiceException";
 

--- a/clients/client-snowball/src/models/models_0.ts
+++ b/clients/client-snowball/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { SnowballServiceException as __BaseException } from "./SnowballServiceException";
 

--- a/clients/client-sns/src/models/models_0.ts
+++ b/clients/client-sns/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { SNSServiceException as __BaseException } from "./SNSServiceException";
 

--- a/clients/client-sqs/src/models/models_0.ts
+++ b/clients/client-sqs/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { SQSServiceException as __BaseException } from "./SQSServiceException";
 

--- a/clients/client-ssm-contacts/src/models/models_0.ts
+++ b/clients/client-ssm-contacts/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { SSMContactsServiceException as __BaseException } from "./SSMContactsServiceException";
 

--- a/clients/client-ssm-incidents/src/models/models_0.ts
+++ b/clients/client-ssm-incidents/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { SSMIncidentsServiceException as __BaseException } from "./SSMIncidentsServiceException";
 

--- a/clients/client-ssm/src/models/models_0.ts
+++ b/clients/client-ssm/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType, SENSITIVE_STRING } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { SSMServiceException as __BaseException } from "./SSMServiceException";
 

--- a/clients/client-ssm/src/models/models_1.ts
+++ b/clients/client-ssm/src/models/models_1.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType, SENSITIVE_STRING } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import {
   AssociationComplianceSeverity,

--- a/clients/client-ssm/src/models/models_2.ts
+++ b/clients/client-ssm/src/models/models_2.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType, SENSITIVE_STRING } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import {
   LoggingInfo,

--- a/clients/client-sso-admin/src/models/models_0.ts
+++ b/clients/client-sso-admin/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType, SENSITIVE_STRING } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { SSOAdminServiceException as __BaseException } from "./SSOAdminServiceException";
 

--- a/clients/client-sso-oidc/src/models/models_0.ts
+++ b/clients/client-sso-oidc/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { SSOOIDCServiceException as __BaseException } from "./SSOOIDCServiceException";
 

--- a/clients/client-sso/src/models/models_0.ts
+++ b/clients/client-sso/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType, SENSITIVE_STRING } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { SSOServiceException as __BaseException } from "./SSOServiceException";
 

--- a/clients/client-storage-gateway/src/models/models_0.ts
+++ b/clients/client-storage-gateway/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType, SENSITIVE_STRING } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { StorageGatewayServiceException as __BaseException } from "./StorageGatewayServiceException";
 

--- a/clients/client-sts/src/models/models_0.ts
+++ b/clients/client-sts/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { STSServiceException as __BaseException } from "./STSServiceException";
 

--- a/clients/client-support/src/models/models_0.ts
+++ b/clients/client-support/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { SupportServiceException as __BaseException } from "./SupportServiceException";
 

--- a/clients/client-swf/src/models/models_0.ts
+++ b/clients/client-swf/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { SWFServiceException as __BaseException } from "./SWFServiceException";
 

--- a/clients/client-synthetics/src/models/models_0.ts
+++ b/clients/client-synthetics/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { SyntheticsServiceException as __BaseException } from "./SyntheticsServiceException";
 

--- a/clients/client-textract/src/models/models_0.ts
+++ b/clients/client-textract/src/models/models_0.ts
@@ -3,7 +3,6 @@ import {
   ExceptionOptionType as __ExceptionOptionType,
   LazyJsonString as __LazyJsonString,
 } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { TextractServiceException as __BaseException } from "./TextractServiceException";
 

--- a/clients/client-timestream-query/src/models/models_0.ts
+++ b/clients/client-timestream-query/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType, SENSITIVE_STRING } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { TimestreamQueryServiceException as __BaseException } from "./TimestreamQueryServiceException";
 

--- a/clients/client-timestream-write/src/models/models_0.ts
+++ b/clients/client-timestream-write/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { TimestreamWriteServiceException as __BaseException } from "./TimestreamWriteServiceException";
 

--- a/clients/client-transcribe-streaming/src/models/models_0.ts
+++ b/clients/client-transcribe-streaming/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { TranscribeStreamingServiceException as __BaseException } from "./TranscribeStreamingServiceException";
 

--- a/clients/client-transcribe/src/models/models_0.ts
+++ b/clients/client-transcribe/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { TranscribeServiceException as __BaseException } from "./TranscribeServiceException";
 

--- a/clients/client-transfer/src/models/models_0.ts
+++ b/clients/client-transfer/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType, SENSITIVE_STRING } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { TransferServiceException as __BaseException } from "./TransferServiceException";
 

--- a/clients/client-translate/src/models/models_0.ts
+++ b/clients/client-translate/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType, SENSITIVE_STRING } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { TranslateServiceException as __BaseException } from "./TranslateServiceException";
 

--- a/clients/client-voice-id/src/models/models_0.ts
+++ b/clients/client-voice-id/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType, SENSITIVE_STRING } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { VoiceIDServiceException as __BaseException } from "./VoiceIDServiceException";
 

--- a/clients/client-waf-regional/src/models/models_0.ts
+++ b/clients/client-waf-regional/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { WAFRegionalServiceException as __BaseException } from "./WAFRegionalServiceException";
 

--- a/clients/client-waf/src/models/models_0.ts
+++ b/clients/client-waf/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { WAFServiceException as __BaseException } from "./WAFServiceException";
 

--- a/clients/client-wafv2/src/models/models_0.ts
+++ b/clients/client-wafv2/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { WAFV2ServiceException as __BaseException } from "./WAFV2ServiceException";
 

--- a/clients/client-wellarchitected/src/models/models_0.ts
+++ b/clients/client-wellarchitected/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { WellArchitectedServiceException as __BaseException } from "./WellArchitectedServiceException";
 

--- a/clients/client-wisdom/src/models/models_0.ts
+++ b/clients/client-wisdom/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType, SENSITIVE_STRING } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { WisdomServiceException as __BaseException } from "./WisdomServiceException";
 

--- a/clients/client-workdocs/src/models/models_0.ts
+++ b/clients/client-workdocs/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType, SENSITIVE_STRING } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { WorkDocsServiceException as __BaseException } from "./WorkDocsServiceException";
 

--- a/clients/client-worklink/src/models/models_0.ts
+++ b/clients/client-worklink/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { WorkLinkServiceException as __BaseException } from "./WorkLinkServiceException";
 

--- a/clients/client-workmail/src/models/models_0.ts
+++ b/clients/client-workmail/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType, SENSITIVE_STRING } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { WorkMailServiceException as __BaseException } from "./WorkMailServiceException";
 

--- a/clients/client-workmailmessageflow/src/models/models_0.ts
+++ b/clients/client-workmailmessageflow/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 import { Readable } from "stream";
 
 import { WorkMailMessageFlowServiceException as __BaseException } from "./WorkMailMessageFlowServiceException";

--- a/clients/client-workspaces-web/src/models/models_0.ts
+++ b/clients/client-workspaces-web/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType, SENSITIVE_STRING } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { WorkSpacesWebServiceException as __BaseException } from "./WorkSpacesWebServiceException";
 

--- a/clients/client-workspaces/src/models/models_0.ts
+++ b/clients/client-workspaces/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { WorkSpacesServiceException as __BaseException } from "./WorkSpacesServiceException";
 

--- a/clients/client-xray/src/models/models_0.ts
+++ b/clients/client-xray/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { XRayServiceException as __BaseException } from "./XRayServiceException";
 

--- a/private/aws-echo-service/src/models/models_0.ts
+++ b/private/aws-echo-service/src/models/models_0.ts
@@ -1,7 +1,6 @@
 // smithy-typescript generated code
 import { EchoServiceServiceException as __BaseException } from "./EchoServiceServiceException";
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 export interface EchoInput {
   string?: string;

--- a/private/aws-protocoltests-ec2/src/models/models_0.ts
+++ b/private/aws-protocoltests-ec2/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { EC2ProtocolServiceException as __BaseException } from "./EC2ProtocolServiceException";
 

--- a/private/aws-protocoltests-json-10/src/models/models_0.ts
+++ b/private/aws-protocoltests-json-10/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { JSONRPC10ServiceException as __BaseException } from "./JSONRPC10ServiceException";
 

--- a/private/aws-protocoltests-json/src/models/models_0.ts
+++ b/private/aws-protocoltests-json/src/models/models_0.ts
@@ -3,7 +3,7 @@ import {
   ExceptionOptionType as __ExceptionOptionType,
   LazyJsonString as __LazyJsonString,
 } from "@aws-sdk/smithy-client";
-import { DocumentType as __DocumentType, MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
+import { DocumentType as __DocumentType } from "@aws-sdk/types";
 
 import { JsonProtocolServiceException as __BaseException } from "./JsonProtocolServiceException";
 

--- a/private/aws-protocoltests-query/src/models/models_0.ts
+++ b/private/aws-protocoltests-query/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { QueryProtocolServiceException as __BaseException } from "./QueryProtocolServiceException";
 

--- a/private/aws-protocoltests-restjson/src/models/models_0.ts
+++ b/private/aws-protocoltests-restjson/src/models/models_0.ts
@@ -3,7 +3,7 @@ import {
   ExceptionOptionType as __ExceptionOptionType,
   LazyJsonString as __LazyJsonString,
 } from "@aws-sdk/smithy-client";
-import { DocumentType as __DocumentType, MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
+import { DocumentType as __DocumentType } from "@aws-sdk/types";
 import { Readable } from "stream";
 
 import { RestJsonProtocolServiceException as __BaseException } from "./RestJsonProtocolServiceException";

--- a/private/aws-protocoltests-restxml/src/models/models_0.ts
+++ b/private/aws-protocoltests-restxml/src/models/models_0.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-client";
-import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 import { RestXmlProtocolServiceException as __BaseException } from "./RestXmlProtocolServiceException";
 


### PR DESCRIPTION
Based on fix in https://github.com/awslabs/smithy-typescript/pull/545

Ran `yarn generate-clients && yarn test:protocols && yarn generate-clients -s && yarn test:server-protocols`

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
